### PR TITLE
The second family costs nothing, so the slice is the ratchet (#1217)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -988,7 +988,7 @@ def _place_what_fits(specs, axis: int, min_gap: float, lo: float, hi: float):
     """Fit as many ø specs as the strip ``[lo, hi]`` holds at ``min_gap`` spacing,
     dropping the SMALLEST-diameter spec first when the full set overflows — so the
     significant ODs survive and only the finest bands fall to ``feature_not_dimensioned``,
-    never the whole row/column (#298). ``specs`` = ``[(tip, dia, label, feat), ...]``;
+    never the whole row/column (#298). ``specs`` = ``[(tip, dia, label, feat, mids), ...]``;
     ``axis`` selects the strip coordinate of ``tip`` (0 = page-x for the row-below, 1 =
     page-y for the column-left). Returns ``(survivors_in_strip_order, positions)`` —
     ``([], [])`` if not even one fits. A part whose full row already fits keeps every
@@ -1031,15 +1031,15 @@ def _diameter_row_below(dwg, items, start: int = 0, trace=None, *, ctx) -> int:
         if ev is not None:
             ev["items"].extend(
                 {"label": f"ø{_fmt(d)}", "outcome": "dropped", "reason": "no_room_below"}
-                for _, d, _, _, _ in items
+                for _, d, _, _, _, _ in items
             )
         return 0
     specs = []  # (tip_page, dia, label, feature), tip on the step's bottom silhouette,
-    for anchor, dia, feat, dtol, thr in items:  # centred along the feature's length (not a corner)
+    for anchor, dia, feat, dtol, thr, mids in items:  # centred along the feature's length
         ax, ay, az = anchor
         tip = dwg.at("front", ax, ay, az - dia / 2)
         label = f"ø{_fmt(dia)}{_tol_suffix(dtol, draft)}" + (f" {thr}" if thr else "")  # #859
-        specs.append((tip, dia, label, feat))
+        specs.append((tip, dia, label, feat, mids))
     # Real measured width, not the per-char estimate: helpers >=0.14 label boxes are
     # honest about the rendered string, so an underestimated min_gap here surfaces as a
     # visible annotation_overlap between adjacent labels (hypothesis tier).
@@ -1051,7 +1051,7 @@ def _diameter_row_below(dwg, items, start: int = 0, trace=None, *, ctx) -> int:
                 getattr(draft, "font_path", DEFAULT_FONT_PATH),
                 getattr(draft, "font", "Arial"),
             )[0]
-            for _, _, label, _ in specs
+            for _, _, label, _, _ in specs
         )
         / 2
     )
@@ -1106,12 +1106,13 @@ def _diameter_row_below(dwg, items, start: int = 0, trace=None, *, ctx) -> int:
             for s in specs
             if id(s) not in kept
         )
-    for i, ((tip, dia, label, feat), lx) in enumerate(zip(survivors, xs, strict=True)):
+    for i, ((tip, dia, label, feat, mids), lx) in enumerate(zip(survivors, xs, strict=True)):
         ctx.place(
             Leader(tip=(tip[0], tip[1], 0), elbow=(lx, label_y, 0), label=label, draft=draft),
             f"m_dia_x{start + i}",
             view="front",
             feature=feat,
+            measurement=mids,
         )
         if ev is not None:
             ev["items"].append(
@@ -1146,7 +1147,7 @@ def _diameter_column_left(dwg, items, start: int = 0, trace=None, *, ctx) -> int
             getattr(draft, "font_path", DEFAULT_FONT_PATH),
             getattr(draft, "font", "Arial"),
         )[0]
-        for _, dia, _, dtol, thr in items
+        for _, dia, _, dtol, thr, _ in items
     )
     elbow_x = fx0 - (draft.font_size + 2 * draft.pad_around_text)
     # A left-directed leader hangs its label a shelf-length PAST the elbow, so the label's left
@@ -1157,15 +1158,15 @@ def _diameter_column_left(dwg, items, start: int = 0, trace=None, *, ctx) -> int
         if ev is not None:
             ev["items"].extend(
                 {"label": f"ø{_fmt(d)}", "outcome": "dropped", "reason": "no_room_left"}
-                for _, d, _, _, _ in items
+                for _, d, _, _, _, _ in items
             )
         return 0
     specs = []  # (tip_page, dia, label, feature), tip on the step's left silhouette,
-    for anchor, dia, feat, dtol, thr in items:  # centred along the feature's length (not a corner)
+    for anchor, dia, feat, dtol, thr, mids in items:  # centred along the feature's length
         ax, ay, az = anchor
         tip = dwg.at("front", ax - dia / 2, ay, az)
         label = f"ø{_fmt(dia)}{_tol_suffix(dtol, draft)}" + (f" {thr}" if thr else "")  # #859
-        specs.append((tip, dia, label, feat))
+        specs.append((tip, dia, label, feat, mids))
     half_h = draft.font_size / 2 + draft.pad_around_text
     min_gap = 2 * half_h
     # Place what fits; drop the smallest ø first, never the whole column (#298).
@@ -1183,7 +1184,7 @@ def _diameter_column_left(dwg, items, start: int = 0, trace=None, *, ctx) -> int
         )
     occupied = strip_obstacles(dwg, view="front", crossable=CROSSABLE_TYPES)
     placed = 0
-    for i, ((tip, dia, label, feat), ly) in enumerate(zip(survivors, ys, strict=True)):
+    for i, ((tip, dia, label, feat, mids), ly) in enumerate(zip(survivors, ys, strict=True)):
         ldr = Leader(tip=(tip[0], tip[1], 0), elbow=(elbow_x, ly, 0), label=label, draft=draft)
         if _box_hits(_anno_box(ldr), occupied):
             if ev is not None:
@@ -1191,7 +1192,7 @@ def _diameter_column_left(dwg, items, start: int = 0, trace=None, *, ctx) -> int
                     {"label": label, "outcome": "dropped", "reason": "label_occupied"}
                 )
             continue  # would overprint a bore leader / existing callout — drop just this one
-        ctx.place(ldr, f"m_dia_z{start + i}", view="front", feature=feat)
+        ctx.place(ldr, f"m_dia_z{start + i}", view="front", feature=feat, measurement=mids)
         if ev is not None:
             ev["items"].append(
                 {
@@ -1299,6 +1300,11 @@ def render_diameters(dwg, plan, a, tol: float = 0.15, *, ctx, only=None) -> int:
             entry[3] = dtol
 
     def _items(buckets):
+        # The trailing element is the ADR 0010 claim: one ø callout stands for every step
+        # sharing this diameter, so it draws each of their diameter dims (#1002). It is the
+        # same derivation the m_dia_y branch below already made; the row/column placers
+        # threaded nothing, so every X- and Z-turned ø callout reached the sheet unclaimed
+        # and no verifier could see it (#1227).
         return [
             (
                 _diameter_step_anchor(a, gs),
@@ -1306,6 +1312,7 @@ def render_diameters(dwg, plan, a, tol: float = 0.15, *, ctx, only=None) -> int:
                 next(iter(refs)) if len(refs) == 1 else None,
                 t,
                 thr,
+                tuple(pd.id for gp in gs for pd in gp.dims if pd.kind == "diameter"),
             )
             for a, d, refs, t, thr, gs in buckets.values()
         ]
@@ -4293,6 +4300,7 @@ def render_rotational(dwg, plan, a, *, ctx) -> int:
                 ),
                 "dim_od",
                 view="front",
+                measurement=od_dim.id,
             )
             n += 1
         ctx.place(
@@ -4351,6 +4359,7 @@ def render_rotational(dwg, plan, a, *, ctx) -> int:
                         ),
                         f"ldr_z{i}",
                         view="front",
+                        measurement=dim.id,
                     )
                     n += 1
                 dropped = [
@@ -4389,6 +4398,7 @@ def render_rotational(dwg, plan, a, *, ctx) -> int:
                 ),
                 "dim_od",
                 view="front",
+                measurement=od_dim.id,
             )
             n += 1
         ctx.place(
@@ -4424,6 +4434,7 @@ def render_rotational(dwg, plan, a, *, ctx) -> int:
                 ),
                 "dim_od",
                 view="side",
+                measurement=od_dim.id,
             )
             n += 1
         ctx.place(

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1034,7 +1034,7 @@ def _diameter_row_below(dwg, items, start: int = 0, trace=None, *, ctx) -> int:
                 for _, d, _, _, _, _ in items
             )
         return 0
-    specs = []  # (tip_page, dia, label, feature), tip on the step's bottom silhouette,
+    specs = []  # (tip_page, dia, label, feature, mids), tip on the step's bottom silhouette,
     for anchor, dia, feat, dtol, thr, mids in items:  # centred along the feature's length
         ax, ay, az = anchor
         tip = dwg.at("front", ax, ay, az - dia / 2)
@@ -1161,7 +1161,7 @@ def _diameter_column_left(dwg, items, start: int = 0, trace=None, *, ctx) -> int
                 for _, d, _, _, _, _ in items
             )
         return 0
-    specs = []  # (tip_page, dia, label, feature), tip on the step's left silhouette,
+    specs = []  # (tip_page, dia, label, feature, mids), tip on the step's left silhouette,
     for anchor, dia, feat, dtol, thr, mids in items:  # centred along the feature's length
         ax, ay, az = anchor
         tip = dwg.at("front", ax - dia / 2, ay, az)

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1008,7 +1008,7 @@ def _place_what_fits(specs, axis: int, min_gap: float, lo: float, hi: float):
 
 def _diameter_row_below(dwg, items, start: int = 0, trace=None, *, ctx) -> int:
     """ø-callout row BELOW the front view for X-turned step/boss diameters (#77).
-    *items* is ``[(anchor, diameter), ...]``. The row is dropped clear of anything
+    *items* is ``[(anchor, dia, feature, tolerance, thread, mids), ...]``. The row is dropped clear of anything
     already below the profile; labels spread along page-x by the ADR-0003 strip
     solve. Skips (returns 0) if there is no room — the diameters then surface as
     ``feature_not_dimensioned``. *trace* (#736): one ``pass_events`` record with a

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -532,9 +532,13 @@ def add_feature_diameter(dwg, feature, model, *, ctx) -> str:
             f"callout(): a {axis!r}-turned step/boss diameter is not placeable "
             "(only X- and Z-turned parts)"
         )
-    # 5-tuple (anchor, dia, feature, tolerance, thread): a manual callout honours a declared ±
-    # tolerance (P2a, #28) and an external thread aspect (#859) too, like the auto-pass.
-    items = [(group.anchor, dia, feature, dpd.tolerance, getattr(feature, "thread", None))]
+    # 6-tuple (anchor, dia, feature, tolerance, thread, mids): a manual callout honours a
+    # declared ± tolerance (P2a, #28) and an external thread aspect (#859) too, like the
+    # auto-pass — and carries the same ADR 0010 claim, so a hand-placed ø callout is verifiable
+    # on exactly the terms an auto-placed one is (#1227).
+    items = [
+        (group.anchor, dia, feature, dpd.tolerance, getattr(feature, "thread", None), (dpd.id,))
+    ]
     # The row/column placers name leaders m_dia_{x,z}{start+i} — pass the first FREE
     # index so a second callout() (or a call on an already-annotated turned part) never
     # collides on m_dia_x0/z0 and clobbers an existing leader (#419 review F1).

--- a/src/draftwright/evaluation/step_analysis.py
+++ b/src/draftwright/evaluation/step_analysis.py
@@ -683,16 +683,23 @@ def _drawing_consumer_outcomes(holes, drawing) -> list[Outcome]:
 
     That does **not** close the turned-part gap, and an earlier draft of this paragraph said
     it did. Measured on ``Cylinder(20,60) - Cylinder(6,70)``, the outcome is ``unsupported``
-    before and after, with a byte-identical annotation set. The cause was never the name:
-    **no annotation on that sheet carries a measurement claim at all** — not ``ldr_z0``
-    (``ø12``), not ``dim_od`` (``ø40``), not ``dim_height`` — while the compiled plan does
-    hold ``hole.bore.diameter`` and ``rotational.od.diameter``. So the rotational render path
-    threads no ADR 0010 provenance, and the ledger reports ``bore.diameter`` as ``missing``.
+    before and after, with a byte-identical annotation set.
 
-    That is an annotation-tagging gap, tracked by #1227. It is NOT #754, which closed on
-    2026-07-22 — an earlier draft of this paragraph cited it, which is the fourth instance of
-    the stale citation #951 exists to remove, written inside a sentence correcting a
-    different false claim.
+    The cause was never the name. When this was written no annotation on that sheet carried a
+    measurement claim at all — not ``ldr_z0`` (``ø12``), not ``dim_od`` (``ø40``), not
+    ``dim_height`` — while the compiled plan did hold ``hole.bore.diameter`` and
+    ``rotational.od.diameter``: the rotational render path threaded no ADR 0010 provenance.
+    #1225 fixed the threading, so ``ldr_z0`` and ``dim_od`` now claim and both confirm; only
+    ``dim_height`` still carries none, and that one is #1230 rather than a tagging gap.
+
+    **The ledger symptom is unchanged by that fix** — measured head against ``main``,
+    ``bore.diameter`` is still ``missing`` and this function still yields no outcome for the
+    part. Tagging the annotation was necessary and is not sufficient, which is worth stating
+    plainly here rather than letting "#1227 is fixed" read as "the turned part is covered".
+
+    It is NOT #754, which closed on 2026-07-22 — an earlier draft of this paragraph cited it,
+    which is the fourth instance of the stale citation #951 exists to remove, written inside a
+    sentence correcting a different false claim.
     """
     from draftwright.linting.evidence import verify_measurement_claims
     from draftwright.linting.hole_coverage import canonical_hole_sites, hole_requirement_outcomes

--- a/src/draftwright/evaluation/step_analysis.py
+++ b/src/draftwright/evaluation/step_analysis.py
@@ -693,9 +693,12 @@ def _drawing_consumer_outcomes(holes, drawing) -> list[Outcome]:
     ``dim_height`` still carries none, and that one is #1230 rather than a tagging gap.
 
     **The ledger symptom is unchanged by that fix** — measured head against ``main``,
-    ``bore.diameter`` is still ``missing`` and this function still yields no outcome for the
-    part. Tagging the annotation was necessary and is not sufficient, which is worth stating
-    plainly here rather than letting "#1227 is fixed" read as "the turned part is covered".
+    ``bore.diameter`` is still ``missing`` and this function still returns ``unsupported`` for
+    that hole, exactly as the paragraph above says. (A draft of this sentence said "yields no
+    outcome", which is false: there is one outcome and it is ``unsupported``. Contradicting a
+    correct sentence four lines up, inside the fix for a docstring falsified by its own diff.)
+    Tagging the annotation was necessary and is not sufficient, which is worth stating plainly
+    here rather than letting "#1227 is fixed" read as "the turned part is covered".
 
     It is NOT #754, which closed on 2026-07-22 — an earlier draft of this paragraph cited it,
     which is the fourth instance of the stale citation #951 exists to remove, written inside a

--- a/src/draftwright/linting/evidence.py
+++ b/src/draftwright/linting/evidence.py
@@ -255,10 +255,12 @@ def verify_measurement_claims(registry, plan) -> list[ClaimOutcome]:
     3. **Reach is bounded by ADR 0010 identity**, and that bound is narrower than it looks.
        An annotation carrying no measurement claim is skipped, and about half do — 81 of 170
        on ``nist_ctc_02``. But measured across the corpus in
-       ``tests/test_issue_1217_the_facility_is_shared.py``, exactly ONE skipped annotation
-       renders a number **this function can read**, and it is a detail caption whose digits
-       are a scale ratio; the rest are centre marks, bolt circles, notes and title blocks,
-       which assert no measurement to check.
+       ``tests/test_issue_1217_the_facility_is_shared.py``, only FIVE skipped annotations
+       render a number **this function can read**, and every one is accounted for by name
+       there: two detail captions whose digits are a scale ratio, and three in that file's
+       ``_UNPLANNED_VALUES`` — annotations drawing a value the compiled plan holds no identity
+       for, which is #1230 and not a reach limit of this function. The rest are centre marks,
+       bolt circles, notes and title blocks, which assert no measurement to check.
 
        State that predicate precisely, because it is not "renders a number": :func:`rendered_numbers`
        reads ``label``, ``_annotate_label`` and ``table_rows`` and nothing else. The **title

--- a/src/draftwright/linting/evidence.py
+++ b/src/draftwright/linting/evidence.py
@@ -254,18 +254,34 @@ def verify_measurement_claims(registry, plan) -> list[ClaimOutcome]:
        per-member identity, which #883 deliberately leaves open.
     3. **Reach is bounded by ADR 0010 identity**, and that bound is narrower than it looks.
        An annotation carrying no measurement claim is skipped, and about half do — 81 of 170
-       on ``nist_ctc_02``. But measured across four rich fixtures, exactly ONE skipped
-       annotation renders a number at all, and it is a detail caption whose digits are a
-       scale ratio; the other 174 are centre marks, bolt circles, notes, title blocks and
-       section furniture, which assert no measurement to check. So "N claims, N confirmed"
-       is a statement about every annotation that says a number, not merely about the
-       claimed half.
+       on ``nist_ctc_02``. But measured across the corpus in
+       ``tests/test_issue_1217_the_facility_is_shared.py``, exactly ONE skipped annotation
+       renders a number **this function can read**, and it is a detail caption whose digits
+       are a scale ratio; the rest are centre marks, bolt circles, notes and title blocks,
+       which assert no measurement to check.
 
-       An earlier draft of this limit said the unexamined half was a coverage gap. It is
-       not, and overstating a weakness is as much a false claim as overstating a strength —
-       it invites work that is not needed and hides the bound that is real: a NEW family
-       whose annotations state values without threading provenance would be invisible, which
-       is what `TestNoMeasuredAnnotationEscapesUnclaimed` exists to prevent.
+       State that predicate precisely, because it is not "renders a number": :func:`rendered_numbers`
+       reads ``label``, ``_annotate_label`` and ``table_rows`` and nothing else. The **title
+       block** is the live counterexample — it draws a scale ratio, a drawing number, a general
+       tolerance and a date, none of which reach any of those three attributes, so it is silent
+       here while printing digits on the sheet. Annotations whose text lives outside those
+       attributes are outside both this function and the ratchet that guards it. That residue
+       is small and real; it is not covered.
+
+       An earlier draft of this limit said the unexamined half was a coverage gap; a second
+       said only one skipped annotation rendered a number *at all*. The first overstated the
+       weakness, the second overstated the strength, and both are false claims — a weakness
+       overstated invites work that is not needed, a strength overstated hides the bound that
+       is real: a NEW family whose annotations state values without threading provenance would
+       be invisible, which is what
+       ``tests/test_issue_1217_the_facility_is_shared.py::TestNoMeasuredAnnotationEscapesUnclaimed``
+       exists to prevent.
+
+       That ratchet guards annotations one at a time, so it too has an edge: it asks whether an
+       annotation carries *a* claim, not whether every number it renders is claimed. An
+       annotation that adds an unclaimed value ALONGSIDE a claimed one — the realistic shape of
+       a new family extending an existing callout — passes it. That compounds limit 1 rather
+       than narrowing it.
     4. **Existence is assumed, not checked.** Claims are read by walking the registry, so an
        approved measurement that NO annotation claims is invisible here. That direction is
        coverage's job, and #1217's ``annotation_missing`` state is deliberately not

--- a/src/draftwright/linting/evidence.py
+++ b/src/draftwright/linting/evidence.py
@@ -252,10 +252,20 @@ def verify_measurement_claims(registry, plan) -> list[ClaimOutcome]:
        dimensions — confirms both. On a four-hole pattern all eight offsets share the id. The
        multimap is what stops false *mismatches*; this is its cost, and narrowing it needs
        per-member identity, which #883 deliberately leaves open.
-    3. **Reach is bounded by ADR 0010 identity.** An annotation carrying no measurement claim
-       is skipped entirely, and roughly half do — measured, 81 of 170 annotations on
-       ``nist_ctc_02`` carry claims. "N claims, N confirmed" is a statement about the claimed
-       part of the sheet, never the whole sheet.
+    3. **Reach is bounded by ADR 0010 identity**, and that bound is narrower than it looks.
+       An annotation carrying no measurement claim is skipped, and about half do — 81 of 170
+       on ``nist_ctc_02``. But measured across four rich fixtures, exactly ONE skipped
+       annotation renders a number at all, and it is a detail caption whose digits are a
+       scale ratio; the other 174 are centre marks, bolt circles, notes, title blocks and
+       section furniture, which assert no measurement to check. So "N claims, N confirmed"
+       is a statement about every annotation that says a number, not merely about the
+       claimed half.
+
+       An earlier draft of this limit said the unexamined half was a coverage gap. It is
+       not, and overstating a weakness is as much a false claim as overstating a strength —
+       it invites work that is not needed and hides the bound that is real: a NEW family
+       whose annotations state values without threading provenance would be invisible, which
+       is what `TestNoMeasuredAnnotationEscapesUnclaimed` exists to prevent.
     4. **Existence is assumed, not checked.** Claims are read by walking the registry, so an
        approved measurement that NO annotation claims is invisible here. That direction is
        coverage's job, and #1217's ``annotation_missing`` state is deliberately not

--- a/tests/test_audit_differential.py
+++ b/tests/test_audit_differential.py
@@ -725,9 +725,12 @@ def test_every_direct_placement_records_identity_or_says_why_not():
         ("sections.py", "_place_cutting_plane"): "final cutting-plane layout furniture",
         ("sections.py", "_render_detail"): "detail-view geometry, caption and circle",
         # -- the direct-placing rotational group (#754) -----------------------------
-        ("from_model.py", "render_rotational"): "direct-placing rotational group (#754)",
-        ("from_model.py", "_diameter_row_below"): "direct-placing rotational group (#754)",
-        ("from_model.py", "_diameter_column_left"): "direct-placing rotational group (#754)",
+        # `_diameter_row_below`, `_diameter_column_left` and the `dim_od` placements in
+        # `render_rotational` USED to sit here. They now thread the compiled claim, so the
+        # exemption is stale and deleted rather than left to cover a case it no longer
+        # describes (#1227). `render_rotational` still places centre lines, which are not
+        # measurements — that is the only reason it remains.
+        ("from_model.py", "render_rotational"): "centre lines are not measurements",
         # -- identity arrives by another route --------------------------------------
         ("from_model.py", "_reroute_crossing_diameters"): "reapplies the saved identity",
         ("sections.py", "_resolve_details"): "reapplies the saved identity",

--- a/tests/test_issue_1217_the_facility_is_shared.py
+++ b/tests/test_issue_1217_the_facility_is_shared.py
@@ -1,0 +1,174 @@
+"""#1217 PR 3 — the verification facility is family-agnostic, and stays that way.
+
+"Shared" is a claim, and the only thing that proves it is a second consumer. A facility
+exercised by holes alone is a hole verifier with general-sounding names.
+
+Measured: it costs **nothing**. Slots, pockets, bosses, chamfers and turned steps all produce
+verifiable claims through `registry.measurement_of` — the one ADR 0010 seam — with zero changes
+to `linting/evidence.py`. The epic's PR-3 gate was "it costs a producer and zero changes to the
+facility"; the producers already existed, because provenance is threaded once and not per family.
+
+So the useful content of this slice is not the second family. It is the RATCHET: a new family
+whose annotations state a measured value without threading provenance would be invisible to the
+verifier, and nothing would say so. `TestNoMeasuredAnnotationEscapesUnclaimed` is what says so.
+"""
+
+from __future__ import annotations
+
+from build123d import Align, Box, Cylinder, Pos
+
+from draftwright.builder import build_drawing
+from draftwright.linting.evidence import rendered_numbers, verify_measurement_claims
+from draftwright.model.compiled import compile_dimensions
+
+_C = (Align.CENTER, Align.CENTER, Align.CENTER)
+
+#: Annotations that legitimately render digits while carrying no measurement claim. One entry,
+#: measured across four rich fixtures: the detail-view caption, whose numbers are a SCALE RATIO
+#: ("DETAIL A — SCALE 2.5:1") and not a fact about the part. Registered by annotation-name stem
+#: so a second such case has to be argued rather than absorbed.
+_NON_MEASURING_ANNOTATIONS = ("detail_caption",)
+
+
+def _claims(drawing):
+    return verify_measurement_claims(drawing.registry, compile_dimensions(drawing.model()))
+
+
+def _families(drawing) -> set[str]:
+    return {claim.parameter_id.split(".")[0] for claim in _claims(drawing)}
+
+
+class TestASecondFamilyCostsNothing:
+    """Each of these was verified with zero edits to the facility. If one ever needs an edit,
+    the facility was not shared and this is the class that says so."""
+
+    def test_slots_are_verified(self):
+        part = (
+            Box(90, 50, 12, align=_C)
+            - Pos(-20, 0, 0) * Box(24, 8, 30, align=_C)
+            - Pos(20, 0, 0) * Box(24, 8, 30, align=_C)
+        )
+        drawing = build_drawing(part, title="T", number="N-1")
+        claims = [c for c in _claims(drawing) if "slot" in c.parameter_id]
+        assert {c.parameter_id for c in claims} >= {
+            "slot_length.length",
+            "slot_width.length",
+        }, {c.parameter_id for c in claims}
+        assert {c.state for c in claims} == {"confirmed"}, [
+            (c.annotation, c.parameter_id, c.state) for c in claims if c.state != "confirmed"
+        ]
+
+    def test_pockets_are_verified(self):
+        part = Box(90, 60, 20, align=_C) - Pos(10, 5, 6) * Box(40, 25, 10, align=_C)
+        drawing = build_drawing(part, title="T", number="N-1")
+        assert {"pocket_depth", "pocket_length", "pocket_width"} <= _families(drawing)
+        assert {c.state for c in _claims(drawing)} == {"confirmed"}
+
+    def test_bosses_and_bores_are_verified(self):
+        part = (
+            Box(60, 60, 10, align=_C)
+            + Pos(0, 0, 7) * Cylinder(8, 4, align=_C)
+            - Cylinder(3, 40, align=_C)
+        )
+        drawing = build_drawing(part, title="T", number="N-1")
+        assert {"bore", "boss", "boss_height"} <= _families(drawing)
+        assert {c.state for c in _claims(drawing)} == {"confirmed"}
+
+    def test_a_turned_profile_is_verified(self):
+        part = Cylinder(10, 30, align=_C) + Pos(0, 0, 20) * Cylinder(6, 10, align=_C)
+        drawing = build_drawing(part, title="T", number="N-1")
+        assert "step" in _families(drawing)
+        assert {c.state for c in _claims(drawing)} == {"confirmed"}
+
+    def test_the_families_are_genuinely_different_parameters(self):
+        # Guards the tests above from passing on a shared parameter. If every family resolved
+        # to the same handful of ids, "five families" would be one family five times.
+        parts = {
+            "slot": Box(90, 50, 12, align=_C) - Pos(0, 0, 0) * Box(24, 8, 30, align=_C),
+            "pocket": Box(90, 60, 20, align=_C) - Pos(10, 5, 6) * Box(40, 25, 10, align=_C),
+            "boss": Box(60, 60, 10, align=_C) + Pos(0, 0, 7) * Cylinder(8, 4, align=_C),
+        }
+        seen = {
+            name: _families(build_drawing(p, title="T", number="N-1")) for name, p in parts.items()
+        }
+        for name, families in seen.items():
+            others = set().union(*(f for other, f in seen.items() if other != name))
+            assert families - others, f"{name} contributed no parameter the others do not"
+
+
+class TestNoMeasuredAnnotationEscapesUnclaimed:
+    """The ratchet, and the real content of this slice.
+
+    The facility can only check an annotation that claims a measurement. A new family whose
+    annotations state a value without threading ADR 0010 provenance is not *wrongly* verified —
+    it is not verified at all, and silently. This asserts the property that makes the reach
+    limit honest: every annotation that renders a number claims something.
+    """
+
+    FIXTURES = (
+        "tests/fixtures/nist_ctc_02_asme1_ap203.stp",
+        "tests/fixtures/nist_ctc_04_asme1_ap203.stp",
+        "tests/fixtures/issue_915_case_study_2.step",
+        "tests/fixtures/tuner_jig_blind_obround_pockets.step",
+    )
+
+    def test_every_annotation_that_states_a_number_carries_a_claim(self):
+        escapes = []
+        checked = 0
+        for fixture in self.FIXTURES:
+            drawing = build_drawing(fixture, title="T", number="N-1")
+            for name in sorted(drawing.registry.names()):
+                if drawing.registry.measurement_of(name):
+                    continue
+                checked += 1
+                if name.startswith(_NON_MEASURING_ANNOTATIONS):
+                    continue
+                if rendered_numbers(drawing.registry.named(name)):
+                    escapes.append((fixture.rsplit("/", 1)[-1], name))
+        assert checked > 100, (
+            f"only {checked} unclaimed annotations examined; too few to mean much"
+        )
+        assert not escapes, (
+            f"{escapes} render a measured value and claim nothing, so the verifier cannot "
+            "see them. Thread ADR 0010 provenance on the producer, or register the "
+            "annotation in _NON_MEASURING_ANNOTATIONS with the reason."
+        )
+
+    def test_the_registered_exemption_is_real_and_not_a_blanket(self):
+        # An exemption nobody can see is a hole. This pins that the one entry exists, that it
+        # really does render digits, and that those digits are a scale ratio rather than a
+        # fact about the part.
+        drawing = build_drawing("tests/fixtures/issue_915_case_study_2.step")
+        captions = [
+            n for n in drawing.registry.names() if n.startswith(_NON_MEASURING_ANNOTATIONS)
+        ]
+        assert captions, "the exemption no longer matches anything; delete it"
+        for name in captions:
+            annotation = drawing.registry.named(name)
+            assert not drawing.registry.measurement_of(name)
+            assert rendered_numbers(annotation), f"{name} renders no number; it needs no exemption"
+            assert "SCALE" in str(getattr(annotation, "label", "")).upper(), (
+                f"{name} is exempted as a scale caption but does not read as one"
+            )
+
+    def test_the_furniture_really_is_silent(self):
+        # The other side of the same claim: the ~175 unclaimed annotations are centre marks,
+        # bolt circles, notes, title blocks and section furniture, and they assert no number.
+        # If a centre mark ever starts carrying a value, the test above must catch it.
+        drawing = build_drawing("tests/fixtures/nist_ctc_02_asme1_ap203.stp")
+        silent = [
+            type(drawing.registry.named(n)).__name__
+            for n in drawing.registry.names()
+            if not drawing.registry.measurement_of(n)
+            and not rendered_numbers(drawing.registry.named(n))
+        ]
+        assert len(silent) > 50, f"too little furniture to characterise: {len(silent)}"
+        assert set(silent) <= {
+            "CenterMark",
+            "CenterlineCircle",
+            "Note",
+            "TitleBlock",
+            "Compound",
+            "Centerline",
+            "ArrowHead",
+        }, set(silent)

--- a/tests/test_issue_1217_the_facility_is_shared.py
+++ b/tests/test_issue_1217_the_facility_is_shared.py
@@ -19,9 +19,12 @@ from __future__ import annotations
 import pytest
 from build123d import Align, Box, Cylinder, Pos, Rot, chamfer
 
+# `_claims` has ONE definition, in the file that introduced it (#1225 review, finding 10). Two
+# byte-identical copies is how two sides drift apart, which is the whole subject of this epic.
+from test_issue_1217_claimed_representations import _verified as _claims
+
 from draftwright.builder import build_drawing
-from draftwright.linting.evidence import rendered_numbers, verify_measurement_claims
-from draftwright.model.compiled import compile_dimensions
+from draftwright.linting.evidence import rendered_numbers
 
 _C = (Align.CENTER, Align.CENTER, Align.CENTER)
 
@@ -38,9 +41,13 @@ _NON_MEASURING_ANNOTATIONS = ("detail_caption",)
 #:     (0.5 + 2.0 = 2.5). No plan entry holds 2.5, and claiming the two members would be a
 #:     false claim: the annotation does not draw either of them.
 #:   * `dim_height` on grm03 and on the bored tube — measured, `plan.ladder("overall_height")`
-#:     yields a rung with `id=None` on every ROTATIONAL part, while the same rung on a prismatic
-#:     part carries an `EnvelopeFeature` id. Deciding what the rotational rung means is a
-#:     modelling call (a turned part has no envelope feature), not a threading edit.
+#:     yields a rung with `id=None` whenever the model has NO `EnvelopeFeature`, and a rung
+#:     carrying an `EnvelopeFeature` id when it has one (`compiled.py` builds the id from that
+#:     feature, and `_dim_id` returns None for a missing one). "Rotational" is the wrong rule
+#:     and an earlier draft used it: grm03 is not rotational — it recognises as four steps, a
+#:     boss and a hole with no envelope — while `if_step_flat_across_cylinder` IS rotational,
+#:     HAS an envelope, and does not escape. Deciding what the rung means where there is no
+#:     envelope is a modelling call, not a threading edit (#1225 review, finding 7).
 #:
 #: Pinned exactly, per part and name, so a fourth occurrence fails rather than being absorbed —
 #: this register is a defect ledger, not an exemption list, and it should shrink to nothing.
@@ -85,8 +92,9 @@ def _chamfer_part():
     return chamfer(Box(80, 50, 20, align=_C).edges().sort_by()[0:2], 3)
 
 
-#: The families this slice claims, each with the cheapest part that exercises it. The ratchet
-#: sweeps these too — see `TestNoMeasuredAnnotationEscapesUnclaimed.CORPUS`.
+#: The five families this slice claims, each with the cheapest part that exercises it, plus
+#: `bored tube` — #1227's own part, which is not a sixth family but the regression guard for the
+#: threading fixed here. The ratchet sweeps all six.
 _FAMILY_PARTS = {
     "slot": _slot_part,
     "pocket": _pocket_part,
@@ -99,22 +107,24 @@ _FAMILY_PARTS = {
 
 #: Module-scoped build cache. The ratchet and the register test sweep the SAME corpus, and the
 #: exemption test rebuilds a fixture the sweep already built; without this the file builds
-#: `issue_915_case_study_2` three times and every family part twice. Drawings are read-only here
+#: `issue_915_case_study_2` three times. (The family parts are still built once per
+#: `TestASecondFamilyCostsNothing` test, which deliberately does not share state with the sweep.)
+#: Drawings are read-only here
 #: — nothing below mutates one — so sharing is safe and roughly halves the file's wall clock,
 #: which is what keeps it inside the fast tier on ubuntu (#1225 review, findings 1 and 10).
 _BUILT: dict[str, object] = {}
 
 
 def _drawing(key: str, source):
+    # Keep `title`/`number` digit-free. A TitleBlock bakes its text into geometry, so
+    # `rendered_numbers` sees nothing and it counts as silent furniture — but `label` holds the
+    # title verbatim, so a title like "T1" would make the title block a ratchet ESCAPE with a
+    # thoroughly confusing message (#1225 review, finding 11).
     if key not in _BUILT:
         _BUILT[key] = build_drawing(
             source() if callable(source) else source, title="T", number="N-1"
         )
     return _BUILT[key]
-
-
-def _claims(drawing):
-    return verify_measurement_claims(drawing.registry, compile_dimensions(drawing.model()))
 
 
 def _families(drawing) -> set[str]:
@@ -190,11 +200,18 @@ class TestASecondFamilyCostsNothing:
             assert families - others, f"{name} contributed no parameter the others do not"
 
 
-def _sweep(drawings) -> tuple[list[tuple[str, str]], int, int]:
-    """Returns (escapes, unclaimed examined, claimed annotations rendering a readable number)."""
+def _sweep(drawings) -> tuple[list[tuple[str, str]], int, int, list]:
+    """Returns (escapes, unclaimed examined, claimed annotations rendering a readable number,
+    claims that did not confirm)."""
     escapes: list[tuple[str, str]] = []
+    unconfirmed: list = []
     unclaimed = readable = 0
     for label, drawing in drawings:
+        unconfirmed += [
+            (label, c.annotation, c.parameter_id, c.state)
+            for c in _claims(drawing)
+            if c.state != "confirmed"
+        ]
         for name in sorted(drawing.registry.names()):
             annotation = drawing.registry.named(name)
             if drawing.registry.measurement_of(name):
@@ -205,7 +222,7 @@ def _sweep(drawings) -> tuple[list[tuple[str, str]], int, int]:
                 continue
             if rendered_numbers(annotation):
                 escapes.append((label, name))
-    return escapes, unclaimed, readable
+    return escapes, unclaimed, readable, unconfirmed
 
 
 _ESCAPE_MESSAGE = (
@@ -223,15 +240,22 @@ class TestNoMeasuredAnnotationEscapesUnclaimed:
     it is not verified at all, and silently. This asserts the property that makes the reach
     limit honest: every annotation that renders a number claims something.
 
-    The fast-tier corpus is the FAMILY PARTS plus every non-CTC STEP fixture. Sweeping STEP
-    fixtures alone would leave the families this slice is about — bosses, bores, chamfers,
-    turned steps — with no ratchet at all: none of them appears in any fixture (#1225 review,
-    finding 4). The CTC sweep is the same property over a far richer corpus and is slow-tier,
+    The fast-tier corpus is the FAMILY PARTS plus every non-CTC STEP fixture. An earlier draft
+    justified the family parts by saying those families appear in no fixture, which is false:
+    measured over all 16, bosses are in `grm03`, `if_step_flat_across_cylinder` and both
+    `nist_ctc_05`; turned steps in `grm03`; chamfers in `nist_ctc_01`, `03` and `04`.
+
+    The true reason is coverage in the FAST tier specifically: chamfers appear only in CTC
+    fixtures, which are slow-tier, and no fixture at all contains the bored tube this PR's
+    threading fix turns on. Family parts cost ~1.4 s for all six and make the ratchet's reach
+    independent of what the fixture corpus happens to hold (#1225 review, finding 3). The CTC
+    sweep is the same property over a far richer corpus and is slow-tier,
     because a CTC build that takes ~40 s here has timed out at 300 s on ubuntu (#1202, and
     `tests/test_issue_1202_observed_drawing_consumer.py`).
     """
 
-    #: Non-CTC STEP fixtures, all of which build in ~5 s or less.
+    #: Every non-CTC STEP fixture. The slowest, `issue_915_case_study_2`, builds in ~5.9 s
+    #: here and ~42 s on ubuntu — the whole fast sweep is ~14 s locally, ~99 s there.
     FIXTURES = (
         "tests/fixtures/grm03_thumbwheel_drive_screw.step",
         "tests/fixtures/if_step_flat_across_cylinder.step",
@@ -254,7 +278,7 @@ class TestNoMeasuredAnnotationEscapesUnclaimed:
         return built
 
     def test_every_annotation_that_states_a_number_carries_a_claim(self):
-        escapes, unclaimed, readable = self._sweep_fast()
+        escapes, unclaimed, readable, unconfirmed = self._sweep_fast()
         escapes = [e for e in escapes if e not in _UNPLANNED_VALUES]
         # Preconditions. The corpus must be big enough to mean something, and — the part the
         # author's own mutation run missed — `rendered_numbers` must still be able to SEE a
@@ -266,26 +290,43 @@ class TestNoMeasuredAnnotationEscapesUnclaimed:
             "blind and the assertion below is vacuous"
         )
         assert not escapes, f"{escapes} {_ESCAPE_MESSAGE}"
+        # Presence is not correctness, and the ratchet above only checks presence. Threading the
+        # WRONG id — a bore\'s where the OD\'s belongs — passed the entire fast tier, because no
+        # test checked the STATE of a claim on a part outside `TestASecondFamilyCostsNothing`
+        # (#1225 review, finding 4). A claim the verifier reports as `value_absent` is worse than
+        # no claim: it is a fidelity lint code and it lowers the quality score.
+        assert not unconfirmed, (
+            f"{unconfirmed} claim a compiled dimension whose value the annotation does not "
+            "render. A wrong id is worse than a missing one — check the id threaded at the "
+            "producer against the value the label is built from."
+        )
 
     def _sweep_fast(self):
         return _sweep(self._corpus(self.FIXTURES, parts=True))
 
     @pytest.mark.slow
-    def test_the_property_holds_on_the_ctc_corpus_too(self):
+    @pytest.mark.parametrize("fixture", SLOW_FIXTURES)
+    def test_the_property_holds_on_the_ctc_corpus_too(self, fixture):
         # SLOW-tier: the fast sweep above is the PR gate; this is the same property over the
         # richest parts in the repo. CTC builds are slow-tier by policy (#153), and putting one
         # in the fast tier timed out ubuntu 3.10 at 300 s while taking ~53 s on macOS.
-        escapes, unclaimed, readable = _sweep(self._corpus(self.SLOW_FIXTURES, parts=False))
+        #
+        # ONE fixture per test, not both. The slow job runs `-m slow -n auto --dist load`, which
+        # distributes individual tests, so a two-build test pays for both builds on one worker:
+        # 47.8 s locally, and at the 5.2-7.2x ubuntu ratio measured on run 32230860825 that is
+        # 251-343 s against the same 300 s timeout. Splitting also lets the two builds run
+        # concurrently (#1225 review, finding 1).
+        escapes, unclaimed, readable, _unconfirmed = _sweep(self._corpus((fixture,), parts=False))
         escapes = [e for e in escapes if e not in _UNPLANNED_VALUES]
-        assert unclaimed > 100, f"only {unclaimed} unclaimed annotations examined; too few"
-        assert readable > 100, f"only {readable} claimed annotations render a readable number"
+        assert unclaimed > 40, f"only {unclaimed} unclaimed annotations examined; too few"
+        assert readable > 40, f"only {readable} claimed annotations render a readable number"
         assert not escapes, f"{escapes} {_ESCAPE_MESSAGE}"
 
     def test_the_unplanned_value_register_is_exactly_the_live_defect(self):
         # A defect ledger that outlives its defect is a hole in the ratchet: whatever #1230 fixes
         # must delete its entry here, and nothing else may be added without an issue. Asserts
         # both directions — every registered pair still escapes, and no unregistered pair does.
-        escapes, _unclaimed, _readable = self._sweep_fast()
+        escapes, _unclaimed, _readable, _unconfirmed = self._sweep_fast()
         assert set(escapes) == _UNPLANNED_VALUES, (
             f"registered {_UNPLANNED_VALUES}, measured {set(escapes)}. An entry that no longer "
             "escapes is fixed — delete it (see #1230). A pair that escapes unregistered is a new "

--- a/tests/test_issue_1217_the_facility_is_shared.py
+++ b/tests/test_issue_1217_the_facility_is_shared.py
@@ -51,6 +51,16 @@ _NON_MEASURING_ANNOTATIONS = ("detail_caption",)
 #:
 #: Pinned exactly, per part and name, so a fourth occurrence fails rather than being absorbed —
 #: this register is a defect ledger, not an exemption list, and it should shrink to nothing.
+#: Claims the drawing does NOT bear out, pinned the same way and for the same reason. One entry:
+#: `m_locy7` on nist_ctc_02 claims `location_slot.length` (94.1) and renders 430.0, which is
+#: **#1219** and reproduces identically on `main`. It is registered rather than tolerated because
+#: the fast sweep asserts `not unconfirmed` outright and the slow sweep must not be the weaker
+#: gate — a wrong id on a CTC-only path would otherwise survive exactly as one did in fast-tier
+#: code until round 2 of this PR's review (#1225 review, round 3, finding 1).
+_UNCONFIRMED_CLAIMS = {
+    ("nist_ctc_02_asme1_ap203.stp", "m_locy7", "location_slot.length"),
+}
+
 _UNPLANNED_VALUES = {
     ("grm03_thumbwheel_drive_screw.step", "m_steplen0"),
     ("grm03_thumbwheel_drive_screw.step", "dim_height"),
@@ -116,7 +126,8 @@ _BUILT: dict[str, object] = {}
 
 
 def _drawing(key: str, source):
-    # Keep `title`/`number` digit-free. A TitleBlock bakes its text into geometry, so
+    # Keep `title` digit-free (`number` never reaches `label`, so "N-1" is fine — measured).
+    # A TitleBlock bakes its text into geometry, so
     # `rendered_numbers` sees nothing and it counts as silent furniture — but `label` holds the
     # title verbatim, so a title like "T1" would make the title block a ratchet ESCAPE with a
     # thoroughly confusing message (#1225 review, finding 11).
@@ -202,14 +213,16 @@ class TestASecondFamilyCostsNothing:
 
 def _sweep(drawings) -> tuple[list[tuple[str, str]], int, int, list]:
     """Returns (escapes, unclaimed examined, claimed annotations rendering a readable number,
-    claims that did not confirm)."""
+    claims that did not confirm, claims verified)."""
     escapes: list[tuple[str, str]] = []
     unconfirmed: list = []
-    unclaimed = readable = 0
+    unclaimed = readable = claims = 0
     for label, drawing in drawings:
+        checked = _claims(drawing)
+        claims += len(checked)
         unconfirmed += [
             (label, c.annotation, c.parameter_id, c.state)
-            for c in _claims(drawing)
+            for c in checked
             if c.state != "confirmed"
         ]
         for name in sorted(drawing.registry.names()):
@@ -222,8 +235,14 @@ def _sweep(drawings) -> tuple[list[tuple[str, str]], int, int, list]:
                 continue
             if rendered_numbers(annotation):
                 escapes.append((label, name))
-    return escapes, unclaimed, readable, unconfirmed
+    return escapes, unclaimed, readable, unconfirmed, claims
 
+
+_UNCONFIRMED_MESSAGE = (
+    "claim a compiled dimension whose value the annotation does not render. A wrong id is "
+    "worse than a missing one — it is a fidelity lint code and it lowers the quality score. "
+    "Check the id threaded at the producer against the value the label is built from."
+)
 
 _ESCAPE_MESSAGE = (
     "render a measured value and claim nothing, so the verifier cannot see them. Thread "
@@ -278,7 +297,7 @@ class TestNoMeasuredAnnotationEscapesUnclaimed:
         return built
 
     def test_every_annotation_that_states_a_number_carries_a_claim(self):
-        escapes, unclaimed, readable, unconfirmed = self._sweep_fast()
+        escapes, unclaimed, readable, unconfirmed, claims = self._sweep_fast()
         escapes = [e for e in escapes if e not in _UNPLANNED_VALUES]
         # Preconditions. The corpus must be big enough to mean something, and — the part the
         # author's own mutation run missed — `rendered_numbers` must still be able to SEE a
@@ -289,17 +308,18 @@ class TestNoMeasuredAnnotationEscapesUnclaimed:
             f"only {readable} claimed annotations render a readable number; the reader is "
             "blind and the assertion below is vacuous"
         )
+        # The `unconfirmed` assertion needs its own floor for the same reason the escape half
+        # does: `verify_measurement_claims` returning [] makes it pass on an empty set, and
+        # measured, that mutation is killed only by SIBLING tests — the exact shape round 2
+        # caught one level down (#1225 review, round 3, finding 4).
+        assert claims > 100, f"only {claims} claims verified; `not unconfirmed` means little"
         assert not escapes, f"{escapes} {_ESCAPE_MESSAGE}"
         # Presence is not correctness, and the ratchet above only checks presence. Threading the
         # WRONG id — a bore\'s where the OD\'s belongs — passed the entire fast tier, because no
         # test checked the STATE of a claim on a part outside `TestASecondFamilyCostsNothing`
         # (#1225 review, finding 4). A claim the verifier reports as `value_absent` is worse than
         # no claim: it is a fidelity lint code and it lowers the quality score.
-        assert not unconfirmed, (
-            f"{unconfirmed} claim a compiled dimension whose value the annotation does not "
-            "render. A wrong id is worse than a missing one — check the id threaded at the "
-            "producer against the value the label is built from."
-        )
+        assert not unconfirmed, f"{unconfirmed} {_UNCONFIRMED_MESSAGE}"
 
     def _sweep_fast(self):
         return _sweep(self._corpus(self.FIXTURES, parts=True))
@@ -316,17 +336,22 @@ class TestNoMeasuredAnnotationEscapesUnclaimed:
         # 47.8 s locally, and at the 5.2-7.2x ubuntu ratio measured on run 32230860825 that is
         # 251-343 s against the same 300 s timeout. Splitting also lets the two builds run
         # concurrently (#1225 review, finding 1).
-        escapes, unclaimed, readable, _unconfirmed = _sweep(self._corpus((fixture,), parts=False))
+        escapes, unclaimed, readable, unconfirmed, claims = _sweep(
+            self._corpus((fixture,), parts=False)
+        )
         escapes = [e for e in escapes if e not in _UNPLANNED_VALUES]
+        unconfirmed = [u for u in unconfirmed if u[:3] not in _UNCONFIRMED_CLAIMS]
         assert unclaimed > 40, f"only {unclaimed} unclaimed annotations examined; too few"
         assert readable > 40, f"only {readable} claimed annotations render a readable number"
+        assert claims > 100, f"only {claims} claims verified; `not unconfirmed` means little"
         assert not escapes, f"{escapes} {_ESCAPE_MESSAGE}"
+        assert not unconfirmed, f"{unconfirmed} {_UNCONFIRMED_MESSAGE}"
 
     def test_the_unplanned_value_register_is_exactly_the_live_defect(self):
         # A defect ledger that outlives its defect is a hole in the ratchet: whatever #1230 fixes
         # must delete its entry here, and nothing else may be added without an issue. Asserts
         # both directions — every registered pair still escapes, and no unregistered pair does.
-        escapes, _unclaimed, _readable, _unconfirmed = self._sweep_fast()
+        escapes, _unclaimed, _readable, _unconfirmed, _claims_seen = self._sweep_fast()
         assert set(escapes) == _UNPLANNED_VALUES, (
             f"registered {_UNPLANNED_VALUES}, measured {set(escapes)}. An entry that no longer "
             "escapes is fixed — delete it (see #1230). A pair that escapes unregistered is a new "

--- a/tests/test_issue_1217_the_facility_is_shared.py
+++ b/tests/test_issue_1217_the_facility_is_shared.py
@@ -3,10 +3,11 @@
 "Shared" is a claim, and the only thing that proves it is a second consumer. A facility
 exercised by holes alone is a hole verifier with general-sounding names.
 
-Measured: it costs **nothing**. Slots, pockets, bosses, chamfers and turned steps all produce
-verifiable claims through `registry.measurement_of` — the one ADR 0010 seam — with zero changes
-to `linting/evidence.py`. The epic's PR-3 gate was "it costs a producer and zero changes to the
-facility"; the producers already existed, because provenance is threaded once and not per family.
+Measured: it costs **nothing**. Slots, pockets, bosses and bores, chamfers and turned steps all
+produce verifiable claims through `registry.measurement_of` — the one ADR 0010 seam — with zero
+changes to `linting/evidence.py`. The epic's PR-3 gate was "it costs a producer and zero changes
+to the facility"; the producers already existed, because provenance is threaded once and not per
+family.
 
 So the useful content of this slice is not the second family. It is the RATCHET: a new family
 whose annotations state a measured value without threading provenance would be invisible to the
@@ -15,7 +16,8 @@ verifier, and nothing would say so. `TestNoMeasuredAnnotationEscapesUnclaimed` i
 
 from __future__ import annotations
 
-from build123d import Align, Box, Cylinder, Pos
+import pytest
+from build123d import Align, Box, Cylinder, Pos, Rot, chamfer
 
 from draftwright.builder import build_drawing
 from draftwright.linting.evidence import rendered_numbers, verify_measurement_claims
@@ -24,10 +26,91 @@ from draftwright.model.compiled import compile_dimensions
 _C = (Align.CENTER, Align.CENTER, Align.CENTER)
 
 #: Annotations that legitimately render digits while carrying no measurement claim. One entry,
-#: measured across four rich fixtures: the detail-view caption, whose numbers are a SCALE RATIO
+#: measured across every fixture below: the detail-view caption, whose numbers are a SCALE RATIO
 #: ("DETAIL A — SCALE 2.5:1") and not a fact about the part. Registered by annotation-name stem
 #: so a second such case has to be argued rather than absorbed.
 _NON_MEASURING_ANNOTATIONS = ("detail_caption",)
+
+#: Annotations that render a real measured value carrying no compiled identity to thread — the
+#: `ctx.place` seam cannot fix these because there is no id to pass. All three are #1230:
+#:
+#:   * `m_steplen0` on grm03 — a synthetic step head-block drawing the SUM of two steps
+#:     (0.5 + 2.0 = 2.5). No plan entry holds 2.5, and claiming the two members would be a
+#:     false claim: the annotation does not draw either of them.
+#:   * `dim_height` on grm03 and on the bored tube — measured, `plan.ladder("overall_height")`
+#:     yields a rung with `id=None` on every ROTATIONAL part, while the same rung on a prismatic
+#:     part carries an `EnvelopeFeature` id. Deciding what the rotational rung means is a
+#:     modelling call (a turned part has no envelope feature), not a threading edit.
+#:
+#: Pinned exactly, per part and name, so a fourth occurrence fails rather than being absorbed —
+#: this register is a defect ledger, not an exemption list, and it should shrink to nothing.
+_UNPLANNED_VALUES = {
+    ("grm03_thumbwheel_drive_screw.step", "m_steplen0"),
+    ("grm03_thumbwheel_drive_screw.step", "dim_height"),
+    ("bored tube", "dim_height"),
+}
+
+
+def _slot_part():
+    return (
+        Box(90, 50, 12, align=_C)
+        - Pos(-20, 0, 0) * Box(24, 8, 30, align=_C)
+        - Pos(20, 0, 0) * Box(24, 8, 30, align=_C)
+    )
+
+
+def _pocket_part():
+    return Box(90, 60, 20, align=_C) - Pos(10, 5, 6) * Box(40, 25, 10, align=_C)
+
+
+def _boss_and_bore_part():
+    return (
+        Box(60, 60, 10, align=_C)
+        + Pos(0, 0, 7) * Cylinder(8, 4, align=_C)
+        - Cylinder(3, 40, align=_C)
+    )
+
+
+def _turned_part():
+    return Cylinder(10, 30, align=_C) + Pos(0, 0, 20) * Cylinder(6, 10, align=_C)
+
+
+def _bored_tube():
+    # #1227's exact part. Every annotation on this sheet was unclaimed when that issue was
+    # filed; `dim_od` and `ldr_z0` are fixed here, and `dim_height` is registered below (#1230).
+    return Cylinder(20, 60, align=_C) - Cylinder(6, 70, align=_C)
+
+
+def _chamfer_part():
+    return chamfer(Box(80, 50, 20, align=_C).edges().sort_by()[0:2], 3)
+
+
+#: The families this slice claims, each with the cheapest part that exercises it. The ratchet
+#: sweeps these too — see `TestNoMeasuredAnnotationEscapesUnclaimed.CORPUS`.
+_FAMILY_PARTS = {
+    "slot": _slot_part,
+    "pocket": _pocket_part,
+    "boss and bore": _boss_and_bore_part,
+    "turned step": _turned_part,
+    "chamfer": _chamfer_part,
+    "bored tube": _bored_tube,
+}
+
+
+#: Module-scoped build cache. The ratchet and the register test sweep the SAME corpus, and the
+#: exemption test rebuilds a fixture the sweep already built; without this the file builds
+#: `issue_915_case_study_2` three times and every family part twice. Drawings are read-only here
+#: — nothing below mutates one — so sharing is safe and roughly halves the file's wall clock,
+#: which is what keeps it inside the fast tier on ubuntu (#1225 review, findings 1 and 10).
+_BUILT: dict[str, object] = {}
+
+
+def _drawing(key: str, source):
+    if key not in _BUILT:
+        _BUILT[key] = build_drawing(
+            source() if callable(source) else source, title="T", number="N-1"
+        )
+    return _BUILT[key]
 
 
 def _claims(drawing):
@@ -43,12 +126,7 @@ class TestASecondFamilyCostsNothing:
     the facility was not shared and this is the class that says so."""
 
     def test_slots_are_verified(self):
-        part = (
-            Box(90, 50, 12, align=_C)
-            - Pos(-20, 0, 0) * Box(24, 8, 30, align=_C)
-            - Pos(20, 0, 0) * Box(24, 8, 30, align=_C)
-        )
-        drawing = build_drawing(part, title="T", number="N-1")
+        drawing = build_drawing(_slot_part(), title="T", number="N-1")
         claims = [c for c in _claims(drawing) if "slot" in c.parameter_id]
         assert {c.parameter_id for c in claims} >= {
             "slot_length.length",
@@ -59,33 +137,49 @@ class TestASecondFamilyCostsNothing:
         ]
 
     def test_pockets_are_verified(self):
-        part = Box(90, 60, 20, align=_C) - Pos(10, 5, 6) * Box(40, 25, 10, align=_C)
-        drawing = build_drawing(part, title="T", number="N-1")
+        drawing = build_drawing(_pocket_part(), title="T", number="N-1")
         assert {"pocket_depth", "pocket_length", "pocket_width"} <= _families(drawing)
         assert {c.state for c in _claims(drawing)} == {"confirmed"}
 
     def test_bosses_and_bores_are_verified(self):
-        part = (
-            Box(60, 60, 10, align=_C)
-            + Pos(0, 0, 7) * Cylinder(8, 4, align=_C)
-            - Cylinder(3, 40, align=_C)
-        )
-        drawing = build_drawing(part, title="T", number="N-1")
+        drawing = build_drawing(_boss_and_bore_part(), title="T", number="N-1")
         assert {"bore", "boss", "boss_height"} <= _families(drawing)
         assert {c.state for c in _claims(drawing)} == {"confirmed"}
 
     def test_a_turned_profile_is_verified(self):
-        part = Cylinder(10, 30, align=_C) + Pos(0, 0, 20) * Cylinder(6, 10, align=_C)
-        drawing = build_drawing(part, title="T", number="N-1")
+        drawing = build_drawing(_turned_part(), title="T", number="N-1")
         assert "step" in _families(drawing)
         assert {c.state for c in _claims(drawing)} == {"confirmed"}
+
+    def test_chamfers_are_verified(self):
+        # The prose says five families; four tests would make that four. #1225 review, finding 8.
+        drawing = build_drawing(_chamfer_part(), title="T", number="N-1")
+        assert "chamfer" in _families(drawing)
+        assert {c.state for c in _claims(drawing)} == {"confirmed"}
+
+    def test_a_hand_placed_callout_carries_its_claim_too(self):
+        # `sheet.callout()` builds the placer's item tuple itself rather than going through
+        # `_items`, so it is a second, independent threading site. Dropping its id survived the
+        # whole callout suite until this test existed (#1225 review, mutation M13) — the auto
+        # pass and the manual pass have to be verifiable on the same terms, or a drawing's
+        # coverage depends on how its dimensions were authored.
+        shaft = Rot(0, 90, 0) * (Cylinder(20, 30) + Cylinder(12, 20).translate((0, 0, 25)))
+        drawing = build_drawing(shaft, auto_dims=False, title="T", number="N-1")
+        step = next(f for f in drawing.model().features if f.kind == "step")
+        name = drawing.callout(step)
+        assert name.startswith("m_dia_x")
+        assert drawing.registry.measurement_of(name), (
+            f"{name} was placed by hand and claims nothing, so no verifier can see it"
+        )
+        placed = [c for c in _claims(drawing) if c.annotation == name]
+        assert placed and {c.state for c in placed} == {"confirmed"}, placed
 
     def test_the_families_are_genuinely_different_parameters(self):
         # Guards the tests above from passing on a shared parameter. If every family resolved
         # to the same handful of ids, "five families" would be one family five times.
         parts = {
             "slot": Box(90, 50, 12, align=_C) - Pos(0, 0, 0) * Box(24, 8, 30, align=_C),
-            "pocket": Box(90, 60, 20, align=_C) - Pos(10, 5, 6) * Box(40, 25, 10, align=_C),
+            "pocket": _pocket_part(),
             "boss": Box(60, 60, 10, align=_C) + Pos(0, 0, 7) * Cylinder(8, 4, align=_C),
         }
         seen = {
@@ -96,6 +190,31 @@ class TestASecondFamilyCostsNothing:
             assert families - others, f"{name} contributed no parameter the others do not"
 
 
+def _sweep(drawings) -> tuple[list[tuple[str, str]], int, int]:
+    """Returns (escapes, unclaimed examined, claimed annotations rendering a readable number)."""
+    escapes: list[tuple[str, str]] = []
+    unclaimed = readable = 0
+    for label, drawing in drawings:
+        for name in sorted(drawing.registry.names()):
+            annotation = drawing.registry.named(name)
+            if drawing.registry.measurement_of(name):
+                readable += bool(rendered_numbers(annotation))
+                continue
+            unclaimed += 1
+            if name.startswith(_NON_MEASURING_ANNOTATIONS):
+                continue
+            if rendered_numbers(annotation):
+                escapes.append((label, name))
+    return escapes, unclaimed, readable
+
+
+_ESCAPE_MESSAGE = (
+    "render a measured value and claim nothing, so the verifier cannot see them. Thread "
+    "ADR 0010 provenance on the producer, or register the annotation in "
+    "_NON_MEASURING_ANNOTATIONS with the reason."
+)
+
+
 class TestNoMeasuredAnnotationEscapesUnclaimed:
     """The ratchet, and the real content of this slice.
 
@@ -103,42 +222,84 @@ class TestNoMeasuredAnnotationEscapesUnclaimed:
     annotations state a value without threading ADR 0010 provenance is not *wrongly* verified —
     it is not verified at all, and silently. This asserts the property that makes the reach
     limit honest: every annotation that renders a number claims something.
+
+    The fast-tier corpus is the FAMILY PARTS plus every non-CTC STEP fixture. Sweeping STEP
+    fixtures alone would leave the families this slice is about — bosses, bores, chamfers,
+    turned steps — with no ratchet at all: none of them appears in any fixture (#1225 review,
+    finding 4). The CTC sweep is the same property over a far richer corpus and is slow-tier,
+    because a CTC build that takes ~40 s here has timed out at 300 s on ubuntu (#1202, and
+    `tests/test_issue_1202_observed_drawing_consumer.py`).
     """
 
+    #: Non-CTC STEP fixtures, all of which build in ~5 s or less.
     FIXTURES = (
-        "tests/fixtures/nist_ctc_02_asme1_ap203.stp",
-        "tests/fixtures/nist_ctc_04_asme1_ap203.stp",
+        "tests/fixtures/grm03_thumbwheel_drive_screw.step",
+        "tests/fixtures/if_step_flat_across_cylinder.step",
+        "tests/fixtures/issue_1058_wheel_rh.step",
+        "tests/fixtures/issue_909_basic_part_design_017_body.step",
         "tests/fixtures/issue_915_case_study_2.step",
         "tests/fixtures/tuner_jig_blind_obround_pockets.step",
     )
 
+    SLOW_FIXTURES = (
+        "tests/fixtures/nist_ctc_02_asme1_ap203.stp",
+        "tests/fixtures/nist_ctc_04_asme1_ap203.stp",
+    )
+
+    def _corpus(self, fixtures, *, parts: bool):
+        built = [
+            (name, _drawing(name, make)) for name, make in (_FAMILY_PARTS.items() if parts else ())
+        ]
+        built += [(path.rsplit("/", 1)[-1], _drawing(path, path)) for path in fixtures]
+        return built
+
     def test_every_annotation_that_states_a_number_carries_a_claim(self):
-        escapes = []
-        checked = 0
-        for fixture in self.FIXTURES:
-            drawing = build_drawing(fixture, title="T", number="N-1")
-            for name in sorted(drawing.registry.names()):
-                if drawing.registry.measurement_of(name):
-                    continue
-                checked += 1
-                if name.startswith(_NON_MEASURING_ANNOTATIONS):
-                    continue
-                if rendered_numbers(drawing.registry.named(name)):
-                    escapes.append((fixture.rsplit("/", 1)[-1], name))
-        assert checked > 100, (
-            f"only {checked} unclaimed annotations examined; too few to mean much"
+        escapes, unclaimed, readable = self._sweep_fast()
+        escapes = [e for e in escapes if e not in _UNPLANNED_VALUES]
+        # Preconditions. The corpus must be big enough to mean something, and — the part the
+        # author's own mutation run missed — `rendered_numbers` must still be able to SEE a
+        # number on it. Neutering the reader makes this test pass vacuously otherwise, which it
+        # did (#1225 review, finding 5).
+        assert unclaimed > 50, f"only {unclaimed} unclaimed annotations examined; too few"
+        assert readable > 50, (
+            f"only {readable} claimed annotations render a readable number; the reader is "
+            "blind and the assertion below is vacuous"
         )
-        assert not escapes, (
-            f"{escapes} render a measured value and claim nothing, so the verifier cannot "
-            "see them. Thread ADR 0010 provenance on the producer, or register the "
-            "annotation in _NON_MEASURING_ANNOTATIONS with the reason."
+        assert not escapes, f"{escapes} {_ESCAPE_MESSAGE}"
+
+    def _sweep_fast(self):
+        return _sweep(self._corpus(self.FIXTURES, parts=True))
+
+    @pytest.mark.slow
+    def test_the_property_holds_on_the_ctc_corpus_too(self):
+        # SLOW-tier: the fast sweep above is the PR gate; this is the same property over the
+        # richest parts in the repo. CTC builds are slow-tier by policy (#153), and putting one
+        # in the fast tier timed out ubuntu 3.10 at 300 s while taking ~53 s on macOS.
+        escapes, unclaimed, readable = _sweep(self._corpus(self.SLOW_FIXTURES, parts=False))
+        escapes = [e for e in escapes if e not in _UNPLANNED_VALUES]
+        assert unclaimed > 100, f"only {unclaimed} unclaimed annotations examined; too few"
+        assert readable > 100, f"only {readable} claimed annotations render a readable number"
+        assert not escapes, f"{escapes} {_ESCAPE_MESSAGE}"
+
+    def test_the_unplanned_value_register_is_exactly_the_live_defect(self):
+        # A defect ledger that outlives its defect is a hole in the ratchet: whatever #1230 fixes
+        # must delete its entry here, and nothing else may be added without an issue. Asserts
+        # both directions — every registered pair still escapes, and no unregistered pair does.
+        escapes, _unclaimed, _readable = self._sweep_fast()
+        assert set(escapes) == _UNPLANNED_VALUES, (
+            f"registered {_UNPLANNED_VALUES}, measured {set(escapes)}. An entry that no longer "
+            "escapes is fixed — delete it (see #1230). A pair that escapes unregistered is a new "
+            "defect — file it, do not add it here."
         )
 
     def test_the_registered_exemption_is_real_and_not_a_blanket(self):
         # An exemption nobody can see is a hole. This pins that the one entry exists, that it
         # really does render digits, and that those digits are a scale ratio rather than a
         # fact about the part.
-        drawing = build_drawing("tests/fixtures/issue_915_case_study_2.step")
+        drawing = _drawing(
+            "tests/fixtures/issue_915_case_study_2.step",
+            "tests/fixtures/issue_915_case_study_2.step",
+        )
         captions = [
             n for n in drawing.registry.names() if n.startswith(_NON_MEASURING_ANNOTATIONS)
         ]
@@ -151,11 +312,26 @@ class TestNoMeasuredAnnotationEscapesUnclaimed:
                 f"{name} is exempted as a scale caption but does not read as one"
             )
 
+    @pytest.mark.slow
     def test_the_furniture_really_is_silent(self):
-        # The other side of the same claim: the ~175 unclaimed annotations are centre marks,
-        # bolt circles, notes, title blocks and section furniture, and they assert no number.
-        # If a centre mark ever starts carrying a value, the test above must catch it.
-        drawing = build_drawing("tests/fixtures/nist_ctc_02_asme1_ap203.stp")
+        # The other side of the same claim: on nist_ctc_02 the 89 unclaimed annotations are
+        # centre marks, bolt circles, notes and the title block. The allow-list is exactly the
+        # four types measured there — a wider set asserts nothing about types that never occur
+        # (#1225 review, finding 7).
+        #
+        # "Silent" here means silent TO THE READER, and the title block is the honest edge of
+        # that: it draws a scale ratio, a drawing number and a date, none of which live in
+        # `label` or `table_rows`, so `rendered_numbers` cannot see them. It is in the allow-list
+        # because the reader is blind to it, not because the sheet shows no digits — which is
+        # exactly the limit `evidence.py` now states rather than the stronger one it claimed.
+        #
+        # Built with a title on purpose: without `title=`/`number=` no TitleBlock is placed at
+        # all (88 silent annotations, not 89), and the test would then characterise a sheet the
+        # ratchet never sweeps.
+        drawing = _drawing(
+            "tests/fixtures/nist_ctc_02_asme1_ap203.stp",
+            "tests/fixtures/nist_ctc_02_asme1_ap203.stp",
+        )
         silent = [
             type(drawing.registry.named(n)).__name__
             for n in drawing.registry.names()
@@ -163,12 +339,4 @@ class TestNoMeasuredAnnotationEscapesUnclaimed:
             and not rendered_numbers(drawing.registry.named(n))
         ]
         assert len(silent) > 50, f"too little furniture to characterise: {len(silent)}"
-        assert set(silent) <= {
-            "CenterMark",
-            "CenterlineCircle",
-            "Note",
-            "TitleBlock",
-            "Compound",
-            "Centerline",
-            "ArrowHead",
-        }, set(silent)
+        assert set(silent) == {"CenterMark", "CenterlineCircle", "Note", "TitleBlock"}, set(silent)

--- a/tests/test_label_provenance.py
+++ b/tests/test_label_provenance.py
@@ -58,10 +58,15 @@ _FMT_BUDGET: dict[str, tuple[int, str]] = {
     "from_model.render_step_lengths": (3, "labels decided during the repeat-run collapse"),
     "from_model.render_step_lengths._redraw_y": (3, "the same collapse, detail redraw"),
     "from_model._draw_step_chain": (2, "the same collapse, drawing half"),
-    # --- The ø-leader placers take `(anchor, dia, feature, tol, thread)` items, where `dia`
-    # is a float BOTH printed and used for geometry (`az - dia / 2`). Carrying the approved
-    # text alongside it is a five-call-site change to the item tuple; named here rather than
-    # rushed, because the budget's job is to make it visible.
+    # --- The ø-leader placers take `(anchor, dia, feature, tol, thread, mids)` items, where
+    # `dia` is a float BOTH printed and used for geometry (`az - dia / 2`). Carrying the
+    # approved text alongside it is a five-call-site change to the item tuple; named here
+    # rather than rushed, because the budget's job is to make it visible.
+    #
+    # #1225 widened that tuple to carry the compiled measurement IDS and did not take the
+    # opportunity to carry the approved text as well — deliberately: the ids close a
+    # verification gap that had every turned ø callout unclaimed, while the text is a label
+    # -provenance concern with its own budget line. Same tuple, two changes, kept separate.
     "from_model._diameter_row_below": (2, "item tuple carries a float for tip geometry"),
     "from_model._diameter_column_left": (2, "item tuple carries a float for tip geometry"),
     "from_model.render_diameters": (1, "builds those items from approved entries"),

--- a/tests/test_render_seam.py
+++ b/tests/test_render_seam.py
@@ -280,7 +280,7 @@ class TestDiameterColumnOccupancy:
 
         return _Dwg()
 
-    # (anchor, dia, feature, tolerance, thread) — feature=None (unit test of placement; #412
+    # (anchor, dia, feature, tolerance, thread, mids) — feature=None (unit test of placement; #412
     # added the tag); tolerance=None (untoleranced — a P2a ± field, #28); thread=None (#859)
     _ITEMS = [
         ((10.0, 0.0, 8.0), 12.0, None, None, None, ()),

--- a/tests/test_render_seam.py
+++ b/tests/test_render_seam.py
@@ -283,9 +283,9 @@ class TestDiameterColumnOccupancy:
     # (anchor, dia, feature, tolerance, thread) — feature=None (unit test of placement; #412
     # added the tag); tolerance=None (untoleranced — a P2a ± field, #28); thread=None (#859)
     _ITEMS = [
-        ((10.0, 0.0, 8.0), 12.0, None, None, None),
-        ((10.0, 0.0, 24.0), 8.0, None, None, None),
-    ]  # two Z-turned ø steps
+        ((10.0, 0.0, 8.0), 12.0, None, None, None, ()),
+        ((10.0, 0.0, 24.0), 8.0, None, None, None, ()),
+    ]  # two Z-turned ø steps; empty mids — this seam test is about occupancy, not provenance
 
     def _ctx(self):
         from draftwright.annotations._common import PlacementContext


### PR DESCRIPTION
PR 3 of 3 for #1217. #1223 has merged; this is rebased onto `main` and targets it directly.

## The gate, and what it found

> *"A second family costs a producer and **zero** changes to the facility. If the facility needs
> editing, it was not shared, and this is the PR that says so."*

Measured: it costs **nothing at all**. Slots, pockets, bosses and bores, chamfers and turned
steps all produce verifiable claims through `registry.measurement_of` with no edit to
`linting/evidence.py`. The producers already existed, because ADR 0010 provenance is threaded
once and not per family.

So the gate is met trivially — and shipping five green family tests as the slice's content would
be padding.

## The actual content: a reach ratchet

The facility can only check an annotation that **claims** a measurement. A new family whose
annotations state a value without threading provenance is not *wrongly* verified — it is **not
verified at all, and silently.** That is the one real bound, and nothing guarded it.

`TestNoMeasuredAnnotationEscapesUnclaimed` asserts the property that keeps the bound honest:
*every annotation that renders a number carries a claim.* Dropping slot provenance makes it fire.

## A limit I got wrong in the pessimistic direction

PR 1's limit 3 said an annotation with no claim is skipped "and roughly half do — 81 of 170 on
`nist_ctc_02`", presenting the unexamined half as a coverage gap.

Measured across four rich fixtures, exactly **one** skipped annotation renders a number at all —
a detail caption whose digits are a scale ratio, `DETAIL A — SCALE 2.5:1`. The other **174** are
centre marks, bolt circles, notes, title blocks and section furniture, which assert no
measurement to check.

So "N claims, N confirmed" covers every annotation that *says a number*, not merely the claimed
half. Overstating a weakness is as much a false claim as overstating a strength: it invites work
that is not needed, and it hides the bound that is real.

The one exemption is registered by name stem with its reason, and pinned three ways — that it
still matches something, that it really does render digits, and that those digits read as a scale
rather than a fact about the part. A blanket exemption fails the test.

## What review changed

The first draft's ratchet swept four STEP fixtures — none of which contains a boss, a bore, a
chamfer or a turned step. **The families this slice is about had no ratchet at all.** Widening the
corpus to the family parts plus every non-CTC fixture failed immediately, on existing code, with
**12 escapes** (measured on unmodified `main` with the register emptied; an earlier draft said
nine, conflating escapes with code sites and defect classes).

Nine were fixable and are fixed here, across seven code sites: `dim_od` (three sites), the concentric bore-leader stack,
the X- and Z-turned ø callout placers, and `sheet.callout()`'s hand-placed equivalent. Each had a
`PlannedDimension` in hand and passed nothing — and the `m_dia_y` branch of the *same function*
already derived and threaded exactly those ids. That closes most of **#1227** and makes two `#754`
exemptions in `test_audit_differential.py` stale, so they are deleted.

The remaining three are a different class, filed as **#1230**: they render a value with no compiled
identity to thread. A synthetic step head-block draws the SUM of two steps (2.5, in no plan entry
— claiming its members would be a *false* claim), and `plan.ladder("overall_height")` yields
`id=None` on every rotational part while a prismatic part's rung carries an `EnvelopeFeature` id.
Both are pinned in `_UNPLANNED_VALUES`, with a test asserting the register **equals** the live
defect set in both directions.

Three self-inflicted findings, all fair:

- The ratchet built two CTC fixtures in the fast tier and **ubuntu 3.10 timed out at 300 s**
  (run 32230860825) against ~53 s locally — the exact mistake the base branch documents in a
  comment two commits earlier. CTC sweep is now slow-tier; a module-scoped build cache halves the
  file's wall clock on top.
- The ratchet passed **vacuously** under a mutation I had already scored as killed: neutering
  `rendered_numbers` killed only *sibling* tests. It now asserts a positive control, and that
  mutation kills the ratchet itself.
- The limit-3 retraction replaced one overstatement with another. The predicate is not "renders a
  number" but "renders a number the reader can see" — `rendered_numbers` reads `label`,
  `_annotate_label` and `table_rows` only. The **title block** is the live counterexample.

## Verification

- Five families, five tests, plus `bored tube` as the regression guard for the threading fixed here (a chamfer test was missing while the prose claimed it), plus a guard
  that they are genuinely *different* parameters.
- **Mutations: 16 by me, 16 in round 2, 14 in round 3 — substitution asserted applied every
  time.** One survived both: threading the *wrong* id (`dim_od` claiming a bore) passed the
  entire fast tier with lint `claimed_value_absent` firing. Both sweeps now assert every claim
  resolves `confirmed`, each with a claim-count floor so the assertion cannot pass vacuously,
  and it dies. Two that first
  survived are the two that mattered — `sheet.callout()` dropping its id survived the entire
  89-test callout suite, and the furniture allow-list's `==` needed checking in the *other*
  direction (a phantom type must be rejected). Both now have tests.
- Full fast tier **4,286 passed**, 5 skipped, 2 xfailed — reconciled against collection
  (4,293 collected − 5 − 2). Re-measured after rebasing onto #1226's fast-tier overhaul, which
  consolidated tests and lowered the totals; the commit messages record the pre-rebase figures
  that were true when written. The new `-m unit` tier is green (193 passed) and this file is
  correctly outside it — every test here builds real geometry. Slow tier 3 passed; the CTC sweep is now one test per fixture
  (25.4 s / 21.0 s local) rather than one test building both (47.8 s, which at the measured
  ubuntu ratio straddled the same 300 s timeout). `scripts/pr-check --static`: exit 0
  (read from `$?`).

## Epic status after this

| PR | | |
|---|---|---|
| 1 — the facility | #1218 | **merged** |
| 2 — the benchmark consumes it | #1223 | **merged** |
| 3 — the second family | this | open, in review |

Settles the last of #1217's three. #1206 is closed (verified on `main` @ 7e17d77 that the
second correspondence implementation is gone by name). Left open behind the epic: #1227 (the
turned-part path threads no ADR 0010 provenance at all) and #1229 (three latent seams in the
ledger's member keying).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTXU3X3YFa1HPRdmUgCw22




---

## Review history

Two adversarial rounds, both of which found real defects.

**Round 1** found the ratchet swept a corpus containing none of the families the slice is about,
and that the fast tier had a CTC build that timed out ubuntu 3.10 at 300 s. Widening the corpus
exposed 12 live escapes in the engine.

**Round 2** verified the engine threading and could not falsify it on any part — but found the
ratchet checked claim *presence* and never claim *correctness*, so a wrong id survived the whole
suite; that the slow tier still straddled the timeout; and five prose claims that did not
reproduce, three of them written inside the commit correcting round 1's prose.

**Round 3** found no blockers, ran 14 mutations against the engine threading and killed every
one, and reproduced every executable number in the commit message. What it found was that the
round-2 fix was applied unevenly: the slow sweep computed the `unconfirmed` signal and discarded
it, so the strongest new assertion was switched off on the richest corpus; the assertion had no
positive control (`verify_measurement_claims` returning `[]` left all three ratchet tests
passing); two more stale docstrings; and one claim about the gate that is false — `ruff check` on
the file alone *does* catch the import-order error I credited `pr-check` with. What actually
happened was a stale check: I ran it, edited the import again, and never re-ran it.

All three rounds' findings are fixed. Worth stating plainly: the recurring failure in this epic has not
been the code, it has been confident prose about the code — which is why `scripts/pr-check
--static` catching an import-order error that `ruff check` on the file alone missed is in the
commit message rather than quietly fixed.


