### PR TITLE
Slim the working map; audit the structural guards and trim the won battles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,4 +117,4 @@ paths = dwg.export("out", formats=("svg", "dxf", "pdf", "png"))   # -> {format: 
 
 `docs/adr/` — especially 0004 (compose-then-pack layout), 0014 (collect-then-solve placement),
 0011 (declare features), 0012 (edits as pinned candidates), 0015 (the compiler pipeline).
-`CLAUDE.md` has the module map.
+`CLAUDE.md` has the compact module map; `docs/architecture.md` the detailed one.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,553 +5,120 @@ Licensed under **AGPL-3.0**. Depends on `build123d-drafting-helpers` for annotat
 
 ## What this is
 
-`draftwright` is the application-level drawing engine. It takes a build123d solid and
-produces a fully-annotated multi-view technical drawing (orthographic views, dimensions,
-section A–A, ISO hatching, title block) ready for DXF/SVG export.
+`draftwright` is the application-level drawing engine: it takes a build123d solid (or a
+declared feature model) and produces a fully-annotated multi-view technical drawing
+(orthographic views, dimensions, section A–A, ISO hatching, title block) exported to
+SVG/DXF/PDF/PNG.
 
 It sits on top of three Apache 2.0 libraries:
-- `build123d-drafting-helpers` — annotation primitives (`Dimension`, `Leader`, `HoleCallout`, …).
-  The rendering library; Draftwright owns linting and drafting policy (ADR 0007).
+- `build123d-drafting-helpers` — annotation primitives (`Dimension`, `Leader`,
+  `HoleCallout`, …); the rendering library. Draftwright owns linting and drafting
+  policy (ADR 0007).
 - `b123d-recognisers` — deterministic geometry-only feature recognition (ADR 0013).
-- `build123d` — the underlying CAD kernel
+- `build123d` — the underlying CAD kernel.
+
+`AGENTS.md` is the "drive it correctly" usage guide; this file is the working map for
+changing the engine.
 
 ## Architecture
 
-The dependency graph is a DAG (the #138 / ADR 0005 split is complete). Bottom to
-top: leaf modules (`layout.py`, `registry.py`, `fonts.py`, `_geometry.py`,
-`fits.py`, `intents.py`, `recognition_cache.py`, and the `linting/` subpackage) →
-`_core.py` → stage modules (`export.py`,
-`repair.py`, `projection.py`, `compose.py`, `analysis.py`, `drawing.py`, the
-`model/` IR subpackage, the `annotations/` subpackage) → `builder.py` → the
-user-facing surfaces: the `make_drawing.py` / `annotate.py` compat facades, the
-fluent `Sheet` facade (`sheet.py`), the Sheet-script emitter
-(`sheet_emit.py`), the recognition-evaluation package (`evaluation/`), and the
-`cli.py` entry point. No lower module imports an
-upper one. (All surfaces are front doors onto the one engine,
-`build_drawing` → `_auto_annotate` — there is no second engine.)
+**One engine**: every user-facing surface is a front door onto
+`build_drawing` → `_auto_annotate`; there is no second engine.
 
-This DAG is **machine-enforced** by `tests/test_import_boundaries.py` (#640): the
-`_LAYERS` table there is the precise, ranked form of this section — a module-level
-import that points up a layer fails CI, as does an import cycle. The precise
-placement refines the coarse grouping above (e.g. `linting`/`pmi`/`export`/`repair`/
-`projection`/`compose` sit *above* `_core` since they depend on it; `model/` is the
-IR-waist leaf it is guarded as). The `_LAZY_UPWARD_EXEMPT` sanctioned-cycle-breaker
-mechanism is now empty (#523 removed its last occupant, the `builder→cli` edge — see
-below); a new upward lazy import must earn an entry with a rationale. The remaining
-lazy in-function imports (`cli`→`builder`/`sheet_emit`, for the #313 build123d
-lazy-load) are *downward*, not cycle-breakers. The one type-only upward reference
-(`_core`→`compose.StripDepths`, under `TYPE_CHECKING`) is an explicit allowlist
-entry. Keep `_LAYERS` and this section in step.
+The module graph is a strict layered DAG, **machine-enforced** by
+`tests/test_import_boundaries.py` — the `_LAYERS` table there is the authoritative
+ranked map (an upward module-level import or a cycle fails CI). The detailed
+module-by-module prose map lives in [`docs/architecture.md`](docs/architecture.md);
+keep `_LAYERS`, that document, and this compact map in step.
 
-`evaluation/` owns the versioned, independently-authored STEP-analysis benchmark and its
-scoring model. It is a top-layer consumer of the recognition contract; production recognition,
-IR, generation, and drawing code must not depend on benchmark expectations or scores.
+Compact map, bottom to top:
 
-- **`make_drawing.py`** — thin compat facade (~20 lines) re-exporting the public
-  surface (`Drawing`, `build_drawing`, `make_drawing`, `_cli`,
-  `FeatureInfo`, `fix_svg_page_size`, `lint_feature_coverage`) so existing imports
-  and the `draftwright` CLI entry point keep working. The engine lives in:
-  - **`builder.py`** — build orchestration: `build_drawing` (analyse → assemble →
-    measure-and-repack → `Drawing`) and `make_drawing` (+ export). Imports
-    `drawing`/`analysis`/the annotation orchestrator/the stage modules — never
-    `make_drawing` (a DAG). *(`generate_script`, the imperative editable-script
-    generator, was retired by #940 — ADR 0016 phase 6 / ADR 0001 Amdt 2 — and
-    **deleted** at its 0.4.0 date (#720), along with the raising stub that stood
-    in for it and the bespoke `--style imperative` message. `--style` itself
-    survives with the single value `sheet` so existing invocations keep
-    working.)*
-    *(The CLI moved out to `cli.py`; the `_cli` compat shim lives there too (#523),
-    so `builder` no longer imports `cli`.)*
-  - **`cli.py`** — the Typer command-line interface (#289): argument parsing,
-    `--version`, shell completion, `--format`, rich help. The engine (build123d)
-    is imported **lazily inside the command body** so completion/`--help`/
-    `--version` stay sub-second (#313). Entry point: `draftwright.cli:app`.
-  - **`drawing.py`** — the `Drawing` result object (`.lint()`/`.add()`/`.place_dim()`/
-    `.repair()`/`.export*()`; delegates identity to `registry`, coverage to `lint`)
-    plus `FeatureInfo` (`_build_table` moved beside `_table_metrics` in `_core`, #699).
-    Sits below `builder` (which constructs it).
-    *(The build context lives in ONE typed `BuildState` on `Drawing` (`_build`:
-    analysis, part model, lint's geometry caches) — filled at a single site in
-    `builder._assemble`, read through compat properties, single-writer-guarded
-    by `test_drawing_encapsulation`. ADR 0005 §2 / #639 closed: `annotations/`
-    has zero private `Drawing` reads (empty allowlist ratchet) — and since #699
-    slice d the state-bus guard covers the WHOLE engine: no module but
-    `drawing.py` touches `dwg._*` (rationale-carrying allowlist, builder's
-    fill site only).)*
-- **`annotate.py`** — thin compat facade re-exporting `_auto_annotate` (the
-  orchestrator) from `annotations/`. The annotation passes were split into the
-  **`annotations/`** subpackage (#164 / ADR 0005, P5):
-  - **`annotations/orchestrator.py`** — `_auto_annotate`, the single entry point
-    (called by `build_drawing`); classifies the part and drives the render passes
-    + title block. Owns **`_PASS_SEQUENCE`** — the ONE canonical stage order
-    (#699 slice b): `_auto_annotate` and `Drawing._drain_intents` (the finalize
-    drain) both hand name→thunk dicts to the shared `run_stages`, so the two
-    build paths cannot diverge in sequencing (the drain step itself is the
-    shared `drain_and_reconcile`). The current ADR 0015 shape is
-    `build model → plan/model-routed intents → render`; some inline engine code remains — chiefly
-    `_maybe_tabulate_holes` (the hole-table/balloon escalation resolver) and the
-    iso right-strip outer-limit tightening — pending the last convergence steps.
-  - **`annotations/from_model.py`** — the **IR render layer** (largest annotations
-    module): turns the planner's `DimensionGroup`/render-intents into placed
-    dimensions/callouts/centre marks/section triggers. This is where the turned,
-    PMI/GD&T, envelope/OD, centre-mark and step-length passes converged (ADR 0015,
-    #200/#208/#237) — the old per-feature `annotations/{turned,pmi}.py` modules
-    were deleted as each migrated here.
-  - **`annotations/holes.py`** — hole/pattern callouts, balloons, location dims
-    (incl. side-drilled #133), pitch/grid dims, slots (the largest *pass*).
-  - **`annotations/leaders.py`** — the one bounded late inventory for compatible
-  automatic/deferred same-view feature leaders (#1166): sparse ordinary
-  side/plan hole jobs and the five post-drain machined-feature families lower
-  exact committed component ink conflicts (including component-local curved
-  centre furniture and rendered shifted-dimension arrows), retaining any
-  rendered residual triangle not covered by one same known component and any
-  curved residual area between tessellation stations, including filled
-  datum/GD&T faces without segment metadata; candidate construction fails closed
-  per alternative, while a selected-survivor construction exception or mismatch
-  replays the canonical lazy producer tail rather than silently reducing
-  cardinality, with validation-stage diagnostics and without swallowing compiler
-  invariant errors; fixed components are lowered once under the same resource
-  discipline and reused; the complete title
-  band stays hard after rendering; only explicitly
-  marked global turning axes exempt only the arrow-local tip attachment (not
-  near-collinear shaft travel),
-  priorities, Policy-B penalties, and numeric costs into `layout.py`; optional
-  sections enter only a separately bounded no-worse refinement, then validate
-  their final ink against landed leaders, repair one end-symbol extent, and yield on conflict,
-  then validate the selected OCC ink and emit it with its original provenance;
-  any retained fixed-ink Policy-B crossing persists as
-  `feature_leader_crossing`, independently of opt-in tracing, while a producer
-  replay beyond the exact fixed-probe budget persists as
-  `feature_leader_fixed_ink_unverified` without exceeding that bound and cannot
-  report a perfect legibility quality score. ADR 0014 Amendment 3 (#798) adds
-  material re-entry to that Policy-B penalty at a stated exchange rate (one unit
-  per visible stroke width of buried shaft) — a cost, never an eligibility gate
-  and never an acceptance test, so no callout is dropped because its route cuts.
-  The resource-cap floor, which is what actually runs on dense parts, gained a
-  bounded lookahead past a first acceptable-but-cutting route; a job whose first
-  acceptable route already clears the body selects it exactly where it always did.
-  - **`annotations/sections.py`** — section A–A + detail views (ISO 128-44 arrows,
-    ISO 128-50 hatching).
-  - **`annotations/balloons.py`** — the leadered hole-balloon pass (#111/#516;
-    moved down from `Drawing`, #699). `Drawing.add_balloons` is the public verb
-    threading build state in; the band-assignment flow solver lives in `layout.py`.
-  - **`annotations/gears.py`** — standards-backed data-table presentation for the
-    declaration-only metric external spur gear; the table flows through the generic
-    solver-owned late-furniture path (#1086).
-  - **`annotations/_common.py`** — the ADR 0014 corridor-solve engine
-    (`CorridorCandidate`, `solve_corridor`, `register_corridor`/`drain_corridors`,
-    `place_strip_candidates`, `PlacementContext`) plus `_box_hits`, at the
-    bottom of the annotations DAG. (The bbox/segment primitives it delegates to
-    live in `_core`/`_geometry` since #700.) It also owns the **post-fit
-    late-furniture** seam (#1197): `late_furniture_obstacles` is the ONE occupancy
-    a placer facing the finished sheet uses — views, decomposed annotation ink,
-    minus the page-spanning riders, plus the title block as one hull — shared by
-    `Drawing.add_table` and by `place_iso_nts_note`, the iso's NTS caption, which
-    lives here rather than in `projection` because rank-2 cannot reach that
-    occupancy and a hand-rolled substitute was wrong twice.
-  Submodules import only down or sideways — `_core`/`layout`/`analysis`/
-  `projection`/the `model/` IR/`linting.structural`/third-party, never
-  `annotate`/`make_drawing`/`drawing` (the drawing is duck-typed as `dwg`) — so
-  the orchestrator calls down with no cycle.
-- **`_core.py`** — shared primitives below both `make_drawing.py` and `annotate.py`:
-  the `Analysis` namespace and its field types (`_Projector`, `Strip`, `ViewZones`),
-  the dimension/format helpers (`_dim`, `_fmt`, `_add_title_block`, …), and the
-  page/slot/margin layout constants.
-- **`layout.py`** — the deterministic placement primitives used by ADRs 0004/0014:
-  the deterministic
-  1D PAVA strip solve (`_solve_strip_1d_pava`, plus `plan_strip`/`StripCandidate`,
-  the ADR 0014 collect-then-solve entry point), the 2D free-rectangle placer
-  (`fit_box`), and the balloon band-assignment min-cost max-flow solve
-  (`_assign_balloon_bands`, #516; here since #699 — solvers live in the solver
-  layer). Sits *below* the domain API.
-- **`_geometry.py`** — model-neutral geometry primitives (`_xyz`, `HoleRef`,
-  `_axis_letter`, `_END_ON`) plus the #700 shared page-plane maths (`_fmt`,
-  `_boxes_overlap`, the two segment/box tests) and `plane_axes` — the one
-  in-plane `(u, v)` basis per axis, shared by `recognition._features._plane_uv`
-  and `model.declare._plane_axes` so a pattern's `angle` means the same thing
-  detected as declared (#969); the DAG's bottom leaf (guarded
-  by `test_geometry_is_a_leaf`) so the IR waist uses them without importing
-  `_core`. Also the ADR 0014 Amendment 3 **filled material field** (#798):
-  `MaterialField`/`material_field` (page-plane triangles + a uniform grid index),
-  `material_span`, `material_intervals`, and `material_reentry_span` — exact
-  half-plane clipping with a fixed-point interval union and an incremental cell
-  walk, no sampling. Re-entry, not traversal, is the routing defect: a leader's
-  first passage out of the body is the legitimate exit every callout makes.
-- **`_pmi_part21.py`** — the rank-0 structured ISO 10303-21 adapter for AP242
-  geometric-tolerance facts that OCCT's XCAF transfer drops. It resolves explicit
-  Part21 references and SI length units, and requires unique semantic-name + kind
-  correspondence; it knows nothing about XCAF, drafting IR, or placement.
-- **`_warnings.py`** — the public warning categories (`SoftDeprecationWarning`), a
-  dependency-free leaf. Separate from `_core` on purpose: `_core` imports build123d, so a
-  category defined there costs the CAD kernel (~6 s) to reach, and the pytest
-  `filterwarnings` entry naming it pays that on every invocation (#1043).
-- **`fits.py`** — the ISO 286 fit tables (`fit_deviation`, `FitClass`; ADR 0011
-  P2a.2): a rank-0 leaf consumed by `_core`, `model/ir` and `sheet`.
-- **`intents.py`** — the deferred-placement "low IR" behind `Drawing.finalize()`
-  (#426): a dependency-free leaf recording edit-verb intents for the recompose
-  (deliberately stringly-typed in its Phase-1 form).
-- **`registry.py`** — `AnnotationRegistry`: the single owner of annotation
-  identity/ownership/pins/build-issues (#138 / ADR 0005, Step 2). `Drawing`
-  delegates here and keeps the render list. The `_named`/`_anno_view`/`_pinned`/
-  `_build_issues` aliases on `Drawing` (and coverage's three) were **deleted** at
-  their §4 date (#720): reach the state through `dwg.registry` (`in reg`,
-  `names()`, `issues`, `restore_issues()`) and `dwg.coverage`. Their absence is
-  asserted by `test_the_expired_compat_aliases_stay_deleted`.
-- **`linting/`** — the lint subpackage (#138 / ADR 0005; ADR 0007: draftwright
-  owns linting): `coverage.py` (`lint_feature_coverage` + `CoverageState`),
-  `structural.py` (geometry/standards checks), `issues.py` (the `LintIssue` type),
-  `gear_coverage.py` (declared gear table/profile reconciliation), and `suggest.py`
-  (`_suggest_fix`, #29 snippets). Depends only on `_core`,
-  `b123d_recognisers` (typed hole records in `coverage.py`) + build123d_drafting.
-  `_QUOTED_RE` (a lint-message label regex shared with the
-  repair loop) lives in `_core`.
-- **`recognition_cache.py`** — Draftwright's ADR 0017 one-result lifecycle owner. It calls
-  external `build_recognition_result(part)` at most once for a build/lazy-critique run; the
-  package owns recognition, while Draftwright owns when the result is computed and reused.
-- **`recogniser_contract.py`** — the fail-closed cross-repository capability join. It consumes
-  only the installed `b123d-recognisers` public manifest, then validates Draftwright-owned IR,
-  `Sheet`, generated-code, drawing, completeness, and documentation declarations. It is rank 7
-  because validation dynamically resolves implementation references across every lower layer;
-  package geometry policy never imports or owns this consumer overlay.
-- **`model/`** — the ADR 0015 IR waist: `ir.py` (the `Feature`/`DimParameter`/
-  `Datum`/`PartModel` types — the one inventory), `detect.py` (detectors →
-  `Feature` objects, adapting `b123d_recognisers` records), `planner.py`
-  (`plan_dimensions` —
-  one rule set → a `DimensionGroup` per feature, + `plan_sections`; and, since #1154,
-  the one cross-feature reconciliation: two features measuring between the same two
-  support planes state one fact, so the overall extent keeps it and the feature-local
-  one records where it went), and
-  `declare.py` (ADR 0011 object→feature constructors: `hole`/`boss`/`step`/… read
-  a feature's size off the build123d object — a second, *declared* front-end into
-  the same IR the detectors fill). The narrow middle of the compiler hourglass;
-  consumed by `annotations/from_model.py`.
-- **`compose.py`** — the ADR 0004 **outer** compose-then-pack layout engine
-  (`choose_scale`, `ViewBlock`, zone/strip depths). Née `sheet.py`; renamed
-  (#640) so the layout engine stops shadowing the user-facing `Sheet` facade
-  (which now owns the `sheet.py` name).
-- **`analysis.py`** — the `_analyse` stage: solid classification, the one-shot
-  feature-inventory detection (ADR 0015), view sizing, and the strip/zone
-  model (`fv_zones`/`pv_zones`/`sv_zones`) that ADR 0014 placement reads.
-- **`projection.py`** — HLR projection and view-coordinate transforms
-  (`_assemble`'s geometry half; #161). Also the #798 **material lowering**:
-  `part_material_mesh` tessellates the part once per build and
-  `view_material_field` projects that one mesh per view, so every view measures
-  the same material. The mesh is taken under explicit control (copy →
-  `BRepTools.Clean_s` → `BRepMesh_IncrementalMesh`) because OCC caches a
-  triangulation on the shape and returns it for any later request — even a finer
-  one — which would make the field a function of build *history* (the ADR 0006
-  hazard). `Drawing.material_fields()` holds the result on `BuildState`.
-  `_fit_iso_view` **returns** the iso bbox when the fitted iso is off sheet scale and
-  therefore needs an NTS caption, else `None`; it does not place that caption. `builder`
-  does, at the common post-fit point *before* `render_gear_tables` — the caption is tied
-  to the block it labels while a table may sit anywhere, so the constrained furniture
-  claims space first (#1197).
-- **`sheet.py`** — the fluent declarative **`Sheet`** facade (ADR 0011):
-  feature verbs (`hole`/`boss`/`slot`/…), aspect verbs (`.tolerance`/`.fit`/
-  `.finish`), GD&T (`datum`/`control`). Facade tier: builds a `PartModel` via
-  `model/declare.py` and calls `build_drawing(model=…)`. Née `sheet_dsl.py`
-  (renamed #640 — it's a fluent facade, not a DSL, per ADR 0001; the `sheet_dsl`
-  alias shim was deleted at 0.4.0, #720).
-- **`sheet_emit.py`** — **the** script emitter, behind `--script` (#940 retired the
-  imperative alternative): generates an editable `Sheet` script from a detected
-  model — one named binding per feature, an explicit dimension source. Facade tier;
-  imports `builder` downward at module level. The old builder→cli→sheet_emit
-  lazy cycle is **gone** (#523): the `_cli` compat shim moved from `builder` to
-  `cli.py` (beside the Typer `app`), so `builder` no longer imports `cli` and
-  `_LAZY_UPWARD_EXEMPT` is now empty. The graph is a plain DAG —
-  `cli → {builder, sheet_emit}`, `sheet_emit → builder`, `builder → ∅`.
-- **`score.py` / `recognition/`** — temporary public compatibility re-exports of
-  `b123d_recognisers`, identity-preserving and scheduled for removal in 0.6.0. There are no
-  embedded recogniser modules. Engine code imports the external package directly; private
-  historical `draftwright.recognition.*` paths are intentionally unsupported.
-- **`b123d_recognisers` (external)** — the ADR 0013 geometry-only bottom layer: uniform
-  deterministic `recognise_*` functions, frozen serialisable records, shared substrates,
-  `RecognitionResult` orchestration/manifest, repeating-profile correspondence, and
-  `feature_census`. It imports build123d/OCP and never imports Draftwright.
-- **`fonts.py`** — vendored, path-pinned IBM Plex fonts for deterministic
-  cross-platform layout (ADR 0006).
-- **`export.py`** — SVG/DXF/PDF/PNG export + post-processing (page-size fix,
-  attribution hyperlink/metadata, DXF metadata, arc sanitisation, element-wise
-  shape-export degradation). The render chain is **SVG → PDF → PNG**: PDF via
-  svglib + reportlab (`_render_pdf`, #288), PNG via **pypdfium2 + Pillow**
-  (`_render_png`) — both pure-wheel, **no native cairo** and permissively
-  licensed (BSD/Apache/HPND, dual-license-clean). The unified
-  `Drawing.export(out, *, formats=("pdf",)) → {format: path}` is the front door
-  (the legacy `svg=`/`dxf=` tuple form + `export_pdf` are back-compat/deprecated
-  wrappers). Sits below `make_drawing.py`, above `_core.py`.
-- **`repair.py`** — the deterministic lint→repair loop (#30 / ADR 0002): the
-  re-place helpers (`_find_dim`/`_replace_dim`/`_repair_*`/`repair_drawing`) take
-  the drawing duck-typed as `dwg`; `Drawing.repair()` stays a thin wrapper.
-  Depends only on `_core`.
-- **`pmi.py`** — PMI (product manufacturing information) extraction from STEP AP242.
-  Owns the XCAF source census and overlays `_pmi_part21` facts only after exact
-  correspondence. It inventories the complete OCCT geometric-tolerance modifier vocabulary,
-  preserves unsupported facts in the raw IR fallback, and exposes explicit blockers to typed
-  lowering; XCAF and Part21 source identities survive both paths.
+- **Leaf modules** — `layout.py` (the deterministic placement solvers: 1D PAVA strip
+  solve, `fit_box`, balloon band flow), `registry.py` (annotation identity/pins/issues),
+  `_geometry.py` (page-plane maths + the ADR 0014 Amdt 3 material field; the DAG's
+  bottom leaf), `fonts.py` (pinned IBM Plex, ADR 0006), `fits.py` (ISO 286),
+  `intents.py` (deferred-edit low IR), `recognition_cache.py` (ADR 0017 one-result
+  lifecycle), `_warnings.py`, `_pmi_part21.py`, and the `linting/` subpackage
+  (draftwright owns lint, ADR 0007).
+- **`_core.py`** — shared primitives: the `Analysis` namespace, dim/format helpers,
+  page/slot/margin constants.
+- **Stage modules** — `analysis.py` (classification + one-shot feature inventory),
+  `projection.py` (HLR + material lowering), `compose.py` (the ADR 0004 outer
+  compose-then-pack layout), `export.py` (SVG→PDF→PNG chain, DXF), `repair.py`
+  (the ADR 0002 lint→repair safety net), `pmi.py` (STEP AP242 PMI),
+  `model/` (the ADR 0015 IR waist: `ir`/`detect`/`planner`/`declare`/`compiled`),
+  `drawing.py` (the `Drawing` result object; single-owner `BuildState`), and
+  `annotations/` (the render passes; `orchestrator.py` owns `_PASS_SEQUENCE`, the one
+  canonical stage order; `_common.py` owns the corridor solve + late-furniture seam).
+- **`builder.py`** — build orchestration: `build_drawing`, `make_drawing`.
+- **Facades / top layer** — `make_drawing.py` + `annotate.py` (thin compat),
+  `sheet.py` (the fluent `Sheet` facade, ADR 0011), `sheet_emit.py` (the `--script`
+  emitter), `cli.py` (Typer; engine imported lazily inside command bodies, #313),
+  `evaluation/` (the versioned STEP-analysis benchmark — production code must never
+  depend on benchmark expectations or scores), `recogniser_contract.py` (the
+  fail-closed cross-repository capability join).
+- `score.py` / `recognition/` — temporary identity-preserving re-exports of
+  `b123d_recognisers`; removal scheduled for 0.6.0.
+
+Key invariants — each is machine-enforced, and the guard test is the authority:
+
+- No module but `drawing.py` touches `dwg._*`; build state is filled at one site in
+  `builder._assemble` (`test_drawing_encapsulation`, ADR 0005).
+- `annotations/` submodules import only down or sideways; the drawing is duck-typed
+  as `dwg` (`test_import_boundaries`).
+- Recognition runs at most once per build, owned by `BuildState`; a declared build
+  recognises nothing until physical critique or export asks (ADR 0017,
+  `test_recognition_manifest` fail-closed).
+- Renderers emit dimensional content only from `model/compiled.py`'s plan — suppression
+  is content they never receive (ADR 0016 Amdt 1, `test_compiled_plan_boundary`,
+  `test_label_provenance`).
 
 ## Architecture decisions — READ `docs/adr/` FIRST
 
 **Before any change to layout, scaling, page selection, annotation placement, or
-generation strategy, read `docs/adr/` and follow the accepted ADRs.** They are
-the source of truth for *why* the engine is shaped the way it is; do not
-re-derive or contradict them. If a change conflicts with an ADR, amend the ADR
-in the same PR (status, reasoning, date) rather than silently diverging — and if
-a decision turns out wrong, record that too.
+generation strategy, read `docs/adr/` and follow the accepted ADRs.** They are the
+source of truth for *why* the engine is shaped the way it is; do not re-derive or
+contradict them. If a change conflicts with an ADR, amend the ADR in the same PR
+(status, reasoning, date) rather than silently diverging — and if a decision turns
+out wrong, record that too.
 
-**Assess architectural fit — always.** An issue, a PR, and a review are each
-incomplete until they weigh the change against the ADRs, not just its local
-correctness. Ask: does this feature round-trip **all** the surfaces its kind
-requires — recognise **+** emit **+** declare (ADR 0011 / epic #574; no
-recognition-only debt)? Does it fit the compiler pipeline and one-inventory waist
-(ADR 0015)? Does it conform to the recogniser contract (ADR 0013)? Does it sit
-where it belongs in the DAG, or re-introduce a coupling an ADR removed? Does it
-place geometry through the corridor solve rather than around it, and extend a
-shared pass rather than adding another copy (consolidation epic #635)? A change
-that is locally correct but architecturally off-pattern *is* tech debt — call it
-out in the issue/PR/review, not after merge.
+**Assess architectural fit — always.** An issue, a PR, and a review are incomplete
+until they weigh the change against the ADRs, not just its local correctness: does a
+feature round-trip recognise **+** emit **+** declare (ADR 0011)? Does it fit the
+compiler pipeline and one-inventory waist (ADR 0015) and the recogniser contract
+(ADR 0013)? Does it sit at its DAG rank, place geometry through the corridor solve,
+and extend a shared pass rather than adding a copy? A change that is locally correct
+but architecturally off-pattern *is* tech debt — call it out in the issue/PR/review,
+not after merge.
 
-When an ADR has grown unwieldy with amendments, read its **Current decision**
-header first (the amended state in one place); the amendments below are the *why*
-trail. Once an ADR passes ~3–4 amendments, prefer a new **superseding** ADR over
-amendment N+1.
+Read an amended ADR's **Current decision** header first; the amendments are the why
+trail. Past ~3–4 amendments, prefer a new superseding ADR. Per-ADR status detail:
+[`docs/architecture.md`](docs/architecture.md).
 
-Current ADRs:
-- **0001** — deterministic generation over an editable DSL.
-- **0002** — iterate via lint-critique and domain-repair (repair is a *safety
-  net*, not the primary placement mechanism).
-- **0003** — **Retired**: historical universal-solver exploration. Its live
-  responsibilities are split between 0004 (outer layout) and 0014 (inner placement).
-- **0004** — **compose-then-pack** (Accepted; the **outer** layout): each view is
-  a *block* = `view_rect(scale) + its annotation boxes`; choose `(scale, page)`
-  by a monotone search whose fitness function is composing + packing the blocks
-  **disjoint**; build OCC geometry once at the end. Footprints are page-mm
-  **box layouts**, never bbox-measured geometry (perf). Byte-identity is **not**
-  required — output may change; acceptance = plan-view labels never overlap
-  front-view dimensions (CTC-02) + lint clean. Execution (**#121**) **landed** —
-  all nine implementation steps done (see the ADR's 2026-07-09 status amendment).
-- **0005** — **Accepted (split complete)** (#138): compiler-pipeline module
-  boundaries + single-owner build state. `Drawing` stops being the implicit state
-  bus; annotation identity/pins/build-issues moved to `registry.py`, coverage
-  state to `linting/`, build context (`Analysis`, edge cache) into the pipeline.
-  Stages split into `builder`/`analysis`/`compose` (née `sheet`, #640)/`projection`/`linting/`/`repair`/
-  `export`/`annotations/` (all #160–#166 landed; `make_drawing.py` 3,907 → ~20
-  facade). `layout.py` unchanged. **Roadmap:** `docs/plans/138-module-split-roadmap.md`.
-  Both deferred follow-ups are resolved: the §2 build-context threading closed
-  via **#639** (epic #635 — one typed `BuildState`, empty-allowlist ratchet), and
-  `annotations/envelope.py` was overtaken by the compiler convergence now
-  recorded in ADR 0015 (the envelope pass
-  converged into `annotations/from_model.py` instead). §4's compat-alias exit is
-  tracked by **#720** for 0.4.0.
-- **0006** — **Accepted** (#149): deterministic cross-platform layout via bundled,
-  path-pinned fonts. Layout depends on measured text width; resolving a font *name*
-  (`"Arial"`) substitutes a different font on Linux, drifting the whole sheet ~1 mm.
-  draftwright vendors IBM Plex (OFL) and pins it by `font_path` (Plex Mono for
-  dimensions, Plex Sans Condensed for title blocks); the helper renders via
-  `font_path` (needs `>=0.13.0`). Output changed once for every drawing.
-- **0007** — **Accepted, amended by the deployed extraction**: Draftwright owns linting,
-  recognition lifecycle/cache, IR conversion, and drafting policy; `b123d-recognisers`
-  owns geometry recognition; `build123d-drafting-helpers` is the rendering library.
-  (The 0005 golden harness, `tests/test_golden.py`,
-  was **retired** here — byte-exact digests are friction during deliberate output
-  evolution; regression coverage rests on the geometry-level + `test_e2e_standards`
-  suites. See ADR 0005 §3's retirement note.)
-- **0008** — **Superseded by 0015** (#697): the compiler-convergence why-trail,
-  frozen. Read 0015 for current state.
-- **0009** — **Superseded by 0014** (#697): the collect-then-solve why-trail
-  (9 amendments), frozen. Read 0014 for current state.
-- **0010** — **Accepted; landed**: **annotation provenance seam**.
-  The editable-surface epic needs "which annotations did this feature/intent
-  produce?" (for `drop`/`dimension`/`finalize`/the #400 emitter). Rather than
-  tagging each render pass (the link is lost at the corridor placer, the
-  diameter-spec flattening, and the recognition→IR boundary), record
-  `intent → [names]` **once** at the intent→render seam, with an `origin` back-link
-  on every IR feature was rejected; aspect features retain targeting handles.
-  The render seam is the automatic populator and the contract is audit-tested.
-- **0011** — **Accepted** (core landed; #62/#462/#495 remain):
-  **the IR as a public input** — declare features, don't only detect them.
-  `build_drawing(part, model=…)` accepts a caller-supplied `PartModel`/`Sequence[Feature]`
-  and **skips detection**; object→feature constructors
-  (`model.hole`/`boss`/`step`/`slot`/`pattern`/`envelope`) read a feature's size off the
-  build123d object you built (⌀ from the cylindrical face; axis/location from the bbox),
-  with an explicit-value flavour. The fluent `Sheet` façade (`draftwright.Sheet`) is the
-  "beautiful-Python" surface over the existing renderers. **Aspects geometry can't carry
-  are now built:** tolerance/fit ride `DimParameter` (P2a/P2a.2); **GD&T + surface finish**
-  are standalone IR features (`ControlFrame`/`DatumRef`/`Finish`, `model/ir.py`) placed as
-  first-class ADR 0014 corridor candidates by `render_gdt` (P2b #478), authored via
-  `sheet.datum`/`sheet.control(…).position(…)`/`.finish` whose target view+strip derive
-  from the referenced feature/face (`declare.gdt_target`, P2c #480/#482). Complete AP242
-  geometric tolerances with no modifier, or the export-safe all-around modifier, lower through
-  that same `ControlFrame` path (#1095); unsupported modifiers remain provenance-rich raw
-  fallbacks, and all-over export is tracked by #1097. Datum lowering remains #62; number-free
-  aspects remain #462 and raw-cutter slot reading remains #495. Sidesteps #298 misdetection;
-  complements #400 (read + edit → now also input). Roadmap:
-  `docs/plans/0011-phase2-aspects-roadmap.md`; #446/#445.
-- **0012** — **Accepted; partially landed** (2026-07-08; corrected 2026-07-19):
-  user annotation edits are pinned, priority-ranked corridor candidates. A
-  `dimension(..., pin=, priority=)` edit records a
-  scale-independent *dimension intent* on the model — **pin** = the solver's `anchored`/
-  `_ANCHOR_WEIGHT` (stays put while the rest flow around it), **priority** =
-  `CorridorCandidate.priority` (#357). `Drawing.finalize()` drains only recorded
-  deferred intents through `_PASS_SEQUENCE`; it does not reconstruct auto candidates or
-  perform a global auto-plus-user recompose. `place_dim()` remains the deprecated raw-
-  coordinate escape hatch. Full recomposition/parity remains #426/#661/#707.
-- **0013** — **Accepted** (#568; **Phases 1–2 deployed**): the **uniform recogniser
-  contract** — `recognise_<feature>(part, *, <injected deps>) -> list[<frozen
-  record>]` (plus the part-less *derived* shape, e.g.
-  `recognise_hole_patterns(holes)`), mechanically enforced by
-  `tests/test_recogniser_contract.py`; and the typed record→`Feature` converter
-  registry in `model/detect.py` (roadmap 1c / #752), whose completeness+uniqueness
-  is fail-closed by `tests/test_detect_registry.py`. The shared `b123d-recognisers`
-  `v0.1.0a1` package is now the implementation; Draftwright's duplicate modules are deleted.
-  Roadmap: `docs/plans/0013-shared-recognisers-roadmap.md`.
-- **0014** — **Accepted** (supersedes 0009, #697): **collect-then-solve
-  annotation placement as built** — collect every strip occupant as a
-  candidate; one solve per strip (select → order(=feature order ⇒
-  crossing-free) → space, the PAVA L1 solve); post-#636 the guarantee holds for
-  every auto-pass occupant, with the `carve_free_position` exemptions pinned
-  fail-closed. Includes the strip/zone/corridor glossary and the
-  StripCandidate↔CorridorCandidate layering. Amendment 1 (#740) introduced
-  bounded within-pass machined-leader assignment; Amendment 2 (#1166) collects
-  compatible sparse ordinary side/plan hole and post-drain machined leaders into
-  one canonical late stage (maximum placed, priority, clear-route penalty, then
-  leader length), retaining the old lazy greedy result as the resource-cap floor
-  without relaxing page/view/title hard constraints and preserving the abandoned
-  admitted inventory in state-cap traces. Amendment 3 (#798) prices a shaft
-  cutting back through the part into that same Policy-B penalty, measured on one
-  filled projected-material lowering **shared with the
-  `leader_crosses_silhouette` critique**, so router and lint cannot disagree; it
-  is a cost, never an acceptance test, and the resource-cap floor — which is what
-  actually runs on dense parts — gained a bounded clear-route lookahead. Amendment 4
-  (2026-08-16) records that a work budget must bound **measured** work rather than
-  predict it: three guards were found silently disabling the feature they protect on
-  ordinary input (the joint assignment never running on any dense part; two balloon
-  bounds over by 1.5x and **497x**, the latter refusing a hole table at 0.4% of its
-  real cost). Prefer a live counter; an unavoidable pre-check must be exact rather
-  than conservative; and a budget that fires is a capability loss that should say so.
-- **0015** — **Accepted** (supersedes 0008, #697): **the part-drawing compiler
-  as built** — detectors + declared features → the one PartModel waist (two
-  tiers, ADR 0013) → planner → render-intents → shared infra; with the
-  planner-coverage split (the #698 migrations are complete; correlated
-  furniture/aspects remain model-routed by design, while rotational OD/bore
-  groups are residual debt tracked by #754) and the lint/coverage carve-out
-  stated properly. New kinds must add every applicable IR, planning, rendering,
-  coverage, and test surface while keeping orientation data-driven.
-- **0016** — **Accepted; epic #867 complete** (PR0–PR8, #868–#876): **declared
-  dimensioning intent**. `sheet.dimension(feature, role)` is *referential* — it names
-  a measurement and carries no number; the engine still derives the value from the
-  geometry and owns placement. Three parts landed:
-  - **A build must say where its dimensions come from** (#874, breaking): either
-    `auto_dimensions()` (the planner's set, optionally augmented by `add_dimension`)
-    or an authored set of `dimension(...)` declarations. Mutually exclusive, because
-    "everything the planner chooses, plus these" and "only these" cannot both hold.
-  - **Omission from an authored set means suppression** (#876) — on *every* generated
-    dimensional path, positions included. A dimension the author cannot address is a
-    dimension the author cannot omit, so `location` became addressable per feature
-    (`planner.location_datum` is the single eligibility answer; per-*member* identity
-    remains #883).
-  - **Amendment 1 — the compiled-plan boundary**: renderers may emit dimensional
-    content only from `model/compiled.py`'s `RenderableDimensionPlan`. *Suppression is
-    not a flag renderers check, it is content they never receive* — `ApprovedDimension`
-    has no `suppressed` field. Guarded on both the symptom
-    (`tests/test_compiled_plan_boundary.py`: an empty plan draws nothing) and the cause
-    (`tests/test_label_provenance.py`: a renderer that formats a number got it as a
-    number rather than as the compiler's `value_text`). Hole callouts (`hc_`) are the
-    one renderer still on the legacy surface (#926); the label budget drawdown is #927.
-  **Not** shipped: the emitter dimension-mirror (phase 4). `emit_sheet_script` refuses a
-  model with an authored set rather than silently writing `auto_dimensions()`, because
-  naming a feature in a generated script would have to address it by position — #922.
-- **0017** — **Accepted with narrowed scope; ownership phase landed, correspondence work is
-  evidence-gated by epic #1018**: **the recognition inventory as a first-class result**.
-  Recognition stops being a
-  scatter of ad-hoc calls: one orchestration per build produces a frozen
-  external `RecognitionResult`, held by Draftwright's `RecognitionCache` in `BuildState` and reused by
-  model construction *and* by critique. Automatic-path lint reads its inventories off
-  `Analysis`; declared-path critique obtains the same aggregate lazily through `BuildState`.
-  ADR 0017 §5 explicitly permits both (independence from the *plan* is not independence from
-  the *recognition*).
-  Phase 1 (#1019) landed the **fail-closed manifest** — `MIGRATED` / `DEFERRED` in
-  `b123d_recognisers.result` classify every public `recognise_*` family, and
-  `tests/test_recognition_manifest.py` fails when a new one appears without that decision,
-  so a recogniser cannot be added and then quietly re-scanned from three call sites. A
-  deferral is a `Deferral` reason **code** plus the issue that removes it, not a paragraph:
-  prose in a constant CI reads goes stale silently, and the first cut's did. The why-trail
-  lives in the blocking issue.
-  **#1022** landed the **ADR 0011 declared-path gate**: a declared build now recognises
-  **nothing**. It was not one `if` — sizing sources the turned profile and step ladder from
-  the declaration (`_declared_turned_profile` / `_declared_step_zs` in `analysis.py`), and
-  the lint→repair loop stopped asking for the feature-coverage half it never used
-  (`Drawing.lint(physical=False)`; repair acts on `dim_inside_part` alone, ADR 0002).
-  Critique on that path still needs an inventory, so `BuildState.ensure_recognition()` builds
-  one lazily, once — in the typed build state, not a lint- or `Drawing`-side memo, which
-  would make critique a second recognition owner. Exporting a declared drawing pays for that
-  one aggregate by design: `export` logs the coverage critique, and suppressing it to reach
-  "zero" would trade a user-facing diagnostic for a benchmark number. Two consequences worth
-  knowing: lint takes `step_zs`/`pads`/`pockets` from the **aggregate**, never from
-  `Analysis` on the declared path (ADR 0015 — critique must not inventory from the model);
-  and `recognise_face_levels` migrated into the aggregate as `step_levels`, its
-  `NO_INDEPENDENT_CONSUMER` deferral having stopped being true the moment declared-path
-  critique needed the geometry ladder. The gate also exposed a latent strip-sizing bug on
-  *both* paths: `_est_right_strip_depth` counted ladder steps only, while boss heights share
-  that strip — detected builds hid it in the ladder's slack (`_n_right_strip_boss_heights`,
-  `compose.py`).
-  **Phase 1 is complete.** #1025 split `recognise_step_shoulders` into level-free riser
-  evidence the aggregate owns (`recognise_risers`) plus a pure `project_step_shoulders` each
-  consumer applies with its own level set — which took *lint's* per-pass rescan to zero, epic
-  #1018's third phase-0 guard, and closed a false-negative door on the way (coverage's
-  `step_zs=` argument fully determined the shoulder answer, so `step_zs=[]` silenced
-  `unrecognised_defining_geometry`). #1026 then migrated the three `BUILD_MODEL_ONLY`
-  families once #1022 had removed their cost, and #1028 migrated the last three by moving
-  their classification gate *into* the orchestration — the distinction that made it possible
-  being that **owning a family and always running it are different things**: the aggregate
-  owns `recognise_chamfers` and still does not run it for a turned part.
-  **`DEFERRED` is now empty** — every public `recognise_*` family is owned by the one
-  orchestration. The mechanism stays fail-closed (a new family must still be classified, and
-  every `Deferral` member survives for a future one); what went was each deferral, as its
-  stated constraint stopped being true. Measured per family: a prismatic build runs 17 once
-  each, a turned build 14 (the gated three excluded by design), a declared build/render
-  **zero**. Physical critique or export may then obtain one cached aggregate.
-  The accepted contract stops there. `BuildState` proves result-to-build provenance; it does
-  **not** yet provide recognition-record→IR-feature→requirement correspondence. The original
-  four-type identity taxonomy, shared requirements module, general outcome ledger,
-  reconciliation stage, and diagnostics model are candidate extensions rather than an
-  approved phase sequence. #1018 now requires two end-to-end slices before any of them is
-  generalised: flats first (using #1011's fixtures without label/tip/page inference), then
-  off-centre slots plus N:1 slot patterns. Each new semantic guard needs the mutation that
-  breaks its claimed contract; a green suite alone is not evidence that the guard is
-  load-bearing.
-
-- **0018** — **Accepted** (2026-08-16; #1130): **requirement-driven view planning
-  and editable sheet layout**. One view-planning model between drawing requirements and
-  projection: authored `ViewConstraints` and the automatic planner share one semantic
-  `ViewSpec`/layout vocabulary and produce one immutable `ResolvedViewPlan`. Page,
-  preferred scale, view set and arrangement are chosen **jointly** against complete view
-  blocks measured with fixed paper-space typography; a candidate is feasible only when
-  the real shared annotation solve preserves every supported requirement and all blocks
-  stay in bounds. Supersedes ADR 0004's **fixed four-view topology** (0004's
-  compose-then-pack of each selected block still stands). Users edit whole view blocks,
-  never feature-annotation coordinates (ADR 0012/0014 keep those). Infeasibility is a
-  first-class `plan_infeasible` result, never a silent relaxation of an authored
-  constraint.
-  **Nothing is implemented yet** — there is no `ViewSpec`/`ResolvedViewPlan` in the code
-  and the engine still builds fixed front/plan/side/iso. The ADR's "Required evidence
-  before acceptance" list is the per-slice delivery gate, not waived by acceptance.
-  Accepted on converging evidence from #1187 (leaders that cut the part have no clear
-  route because the SHEET is full — every remedy is compositional) and #1190 (the
-  section is placed into leftover space, so its presence tracks room rather than need).
+Index: **0001** deterministic generation (no imperative editable script — retired
+#940) · **0002** lint-critique + repair as safety net · **0003** retired ·
+**0004** compose-then-pack outer layout · **0005** pipeline module boundaries +
+single-owner build state (complete) · **0006** pinned vendored fonts for
+deterministic layout · **0007** draftwright owns lint/recognition-lifecycle/policy ·
+**0008, 0009** superseded (read 0015, 0014) · **0010** annotation-provenance seam ·
+**0011** the IR as public input: declare features (`Sheet`, `model/declare`) ·
+**0012** user edits as pinned, ranked corridor candidates · **0013** uniform
+recogniser contract (external `b123d-recognisers`) · **0014** collect-then-solve
+placement, 4 amendments (late leader stage; material-re-entry penalty; budgets must
+measure, not predict) · **0015** the part-drawing compiler as built ·
+**0016** declared dimensioning intent (authored sets suppress by omission; compiled-
+plan boundary) · **0017** recognition inventory as first-class result (ownership
+landed; correspondence work evidence-gated by #1018) · **0018** requirement-driven
+view planning (**accepted, nothing implemented yet** — the evidence list is the
+per-slice gate).
 
 ## Dependencies
 
-- `build123d-drafting-helpers>=0.13.0` (Apache 2.0)
-- `build123d>=0.9.0` (Apache 2.0)
-- Export render chain: `reportlab` (BSD) + `svglib` (LGPL) for PDF; `pypdfium2`
-  (Apache-2.0, wrapping Google PDFium BSD-3) + `pillow` (HPND) for PNG. All
-  pure-wheel (no native cairo) and — except svglib's weak-copyleft LGPL — permissive,
-  so the render path stays dual-license-friendly.
-
-The 1D strip solve (`layout.py`) is the dependency-free minimum-total-leader-length
-**PAVA** algorithm (`_solve_strip_1d_pava`, ADR 0009 Amdt 4); the earlier Cassowary
-(`kiwisolver`) constraint-satisfaction solve was retired once PAVA gave the exact
-L1 placement, so `kiwisolver` is no longer a direct dependency.
+- `build123d-drafting-helpers>=0.13.0` (Apache 2.0), `build123d>=0.9.0` (Apache 2.0)
+- Export render chain: `reportlab` + `svglib` (PDF), `pypdfium2` + `pillow` (PNG) —
+  all pure-wheel, no native cairo; svglib is the one weak-copyleft (LGPL) member.
+- The 1D strip solve is dependency-free PAVA (`_solve_strip_1d_pava`); `kiwisolver`
+  was retired.
 
 ## Testing
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,510 @@
+# Architecture — the detailed module map
+
+The module-by-module map of the draftwright engine, moved out of `CLAUDE.md`
+(which keeps the compact map and the working rules). The machine-enforced
+authority for the layering is `tests/test_import_boundaries.py` (`_LAYERS`);
+keep that table, this document, and `CLAUDE.md`'s compact map in step. The
+*why* behind every shape here lives in `docs/adr/`.
+
+## The module map
+
+The dependency graph is a DAG (the #138 / ADR 0005 split is complete). Bottom to
+top: leaf modules (`layout.py`, `registry.py`, `fonts.py`, `_geometry.py`,
+`fits.py`, `intents.py`, `recognition_cache.py`, and the `linting/` subpackage) →
+`_core.py` → stage modules (`export.py`,
+`repair.py`, `projection.py`, `compose.py`, `analysis.py`, `drawing.py`, the
+`model/` IR subpackage, the `annotations/` subpackage) → `builder.py` → the
+user-facing surfaces: the `make_drawing.py` / `annotate.py` compat facades, the
+fluent `Sheet` facade (`sheet.py`), the Sheet-script emitter
+(`sheet_emit.py`), the recognition-evaluation package (`evaluation/`), and the
+`cli.py` entry point. No lower module imports an
+upper one. (All surfaces are front doors onto the one engine,
+`build_drawing` → `_auto_annotate` — there is no second engine.)
+
+This DAG is **machine-enforced** by `tests/test_import_boundaries.py` (#640): the
+`_LAYERS` table there is the precise, ranked form of this section — a module-level
+import that points up a layer fails CI, as does an import cycle. The precise
+placement refines the coarse grouping above (e.g. `linting`/`pmi`/`export`/`repair`/
+`projection`/`compose` sit *above* `_core` since they depend on it; `model/` is the
+IR-waist leaf it is guarded as). The `_LAZY_UPWARD_EXEMPT` sanctioned-cycle-breaker
+mechanism is now empty (#523 removed its last occupant, the `builder→cli` edge — see
+below); a new upward lazy import must earn an entry with a rationale. The remaining
+lazy in-function imports (`cli`→`builder`/`sheet_emit`, for the #313 build123d
+lazy-load) are *downward*, not cycle-breakers. The one type-only upward reference
+(`_core`→`compose.StripDepths`, under `TYPE_CHECKING`) is an explicit allowlist
+entry. Keep `_LAYERS` and this section in step.
+
+`evaluation/` owns the versioned, independently-authored STEP-analysis benchmark and its
+scoring model. It is a top-layer consumer of the recognition contract; production recognition,
+IR, generation, and drawing code must not depend on benchmark expectations or scores.
+
+- **`make_drawing.py`** — thin compat facade (~20 lines) re-exporting the public
+  surface (`Drawing`, `build_drawing`, `make_drawing`, `_cli`,
+  `FeatureInfo`, `fix_svg_page_size`, `lint_feature_coverage`) so existing imports
+  and the `draftwright` CLI entry point keep working. The engine lives in:
+  - **`builder.py`** — build orchestration: `build_drawing` (analyse → assemble →
+    measure-and-repack → `Drawing`) and `make_drawing` (+ export). Imports
+    `drawing`/`analysis`/the annotation orchestrator/the stage modules — never
+    `make_drawing` (a DAG). *(`generate_script`, the imperative editable-script
+    generator, was retired by #940 — ADR 0016 phase 6 / ADR 0001 Amdt 2 — and
+    **deleted** at its 0.4.0 date (#720), along with the raising stub that stood
+    in for it and the bespoke `--style imperative` message. `--style` itself
+    survives with the single value `sheet` so existing invocations keep
+    working.)*
+    *(The CLI moved out to `cli.py`; the `_cli` compat shim lives there too (#523),
+    so `builder` no longer imports `cli`.)*
+  - **`cli.py`** — the Typer command-line interface (#289): argument parsing,
+    `--version`, shell completion, `--format`, rich help. The engine (build123d)
+    is imported **lazily inside the command body** so completion/`--help`/
+    `--version` stay sub-second (#313). Entry point: `draftwright.cli:app`.
+  - **`drawing.py`** — the `Drawing` result object (`.lint()`/`.add()`/`.place_dim()`/
+    `.repair()`/`.export*()`; delegates identity to `registry`, coverage to `lint`)
+    plus `FeatureInfo` (`_build_table` moved beside `_table_metrics` in `_core`, #699).
+    Sits below `builder` (which constructs it).
+    *(The build context lives in ONE typed `BuildState` on `Drawing` (`_build`:
+    analysis, part model, lint's geometry caches) — filled at a single site in
+    `builder._assemble`, read through compat properties, single-writer-guarded
+    by `test_drawing_encapsulation`. ADR 0005 §2 / #639 closed: `annotations/`
+    has zero private `Drawing` reads (empty allowlist ratchet) — and since #699
+    slice d the state-bus guard covers the WHOLE engine: no module but
+    `drawing.py` touches `dwg._*` (rationale-carrying allowlist, builder's
+    fill site only).)*
+- **`annotate.py`** — thin compat facade re-exporting `_auto_annotate` (the
+  orchestrator) from `annotations/`. The annotation passes were split into the
+  **`annotations/`** subpackage (#164 / ADR 0005, P5):
+  - **`annotations/orchestrator.py`** — `_auto_annotate`, the single entry point
+    (called by `build_drawing`); classifies the part and drives the render passes
+    + title block. Owns **`_PASS_SEQUENCE`** — the ONE canonical stage order
+    (#699 slice b): `_auto_annotate` and `Drawing._drain_intents` (the finalize
+    drain) both hand name→thunk dicts to the shared `run_stages`, so the two
+    build paths cannot diverge in sequencing (the drain step itself is the
+    shared `drain_and_reconcile`). The current ADR 0015 shape is
+    `build model → plan/model-routed intents → render`; some inline engine code remains — chiefly
+    `_maybe_tabulate_holes` (the hole-table/balloon escalation resolver) and the
+    iso right-strip outer-limit tightening — pending the last convergence steps.
+  - **`annotations/from_model.py`** — the **IR render layer** (largest annotations
+    module): turns the planner's `DimensionGroup`/render-intents into placed
+    dimensions/callouts/centre marks/section triggers. This is where the turned,
+    PMI/GD&T, envelope/OD, centre-mark and step-length passes converged (ADR 0015,
+    #200/#208/#237) — the old per-feature `annotations/{turned,pmi}.py` modules
+    were deleted as each migrated here.
+  - **`annotations/holes.py`** — hole/pattern callouts, balloons, location dims
+    (incl. side-drilled #133), pitch/grid dims, slots (the largest *pass*).
+  - **`annotations/leaders.py`** — the one bounded late inventory for compatible
+  automatic/deferred same-view feature leaders (#1166): sparse ordinary
+  side/plan hole jobs and the five post-drain machined-feature families lower
+  exact committed component ink conflicts (including component-local curved
+  centre furniture and rendered shifted-dimension arrows), retaining any
+  rendered residual triangle not covered by one same known component and any
+  curved residual area between tessellation stations, including filled
+  datum/GD&T faces without segment metadata; candidate construction fails closed
+  per alternative, while a selected-survivor construction exception or mismatch
+  replays the canonical lazy producer tail rather than silently reducing
+  cardinality, with validation-stage diagnostics and without swallowing compiler
+  invariant errors; fixed components are lowered once under the same resource
+  discipline and reused; the complete title
+  band stays hard after rendering; only explicitly
+  marked global turning axes exempt only the arrow-local tip attachment (not
+  near-collinear shaft travel),
+  priorities, Policy-B penalties, and numeric costs into `layout.py`; optional
+  sections enter only a separately bounded no-worse refinement, then validate
+  their final ink against landed leaders, repair one end-symbol extent, and yield on conflict,
+  then validate the selected OCC ink and emit it with its original provenance;
+  any retained fixed-ink Policy-B crossing persists as
+  `feature_leader_crossing`, independently of opt-in tracing, while a producer
+  replay beyond the exact fixed-probe budget persists as
+  `feature_leader_fixed_ink_unverified` without exceeding that bound and cannot
+  report a perfect legibility quality score. ADR 0014 Amendment 3 (#798) adds
+  material re-entry to that Policy-B penalty at a stated exchange rate (one unit
+  per visible stroke width of buried shaft) — a cost, never an eligibility gate
+  and never an acceptance test, so no callout is dropped because its route cuts.
+  The resource-cap floor, which is what actually runs on dense parts, gained a
+  bounded lookahead past a first acceptable-but-cutting route; a job whose first
+  acceptable route already clears the body selects it exactly where it always did.
+  - **`annotations/sections.py`** — section A–A + detail views (ISO 128-44 arrows,
+    ISO 128-50 hatching).
+  - **`annotations/balloons.py`** — the leadered hole-balloon pass (#111/#516;
+    moved down from `Drawing`, #699). `Drawing.add_balloons` is the public verb
+    threading build state in; the band-assignment flow solver lives in `layout.py`.
+  - **`annotations/gears.py`** — standards-backed data-table presentation for the
+    declaration-only metric external spur gear; the table flows through the generic
+    solver-owned late-furniture path (#1086).
+  - **`annotations/_common.py`** — the ADR 0014 corridor-solve engine
+    (`CorridorCandidate`, `solve_corridor`, `register_corridor`/`drain_corridors`,
+    `place_strip_candidates`, `PlacementContext`) plus `_box_hits`, at the
+    bottom of the annotations DAG. (The bbox/segment primitives it delegates to
+    live in `_core`/`_geometry` since #700.) It also owns the **post-fit
+    late-furniture** seam (#1197): `late_furniture_obstacles` is the ONE occupancy
+    a placer facing the finished sheet uses — views, decomposed annotation ink,
+    minus the page-spanning riders, plus the title block as one hull — shared by
+    `Drawing.add_table` and by `place_iso_nts_note`, the iso's NTS caption, which
+    lives here rather than in `projection` because rank-2 cannot reach that
+    occupancy and a hand-rolled substitute was wrong twice.
+  Submodules import only down or sideways — `_core`/`layout`/`analysis`/
+  `projection`/the `model/` IR/`linting.structural`/third-party, never
+  `annotate`/`make_drawing`/`drawing` (the drawing is duck-typed as `dwg`) — so
+  the orchestrator calls down with no cycle.
+- **`_core.py`** — shared primitives below both `make_drawing.py` and `annotate.py`:
+  the `Analysis` namespace and its field types (`_Projector`, `Strip`, `ViewZones`),
+  the dimension/format helpers (`_dim`, `_fmt`, `_add_title_block`, …), and the
+  page/slot/margin layout constants.
+- **`layout.py`** — the deterministic placement primitives used by ADRs 0004/0014:
+  the deterministic
+  1D PAVA strip solve (`_solve_strip_1d_pava`, plus `plan_strip`/`StripCandidate`,
+  the ADR 0014 collect-then-solve entry point), the 2D free-rectangle placer
+  (`fit_box`), and the balloon band-assignment min-cost max-flow solve
+  (`_assign_balloon_bands`, #516; here since #699 — solvers live in the solver
+  layer). Sits *below* the domain API.
+- **`_geometry.py`** — model-neutral geometry primitives (`_xyz`, `HoleRef`,
+  `_axis_letter`, `_END_ON`) plus the #700 shared page-plane maths (`_fmt`,
+  `_boxes_overlap`, the two segment/box tests) and `plane_axes` — the one
+  in-plane `(u, v)` basis per axis, shared by `recognition._features._plane_uv`
+  and `model.declare._plane_axes` so a pattern's `angle` means the same thing
+  detected as declared (#969); the DAG's bottom leaf (guarded
+  by `test_geometry_is_a_leaf`) so the IR waist uses them without importing
+  `_core`. Also the ADR 0014 Amendment 3 **filled material field** (#798):
+  `MaterialField`/`material_field` (page-plane triangles + a uniform grid index),
+  `material_span`, `material_intervals`, and `material_reentry_span` — exact
+  half-plane clipping with a fixed-point interval union and an incremental cell
+  walk, no sampling. Re-entry, not traversal, is the routing defect: a leader's
+  first passage out of the body is the legitimate exit every callout makes.
+- **`_pmi_part21.py`** — the rank-0 structured ISO 10303-21 adapter for AP242
+  geometric-tolerance facts that OCCT's XCAF transfer drops. It resolves explicit
+  Part21 references and SI length units, and requires unique semantic-name + kind
+  correspondence; it knows nothing about XCAF, drafting IR, or placement.
+- **`_warnings.py`** — the public warning categories (`SoftDeprecationWarning`), a
+  dependency-free leaf. Separate from `_core` on purpose: `_core` imports build123d, so a
+  category defined there costs the CAD kernel (~6 s) to reach, and the pytest
+  `filterwarnings` entry naming it pays that on every invocation (#1043).
+- **`fits.py`** — the ISO 286 fit tables (`fit_deviation`, `FitClass`; ADR 0011
+  P2a.2): a rank-0 leaf consumed by `_core`, `model/ir` and `sheet`.
+- **`intents.py`** — the deferred-placement "low IR" behind `Drawing.finalize()`
+  (#426): a dependency-free leaf recording edit-verb intents for the recompose
+  (deliberately stringly-typed in its Phase-1 form).
+- **`registry.py`** — `AnnotationRegistry`: the single owner of annotation
+  identity/ownership/pins/build-issues (#138 / ADR 0005, Step 2). `Drawing`
+  delegates here and keeps the render list. The `_named`/`_anno_view`/`_pinned`/
+  `_build_issues` aliases on `Drawing` (and coverage's three) were **deleted** at
+  their §4 date (#720): reach the state through `dwg.registry` (`in reg`,
+  `names()`, `issues`, `restore_issues()`) and `dwg.coverage`. Their absence is
+  asserted by `test_the_expired_compat_aliases_stay_deleted`.
+- **`linting/`** — the lint subpackage (#138 / ADR 0005; ADR 0007: draftwright
+  owns linting): `coverage.py` (`lint_feature_coverage` + `CoverageState`),
+  `structural.py` (geometry/standards checks), `issues.py` (the `LintIssue` type),
+  `gear_coverage.py` (declared gear table/profile reconciliation), and `suggest.py`
+  (`_suggest_fix`, #29 snippets). Depends only on `_core`,
+  `b123d_recognisers` (typed hole records in `coverage.py`) + build123d_drafting.
+  `_QUOTED_RE` (a lint-message label regex shared with the
+  repair loop) lives in `_core`.
+- **`recognition_cache.py`** — Draftwright's ADR 0017 one-result lifecycle owner. It calls
+  external `build_recognition_result(part)` at most once for a build/lazy-critique run; the
+  package owns recognition, while Draftwright owns when the result is computed and reused.
+- **`recogniser_contract.py`** — the fail-closed cross-repository capability join. It consumes
+  only the installed `b123d-recognisers` public manifest, then validates Draftwright-owned IR,
+  `Sheet`, generated-code, drawing, completeness, and documentation declarations. It is rank 7
+  because validation dynamically resolves implementation references across every lower layer;
+  package geometry policy never imports or owns this consumer overlay.
+- **`model/`** — the ADR 0015 IR waist: `ir.py` (the `Feature`/`DimParameter`/
+  `Datum`/`PartModel` types — the one inventory), `detect.py` (detectors →
+  `Feature` objects, adapting `b123d_recognisers` records), `planner.py`
+  (`plan_dimensions` —
+  one rule set → a `DimensionGroup` per feature, + `plan_sections`; and, since #1154,
+  the one cross-feature reconciliation: two features measuring between the same two
+  support planes state one fact, so the overall extent keeps it and the feature-local
+  one records where it went), and
+  `declare.py` (ADR 0011 object→feature constructors: `hole`/`boss`/`step`/… read
+  a feature's size off the build123d object — a second, *declared* front-end into
+  the same IR the detectors fill). The narrow middle of the compiler hourglass;
+  consumed by `annotations/from_model.py`.
+- **`compose.py`** — the ADR 0004 **outer** compose-then-pack layout engine
+  (`choose_scale`, `ViewBlock`, zone/strip depths). Née `sheet.py`; renamed
+  (#640) so the layout engine stops shadowing the user-facing `Sheet` facade
+  (which now owns the `sheet.py` name).
+- **`analysis.py`** — the `_analyse` stage: solid classification, the one-shot
+  feature-inventory detection (ADR 0015), view sizing, and the strip/zone
+  model (`fv_zones`/`pv_zones`/`sv_zones`) that ADR 0014 placement reads.
+- **`projection.py`** — HLR projection and view-coordinate transforms
+  (`_assemble`'s geometry half; #161). Also the #798 **material lowering**:
+  `part_material_mesh` tessellates the part once per build and
+  `view_material_field` projects that one mesh per view, so every view measures
+  the same material. The mesh is taken under explicit control (copy →
+  `BRepTools.Clean_s` → `BRepMesh_IncrementalMesh`) because OCC caches a
+  triangulation on the shape and returns it for any later request — even a finer
+  one — which would make the field a function of build *history* (the ADR 0006
+  hazard). `Drawing.material_fields()` holds the result on `BuildState`.
+  `_fit_iso_view` **returns** the iso bbox when the fitted iso is off sheet scale and
+  therefore needs an NTS caption, else `None`; it does not place that caption. `builder`
+  does, at the common post-fit point *before* `render_gear_tables` — the caption is tied
+  to the block it labels while a table may sit anywhere, so the constrained furniture
+  claims space first (#1197).
+- **`sheet.py`** — the fluent declarative **`Sheet`** facade (ADR 0011):
+  feature verbs (`hole`/`boss`/`slot`/…), aspect verbs (`.tolerance`/`.fit`/
+  `.finish`), GD&T (`datum`/`control`). Facade tier: builds a `PartModel` via
+  `model/declare.py` and calls `build_drawing(model=…)`. Née `sheet_dsl.py`
+  (renamed #640 — it's a fluent facade, not a DSL, per ADR 0001; the `sheet_dsl`
+  alias shim was deleted at 0.4.0, #720).
+- **`sheet_emit.py`** — **the** script emitter, behind `--script` (#940 retired the
+  imperative alternative): generates an editable `Sheet` script from a detected
+  model — one named binding per feature, an explicit dimension source. Facade tier;
+  imports `builder` downward at module level. The old builder→cli→sheet_emit
+  lazy cycle is **gone** (#523): the `_cli` compat shim moved from `builder` to
+  `cli.py` (beside the Typer `app`), so `builder` no longer imports `cli` and
+  `_LAZY_UPWARD_EXEMPT` is now empty. The graph is a plain DAG —
+  `cli → {builder, sheet_emit}`, `sheet_emit → builder`, `builder → ∅`.
+- **`score.py` / `recognition/`** — temporary public compatibility re-exports of
+  `b123d_recognisers`, identity-preserving and scheduled for removal in 0.6.0. There are no
+  embedded recogniser modules. Engine code imports the external package directly; private
+  historical `draftwright.recognition.*` paths are intentionally unsupported.
+- **`b123d_recognisers` (external)** — the ADR 0013 geometry-only bottom layer: uniform
+  deterministic `recognise_*` functions, frozen serialisable records, shared substrates,
+  `RecognitionResult` orchestration/manifest, repeating-profile correspondence, and
+  `feature_census`. It imports build123d/OCP and never imports Draftwright.
+- **`fonts.py`** — vendored, path-pinned IBM Plex fonts for deterministic
+  cross-platform layout (ADR 0006).
+- **`export.py`** — SVG/DXF/PDF/PNG export + post-processing (page-size fix,
+  attribution hyperlink/metadata, DXF metadata, arc sanitisation, element-wise
+  shape-export degradation). The render chain is **SVG → PDF → PNG**: PDF via
+  svglib + reportlab (`_render_pdf`, #288), PNG via **pypdfium2 + Pillow**
+  (`_render_png`) — both pure-wheel, **no native cairo** and permissively
+  licensed (BSD/Apache/HPND, dual-license-clean). The unified
+  `Drawing.export(out, *, formats=("pdf",)) → {format: path}` is the front door
+  (the legacy `svg=`/`dxf=` tuple form + `export_pdf` are back-compat/deprecated
+  wrappers). Sits below `make_drawing.py`, above `_core.py`.
+- **`repair.py`** — the deterministic lint→repair loop (#30 / ADR 0002): the
+  re-place helpers (`_find_dim`/`_replace_dim`/`_repair_*`/`repair_drawing`) take
+  the drawing duck-typed as `dwg`; `Drawing.repair()` stays a thin wrapper.
+  Depends only on `_core`.
+- **`pmi.py`** — PMI (product manufacturing information) extraction from STEP AP242.
+  Owns the XCAF source census and overlays `_pmi_part21` facts only after exact
+  correspondence. It inventories the complete OCCT geometric-tolerance modifier vocabulary,
+  preserves unsupported facts in the raw IR fallback, and exposes explicit blockers to typed
+  lowering; XCAF and Part21 source identities survive both paths.
+
+## Current ADRs — status detail
+
+The working rules (read ADRs first, assess architectural fit, the amendment
+policy) live in `CLAUDE.md`. This is the per-ADR status trail; each ADR's
+**Current decision** header remains the authoritative amended state.
+- **0001** — deterministic generation over an editable DSL.
+- **0002** — iterate via lint-critique and domain-repair (repair is a *safety
+  net*, not the primary placement mechanism).
+- **0003** — **Retired**: historical universal-solver exploration. Its live
+  responsibilities are split between 0004 (outer layout) and 0014 (inner placement).
+- **0004** — **compose-then-pack** (Accepted; the **outer** layout): each view is
+  a *block* = `view_rect(scale) + its annotation boxes`; choose `(scale, page)`
+  by a monotone search whose fitness function is composing + packing the blocks
+  **disjoint**; build OCC geometry once at the end. Footprints are page-mm
+  **box layouts**, never bbox-measured geometry (perf). Byte-identity is **not**
+  required — output may change; acceptance = plan-view labels never overlap
+  front-view dimensions (CTC-02) + lint clean. Execution (**#121**) **landed** —
+  all nine implementation steps done (see the ADR's 2026-07-09 status amendment).
+- **0005** — **Accepted (split complete)** (#138): compiler-pipeline module
+  boundaries + single-owner build state. `Drawing` stops being the implicit state
+  bus; annotation identity/pins/build-issues moved to `registry.py`, coverage
+  state to `linting/`, build context (`Analysis`, edge cache) into the pipeline.
+  Stages split into `builder`/`analysis`/`compose` (née `sheet`, #640)/`projection`/`linting/`/`repair`/
+  `export`/`annotations/` (all #160–#166 landed; `make_drawing.py` 3,907 → ~20
+  facade). `layout.py` unchanged. **Roadmap:** `docs/plans/138-module-split-roadmap.md`.
+  Both deferred follow-ups are resolved: the §2 build-context threading closed
+  via **#639** (epic #635 — one typed `BuildState`, empty-allowlist ratchet), and
+  `annotations/envelope.py` was overtaken by the compiler convergence now
+  recorded in ADR 0015 (the envelope pass
+  converged into `annotations/from_model.py` instead). §4's compat-alias exit is
+  tracked by **#720** for 0.4.0.
+- **0006** — **Accepted** (#149): deterministic cross-platform layout via bundled,
+  path-pinned fonts. Layout depends on measured text width; resolving a font *name*
+  (`"Arial"`) substitutes a different font on Linux, drifting the whole sheet ~1 mm.
+  draftwright vendors IBM Plex (OFL) and pins it by `font_path` (Plex Mono for
+  dimensions, Plex Sans Condensed for title blocks); the helper renders via
+  `font_path` (needs `>=0.13.0`). Output changed once for every drawing.
+- **0007** — **Accepted, amended by the deployed extraction**: Draftwright owns linting,
+  recognition lifecycle/cache, IR conversion, and drafting policy; `b123d-recognisers`
+  owns geometry recognition; `build123d-drafting-helpers` is the rendering library.
+  (The 0005 golden harness, `tests/test_golden.py`,
+  was **retired** here — byte-exact digests are friction during deliberate output
+  evolution; regression coverage rests on the geometry-level + `test_e2e_standards`
+  suites. See ADR 0005 §3's retirement note.)
+- **0008** — **Superseded by 0015** (#697): the compiler-convergence why-trail,
+  frozen. Read 0015 for current state.
+- **0009** — **Superseded by 0014** (#697): the collect-then-solve why-trail
+  (9 amendments), frozen. Read 0014 for current state.
+- **0010** — **Accepted; landed**: **annotation provenance seam**.
+  The editable-surface epic needs "which annotations did this feature/intent
+  produce?" (for `drop`/`dimension`/`finalize`/the #400 emitter). Rather than
+  tagging each render pass (the link is lost at the corridor placer, the
+  diameter-spec flattening, and the recognition→IR boundary), record
+  `intent → [names]` **once** at the intent→render seam, with an `origin` back-link
+  on every IR feature was rejected; aspect features retain targeting handles.
+  The render seam is the automatic populator and the contract is audit-tested.
+- **0011** — **Accepted** (core landed; #62/#462/#495 remain):
+  **the IR as a public input** — declare features, don't only detect them.
+  `build_drawing(part, model=…)` accepts a caller-supplied `PartModel`/`Sequence[Feature]`
+  and **skips detection**; object→feature constructors
+  (`model.hole`/`boss`/`step`/`slot`/`pattern`/`envelope`) read a feature's size off the
+  build123d object you built (⌀ from the cylindrical face; axis/location from the bbox),
+  with an explicit-value flavour. The fluent `Sheet` façade (`draftwright.Sheet`) is the
+  "beautiful-Python" surface over the existing renderers. **Aspects geometry can't carry
+  are now built:** tolerance/fit ride `DimParameter` (P2a/P2a.2); **GD&T + surface finish**
+  are standalone IR features (`ControlFrame`/`DatumRef`/`Finish`, `model/ir.py`) placed as
+  first-class ADR 0014 corridor candidates by `render_gdt` (P2b #478), authored via
+  `sheet.datum`/`sheet.control(…).position(…)`/`.finish` whose target view+strip derive
+  from the referenced feature/face (`declare.gdt_target`, P2c #480/#482). Complete AP242
+  geometric tolerances with no modifier, or the export-safe all-around modifier, lower through
+  that same `ControlFrame` path (#1095); unsupported modifiers remain provenance-rich raw
+  fallbacks, and all-over export is tracked by #1097. Datum lowering remains #62; number-free
+  aspects remain #462 and raw-cutter slot reading remains #495. Sidesteps #298 misdetection;
+  complements #400 (read + edit → now also input). Roadmap:
+  `docs/plans/0011-phase2-aspects-roadmap.md`; #446/#445.
+- **0012** — **Accepted; partially landed** (2026-07-08; corrected 2026-07-19):
+  user annotation edits are pinned, priority-ranked corridor candidates. A
+  `dimension(..., pin=, priority=)` edit records a
+  scale-independent *dimension intent* on the model — **pin** = the solver's `anchored`/
+  `_ANCHOR_WEIGHT` (stays put while the rest flow around it), **priority** =
+  `CorridorCandidate.priority` (#357). `Drawing.finalize()` drains only recorded
+  deferred intents through `_PASS_SEQUENCE`; it does not reconstruct auto candidates or
+  perform a global auto-plus-user recompose. `place_dim()` remains the deprecated raw-
+  coordinate escape hatch. Full recomposition/parity remains #426/#661/#707.
+- **0013** — **Accepted** (#568; **Phases 1–2 deployed**): the **uniform recogniser
+  contract** — `recognise_<feature>(part, *, <injected deps>) -> list[<frozen
+  record>]` (plus the part-less *derived* shape, e.g.
+  `recognise_hole_patterns(holes)`), mechanically enforced by
+  `tests/test_recogniser_contract.py`; and the typed record→`Feature` converter
+  registry in `model/detect.py` (roadmap 1c / #752), whose completeness+uniqueness
+  is fail-closed by `tests/test_detect_registry.py`. The shared `b123d-recognisers`
+  `v0.1.0a1` package is now the implementation; Draftwright's duplicate modules are deleted.
+  Roadmap: `docs/plans/0013-shared-recognisers-roadmap.md`.
+- **0014** — **Accepted** (supersedes 0009, #697): **collect-then-solve
+  annotation placement as built** — collect every strip occupant as a
+  candidate; one solve per strip (select → order(=feature order ⇒
+  crossing-free) → space, the PAVA L1 solve); post-#636 the guarantee holds for
+  every auto-pass occupant, with the `carve_free_position` exemptions pinned
+  fail-closed. Includes the strip/zone/corridor glossary and the
+  StripCandidate↔CorridorCandidate layering. Amendment 1 (#740) introduced
+  bounded within-pass machined-leader assignment; Amendment 2 (#1166) collects
+  compatible sparse ordinary side/plan hole and post-drain machined leaders into
+  one canonical late stage (maximum placed, priority, clear-route penalty, then
+  leader length), retaining the old lazy greedy result as the resource-cap floor
+  without relaxing page/view/title hard constraints and preserving the abandoned
+  admitted inventory in state-cap traces. Amendment 3 (#798) prices a shaft
+  cutting back through the part into that same Policy-B penalty, measured on one
+  filled projected-material lowering **shared with the
+  `leader_crosses_silhouette` critique**, so router and lint cannot disagree; it
+  is a cost, never an acceptance test, and the resource-cap floor — which is what
+  actually runs on dense parts — gained a bounded clear-route lookahead. Amendment 4
+  (2026-08-16) records that a work budget must bound **measured** work rather than
+  predict it: three guards were found silently disabling the feature they protect on
+  ordinary input (the joint assignment never running on any dense part; two balloon
+  bounds over by 1.5x and **497x**, the latter refusing a hole table at 0.4% of its
+  real cost). Prefer a live counter; an unavoidable pre-check must be exact rather
+  than conservative; and a budget that fires is a capability loss that should say so.
+- **0015** — **Accepted** (supersedes 0008, #697): **the part-drawing compiler
+  as built** — detectors + declared features → the one PartModel waist (two
+  tiers, ADR 0013) → planner → render-intents → shared infra; with the
+  planner-coverage split (the #698 migrations are complete; correlated
+  furniture/aspects remain model-routed by design, while rotational OD/bore
+  groups are residual debt tracked by #754) and the lint/coverage carve-out
+  stated properly. New kinds must add every applicable IR, planning, rendering,
+  coverage, and test surface while keeping orientation data-driven.
+- **0016** — **Accepted; epic #867 complete** (PR0–PR8, #868–#876): **declared
+  dimensioning intent**. `sheet.dimension(feature, role)` is *referential* — it names
+  a measurement and carries no number; the engine still derives the value from the
+  geometry and owns placement. Three parts landed:
+  - **A build must say where its dimensions come from** (#874, breaking): either
+    `auto_dimensions()` (the planner's set, optionally augmented by `add_dimension`)
+    or an authored set of `dimension(...)` declarations. Mutually exclusive, because
+    "everything the planner chooses, plus these" and "only these" cannot both hold.
+  - **Omission from an authored set means suppression** (#876) — on *every* generated
+    dimensional path, positions included. A dimension the author cannot address is a
+    dimension the author cannot omit, so `location` became addressable per feature
+    (`planner.location_datum` is the single eligibility answer; per-*member* identity
+    remains #883).
+  - **Amendment 1 — the compiled-plan boundary**: renderers may emit dimensional
+    content only from `model/compiled.py`'s `RenderableDimensionPlan`. *Suppression is
+    not a flag renderers check, it is content they never receive* — `ApprovedDimension`
+    has no `suppressed` field. Guarded on both the symptom
+    (`tests/test_compiled_plan_boundary.py`: an empty plan draws nothing) and the cause
+    (`tests/test_label_provenance.py`: a renderer that formats a number got it as a
+    number rather than as the compiler's `value_text`). Hole callouts (`hc_`) are the
+    one renderer still on the legacy surface (#926); the label budget drawdown is #927.
+  **Not** shipped: the emitter dimension-mirror (phase 4). `emit_sheet_script` refuses a
+  model with an authored set rather than silently writing `auto_dimensions()`, because
+  naming a feature in a generated script would have to address it by position — #922.
+- **0017** — **Accepted with narrowed scope; ownership phase landed, correspondence work is
+  evidence-gated by epic #1018**: **the recognition inventory as a first-class result**.
+  Recognition stops being a
+  scatter of ad-hoc calls: one orchestration per build produces a frozen
+  external `RecognitionResult`, held by Draftwright's `RecognitionCache` in `BuildState` and reused by
+  model construction *and* by critique. Automatic-path lint reads its inventories off
+  `Analysis`; declared-path critique obtains the same aggregate lazily through `BuildState`.
+  ADR 0017 §5 explicitly permits both (independence from the *plan* is not independence from
+  the *recognition*).
+  Phase 1 (#1019) landed the **fail-closed manifest** — `MIGRATED` / `DEFERRED` in
+  `b123d_recognisers.result` classify every public `recognise_*` family, and
+  `tests/test_recognition_manifest.py` fails when a new one appears without that decision,
+  so a recogniser cannot be added and then quietly re-scanned from three call sites. A
+  deferral is a `Deferral` reason **code** plus the issue that removes it, not a paragraph:
+  prose in a constant CI reads goes stale silently, and the first cut's did. The why-trail
+  lives in the blocking issue.
+  **#1022** landed the **ADR 0011 declared-path gate**: a declared build now recognises
+  **nothing**. It was not one `if` — sizing sources the turned profile and step ladder from
+  the declaration (`_declared_turned_profile` / `_declared_step_zs` in `analysis.py`), and
+  the lint→repair loop stopped asking for the feature-coverage half it never used
+  (`Drawing.lint(physical=False)`; repair acts on `dim_inside_part` alone, ADR 0002).
+  Critique on that path still needs an inventory, so `BuildState.ensure_recognition()` builds
+  one lazily, once — in the typed build state, not a lint- or `Drawing`-side memo, which
+  would make critique a second recognition owner. Exporting a declared drawing pays for that
+  one aggregate by design: `export` logs the coverage critique, and suppressing it to reach
+  "zero" would trade a user-facing diagnostic for a benchmark number. Two consequences worth
+  knowing: lint takes `step_zs`/`pads`/`pockets` from the **aggregate**, never from
+  `Analysis` on the declared path (ADR 0015 — critique must not inventory from the model);
+  and `recognise_face_levels` migrated into the aggregate as `step_levels`, its
+  `NO_INDEPENDENT_CONSUMER` deferral having stopped being true the moment declared-path
+  critique needed the geometry ladder. The gate also exposed a latent strip-sizing bug on
+  *both* paths: `_est_right_strip_depth` counted ladder steps only, while boss heights share
+  that strip — detected builds hid it in the ladder's slack (`_n_right_strip_boss_heights`,
+  `compose.py`).
+  **Phase 1 is complete.** #1025 split `recognise_step_shoulders` into level-free riser
+  evidence the aggregate owns (`recognise_risers`) plus a pure `project_step_shoulders` each
+  consumer applies with its own level set — which took *lint's* per-pass rescan to zero, epic
+  #1018's third phase-0 guard, and closed a false-negative door on the way (coverage's
+  `step_zs=` argument fully determined the shoulder answer, so `step_zs=[]` silenced
+  `unrecognised_defining_geometry`). #1026 then migrated the three `BUILD_MODEL_ONLY`
+  families once #1022 had removed their cost, and #1028 migrated the last three by moving
+  their classification gate *into* the orchestration — the distinction that made it possible
+  being that **owning a family and always running it are different things**: the aggregate
+  owns `recognise_chamfers` and still does not run it for a turned part.
+  **`DEFERRED` is now empty** — every public `recognise_*` family is owned by the one
+  orchestration. The mechanism stays fail-closed (a new family must still be classified, and
+  every `Deferral` member survives for a future one); what went was each deferral, as its
+  stated constraint stopped being true. Measured per family: a prismatic build runs 17 once
+  each, a turned build 14 (the gated three excluded by design), a declared build/render
+  **zero**. Physical critique or export may then obtain one cached aggregate.
+  The accepted contract stops there. `BuildState` proves result-to-build provenance; it does
+  **not** yet provide recognition-record→IR-feature→requirement correspondence. The original
+  four-type identity taxonomy, shared requirements module, general outcome ledger,
+  reconciliation stage, and diagnostics model are candidate extensions rather than an
+  approved phase sequence. #1018 now requires two end-to-end slices before any of them is
+  generalised: flats first (using #1011's fixtures without label/tip/page inference), then
+  off-centre slots plus N:1 slot patterns. Each new semantic guard needs the mutation that
+  breaks its claimed contract; a green suite alone is not evidence that the guard is
+  load-bearing.
+
+- **0018** — **Accepted** (2026-08-16; #1130): **requirement-driven view planning
+  and editable sheet layout**. One view-planning model between drawing requirements and
+  projection: authored `ViewConstraints` and the automatic planner share one semantic
+  `ViewSpec`/layout vocabulary and produce one immutable `ResolvedViewPlan`. Page,
+  preferred scale, view set and arrangement are chosen **jointly** against complete view
+  blocks measured with fixed paper-space typography; a candidate is feasible only when
+  the real shared annotation solve preserves every supported requirement and all blocks
+  stay in bounds. Supersedes ADR 0004's **fixed four-view topology** (0004's
+  compose-then-pack of each selected block still stands). Users edit whole view blocks,
+  never feature-annotation coordinates (ADR 0012/0014 keep those). Infeasibility is a
+  first-class `plan_infeasible` result, never a silent relaxation of an authored
+  constraint.
+  **Nothing is implemented yet** — there is no `ViewSpec`/`ResolvedViewPlan` in the code
+  and the engine still builds fixed front/plan/side/iso. The ADR's "Required evidence
+  before acceptance" list is the per-slice delivery gate, not waived by acceptance.
+  Accepted on converging evidence from #1187 (leaders that cut the part have no clear
+  route because the SHEET is full — every remedy is compositional) and #1190 (the
+  section is placed into leftover space, so its presence tracks room rather than need).
+

--- a/docs/guard-audit.md
+++ b/docs/guard-audit.md
@@ -1,0 +1,46 @@
+# Meta-guard audit (#1222)
+
+The verdict table required by #1222: every structural guard either names the failure
+it demonstrably prevents, or it goes. A guard is **load-bearing** when its failure
+mode has actually occurred in this repository's history (the issue is cited), or when
+it carries its own anti-tautology self-test proving the detector detects. "Keep"
+verdicts are not permanent: a guard whose allowlist stops shrinking or whose failure
+mode becomes unreachable should be re-audited, and the moratorium from #1221 applies
+to all growth — no new ratchet/allowlist/meta-test lands without the mutation that
+breaks its claimed contract (#1018 rule).
+
+## A. Structural meta-tests — audited 2026-08-18
+
+| Guard | Verdict | Why |
+|---|---|---|
+| `test_import_boundaries.py` | **keep** | `_LAYERS` is the authoritative DAG map (CLAUDE.md defers to it); upward imports were the pre-#640 norm, not a hypothetical. |
+| `test_drawing_encapsulation.py` | **keep** | Single-owner build state (ADR 0005). The stay-deleted halves guard against reintroduction of removed surfaces — a failure mode LLM sessions are *specifically* prone to (regenerating deleted code from stale context). |
+| `test_compiled_plan_boundary.py` | **keep** | ADR 0016 Amdt 1: suppression-by-omission is unenforceable without it. |
+| `test_label_provenance.py` | **keep** | Active drawdown ratchet (#927, 26 sites). Re-audit when the budget reaches zero — at zero it becomes a simple boundary test. |
+| `test_recognition_manifest.py` | **keep** | Fail-closed classification is the ADR 0017 contract itself. |
+| `test_recogniser_contract.py` | **keep** | Cross-repository capability join; fail-closed by design. |
+| `test_detect_registry.py` | **keep** | Record→Feature completeness; a silently unadapted record family is invisible in output. |
+| `test_carve_free_position_callers.py` | **keep** | Two features (#555, #559) regressed onto the solver-invisible path before #636 — the failure mode recurred twice. Carries anti-tautology self-tests. |
+| `test_declared_recognition_gate.py` | **keep** | ADR 0017: declared builds must not pay recognition cost; regression is silent (slow, not wrong). |
+| `test_external_recognition_boundary.py` | **keep** | Pins the published recogniser release by hash; the fail-closed join depends on it. |
+| `test_private_test_imports.py` | **keep** | Shrink-only ratchet with per-entry rationale (#641). The stale-entry assertion is the shrink mechanism, not churn. |
+| `test_private_test_attr_reads.py` | **keep** | Cardinality ratchet closing the last reach-through quadrant (#741); deliberately line-number-churn-free. |
+| `test_architecture_docs.py` | **trimmed** | Three of four assertions policed phrase absences from battles won weeks ago (stale ADR 0008/0009 references); only the live no-line-anchors rule survives. |
+
+Audit finding: the structural guards individually earn their keep — most cite the
+concrete regression they exist to prevent, and the two AST detectors prove their own
+detection. The guard *tax* identified by #1221 is the aggregate context cost, which
+is addressed by CLAUDE.md pointing here instead of restating each guard, not by
+deleting guards.
+
+## B. Runtime budgets/caps — pending
+
+Still open under #1222: each budget below must bound *measured* work via a live
+counter, emit a named diagnostic when it fires (per ADR 0014 Amdt 4), and have a
+fixture demonstrating the fire path.
+
+`_FEATURE_LEADER_MAX_{CANDIDATES,FIXED_PROBES,PAIR_PROBES}`,
+`_LEADER_ASSIGN_MAX_{JOBS,CANDIDATES,PAIR_PROBES,STATES}`,
+`_GUARDED_TOP_LANE_MAX_OBSTACLE_PROBES`, `_GUARDED_CARVE_MAX_LABEL_PROBES`,
+`_GUARDED_STRIP_MAX_STATES`, `_GUARDED_STRIP_MAX_INTERVAL_PROBES`,
+`_REPACK_MAX_ITER`, `_ISO_WIDTH_BUDGET`, `_MATERIAL_MAX_GRID`.

--- a/tests/test_architecture_docs.py
+++ b/tests/test_architecture_docs.py
@@ -1,30 +1,18 @@
-"""Small drift guards for documents that present current architecture.
+"""Drift guard for documents that present current architecture.
 
 Frozen ADRs and historical roadmaps are deliberately outside this scope.
+
+One live editorial rule survives the #1222 guard audit: current-architecture
+documents must not cite source line numbers, which rot on every edit. The
+former phrase-absence assertions (stale ADR 0008/0009 references) guarded
+already-won battles — the phrasing they policed has been gone for weeks and
+could only return through a deliberate edit that review would see — and were
+retired by the audit.
 """
 
 from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parent.parent
-
-
-def _read(relative: str) -> str:
-    return (_ROOT / relative).read_text(encoding="utf-8")
-
-
-def test_live_architecture_docs_name_current_compiler_authority():
-    target = _read("docs/target-architecture.md")
-    readme = _read("README.md")
-    assert "target state defined by [ADR 0008]" not in target
-    assert "part-drawing compiler** (ADR 0008)" not in readme
-
-
-def test_live_architecture_docs_record_planner_convergence_complete():
-    adr = _read("docs/adr/0015-part-drawing-compiler-as-built.md")
-    claude = _read("CLAUDE.md")
-    assert "while #698 proceeds" not in adr
-    assert "convergence tracked by #698" not in claude
-    assert "deliberately does **not** claim that work done" not in adr
 
 
 def test_current_architecture_docs_have_no_source_line_anchors():
@@ -33,11 +21,5 @@ def test_current_architecture_docs_have_no_source_line_anchors():
         "docs/adr/0011-ir-as-public-input.md",
         "docs/adr/0015-part-drawing-compiler-as-built.md",
     ):
-        text = _read(relative)
+        text = (_ROOT / relative).read_text(encoding="utf-8")
         assert "orchestrator.py:" not in text, relative
-
-
-def test_carve_guard_points_to_current_placement_adr():
-    guard = _read("tests/test_carve_free_position_callers.py")
-    assert "ADR 0009's remaining-migration note" not in guard
-    assert "Pending migration (#636)" not in guard


### PR DESCRIPTION
## Symptom and evidence

- User-visible problem: #1221 — every session pays a growing context tax before any change is safe: CLAUDE.md had become a ~6,000-word restatement of invariants that are already machine-enforced, and the meta-guard web had never been audited as a whole (#1222). ADR 0014 Amdt 4 showed unaudited guards are themselves a defect surface.
- Fixture/reproducer: N/A (docs + guard-test trim; no engine behaviour changes).
- Before/after result: CLAUDE.md 578 → 145 lines (compact map + pointers; detailed module map moved **verbatim** to `docs/architecture.md`). `tests/test_architecture_docs.py` 43 → 25 lines. All 13 structural meta-guards read end-to-end with per-guard verdicts recorded in `docs/guard-audit.md`.
- Mutation that makes the guard fail: N/A — this PR removes three guard assertions rather than adding any. The removed assertions policed phrase absences from already-won battles (stale ADR 0008/0009 references); the surviving no-line-anchors rule still fails on a `orchestrator.py:` anchor in a current-architecture doc.

## Contract and scope

- Smallest contract this change tests: the drift-guard file keeps exactly one live editorial rule; everything else in the PR is documentation.
- Relevant ADRs: 0005 (the compact map defers to `_LAYERS` + guard tests as authority), 0014 Amdt 4 and 0017/#1018 (the audit criteria in `docs/guard-audit.md`), 0016 Amdt 1 (invariant summarised, not restated).
- Explicitly deferred: part B of #1222 (live counters + named fire diagnostics + fire-path fixtures for the 13 runtime budget constants); the #1221 follow-up-filing-bar change.

## Validation

- [x] `scripts/pr-check --quick` (91 passed)
- [ ] `scripts/pr-check` before final review
- [x] Cross-repository recogniser changes follow the tests-first delivery protocol — N/A, no recogniser changes
- [x] The named mutation was observed failing before the implementation passed it — N/A, guards removed not added (see above)
- [x] Automatic, declared, and generated-script paths were checked where affected — N/A, no engine changes
- [x] Recognition and repeated-lint call counts were checked where affected — N/A, no engine changes

## Stop check

- [x] No two consecutive review rounds invalidated the same core association strategy
- [x] New prerequisites were split or the work was explicitly reclassified as discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018CAPuTRFuGdGvU7MWdcMku

---
_Generated by [Claude Code](https://claude.ai/code/session_018CAPuTRFuGdGvU7MWdcMku)_