### PR TITLE
The benchmark consumes the ledger, and follows its pointer (#1206)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,18 @@
 
 ### Changed
 
+- `HoleRequirementOutcome` gains `members` and `features`, `ClaimOutcome` gains `measurement`,
+  and `linting.hole_coverage.canonical_hole_sites` is public (#1217). A consumer attributing a
+  requirement outcome to a specific recognised hole needs the evidence the outcome accounts
+  for, and needs to key into the canonical space the ledger publishes it in — a through hole's
+  own-axis coordinate is zeroed there.
+- The STEP-analysis benchmark's `drawing_consumer` boundary now consumes
+  `hole_requirement_outcomes` instead of a second correspondence implementation of its own
+  (#1206), and follows the ledger's pointer through `linting.evidence` rather than trusting it.
+  Holes the ledger reports `unverifiable` now score `unknown` where the duplicate credited them
+  by guessing: 26 holes across the four CTC-02/03/04 fixtures. The five-case evaluation corpus
+  is unchanged.
+
 - `Drawing.suppressions()` rows gain a `conveyed_by` key: the dimension that states a
   withheld measurement instead, or `None` when nothing takes the fact over (#1154). It is not
   a synonym for the existing `authored` flag — that says whose decision it was, this says

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,9 @@
   `hole_requirement_outcomes` instead of a second correspondence implementation of its own
   (#1206), and follows the ledger's pointer through `linting.evidence` rather than trusting it.
   Holes the ledger reports `unverifiable` now score `unknown` where the duplicate credited them
-  by guessing: 26 holes across the four CTC-02/03/04 fixtures. The five-case evaluation corpus
-  is unchanged.
+  by guessing: 26 holes, five on each CTC-03 fixture and eight on each CTC-04 fixture. The
+  five-case evaluation corpus is unchanged, and one lint message on CTC-03 now reports its
+  coordinates in the ledger's own canonical space.
 
 - `Drawing.suppressions()` rows gain a `conveyed_by` key: the dimension that states a
   withheld measurement instead, or `None` when nothing takes the fact over (#1154). It is not

--- a/docs/reference/step-analysis-evaluation.md
+++ b/docs/reference/step-analysis-evaluation.md
@@ -14,9 +14,16 @@ identifier. Expected and observed facts are matched by family plus authored phys
 
 Format 1 currently proves the `holes` vertical slice. The observer reads released
 `b123d-recognisers` geometry records, builds the drawing, and reads the `drawing_consumer`
-outcome off that build through the ADR 0010 provenance seam — `supported` when the hole's
-size reached the sheet as a callout or a hole-table row, `unsupported` when a feature
-accounts for it and carries neither, `unknown` when no feature accounts for it (#1202). The
+outcome off that build through the ADR 0010 provenance seam.
+
+Since #1217 that outcome comes from the engine's own requirement ledger
+(`linting.hole_coverage.hole_requirement_outcomes`) rather than from a second correspondence
+implementation here, and the ledger is treated as a **pointer, not proof**: `supported` requires
+both that the engine recorded an annotation as carrying the hole's size *and* that the annotation
+renders the value the compiler approved, checked through `linting.evidence`. `unsupported` means
+the requirement was not placed, or the annotation contradicts it. `unknown` means the ledger
+declined to join the hole to a feature without guessing — it scores as a miss, so it is an honest
+label rather than an exemption (#1202, #1206). The
 other three downstream boundaries still come from the independently enforced Draftwright
 capability declaration, which is a claim that a code path exists rather than an
 observation. Adding another family requires its own independently authored fixtures, facts,

--- a/src/draftwright/evaluation/step_analysis.py
+++ b/src/draftwright/evaluation/step_analysis.py
@@ -6,7 +6,7 @@ benchmark case supplies the denominator and tolerances.
 
 The ``drawing_consumer`` boundary is OBSERVED from a real build (#1202) rather than read from
 a capability declaration. Known limit of that approach: it reads the ADR 0010 provenance seam,
-which ``Drawing.annotations_of`` documents as growing "as passes are migrated". An un-tagged
+which the registry's measurement provenance carries "as passes are migrated". An un-tagged
 render pass therefore reads as a genuine omission, and this is a CLASS of limitation rather
 than a single case. Two instances are known:
 
@@ -635,17 +635,6 @@ def load_corpus(path: str | Path) -> BenchmarkCorpus:
     return BenchmarkCorpus(corpus_version, _METRIC_VERSION, scope, tuple(cases))
 
 
-#: Position agreement required to call a recognised hole and an IR feature the same hole.
-#: Tiny on purpose: the IR carries the recogniser's own ``hole.location`` verbatim
-#: (``model/detect.py`` builds ``Frame(origin=_xyz(rep.location))``), so agreement is
-#: EXACT on every corpus fixture — worst residual measured at 0.0, including the
-#: side-drilled case whose z is 6.66e-15. An earlier version compared only the in-plane
-#: coordinates, on a guess that the compiler might mint the origin at the far end of the
-#: bore. It does not, and dropping the axis component made two opposed coaxial holes of
-#: equal diameter alias onto one feature, hiding a dropped callout on the second.
-_CORRESPONDENCE_TOLERANCE = 1e-6
-
-
 #: The compiled requirement that carries a hole's SIZE. A table row documents several
 #: requirements per hole (location, through-ness, …); only this one is the fact
 #: ``drawing_consumer`` asks about. Crediting the others would mean a hole with a located
@@ -682,9 +671,16 @@ def _drawing_consumer_outcomes(holes, drawing) -> list[Outcome]:
     through `linting.evidence` and confirms the annotation actually renders the approved
     value. A claim the drawing does not bear out is ``unsupported``, not ``supported``.
 
-    Name prefixes are gone with the duplicate. ``hc_*`` matching is why a bore printed as a
-    plain ``Leader`` scored ``unsupported`` on a turned part; provenance does not care what a
-    renderer called its annotation.
+    Name prefixes are gone with the duplicate: provenance does not care what a renderer called
+    its annotation.
+
+    That does **not** close the turned-part gap, and an earlier draft of this paragraph said
+    it did. Measured on ``Cylinder(20,60) - Cylinder(6,70)``, the outcome is ``unsupported``
+    before and after, with a byte-identical annotation set. The cause was never the name: the
+    bore's ``ø12`` is drawn by ``ldr_z0``, which carries no measurement claim at all, so the
+    ledger reports ``bore.diameter`` as ``missing``. That is the #754 debt this module's own
+    docstring already states in full — which the removed sentence contradicted from twenty
+    lines below it.
     """
     from draftwright.linting.evidence import verify_measurement_claims
     from draftwright.linting.hole_coverage import canonical_hole_sites, hole_requirement_outcomes
@@ -701,10 +697,16 @@ def _drawing_consumer_outcomes(holes, drawing) -> list[Outcome]:
         drawing.registry,
         plan.diagnostics,
     )
-    refuted = {
+    # NOT just `value_absent`. `supported` is meant to mean the annotation carrying the size
+    # renders it, so anything short of `confirmed` fails that: an `unreadable` annotation
+    # draws no text at all, and an `unresolved` one claims a measurement the compiler never
+    # approved (the ADR 0016 Amdt 1 violation). Crediting either was the PR body's own
+    # sentence — "and the annotation carrying it renders that value" — being false of the
+    # code beneath it (#1223 review).
+    unconfirmed = {
         claim.measurement
         for claim in verify_measurement_claims(drawing.registry, plan)
-        if claim.state == "value_absent" and claim.measurement is not None
+        if claim.state != "confirmed" and claim.measurement is not None
     }
 
     def _borne_out(entry) -> bool:
@@ -712,7 +714,7 @@ def _drawing_consumer_outcomes(holes, drawing) -> list[Outcome]:
         return not any(
             getattr(claim, "feature", None) in entry.features
             and str(getattr(claim, "parameter", "")) == _SIZE_REQUIREMENT
-            for claim in refuted
+            for claim in unconfirmed
         )
 
     by_position: dict[tuple, Outcome] = {}
@@ -721,9 +723,12 @@ def _drawing_consumer_outcomes(holes, drawing) -> list[Outcome]:
             state: Outcome = "supported" if entry.state == "placed" else "unsupported"
             if state == "supported" and not _borne_out(entry):
                 state = "unsupported"
-        elif entry.state == "unverifiable":
-            state = "unknown"
         else:
+            # Non-size parameters contribute no site. An `unverifiable` entry needs no arm
+            # of its own: its holes reach `unknown` through the lookup default below, and a
+            # branch that cannot change an outcome is one a reader trusts wrongly. The
+            # property it looked like it was enforcing — that every `unknown` joins an
+            # `unverifiable` entry — is asserted in the tests, where it can fail.
             continue
         for member in entry.members:
             by_position.setdefault(member, state)

--- a/src/draftwright/evaluation/step_analysis.py
+++ b/src/draftwright/evaluation/step_analysis.py
@@ -646,154 +646,96 @@ def load_corpus(path: str | Path) -> BenchmarkCorpus:
 _CORRESPONDENCE_TOLERANCE = 1e-6
 
 
-@dataclass(frozen=True)
-class _Candidate:
-    """One IR feature and the hole positions it can account for."""
-
-    feature: object
-    axis: str
-    diameter: float
-    positions: tuple[tuple[float, ...], ...]
-
-
-def _hole_candidates(drawing) -> list[_Candidate]:
-    """Every IR feature that can account for a recognised hole.
-
-    Patterned holes lower to a ``PatternFeature`` carrying a representative
-    ``HoleFeature`` and the member centres — they are NOT ``HoleFeature`` instances, so
-    matching on that type alone made recognising a pattern (a capability) *lower* the
-    score: four identical holes scored ``unknown`` where the same four at the same
-    positions with distinct diameters scored ``supported``, both fully drawn.
-
-    Dispatch is on the IR's own ``kind`` discriminator, which the engine itself uses,
-    rather than on ``type(f).__name__``.
-    """
-    candidates: list[_Candidate] = []
-    for feature in drawing.model().features:
-        kind = getattr(feature, "kind", None)
-        if kind == "hole":
-            # A grouped ``count×`` callout covers several holes through one feature.
-            positions = feature.members or (feature.frame.origin,)
-            candidates.append(
-                _Candidate(feature, feature.frame.axis, feature.diameter, tuple(positions))
-            )
-        elif kind == "pattern" and getattr(feature.member, "kind", None) == "hole":
-            candidates.append(
-                _Candidate(
-                    feature, feature.frame.axis, feature.member.diameter, tuple(feature.members)
-                )
-            )
-    return candidates
-
-
 #: The compiled requirement that carries a hole's SIZE. A table row documents several
 #: requirements per hole (location, through-ness, …); only this one is the fact
-#: ``drawing_consumer`` asks about.
+#: ``drawing_consumer`` asks about. Crediting the others would mean a hole with a located
+#: row but no diameter counted as consumed.
 _SIZE_REQUIREMENT = "bore.diameter"
 
 
-def _table_represented(drawing) -> list:
-    """Features the engine recorded as carried by a hole TABLE rather than a callout.
-
-    Above ~16 scattered holes the engine withdraws the individual ``hc_*`` callouts and
-    places one table plus balloons, recording the substitution on the table object. Reading
-    only ``hc_`` scored every hole on such a sheet as lost — measured 16 of 16 on a dense
-    plate with no lint issues at all — which inverted the metric: a correct sheet scored
-    worse than the same part with the table forced to fail.
-
-    Read ``covers_hole_representations_by_requirement``. An earlier cut read a
-    ``…_by_feature`` sibling that no caller ever populated — its ``representation_features``
-    argument appeared in the whole tree only at its own definition and its own use — so the
-    read returned nothing on every real drawing while a hand-built stub in the tests made it
-    look correct. The dead field was removed in #1217; this note stays because the lesson is
-    about the stub, not the field.
-
-    Filtered to the SIZE requirement: a table row also documents location and through-ness,
-    and crediting those would mean a hole with a located row but no diameter counted as
-    consumed.
-
-    Safe against a dropped table: the ledger is written only after the table is placed and
-    the balloon-completeness gate passes, and the annotation transaction rolls the table
-    back before that point, so a `table_dropped` sheet carries no entries (verified).
-    """
-    covered = []
-    for _name, annotation in drawing.iter_annotations():
-        for entry in getattr(annotation, "covers_hole_representations_by_requirement", ()):
-            feature, parameter = entry[0], entry[1]
-            if parameter == _SIZE_REQUIREMENT:
-                covered.append(feature)
-    return covered
-
-
-def _consumed(feature, drawing, represented) -> bool:
-    """Did this feature's SIZE reach the sheet, by either sanctioned route?
-
-    Only the callout or the table counts. A hole whose callout was dropped still keeps its
-    centre mark and location dims (measured: ``m_cm0``, ``m_locx0``), so counting any
-    annotation would score a dropped callout as consumed.
-    """
-    if any(name.startswith("hc_") for name in drawing.annotations_of(feature)):
-        return True
-    return any(represented_feature == feature for represented_feature in represented)
-
-
 def _drawing_consumer_outcomes(holes, drawing) -> list[Outcome]:
-    """Per recognised hole: did the DRAWING carry it? — observed, not declared.
+    """Per recognised hole: did the DRAWING carry its size? — observed, not declared.
 
-    ``supported`` its size reached the sheet; ``unsupported`` a feature accounts for the
-    hole and carries neither callout nor table row; ``unknown`` no feature accounts for
-    it, which is a gap in the recognition-record-to-IR correspondence ADR 0017 explicitly
-    does not yet provide.
+    ``supported`` its size reached the sheet **and the annotation carrying it renders that
+    value**; ``unsupported`` the engine accounts for the hole and did not place its size;
+    ``unknown`` nothing can be joined to the hole without guessing.
 
-    Be precise about ``unknown``: :func:`evaluate_case` credits a unit only when the state
-    is ``supported``, so downstream an ``unknown`` scores as a MISS, distinguishable from
-    a dropped callout only in the diagnostic text. It is an honest label, not an exemption
-    — an earlier version of this docstring claimed it was "never scored as either success
-    or failure", which was wrong about the pipeline it feeds.
+    Be precise about ``unknown``: :func:`evaluate_case` credits a unit only when the state is
+    ``supported``, so downstream an ``unknown`` scores as a MISS, distinguishable from a
+    dropped callout only in the diagnostic text. It is an honest label, not an exemption.
 
-    Matching is injective per POSITION: a matched position is consumed, so two opposed
-    coaxial holes of equal diameter cannot both resolve to the first candidate. Grouped
-    features legitimately account for several holes, which is why the position is consumed
-    and not the whole candidate.
+    **One correspondence implementation** (#1206). This used to carry its own — matching
+    recognised holes to IR features by axis, diameter and position, then asking whether any
+    annotation named ``hc_*`` — beside `linting.hole_coverage.hole_requirement_outcomes`,
+    which answers the same question. Two implementations of one question drift, and the copy
+    was the more generous of the two: it credited holes the ledger declines to join.
+
+    That generosity is a measurable score change, not a refactor. On
+    ``nist_ctc_02``/``nist_ctc_04`` the ledger reports eight holes as ``unverifiable`` —
+    it knows they exist and cannot tie them to a feature without guessing — where the old
+    matcher scored them ``supported``. They now score ``unknown``. Crediting a hole whose
+    evidence cannot be located is exactly the self-validation #1206 was opened to remove, so
+    the lower number is the more honest one.
+
+    **The ledger is a pointer, not proof** (@pzfreo's decision on #1206). ``placed`` means the
+    engine recorded an annotation as carrying the requirement; this then follows that pointer
+    through `linting.evidence` and confirms the annotation actually renders the approved
+    value. A claim the drawing does not bear out is ``unsupported``, not ``supported``.
+
+    Name prefixes are gone with the duplicate. ``hc_*`` matching is why a bore printed as a
+    plain ``Leader`` scored ``unsupported`` on a turned part; provenance does not care what a
+    renderer called its annotation.
     """
-    # Imported here, not at module level: `_geometry` imports build123d, so a top-level
-    # import would pull the CAD kernel into every consumer of this module — measured, it
-    # took import cost from 0.01 s to 1.27 s and made the lazy `builder` import below buy
-    # nothing at all. An earlier comment claimed that laziness saved the kernel import
-    # while this line was already paying it.
-    from draftwright._geometry import _axis_letter_of
+    from draftwright.linting.evidence import verify_measurement_claims
+    from draftwright.linting.hole_coverage import canonical_hole_sites, hole_requirement_outcomes
+    from draftwright.model.compiled import compile_dimensions
 
-    remaining = [(candidate, list(candidate.positions)) for candidate in _hole_candidates(drawing)]
-    represented = _table_represented(drawing)
+    model = drawing.model()
+    # Recompiled through the public model rather than read off `Drawing._build`: the compiler
+    # is deterministic over the model, so this is the same inventory the build used, and the
+    # state-bus guard keeps `dwg._*` to `drawing.py` alone.
+    plan = compile_dimensions(model)
+    ledger = hole_requirement_outcomes(
+        drawing.recognition(),
+        getattr(model, "features", ()),
+        drawing.registry,
+        plan.diagnostics,
+    )
+    refuted = {
+        claim.measurement
+        for claim in verify_measurement_claims(drawing.registry, plan)
+        if claim.state == "value_absent" and claim.measurement is not None
+    }
+
+    def _borne_out(entry) -> bool:
+        """Whether the placement the ledger reports is confirmed by what is drawn."""
+        return not any(
+            getattr(claim, "feature", None) in entry.features
+            and str(getattr(claim, "parameter", "")) == _SIZE_REQUIREMENT
+            for claim in refuted
+        )
+
+    by_position: dict[tuple, Outcome] = {}
+    for entry in ledger:
+        if entry.parameter_id == _SIZE_REQUIREMENT:
+            state: Outcome = "supported" if entry.state == "placed" else "unsupported"
+            if state == "supported" and not _borne_out(entry):
+                state = "unsupported"
+        elif entry.state == "unverifiable":
+            state = "unknown"
+        else:
+            continue
+        for member in entry.members:
+            by_position.setdefault(member, state)
+
+    # `canonical_hole_sites`, not `hole.location`: the ledger keys a THROUGH hole with its
+    # axis coordinate zeroed, so the same bore keys identically whichever face it was measured
+    # from. Keying on the raw location matched nothing for every through hole and reported
+    # four otherwise-perfect corpus units as `unknown`.
     outcomes: list[Outcome] = []
     for hole in holes:
-        axis = _axis_letter_of(hole.axis)
-        target = tuple(float(value) for value in hole.location)
-        for candidate, positions in remaining:
-            if candidate.axis != axis or abs(candidate.diameter - hole.diameter) > 1e-9:
-                continue
-            hit = next(
-                (
-                    position
-                    for position in positions
-                    if all(
-                        abs(a - b) <= _CORRESPONDENCE_TOLERANCE
-                        for a, b in zip(tuple(float(v) for v in position), target, strict=True)
-                    )
-                ),
-                None,
-            )
-            if hit is None:
-                continue
-            positions.remove(hit)
-            outcomes.append(
-                "supported"
-                if _consumed(candidate.feature, drawing, represented)
-                else "unsupported"
-            )
-            break
-        else:
-            outcomes.append("unknown")
+        sites = canonical_hole_sites(hole)
+        outcomes.append(next((by_position[s] for s in sites if s in by_position), "unknown"))
     return outcomes
 
 

--- a/src/draftwright/evaluation/step_analysis.py
+++ b/src/draftwright/evaluation/step_analysis.py
@@ -6,7 +6,10 @@ benchmark case supplies the denominator and tolerances.
 
 The ``drawing_consumer`` boundary is OBSERVED from a real build (#1202) rather than read from
 a capability declaration. Known limit of that approach: it reads the ADR 0010 provenance seam,
-which the registry's measurement provenance carries "as passes are migrated". An un-tagged
+which ``registry.measurement_of`` carries and which is populated one render pass at a time
+(the set of tagged renderers is enumerated by ``tests/test_audit_differential.py``, not by
+prose here — that docstring warns the prose version was wrong when first written). An
+un-tagged
 render pass therefore reads as a genuine omission, and this is a CLASS of limitation rather
 than a single case. Two instances are known:
 
@@ -659,10 +662,14 @@ def _drawing_consumer_outcomes(holes, drawing) -> list[Outcome]:
     which answers the same question. Two implementations of one question drift, and the copy
     was the more generous of the two: it credited holes the ledger declines to join.
 
-    That generosity is a measurable score change, not a refactor. On
-    ``nist_ctc_02``/``nist_ctc_04`` the ledger reports eight holes as ``unverifiable`` —
-    it knows they exist and cannot tie them to a feature without guessing — where the old
-    matcher scored them ``supported``. They now score ``unknown``. Crediting a hole whose
+    That generosity is a measurable score change, not a refactor. Measured base against head
+    over all 16 STEP fixtures, 26 holes move: ``nist_ctc_03`` ap203 and ap242 lose five each
+    (15/15 -> 10 supported + 5 unknown) and ``nist_ctc_04`` ap203 and ap242 lose eight each
+    (54/54 -> 46 + 8). Every one is a hole the ledger reports ``unverifiable`` — it knows they
+    exist and cannot tie them to a feature without guessing — where the old matcher scored
+    them ``supported``. They now score ``unknown``. ``nist_ctc_02`` does not move at all; an
+    earlier version of this paragraph named it and omitted CTC-03, which is the fixture that
+    actually diverges. Crediting a hole whose
     evidence cannot be located is exactly the self-validation #1206 was opened to remove, so
     the lower number is the more honest one.
 
@@ -676,11 +683,16 @@ def _drawing_consumer_outcomes(holes, drawing) -> list[Outcome]:
 
     That does **not** close the turned-part gap, and an earlier draft of this paragraph said
     it did. Measured on ``Cylinder(20,60) - Cylinder(6,70)``, the outcome is ``unsupported``
-    before and after, with a byte-identical annotation set. The cause was never the name: the
-    bore's ``ø12`` is drawn by ``ldr_z0``, which carries no measurement claim at all, so the
-    ledger reports ``bore.diameter`` as ``missing``. That is the #754 debt this module's own
-    docstring already states in full — which the removed sentence contradicted from twenty
-    lines below it.
+    before and after, with a byte-identical annotation set. The cause was never the name:
+    **no annotation on that sheet carries a measurement claim at all** — not ``ldr_z0``
+    (``ø12``), not ``dim_od`` (``ø40``), not ``dim_height`` — while the compiled plan does
+    hold ``hole.bore.diameter`` and ``rotational.od.diameter``. So the rotational render path
+    threads no ADR 0010 provenance, and the ledger reports ``bore.diameter`` as ``missing``.
+
+    That is an annotation-tagging gap, tracked by #1227. It is NOT #754, which closed on
+    2026-07-22 — an earlier draft of this paragraph cited it, which is the fourth instance of
+    the stale citation #951 exists to remove, written inside a sentence correcting a
+    different false claim.
     """
     from draftwright.linting.evidence import verify_measurement_claims
     from draftwright.linting.hole_coverage import canonical_hole_sites, hole_requirement_outcomes

--- a/src/draftwright/linting/evidence.py
+++ b/src/draftwright/linting/evidence.py
@@ -148,6 +148,9 @@ class ClaimOutcome:
     state: ClaimState
     expected: tuple[str, ...] = ()
     rendered: str | None = None
+    #: The claim itself, so a consumer can join on the FEATURE as well as the parameter
+    #: name. `parameter_id` alone says `bore.diameter` without saying whose (#1217 PR 2).
+    measurement: object | None = None
 
 
 def compiled_values(plan) -> dict:
@@ -285,15 +288,21 @@ def verify_measurement_claims(registry, plan) -> list[ClaimOutcome]:
                 else frozenset()
             )
             if not entries:
-                outcomes.append(ClaimOutcome(name, parameter, "unresolved"))
+                outcomes.append(ClaimOutcome(name, parameter, "unresolved", measurement=claim))
             elif not wanted:
-                outcomes.append(ClaimOutcome(name, parameter, "no_expected_value", expected))
+                outcomes.append(
+                    ClaimOutcome(name, parameter, "no_expected_value", expected, measurement=claim)
+                )
             elif numbers is None:
-                outcomes.append(ClaimOutcome(name, parameter, "unreadable", expected))
+                outcomes.append(
+                    ClaimOutcome(name, parameter, "unreadable", expected, measurement=claim)
+                )
             elif any(
                 any(abs(want - number) <= _VALUE_TOL for number in numbers) for want in wanted
             ):
-                outcomes.append(ClaimOutcome(name, parameter, "confirmed", expected))
+                outcomes.append(
+                    ClaimOutcome(name, parameter, "confirmed", expected, measurement=claim)
+                )
             else:
                 outcomes.append(
                     ClaimOutcome(
@@ -302,6 +311,7 @@ def verify_measurement_claims(registry, plan) -> list[ClaimOutcome]:
                         "value_absent",
                         expected,
                         ", ".join(str(number) for number in sorted(numbers)) or None,
+                        measurement=claim,
                     )
                 )
     return outcomes

--- a/src/draftwright/linting/hole_coverage.py
+++ b/src/draftwright/linting/hole_coverage.py
@@ -39,6 +39,14 @@ class HoleRequirementOutcome:
     requirement_count: int = 1
     representation: str | None = None
     representation_reason: str | None = None
+    #: The recognised hole positions this outcome accounts for, and the IR features it was
+    #: matched to (#1217). A consumer that must attribute an outcome to a SPECIFIC hole —
+    #: the benchmark zips one observation per recognised hole — cannot do it from
+    #: ``source_at`` and ``member_count``, which describe the group. Carrying the evidence
+    #: is what lets the ledger be a pointer rather than a verdict: ``features`` names what
+    #: to go and check.
+    members: tuple[tuple[float, float, float], ...] = ()
+    features: tuple = ()
 
 
 def _rounded(value) -> float:
@@ -319,6 +327,22 @@ def _tool_center_pattern_key(pattern) -> tuple:
     if key[3] is not None:
         key[3] = _tool_center_members(pattern, (key[3],), depth)[0]
     return tuple(key)
+
+
+def canonical_hole_sites(source) -> tuple[tuple[float, float, float], ...]:
+    """The positions `HoleRequirementOutcome.members` is expressed in (#1217 PR 2).
+
+    Not raw locations. A THROUGH hole's coordinate along its own axis is zeroed, so that the
+    same physical bore keys identically whichever face it was measured from — which is what
+    lets two opposed coaxial holes stay distinct while one hole seen twice does not split.
+
+    Public because the ledger publishes `members` in this space, so a consumer attributing an
+    outcome to a recognised hole has to map into it. Re-deriving the normalisation at the call
+    site would be a second implementation of exactly the kind #1206 exists to remove — and it
+    is a silent one: the benchmark's first cut keyed on raw locations, matched nothing for
+    every through hole, and reported four otherwise-perfect corpus units as `unknown`.
+    """
+    return _members(source)
 
 
 def _source_at(source) -> tuple[float, float, float]:
@@ -710,7 +734,10 @@ def hole_requirement_outcomes(
             # geometry normalization.
             loose_groups[(_recognised_spec(hole), HoleSpec.from_hole(hole).axis)].append(hole)
 
-    sources: list[tuple[HoleSourceKind, object, tuple, int]] = []
+    # Carries the group's member SITES explicitly (#1217 PR 2). The source object is the
+    # representative `holes[0]`, so deriving members from it yields one site for a group of
+    # eight — which a consumer attributing per hole then silently misses seven of.
+    sources: list[tuple[HoleSourceKind, object, tuple, int, tuple]] = []
     for (spec, _direction), holes in loose_groups.items():
         axis_index = "xyz".index(spec[0])
         through = spec[3]
@@ -721,9 +748,15 @@ def hole_requirement_outcomes(
                 site[axis_index] = 0.0
             member_sites.append((site[0], site[1], site[2]))
         members = tuple(sorted(member_sites))
-        sources.append(("hole", holes[0], (spec, members), len(holes)))
+        sources.append(("hole", holes[0], (spec, members), len(holes), members))
     sources.extend(
-        ("hole_pattern", pattern, _pattern_key(pattern), len(pattern.holes))
+        (
+            "hole_pattern",
+            pattern,
+            _pattern_key(pattern),
+            len(pattern.holes),
+            tuple(_members(pattern)),
+        )
         for pattern in recognition.hole_patterns
     )
     attached_countersinks = Counter(
@@ -772,7 +805,7 @@ def hole_requirement_outcomes(
     # recognition-owned sources is ambiguous even when only one source would otherwise
     # propose it as an exact match.
     owner_source_indices: dict[int, set[int]] = defaultdict(set)
-    for index, (kind, _source, key, _member_count) in enumerate(sources):
+    for index, (kind, _source, key, _member_count, _sites) in enumerate(sources):
         if kind == "hole":
             spec, members = key
         else:
@@ -796,7 +829,7 @@ def hole_requirement_outcomes(
     # remain unverifiable.
     exact_proposals: list[tuple] = []
     exact_evidence: list[bool] = []
-    for kind, _source, key, _member_count in sources:
+    for kind, _source, key, _member_count, _sites in sources:
         if kind == "hole":
             source_spec, source_members = key
             spec_features = hole_features_by_spec.get(source_spec, ())
@@ -842,7 +875,7 @@ def hole_requirement_outcomes(
     # simultaneously certify another source at its projected cutter centre.
 
     residual_proposals: dict[int, tuple] = {}
-    for index, (kind, source, key, _member_count) in enumerate(sources):
+    for index, (kind, source, key, _member_count, _sites) in enumerate(sources):
         if matches_by_source[index]:
             continue
         # A partial, duplicate, or multiply-claimed exact owner is contradictory
@@ -906,7 +939,7 @@ def hole_requirement_outcomes(
         if omission.feature is not None and omission.authored
     }
     outcomes = []
-    for index, (kind, source, _key, member_count) in enumerate(sources):
+    for index, (kind, source, _key, member_count, source_sites) in enumerate(sources):
         matched = matches_by_source[index]
         representative = matched[0] if matched else None
         parameters = (
@@ -928,6 +961,7 @@ def hole_requirement_outcomes(
                     "?",
                     "unverifiable",
                     requirement_count=_physical_requirement_count(kind, source, member_count),
+                    members=source_sites,
                 )
             )
             continue
@@ -952,6 +986,8 @@ def hole_requirement_outcomes(
                     state,
                     representation=representation,
                     representation_reason=representation_reason,
+                    members=source_sites,
+                    features=tuple(matched),
                 )
             )
     # The current HoleRecord waist has one countersink slot.  A second seat on the

--- a/src/draftwright/linting/hole_coverage.py
+++ b/src/draftwright/linting/hole_coverage.py
@@ -110,14 +110,22 @@ def _feature_spec(feature) -> tuple:
 
 
 def _members(source, *, rounded: bool = True) -> tuple[tuple[float, float, float], ...]:
+    # `HoleSpec.from_hole(...).axis`, NOT the raw record axis. The producing side keys on
+    # `spec[0]`, i.e. the spec's 6-dp-rounded axis, so deriving the letter from the raw vector
+    # puts the consumer in a different space: a CTC-03 bore at
+    # `(0.707106781186547, 0, -0.707106781186548)` letters as `z` raw and `x` through the
+    # spec, because rounding makes the components an exact tie and `max` takes the first.
+    # Five holes then had no ledger member at all and reached `unknown` through a lookup
+    # default rather than through `unverifiable` — the silent join failure
+    # `canonical_hole_sites` exists to prevent, inside `canonical_hole_sites` (#1223 review).
     recognised = getattr(source, "holes", None)
     if recognised is not None:
         points = tuple(hole.location for hole in recognised)
-        axis = _axis_letter(recognised[0].axis)
+        axis = _axis_letter(HoleSpec.from_hole(recognised[0]).axis)
         through = all(HoleSpec.from_hole(hole).bottom == "through" for hole in recognised)
     elif hasattr(source, "location"):
         points = (source.location,)
-        axis = _axis_letter(source.axis)
+        axis = _axis_letter(HoleSpec.from_hole(source).axis)
         through = HoleSpec.from_hole(source).bottom == "through"
     else:
         points = getattr(source, "members", ()) or (source.frame.origin,)

--- a/tests/test_issue_1202_observed_drawing_consumer.py
+++ b/tests/test_issue_1202_observed_drawing_consumer.py
@@ -30,7 +30,6 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from types import SimpleNamespace
 
 import pytest
 from build123d import Box, Cylinder, Pos
@@ -38,7 +37,6 @@ from build123d import Box, Cylinder, Pos
 from draftwright import build_drawing
 from draftwright.evaluation.step_analysis import (
     _drawing_consumer_outcomes,
-    _hole_candidates,
     evaluate_step_corpus,
     load_corpus,
 )
@@ -66,199 +64,133 @@ def _recognised(part):
     return build_recognition_result(part).holes
 
 
-def _stub_hole(diameter, origin, members=()):
-    """A minimal IR hole feature: what `_hole_candidates` reads, and nothing else."""
-    return SimpleNamespace(
-        kind="hole",
-        frame=SimpleNamespace(origin=origin, axis="z"),
-        diameter=diameter,
-        members=members,
-    )
+def _size_callouts(drawing):
+    """Annotation names carrying a hole's SIZE, read off the provenance seam.
 
-
-class _StubDrawing:
-    """A drawing stand-in with hand-placed features. *drawn* is the set of feature indices
-    that carry a callout, so a test can say precisely which fact reached the sheet."""
-
-    def __init__(self, features, drawn=frozenset()):
-        self._features = tuple(features)
-        self._drawn = set(drawn)
-
-    def model(self):
-        return SimpleNamespace(features=self._features)
-
-    def iter_annotations(self):
-        return ()
-
-    def annotations_of(self, feature):
-        index = next(i for i, f in enumerate(self._features) if f is feature)
-        return {"hc_stub": object()} if index in self._drawn else {}
-
-
-class _StrippedDrawing:
-    """A real drawing with its provenance answers emptied — what a dropped callout looks
-    like to a consumer. Delegates everything else, so the IR and the table ledger are the
-    engine's own."""
-
-    def __init__(self, drawing, annotations):
-        self._drawing = drawing
-        self._annotations = annotations
-
-    def __getattr__(self, name):
-        return getattr(self._drawing, name)
-
-    def annotations_of(self, _feature):
-        return self._annotations
+    Not a name prefix. `hc_*` matching is what made a bore printed as a plain `Leader`
+    score `unsupported` on a turned part, and it went with the duplicate correspondence
+    in #1217.
+    """
+    return [
+        name
+        for name in drawing.registry.names()
+        for measurement in drawing.registry.measurement_of(name)
+        if str(getattr(measurement, "parameter", "")) == "bore.diameter"
+    ]
 
 
 class TestTheOutcomeIsReadOffTheDrawing:
+    """Driven by REMOVING a real annotation, not by a hand-built drawing stand-in.
+
+    The stubs these tests used (`_StubDrawing`, `_StrippedDrawing`) emptied
+    `annotations_of`, which the consumer no longer reads — it goes through the registry's
+    measurement provenance (ADR 0010). A stub of a seam the code has stopped using would
+    have kept passing while testing nothing, which is this file's own founding lesson.
+    """
+
     def test_a_hole_the_drawing_calls_out_is_supported(self):
         part = _part()
         drawing = build_drawing(part)
-        assert _hole_candidates(drawing), "no IR candidate accounts for any hole"
         holes = _recognised(part)
         assert holes, "fixture produced no recognised holes"
+        assert _size_callouts(drawing), "no annotation claims a bore diameter"
         assert set(_drawing_consumer_outcomes(holes, drawing)) == {"supported"}
 
     def test_a_hole_whose_callout_never_reached_the_sheet_is_unsupported(self):
-        # THE case the declared state could not express. Mutation: restore the declared
-        # constant and this reports `supported` for a hole that was never drawn.
+        # THE case the declared state could not express. Removing the callout is the real
+        # mechanism a dropped placement produces, so nothing here depends on a stand-in.
         part = _part()
         drawing = build_drawing(part)
         holes = _recognised(part)
         assert set(_drawing_consumer_outcomes(holes, drawing)) == {"supported"}
-        stripped = _StrippedDrawing(drawing, {})
-        assert set(_drawing_consumer_outcomes(holes, stripped)) == {"unsupported"}
+        for name in _size_callouts(drawing):
+            drawing.remove(name)
+        assert set(_drawing_consumer_outcomes(holes, drawing)) == {"unsupported"}
 
     def test_furniture_without_a_callout_does_not_count_as_consumed(self):
         # A centre mark and location dims are still placed for a hole whose SIZE callout
-        # was dropped — measured on a real drop: the feature keeps `m_cm0`, sometimes
-        # `m_locy1`, and no `hc_`. Counting any annotation would score that as consumed.
+        # was dropped. Counting any annotation would score that as consumed.
         part = _part()
         drawing = build_drawing(part)
         holes = _recognised(part)
-        furniture = _StrippedDrawing(drawing, {"m_cm0": object(), "m_locx0": object()})
-        assert set(_drawing_consumer_outcomes(holes, furniture)) == {"unsupported"}
-
-    def test_a_hole_with_no_corresponding_feature_is_unknown(self):
-        # ADR 0017 states plainly that recognition-record -> IR-feature correspondence is
-        # NOT yet provided. Where it fails, the label is `unknown`. It still scores as a
-        # MISS downstream — `evaluate_case` credits only `supported` — so this is an
-        # honest label, not an exemption.
-        part = _part()
-        holes = _recognised(part)
-        no_features = SimpleNamespace(
-            model=lambda: SimpleNamespace(features=()),
-            iter_annotations=lambda: (),
-            annotations_of=lambda _f: {},
+        for name in _size_callouts(drawing):
+            drawing.remove(name)
+        remaining = set(drawing.registry.names())
+        assert any(n.startswith(("m_cm", "m_loc")) for n in remaining), (
+            f"no furniture survived the removal, so this proves nothing: {sorted(remaining)}"
         )
-        assert set(_drawing_consumer_outcomes(holes, no_features)) == {"unknown"}
+        assert set(_drawing_consumer_outcomes(holes, drawing)) == {"unsupported"}
+
+    def test_a_hole_the_ledger_cannot_join_is_unknown(self):
+        # ADR 0017 states plainly that recognition-record -> IR-feature correspondence is
+        # NOT yet provided. Where it fails the ledger says `unverifiable` and this says
+        # `unknown` — which still scores as a MISS, so it is an honest label, not an
+        # exemption. Pinned on real geometry: CTC-04 has eight such holes.
+        drawing = build_drawing("tests/fixtures/nist_ctc_04_asme1_ap203.stp")
+        outcomes = _drawing_consumer_outcomes(drawing.recognition().holes, drawing)
+        assert outcomes.count("unknown") == 8, (
+            f"the fixture no longer carries unjoinable holes: {set(outcomes)}"
+        )
 
 
 class TestTheCorrespondenceIsNotFooledByGeometry:
-    """The matcher was originally axis + diameter + IN-PLANE position, first match wins.
-    Adversarial review found three ways that answers wrongly."""
+    """The properties that matter, asserted end to end.
+
+    The matcher these tests used to drive — axis + diameter + position, first match wins,
+    living in this module — was deleted in #1217: `hole_requirement_outcomes` already
+    answered the same question, and two implementations of one question drift. The tests
+    that poked its internals (`_hole_candidates`'s kind and axis filters, the position
+    tolerance, the depth compare) went with it; those guarantees are now
+    `linting/hole_coverage.py`'s and are covered by `test_issue_1143_hole_completeness.py`.
+
+    What survives here is the OBSERVABLE property, which must hold whoever computes it.
+    """
 
     def test_two_coaxial_holes_of_equal_diameter_do_not_alias(self):
-        # Dropping the axis component made two opposed bores at the same (x, y) resolve to
-        # the SAME feature, so a dropped callout on the second was invisible.
-        #
-        # An earlier version of this test never called `_drawing_consumer_outcomes` at all
-        # — it counted candidate positions — so it passed with the function replaced by
-        # `raise NotImplementedError`, and the in-plane mutation it claimed to guard
-        # survived. It now blinds ONE of the two features and requires the outcome to move
-        # with it, which is the property "these do not alias" actually means.
+        # Two opposed bores at the same (x, y) must resolve distinctly, or a dropped
+        # callout on the second is invisible. Blind one and exactly one outcome moves.
         part = Box(60, 30, 20) - Pos(0, 0, 8) * Cylinder(3, 8) - Pos(0, 0, -5) * Cylinder(3, 14)
         drawing = build_drawing(part)
         holes = list(drawing.recognition().holes)
         if len({tuple(h.location) for h in holes}) < 2:
             pytest.skip("this build did not recognise two distinct coaxial holes")
-        candidates = _hole_candidates(drawing)
-        assert len(candidates) >= 2, "the two bores collapsed to one candidate"
-
-        def blinded(index):
-            hidden = candidates[index].feature
-            view = _StrippedDrawing(drawing, None)
-            view.annotations_of = lambda f: {} if f == hidden else drawing.annotations_of(f)
-            return _drawing_consumer_outcomes(holes, view)
-
-        first, second = blinded(0), blinded(1)
-        assert first.count("unsupported") == 1 and second.count("unsupported") == 1, (
-            f"blinding one bore did not lose exactly one hole: {first} / {second}"
-        )
-        assert first != second, (
-            f"blinding either bore gave the same answer {first} — they alias onto one "
-            f"feature, so a dropped callout on the second is invisible"
+        callouts = _size_callouts(drawing)
+        assert len(callouts) >= 2, f"the two bores share one callout: {callouts}"
+        before = _drawing_consumer_outcomes(holes, drawing)
+        assert before.count("supported") == len(holes), before
+        drawing.remove(callouts[0])
+        after = _drawing_consumer_outcomes(holes, drawing)
+        assert after.count("supported") == len(holes) - 1, (
+            f"removing one bore's callout lost {before.count('supported') - after.count('supported')} "
+            f"holes, not exactly one: {before} -> {after}"
         )
 
     def test_a_patterned_hole_is_accounted_for(self):
-        # Patterned holes lower to a PatternFeature, NOT a HoleFeature. Matching on that
-        # type alone made recognising a pattern — a capability — LOWER the score: four
-        # identical holes scored `unknown` where the same four with distinct diameters
-        # scored `supported`, both fully drawn.
+        # Patterned holes lower to a PatternFeature, not a HoleFeature. Matching on that
+        # type alone made recognising a pattern — a capability — LOWER the score.
         part = Box(80, 80, 10)
-        for x, y in ((-20, -20), (20, -20), (-20, 20), (20, 20)):
-            part -= Pos(x, y, 0) * Cylinder(2.5, 40)
+        for x, y in ((-25, -25), (25, -25), (-25, 25), (25, 25)):
+            part -= Pos(x, y, 0) * Cylinder(3, 40)
         drawing = build_drawing(part)
-        holes = _recognised(part)
-        assert holes, "fixture recognised no holes"
+        holes = list(drawing.recognition().holes)
+        assert len(holes) == 4, f"the fixture no longer makes four holes: {len(holes)}"
         outcomes = _drawing_consumer_outcomes(holes, drawing)
-        assert "unknown" not in outcomes, (
-            f"a patterned hole was not accounted for by any IR feature: {outcomes}"
+        assert set(outcomes) == {"supported"}, (
+            f"a recognised pattern scored worse than four loose holes would: {outcomes}"
         )
-        assert set(outcomes) == {"supported"}, outcomes
 
-    def test_a_grouped_count_callout_accounts_for_every_member(self):
-        # One HoleFeature with `members` covers several holes. The corpus has no two
-        # holes of equal diameter, so this path was never exercised there.
-        part = Box(60, 30, 12) - Pos(-15, 0, 0) * Cylinder(3, 40) - Pos(15, 0, 0) * Cylinder(3, 40)
+    def test_a_grouped_callout_accounts_for_every_member(self):
+        # One `4× ⌀6` callout covers four holes through a single feature. Crediting only
+        # the representative would score three of the four as lost.
+        part = Box(80, 80, 10)
+        for x, y in ((-25, -25), (25, -25), (-25, 25), (25, 25)):
+            part -= Pos(x, y, 0) * Cylinder(3, 40)
         drawing = build_drawing(part)
-        grouped = [c for c in _hole_candidates(drawing) if len(c.positions) > 1]
-        assert grouped, "fixture no longer produces a grouped feature; the path is untested"
-        outcomes = _drawing_consumer_outcomes(_recognised(part), drawing)
-        assert set(outcomes) == {"supported"}, outcomes
-
-    def test_one_ir_position_cannot_account_for_two_recognised_holes(self):
-        # A matched position is CONSUMED. Without that, one feature answers for every hole
-        # that lands on it, so a duplicate or spurious recognition record silently
-        # inherits a real feature's "supported" instead of showing up as unaccounted.
-        # (With full-3D matching this is the residual case: distinct positions no longer
-        # alias, which is what the in-plane projection used to allow.)
-        hole = SimpleNamespace(axis=(0.0, 0.0, -1.0), location=(0.0, 0.0, 5.0), diameter=6.0)
-        drawing = _StubDrawing(features=(_stub_hole(6.0, (0.0, 0.0, 5.0)),), drawn={0})
-        assert _drawing_consumer_outcomes([hole, hole], drawing) == ["supported", "unknown"], (
-            "one IR position answered for two recognised holes"
-        )
-
-    def test_the_diameter_guard_refuses_a_positional_coincidence(self):
-        # With full-3D matching a position is very nearly unique on its own, so the
-        # axis+diameter test is a CROSS-CHECK, not the primary key — an earlier version of
-        # this test used distinct positions and therefore passed with the guard deleted.
-        # It bites exactly where two features share a position and differ in size, which
-        # is what a counterbore-like arrangement looks like to the matcher.
-        hole = SimpleNamespace(axis=(0.0, 0.0, -1.0), location=(0.0, 0.0, 5.0), diameter=6.0)
-        drawing = _StubDrawing(
-            features=(
-                _stub_hole(diameter=12.0, origin=(0.0, 0.0, 5.0)),  # same place, wrong size
-                _stub_hole(diameter=6.0, origin=(0.0, 0.0, 5.0)),  # the right one
-            ),
-            drawn={1},
-        )
-        assert _drawing_consumer_outcomes([hole], drawing) == ["supported"], (
-            "the hole matched the wrong-diameter feature sharing its position"
-        )
-
-    def test_the_position_tolerance_admits_analytic_noise_but_not_a_real_offset(self):
-        # The IR carries the recogniser's `hole.location` verbatim, so agreement is EXACT
-        # on every fixture (worst residual measured at 0.0, including a side-drilled case
-        # whose z is 6.66e-15). The tolerance is therefore never exercised by a build and
-        # survived being set to 0.0 — an untested constant. Driven directly instead.
-        hole = SimpleNamespace(axis=(0.0, 0.0, -1.0), location=(0.0, 0.0, 5.0), diameter=6.0)
-        near = _StubDrawing(features=(_stub_hole(6.0, (0.0, 5e-7, 5.0)),), drawn={0})
-        far = _StubDrawing(features=(_stub_hole(6.0, (0.0, 1e-3, 5.0)),), drawn={0})
-        assert _drawing_consumer_outcomes([hole], near) == ["supported"]
-        assert _drawing_consumer_outcomes([hole], far) == ["unknown"], (
-            "a millimetre-scale offset was accepted as the same hole"
+        holes = list(drawing.recognition().holes)
+        outcomes = _drawing_consumer_outcomes(holes, drawing)
+        assert len(outcomes) == len(holes) == 4
+        assert outcomes.count("supported") == 4, (
+            f"a grouped callout credited only some of its members: {outcomes}"
         )
 
 
@@ -321,11 +253,11 @@ class TestAHoleTableIsAlsoTheFactReachingTheSheet:
         )
 
     def test_a_dropped_table_is_not_credited(self):
-        # The ledger is written only after the table is placed and the balloon gate
-        # passes, and the annotation transaction rolls it back before that — so a
-        # `table_dropped` sheet must carry no entries to credit.
+        # The ledger is written only after the table is placed and the balloon gate passes,
+        # and the annotation transaction rolls it back before that — so a `table_dropped`
+        # sheet must credit nothing. Asserted on the OUTCOME now that `_table_represented`
+        # is gone with the duplicate correspondence.
         from draftwright import drawing as drawing_module
-        from draftwright.evaluation.step_analysis import _table_represented
 
         original = drawing_module.fit_box
         drawing_module.fit_box = lambda *a, **k: None
@@ -333,38 +265,21 @@ class TestAHoleTableIsAlsoTheFactReachingTheSheet:
             broken = build_drawing(self._dense(), page="A3")
         finally:
             drawing_module.fit_box = original
-        assert _table_represented(broken) == [], (
-            "a table that never reached the sheet still credited its holes"
+        names = {n for n, _o in broken.iter_annotations()}
+        assert not any(n.startswith("hole_table") for n in names), (
+            "the table reached the sheet after all; nothing is under test"
         )
-
-    def test_a_row_without_the_size_requirement_is_not_credited(self):
-        # On a real dense plate every feature gets every requirement, so filtering or not
-        # gives the same answer there and the mutation survives. Driven directly. The
-        # attribute name and tuple shape are verified against a real build by the test
-        # below — this varies the PARAMETER, not the structure, so it is not the kind of
-        # invented stub that made the original defect look fixed.
-        from draftwright.evaluation.step_analysis import _table_represented
-
-        located_only = SimpleNamespace(
-            covers_hole_representations_by_requirement=(
-                ("feature-A", "location.location", "hole_table", "escalation"),
-            )
-        )
-        sized = SimpleNamespace(
-            covers_hole_representations_by_requirement=(
-                ("feature-B", "bore.diameter", "hole_table", "escalation"),
-            )
-        )
-        drawing = SimpleNamespace(iter_annotations=lambda: (("t1", located_only), ("t2", sized)))
-        assert _table_represented(drawing) == ["feature-B"], (
-            "a hole whose table row carries only its LOCATION was credited as having its "
-            "size on the sheet"
+        outcomes = _drawing_consumer_outcomes(broken.recognition().holes, broken)
+        assert outcomes.count("supported") < len(outcomes), (
+            "a table that never reached the sheet still credited every hole"
         )
 
     def test_only_the_size_requirement_counts(self):
-        # A table row documents location and through-ness as well. Crediting those would
-        # let a hole with a located row but no diameter score as consumed.
-        from draftwright.evaluation.step_analysis import _SIZE_REQUIREMENT, _table_represented
+        # A table row documents location and through-ness as well. Crediting those would let
+        # a hole with a located row but no diameter score as consumed. The filter now lives
+        # in `hole_coverage`; this pins that the table really does carry more than size, so
+        # the filter cannot be vacuous.
+        from draftwright.evaluation.step_analysis import _SIZE_REQUIREMENT
 
         drawing = build_drawing(self._dense(), page="A3")
         parameters = {
@@ -375,70 +290,97 @@ class TestAHoleTableIsAlsoTheFactReachingTheSheet:
         assert parameters > {_SIZE_REQUIREMENT}, (
             f"the table documents only {parameters}; the filter cannot be shown to matter"
         )
-        assert _table_represented(drawing), "nothing was credited at all"
+        outcomes = _drawing_consumer_outcomes(drawing.recognition().holes, drawing)
+        assert set(outcomes) == {"supported"}, outcomes
 
 
 class TestTheCreditGoesToTheRightFeature:
-    def test_a_table_credits_only_the_features_it_carries(self):
-        # `_consumed` reduced to `bool(represented)` passed all 21 tests: the table route
-        # was only ever asserted where EVERY feature happened to be credited, so nothing
-        # pinned the credit to the right one. That is round 2's failure shape exactly —
-        # an assertion that holds for the wrong reason.
-        #
-        # Reachable in principle: a grouped pattern marker "has no defining table row and
-        # therefore remains deliberately non-certifying" (annotations/orchestrator.py), so
-        # a sheet can carry a table covering some features and a pattern covering others.
-        from draftwright.evaluation.step_analysis import _consumed
-
-        carried, not_carried = object(), object()
-        drawing = SimpleNamespace(annotations_of=lambda _f: {"m_cm0": object()})
-        assert _consumed(carried, drawing, [carried]) is True
-        assert _consumed(not_carried, drawing, [carried]) is False, (
-            "a feature the table does not carry was credited because some other feature was"
+    def test_removing_one_holes_callout_moves_exactly_one_outcome(self):
+        # `_consumed` reduced to `bool(represented)` once passed all 21 tests: the credit was
+        # only ever asserted where EVERY feature happened to be carried, so nothing pinned it
+        # to the right one. Per-hole attribution is the property that matters, and it is what
+        # `HoleRequirementOutcome.members` exists to make possible.
+        part = Box(90, 40, 12)
+        for x, r in ((-30, 2.0), (0, 3.0), (30, 4.0)):
+            part -= Pos(x, 0, 0) * Cylinder(r, 40)
+        drawing = build_drawing(part)
+        holes = list(drawing.recognition().holes)
+        assert len(holes) == 3, f"the fixture no longer makes three distinct holes: {len(holes)}"
+        before = _drawing_consumer_outcomes(holes, drawing)
+        assert before.count("supported") == 3, before
+        drawing.remove(_size_callouts(drawing)[0])
+        after = _drawing_consumer_outcomes(holes, drawing)
+        assert after.count("supported") == 2, (
+            f"removing one callout changed {3 - after.count('supported')} outcomes: {after}"
         )
 
 
-class TestTheCandidateFilterIsLoadBearing:
-    def test_a_hole_is_not_matched_to_a_feature_on_another_axis(self):
-        # The axis half of the axis+diameter cross-check had no test, while the diameter
-        # half did — on the stated reasoning that a redundant cross-check needs one.
-        hole = SimpleNamespace(axis=(0.0, 0.0, -1.0), location=(0.0, 0.0, 5.0), diameter=6.0)
-        sideways = _stub_hole(6.0, (0.0, 0.0, 5.0))
-        sideways.frame = SimpleNamespace(origin=(0.0, 0.0, 5.0), axis="x")
-        drawing = _StubDrawing(features=(sideways,), drawn={0})
-        assert _drawing_consumer_outcomes([hole], drawing) == ["unknown"], (
-            "a z-axis hole was matched to an x-axis feature sharing its position"
+class TestThePointerIsFollowedNotBelieved:
+    """@pzfreo's decision on #1206: the ledger is a pointer to the claimed representation,
+    NOT final proof. `placed` means the engine recorded an annotation as carrying the
+    requirement; the consumer then has to check the annotation actually renders the value.
+
+    Deleting that check left every test in this file passing — which is the shape of defect
+    the whole epic exists to remove, so it is pinned here rather than assumed.
+    """
+
+    def test_a_placed_requirement_the_drawing_contradicts_is_not_supported(self):
+        part = _part()
+        drawing = build_drawing(part)
+        holes = _recognised(part)
+        assert set(_drawing_consumer_outcomes(holes, drawing)) == {"supported"}
+
+        # The ledger still says `placed` — the annotation is on the sheet and claims the
+        # measurement. What changes is what it DRAWS.
+        name = _size_callouts(drawing)[0]
+        drawing.registry.named(name).label = "⌀999 THRU"
+        from draftwright.linting.evidence import verify_measurement_claims
+        from draftwright.linting.hole_coverage import hole_requirement_outcomes
+        from draftwright.model.compiled import compile_dimensions
+
+        plan = compile_dimensions(drawing.model())
+        ledger = hole_requirement_outcomes(
+            drawing.recognition(), drawing.model().features, drawing.registry, plan.diagnostics
+        )
+        assert any(o.parameter_id == "bore.diameter" and o.state == "placed" for o in ledger), (
+            "the ledger stopped saying `placed`, so the pointer is not what is under test"
+        )
+        assert any(
+            c.state == "value_absent" for c in verify_measurement_claims(drawing.registry, plan)
+        ), "the verifier did not refute the label, so nothing is being followed"
+
+        outcomes = _drawing_consumer_outcomes(holes, drawing)
+        assert outcomes.count("supported") < len(holes), (
+            f"a hole whose callout draws ⌀999 was credited as carried: {outcomes}"
         )
 
-    def test_only_hole_and_pattern_features_are_candidates(self):
-        # Widening the `kind` filter to admit other feature kinds passed everything: no
-        # test established that a non-hole feature cannot account for a hole.
-        hole = SimpleNamespace(axis=(0.0, 0.0, -1.0), location=(0.0, 0.0, 5.0), diameter=6.0)
-        boss = _stub_hole(6.0, (0.0, 0.0, 5.0))
-        boss.kind = "boss"
-        assert _hole_candidates(_StubDrawing(features=(boss,))) == [], (
-            "a boss was admitted as a candidate for a hole"
-        )
-        assert _drawing_consumer_outcomes([hole], _StubDrawing(features=(boss,))) == ["unknown"]
+    def test_a_contradicted_LOCATION_does_not_unsupport_the_SIZE(self):
+        # `drawing_consumer` asks one question: did this hole's SIZE reach the sheet. A
+        # location dimension drawing the wrong number is a real defect and a different
+        # requirement — crediting it here would make the metric answer a question it does
+        # not ask, and would drag the score down for a fault another check owns.
+        part = _part()
+        drawing = build_drawing(part)
+        holes = _recognised(part)
+        located = [
+            name
+            for name in drawing.registry.names()
+            for measurement in drawing.registry.measurement_of(name)
+            if "location" in str(getattr(measurement, "parameter", ""))
+        ]
+        assert located, "the fixture draws no location dimension, so this proves nothing"
+        drawing.registry.named(located[0]).label = "999"
+        from draftwright.linting.evidence import verify_measurement_claims
+        from draftwright.model.compiled import compile_dimensions
 
-
-class TestTheMatchIsFullyThreeDimensional:
-    def test_a_hole_is_matched_to_the_candidate_at_its_actual_depth(self):
-        # The in-plane defect is MASKED on real geometry by position consumption: two
-        # coaxial bores still resolve distinctly because the first hole consumes the
-        # first candidate's only position. It bites when a hole's true match is not the
-        # first candidate sharing its (x, y) — then the in-plane compare assigns it to
-        # the wrong feature, and the outcome is that feature's, not its own.
-        hole = SimpleNamespace(axis=(0.0, 0.0, -1.0), location=(0.0, 0.0, 10.0), diameter=6.0)
-        drawing = _StubDrawing(
-            features=(
-                _stub_hole(6.0, (0.0, 0.0, 0.0)),  # same (x, y), different depth, DRAWN
-                _stub_hole(6.0, (0.0, 0.0, 10.0)),  # the real match, NOT drawn
-            ),
-            drawn={0},
-        )
-        assert _drawing_consumer_outcomes([hole], drawing) == ["unsupported"], (
-            "the hole was matched to the candidate at the wrong depth and inherited its outcome"
+        assert any(
+            c.state == "value_absent"
+            for c in verify_measurement_claims(
+                drawing.registry, compile_dimensions(drawing.model())
+            )
+        ), "the verifier did not refute the location label"
+        assert set(_drawing_consumer_outcomes(holes, drawing)) == {"supported"}, (
+            "a wrong LOCATION label made the hole's SIZE count as not carried"
         )
 
 
@@ -452,11 +394,15 @@ class TestTheCorpusScoreMovesWithTheDrawing:
 
     def test_the_layer_drops_when_the_sheet_stops_drawing_holes(self, monkeypatch):
         # The load-bearing claim: this score is a function of the DRAWING. Empty the
-        # provenance answer for every feature and the layer must fall. Under the old
-        # declared constant it stayed at 1.0 no matter what the sheet did.
-        from draftwright import drawing as drawing_module
+        # provenance answer and the layer must fall. Under the old declared constant it
+        # stayed at 1.0 no matter what the sheet did.
+        #
+        # The lever is the REGISTRY's measurement provenance — the seam the consumer reads
+        # since #1217. Emptying `annotations_of`, which this test used to do, would now
+        # leave the score at 1.0 and prove the opposite of what it claims.
+        from draftwright.registry import AnnotationRegistry
 
-        monkeypatch.setattr(drawing_module.Drawing, "annotations_of", lambda _s, _f: {})
+        monkeypatch.setattr(AnnotationRegistry, "measurement_of", lambda _s, _n: ())
         evaluation = evaluate_step_corpus(load_corpus(_CORPUS))
         assert evaluation.downstream_usefulness.score is not None
         assert evaluation.downstream_usefulness.score < 1.0, (
@@ -471,10 +417,12 @@ class TestTheRemainingBoundariesAreStillDeclared:
 
     @pytest.mark.parametrize("boundary", ["ir_adapter", "dsl_declaration", "generated_code"])
     def test_a_declared_boundary_does_not_move_with_the_drawing(self, boundary, monkeypatch):
-        from draftwright import drawing as drawing_module
         from draftwright.evaluation.step_analysis import _default_observers
+        from draftwright.registry import AnnotationRegistry
 
-        monkeypatch.setattr(drawing_module.Drawing, "annotations_of", lambda _s, _f: {})
+        # Same lever as the corpus test above: the registry's measurement provenance, not
+        # `annotations_of`, is what the drawing_consumer boundary reads since #1217.
+        monkeypatch.setattr(AnnotationRegistry, "measurement_of", lambda _s, _n: ())
         observed = _default_observers()["holes"](_part())
         assert observed, "no facts observed"
         assert {fact.downstream[boundary] for fact in observed} == {"supported"}

--- a/tests/test_issue_1202_observed_drawing_consumer.py
+++ b/tests/test_issue_1202_observed_drawing_consumer.py
@@ -127,13 +127,23 @@ class TestTheOutcomeIsReadOffTheDrawing:
     @pytest.mark.parametrize(
         ("fixture", "expected"),
         [
-            ("tests/fixtures/nist_ctc_04_asme1_ap203.stp", 8),
-            # CTC-03 carries a 45-degree bore, and it is the ONLY fixture where the raw
-            # record axis and the spec's rounded axis letter differ — the components tie
-            # after rounding and `max` takes the first. CTC-04 is all principal-axis, so it
-            # cannot catch a canonical-space mismatch (#1223 review: the F3 fix survived its
-            # mutation until this case was added).
-            ("tests/fixtures/nist_ctc_03_asme1_ap203.stp", 5),
+            pytest.param("tests/fixtures/nist_ctc_04_asme1_ap203.stp", 8, id="ctc04"),
+            # CTC-03 carries a 45-degree bore and is the only fixture whose raw record axis
+            # and spec-rounded axis letter differ — the components tie after rounding and
+            # `max` takes the first. CTC-04 is all principal-axis, so it cannot catch a
+            # canonical-space mismatch.
+            #
+            # SLOW-tier: this build timed out at 300 s on ubuntu 3.10 while taking ~40 s on
+            # macOS. CTC fixture builds are slow-tier by policy in this repo
+            # (`test_e2e_standards.py`), and putting one in the fast tier was the mistake, not
+            # the timeout. `TestTheCanonicalSpaceIsTheLedgersOwn` below pins the same property
+            # in milliseconds, so the fast tier keeps a guard.
+            pytest.param(
+                "tests/fixtures/nist_ctc_03_asme1_ap203.stp",
+                5,
+                id="ctc03",
+                marks=pytest.mark.slow,
+            ),
         ],
     )
     def test_a_hole_the_ledger_cannot_join_is_unknown(self, fixture, expected):
@@ -461,6 +471,46 @@ class TestThePointerIsFollowedNotBelieved:
         assert _drawing_consumer_outcomes(holes, drawing).count("supported") < len(holes), (
             "an annotation drawing no text at all was credited as carrying the size"
         )
+
+
+class TestTheCanonicalSpaceIsTheLedgersOwn:
+    """`canonical_hole_sites` must key in the same space `HoleRequirementOutcome.members` is
+    published in, and the producer letters the axis from `HoleSpec`'s 6-dp-rounded vector.
+
+    Deriving it from the raw record vector instead put the consumer in a different space
+    whenever rounding changed which component wins: CTC-03's 45-degree bore rounds to an exact
+    tie, `max` takes the first, and five holes then had no ledger member at all. Direct, because
+    the end-to-end case needs a CTC build that belongs in the slow tier — and because whether a
+    given solid produces the tie is a floating-point coin flip, which is no basis for a guard.
+    """
+
+    def test_the_axis_letter_comes_from_the_rounded_spec(self):
+        from types import SimpleNamespace
+
+        from b123d_recognisers import HoleSpec
+
+        from draftwright.linting.hole_coverage import canonical_hole_sites
+
+        # Raw components differ in the last bit — `max` picks z. Rounded to 6 dp they tie, and
+        # `max` picks x. A through hole's site is zeroed along the SPEC axis, so the two
+        # readings put the same bore in different places.
+        record = SimpleNamespace(
+            location=(30.0, 244.0, 141.0),
+            axis=(0.707106781186547, 0.0, -0.707106781186548),
+            diameter=8.0,
+            depth=None,
+            bottom="through",
+            cbore=None,
+            spotface=None,
+            csink=None,
+        )
+        spec_axis = HoleSpec.from_hole(record).axis
+        assert spec_axis == (0.707107, 0.0, -0.707107), spec_axis
+        site = canonical_hole_sites(record)[0]
+        assert site[0] == 0.0, (
+            f"the site was zeroed along the raw-vector axis, not the spec axis: {site}"
+        )
+        assert site[2] == 141.0, f"the spec axis component was zeroed instead: {site}"
 
 
 class TestTheCorpusScoreMovesWithTheDrawing:

--- a/tests/test_issue_1202_observed_drawing_consumer.py
+++ b/tests/test_issue_1202_observed_drawing_consumer.py
@@ -129,9 +129,10 @@ class TestTheOutcomeIsReadOffTheDrawing:
         [
             pytest.param("tests/fixtures/nist_ctc_04_asme1_ap203.stp", 8, id="ctc04"),
             # CTC-03 carries a 45-degree bore and is the only fixture whose raw record axis
-            # and spec-rounded axis letter differ — the components tie after rounding and
-            # `max` takes the first. CTC-04 is all principal-axis, so it cannot catch a
-            # canonical-space mismatch.
+            # and spec-rounded axis LETTER differ — the components tie after rounding and
+            # `max` takes the first. CTC-04 has non-principal-axis holes too (eight of its 54
+            # sit on `(0, -0.3746, 0.9272)`, which is why they are `unverifiable`), but its
+            # raw and rounded letters agree, so it cannot expose a lettering mismatch.
             #
             # SLOW-tier: this build timed out at 300 s on ubuntu 3.10 while taking ~40 s on
             # macOS. CTC fixture builds are slow-tier by policy in this repo
@@ -412,7 +413,7 @@ class TestThePointerIsFollowedNotBelieved:
         holes = _recognised(part)
         located = [
             name
-            for name in drawing.registry.names()
+            for name in sorted(drawing.registry.names())
             for measurement in drawing.registry.measurement_of(name)
             if "location" in str(getattr(measurement, "parameter", ""))
         ]
@@ -483,6 +484,33 @@ class TestTheCanonicalSpaceIsTheLedgersOwn:
     the end-to-end case needs a CTC build that belongs in the slow tier — and because whether a
     given solid produces the tie is a floating-point coin flip, which is no basis for a guard.
     """
+
+    def test_the_grouped_branch_letters_from_the_spec_too(self):
+        # `_members` has two branches. The consumer's join goes through the single-record one,
+        # so reverting the GROUPED branch to the raw axis broke nothing any test noticed —
+        # while silently undoing the coordinates `hole_requirement_unverifiable` reports
+        # (#1223 review). Both branches key the same space or neither does.
+        from types import SimpleNamespace
+
+        from draftwright.linting.hole_coverage import canonical_hole_sites
+
+        def _hole(location):
+            return SimpleNamespace(
+                location=location,
+                axis=(0.707106781186547, 0.0, -0.707106781186548),
+                diameter=8.0,
+                depth=None,
+                bottom="through",
+                cbore=None,
+                spotface=None,
+                csink=None,
+            )
+
+        group = SimpleNamespace(holes=[_hole((30.0, 244.0, 141.0)), _hole((43.0, 225.0, 153.0))])
+        sites = canonical_hole_sites(group)
+        assert all(site[0] == 0.0 for site in sites), (
+            f"the grouped branch zeroed along the raw-vector axis, not the spec axis: {sites}"
+        )
 
     def test_the_axis_letter_comes_from_the_rounded_spec(self):
         from types import SimpleNamespace

--- a/tests/test_issue_1202_observed_drawing_consumer.py
+++ b/tests/test_issue_1202_observed_drawing_consumer.py
@@ -71,9 +71,12 @@ def _size_callouts(drawing):
     score `unsupported` on a turned part, and it went with the duplicate correspondence
     in #1217.
     """
+    # `sorted`, because `registry.names()` is a set: callers index [0], so which annotation
+    # a test corrupts would otherwise vary per process (ADR 0006; `evidence.py` took the
+    # same fix one PR ago).
     return [
         name
-        for name in drawing.registry.names()
+        for name in sorted(drawing.registry.names())
         for measurement in drawing.registry.measurement_of(name)
         if str(getattr(measurement, "parameter", "")) == "bore.diameter"
     ]
@@ -121,16 +124,51 @@ class TestTheOutcomeIsReadOffTheDrawing:
         )
         assert set(_drawing_consumer_outcomes(holes, drawing)) == {"unsupported"}
 
-    def test_a_hole_the_ledger_cannot_join_is_unknown(self):
+    @pytest.mark.parametrize(
+        ("fixture", "expected"),
+        [
+            ("tests/fixtures/nist_ctc_04_asme1_ap203.stp", 8),
+            # CTC-03 carries a 45-degree bore, and it is the ONLY fixture where the raw
+            # record axis and the spec's rounded axis letter differ — the components tie
+            # after rounding and `max` takes the first. CTC-04 is all principal-axis, so it
+            # cannot catch a canonical-space mismatch (#1223 review: the F3 fix survived its
+            # mutation until this case was added).
+            ("tests/fixtures/nist_ctc_03_asme1_ap203.stp", 5),
+        ],
+    )
+    def test_a_hole_the_ledger_cannot_join_is_unknown(self, fixture, expected):
         # ADR 0017 states plainly that recognition-record -> IR-feature correspondence is
         # NOT yet provided. Where it fails the ledger says `unverifiable` and this says
         # `unknown` — which still scores as a MISS, so it is an honest label, not an
         # exemption. Pinned on real geometry: CTC-04 has eight such holes.
-        drawing = build_drawing("tests/fixtures/nist_ctc_04_asme1_ap203.stp")
-        outcomes = _drawing_consumer_outcomes(drawing.recognition().holes, drawing)
-        assert outcomes.count("unknown") == 8, (
+        from draftwright.linting.hole_coverage import (
+            canonical_hole_sites,
+            hole_requirement_outcomes,
+        )
+        from draftwright.model.compiled import compile_dimensions
+
+        drawing = build_drawing(fixture)
+        holes = list(drawing.recognition().holes)
+        outcomes = _drawing_consumer_outcomes(holes, drawing)
+        assert outcomes.count("unknown") == expected, (
             f"the fixture no longer carries unjoinable holes: {set(outcomes)}"
         )
+        # The COUNT alone is equally satisfied by a hole with no ledger entry at all — which
+        # is what a canonical-space mismatch produces, and did on CTC-03 until #1223's review.
+        # Assert the stated property: every `unknown` joins an `unverifiable` entry.
+        ledger = hole_requirement_outcomes(
+            drawing.recognition(),
+            drawing.model().features,
+            drawing.registry,
+            compile_dimensions(drawing.model()).diagnostics,
+        )
+        unverifiable = {m for e in ledger if e.state == "unverifiable" for m in e.members}
+        for hole, outcome in zip(holes, outcomes, strict=True):
+            if outcome == "unknown":
+                assert set(canonical_hole_sites(hole)) & unverifiable, (
+                    f"hole at {tuple(hole.location)} reached `unknown` through a lookup "
+                    "default, not through an `unverifiable` ledger entry"
+                )
 
 
 class TestTheCorrespondenceIsNotFooledByGeometry:
@@ -381,6 +419,47 @@ class TestThePointerIsFollowedNotBelieved:
         ), "the verifier did not refute the location label"
         assert set(_drawing_consumer_outcomes(holes, drawing)) == {"supported"}, (
             "a wrong LOCATION label made the hole's SIZE count as not carried"
+        )
+
+    def test_a_contradicted_callout_unsupports_only_its_own_hole(self):
+        # The scoping had no test: making ANY refuted size claim discredit EVERY hole passed
+        # the entire fast tier, because the two-hole fixture above asserts only
+        # `count("supported") < len(holes)` — true at 0 as well as at 1 (#1223 review).
+        part = Box(90, 40, 12)
+        for x, r in ((-30, 2.0), (0, 3.0), (30, 4.0)):
+            part -= Pos(x, 0, 0) * Cylinder(r, 40)
+        drawing = build_drawing(part)
+        holes = list(drawing.recognition().holes)
+        assert len(holes) == 3, f"the fixture no longer makes three distinct holes: {len(holes)}"
+        assert _drawing_consumer_outcomes(holes, drawing).count("supported") == 3
+        drawing.registry.named(_size_callouts(drawing)[0]).label = "⌀999 THRU"
+        after = _drawing_consumer_outcomes(holes, drawing)
+        assert after.count("supported") == 2, (
+            f"one contradicted callout unsupported {3 - after.count('supported')} holes: {after}"
+        )
+
+    def test_an_annotation_that_draws_nothing_is_not_credited(self):
+        # `supported` is meant to mean the annotation carrying the size RENDERS it. Rejecting
+        # only `value_absent` credited an `unreadable` annotation — one drawing no text at
+        # all — as carrying the size, which is the PR body's own sentence being false of the
+        # code beneath it.
+        part = _part()
+        drawing = build_drawing(part)
+        holes = _recognised(part)
+        assert set(_drawing_consumer_outcomes(holes, drawing)) == {"supported"}
+        drawing.registry.named(_size_callouts(drawing)[0]).label = ""
+        from draftwright.linting.evidence import verify_measurement_claims
+        from draftwright.model.compiled import compile_dimensions
+
+        states = {
+            c.state
+            for c in verify_measurement_claims(
+                drawing.registry, compile_dimensions(drawing.model())
+            )
+        }
+        assert "unreadable" in states, f"the fixture did not produce an unreadable claim: {states}"
+        assert _drawing_consumer_outcomes(holes, drawing).count("supported") < len(holes), (
+            "an annotation drawing no text at all was credited as carrying the size"
         )
 
 

--- a/tests/test_issue_1217_claimed_representations.py
+++ b/tests/test_issue_1217_claimed_representations.py
@@ -263,6 +263,31 @@ class TestEveryOutcomeReachesLint:
         assert [i.code for i in issues] == ["claimed_representation_no_expected_value"]
         assert issues[0].severity == "info"
 
+    def test_every_unconfirmed_state_carries_its_measurement(self):
+        # `measurement` is what lets a consumer join a claim back to its feature — the
+        # benchmark's `_borne_out` reads exactly that. Only the `unreadable` branch had a
+        # test, so dropping it from `unresolved` and `no_expected_value` changed nothing any
+        # test checked, even though the comment justifying the widening names `unresolved`
+        # (#1223 review). Neither state occurs on a real fixture, hence the direct drive.
+        claim = _Claim("bore.diameter")
+        cases = {
+            "unresolved": (SimpleNamespace(label="⌀8"), _plan()),
+            "no_expected_value": (
+                SimpleNamespace(label="20"),
+                _plan(SimpleNamespace(id=claim, value_text="", value=0.0, span=None, axis=None)),
+            ),
+            "unreadable": (
+                SimpleNamespace(),
+                _plan(SimpleNamespace(id=claim, value_text="8", value=8.0, span=None, axis=None)),
+            ),
+        }
+        for state, (annotation, plan) in cases.items():
+            outcomes = verify_measurement_claims(_Registry(annotation, (claim,)), plan)
+            assert [o.state for o in outcomes] == [state], (state, outcomes)
+            assert outcomes[0].measurement is claim, (
+                f"a {state} claim dropped its measurement, so nothing can join it to a feature"
+            )
+
     def test_a_contradicted_claim_is_a_warning_not_an_info(self):
         # Severity is not cosmetic: `claimed_value_absent` is classified as fidelity, and the
         # fidelity score is computed from severity. Demoting it to info leaves the drawing


### PR DESCRIPTION
PR 2 of 3 for #1217. Settles **#1206**.

## What it removes

`evaluation` carried its own hole-correspondence implementation beside
`hole_requirement_outcomes`, which answers the same question. Two implementations of one
question drift — and this one was the more generous of the two: it matched recognised holes to
IR features by axis, diameter and position, then asked whether any annotation was **named**
`hc_*`.

Both halves are gone. `_hole_candidates`, `_table_represented`, `_consumed` and `_Candidate` are
deleted; provenance does not care what a renderer called its annotation.

**This does not close the turned-part false negative**, and an earlier version of this PR said it
did. Measured on `Cylinder(20,60) - Cylinder(6,70)`: `unsupported` before and after, with a
byte-identical annotation set. Name matching was never the mechanism — the bore's `ø12` is drawn
by `ldr_z0`, which carries no measurement claim at all, so the ledger reports `bore.diameter` as
`missing`. That is #754 debt, which this module's own docstring already stated correctly.

## The ledger is a pointer, not proof

Per the decision on #1206: `placed` means the engine *recorded* an annotation as carrying the
requirement. The consumer now follows that pointer through `linting/evidence` and confirms the
annotation renders the approved value. **A hole whose callout draws `⌀999` is not carried,
whatever the ledger says.**

The refutation is filtered to the **size** requirement, deliberately: a wrong *location* label is
a real defect that another check owns, and crediting it here would make this metric answer a
question it does not ask.

## Two enabling changes in `linting/`

- **`HoleRequirementOutcome` names its evidence** — the recognised hole sites it accounts for and
  the IR features it matched. The benchmark zips one observation per hole *positionally*, and a
  group outcome cannot be attributed from `source_at` and `member_count` alone.
- **`ClaimOutcome` carries its measurement**, so a consumer joins on the feature rather than only
  the parameter name.

## The measured divergence, in full

| fixture | before | after |
|---|---|---|
| `nist_ctc_03_asme1_ap203` | 15/15 supported | **10 supported, 5 unknown** |
| `nist_ctc_03_asme1_ap242` | 15/15 | **10 supported, 5 unknown** |
| `nist_ctc_04_asme1_ap203` | 54/54 | **46 supported, 8 unknown** |
| `nist_ctc_04_asme1_ap242` | 54/54 | **46 supported, 8 unknown** |
| CTC-01, CTC-02, CTC-05, `issue_915`, thumbwheel | — | unchanged |
| 5-case evaluation corpus | detection 1.0, fidelity 15/15, downstream 20/20, 5 conformant | **identical** |

**26 holes in total**, and every one of them is a hole the ledger reports `unverifiable` — it
knows they exist and declines to join them to a feature without guessing. The old code credited
them by guessing.

An earlier version of this table omitted CTC-03 entirely and called itself "the divergence in
full". It was half of it, from a fixture I had not looked at.

The eight are the holes the ledger reports `unverifiable` — it knows they exist and declines to
join them to a feature without guessing. The old code credited them by guessing. Crediting a hole
whose evidence cannot be located is the self-validation #1206 was opened to remove, so the lower
number is the more honest one.

## A false story I nearly shipped

An earlier cut derived each outcome's covered positions with `_members(source)` — but the source
object is `holes[0]`, the group's **representative**, so a group of eight registered *one*
position and the other seven scored `unknown`. On CTC-04 that manufactured 15 phantom
unaccounted-for holes, which I then explained with a plausible account of `_parameter_ids`
omitting `bore.diameter` and the ledger's denominator being narrower than the recognition set.

The parameter census I quoted was real. The conclusion was invented to fit my own defect. Sources
now carry their member sites explicitly, and the divergence is exactly the eight predicted before
implementing.

## The stubs go with the code they stood in for

`_StubDrawing` and `_StrippedDrawing` emptied `annotations_of`, which the consumer no longer
reads. A stub of an abandoned seam keeps passing while testing nothing — this file's own founding
lesson, from the #1205 review. Every surviving test drives a real build and removes a real
annotation. Tests that poked the deleted matcher's internals went with it; those guarantees are
`hole_coverage`'s now and are covered by `test_issue_1143_hole_completeness.py`.

## Verification

- **Twenty-four mutations**, each with the substitution asserted applied, **all killed** —
  including the representative-instead-of-members regression, the verifier refutation being
  ignored (which left *every* test in the file passing), and the size-parameter filter.
- Full fast tier **4,284 passed**, 5 skipped, 2 xfailed. `scripts/pr-check --static`: exit 0.
- Benchmark re-run after every change.

PR 3 adds a second feature family, whose gate is that it costs a producer and zero changes to the
facility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTXU3X3YFa1HPRdmUgCw22



---

## Review history

Two adversarial rounds. Round 1 found three blockers — a divergence table missing a whole
fixture, a claimed gate (the turned-part gap) that does not close and whose stated cause was
wrong, and a real defect in `canonical_hole_sites` where the consumer keyed a different axis
space from the ledger. Round 2 verified every fix by execution and found the code right; what it
found wrong was that the corrections lived only in the commit message, while the code comments,
the reference doc and this body still asserted the retracted claims — and that two of the
corrections had introduced new false statements of their own.

Both rounds' findings are fixed. The pattern is worth stating plainly: the implementation has
been stable since the first push; what kept failing review was the prose about it.
