### PR TITLE
A slot's position is not a plan location (#1219)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -684,6 +684,17 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
             and _concentric_with_axis(a, rx, ry)
         ):
             continue
+        # A slot's position is drawn by `render_slots`, from this same entry (it reads
+        # `slot_positions` by role). Reaching it here too is not a second view of one
+        # measurement, it is a DIFFERENT measurement with no compiled backing: this ladder
+        # takes the plan X/Y of `span[1]` and prints an offset from the datum, while the
+        # entry measures along the slot's long axis. It only ever arrived because the
+        # `loc.axis != "z"` filter above reads `axis` as "Z-normal", and for a slot `axis`
+        # is the LONG axis — so a Z-long slot fell through and an X- or Y-long one did not.
+        # The same feature type getting a plan location dim or not, depending on which way
+        # it happens to run, is the incoherence; every slot is now handled the one way (#1219).
+        if loc.role == SlotFeature.LOCATION_STEM:
+            continue
         # Provenance (ADR 0010): the located feature. `resolve_feature` is the sanctioned
         # seam for exactly this — the corridor's feature map keys drop()/annotations_of().
         # `loc.id` rides along as the measurement identity (#1002): the compiler already

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -535,6 +535,14 @@ def render_slots(dwg, plan, a, *, ctx, only=None) -> int:
             ):
                 count += 1
             else:
+                # No `measurement=` here, deliberately, and it was worth checking rather than
+                # "fixing" by symmetry with the width/length drops above. A review reported this
+                # as a dropped slot position that names no measurement; measured on `main`, the
+                # record ALREADY carries `location_slot.length`, because the corridor's own drop
+                # path supplies it. Adding `pos.id` here changed nothing observable — the
+                # mutation removing it again survived the suite — so the line stays as it was
+                # rather than carrying a comment claiming a fix it does not make
+                # (#1231 review, finding 5).
                 _record_slot_drop(ctx, dwg, "position", i, name, s)
         elif s.kind == "pocket" and s.frame.axis != "z":
             # Side-/front-opening pockets need two in-plane coordinates in their
@@ -556,7 +564,15 @@ def render_slots(dwg, plan, a, *, ctx, only=None) -> int:
                 if _place(axis, start, end, perp_lo, perp_hi, entry, kind, anchor="lo"):
                     count += 1
                 else:
-                    _record_slot_drop(ctx, dwg, "position", i, name, s)
+                    # `entry.id`: this is the non-Z POCKET branch — reached only when
+                    # `pos is None`, which is why passing `pos.id` here raises — and it places
+                    # one entry per in-plane coordinate, so `entry` is the measurement being
+                    # dropped. It previously passed none, unlike the width/length drops above.
+                    # Honest about the evidence: NO test observes this. Reverting it passes the
+                    # full tier. It is kept because the branch demonstrably executes and naming
+                    # the dropped measurement is correct by construction, not because anything
+                    # measured it (#1231 review, finding 5).
+                    _record_slot_drop(ctx, dwg, "position", i, name, s, entry.id)
     return count
 
 

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -536,10 +536,13 @@ def render_slots(dwg, plan, a, *, ctx, only=None) -> int:
                 count += 1
             else:
                 # `pos.id`, like the width and length drops above. `render_slots` has TWO drop
-                # paths and only the corridor one (`_far_or_drop`, ~100 lines up) passed a
-                # measurement; this one — the non-corridor branch, reached when `_place` fails —
-                # passed none, so a dropped slot position could reach the coverage ledger with
-                # nothing to identify it and degrade from `dropped` to `missing`.
+                # paths, and for a POSITION drop only the corridor one (`_far_or_drop`, ~100
+                # lines up) named its measurement; this one — the non-corridor branch, reached
+                # when `_place` fails — passed none, so a dropped slot position could reach the
+                # coverage ledger with nothing to identify it and degrade from `dropped` to
+                # `missing`. Scope that precisely: on this same branch the width and length
+                # drops immediately above ALREADY passed `wpd.id`/`lpd.id`. It was the position
+                # drop alone that was anonymous, which is why the asymmetry was easy to miss.
                 #
                 # I reverted this once, having "measured `main`" and found the record already
                 # carried `location_slot.length`. That measurement was of the OTHER call site:
@@ -567,10 +570,16 @@ def render_slots(dwg, plan, a, *, ctx, only=None) -> int:
                 if _place(axis, start, end, perp_lo, perp_hi, entry, kind, anchor="lo"):
                     count += 1
                 else:
-                    # `entry.id`: this is the non-Z POCKET branch — reached only when
-                    # `pos is None`, which is why passing `pos.id` here raises — and it places
-                    # one entry per in-plane coordinate, so `entry` is the measurement being
-                    # dropped. It previously passed none, unlike the width/length drops above.
+                    # `entry.id`: this is the non-Z POCKET branch, and it places one entry per
+                    # in-plane coordinate, so `entry` is the measurement being dropped. It
+                    # previously passed none, unlike the width/length drops above.
+                    #
+                    # `pos` is always None here, which is why passing `pos.id` raises — but not
+                    # for the reason an earlier version of this comment gave. The `elif` is
+                    # reached whenever the `if` is false, which includes a slot whose position
+                    # is merely too small to draw. It is None because `_compile_slot_positions`
+                    # emits only for `SlotFeature`, and `PocketFeature` is not a subclass of it
+                    # (#1231 review round 4).
                     #
                     # No TEST observes this — reverting it passes the full tier — but the
                     # product does: 29 `pocket_dim_dropped` records across nist_ctc_01 and both

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -535,15 +535,18 @@ def render_slots(dwg, plan, a, *, ctx, only=None) -> int:
             ):
                 count += 1
             else:
-                # No `measurement=` here, deliberately, and it was worth checking rather than
-                # "fixing" by symmetry with the width/length drops above. A review reported this
-                # as a dropped slot position that names no measurement; measured on `main`, the
-                # record ALREADY carries `location_slot.length`, because the corridor's own drop
-                # path supplies it. Adding `pos.id` here changed nothing observable — the
-                # mutation removing it again survived the suite — so the line stays as it was
-                # rather than carrying a comment claiming a fix it does not make
-                # (#1231 review, finding 5).
-                _record_slot_drop(ctx, dwg, "position", i, name, s)
+                # `pos.id`, like the width and length drops above. `render_slots` has TWO drop
+                # paths and only the corridor one (`_far_or_drop`, ~100 lines up) passed a
+                # measurement; this one — the non-corridor branch, reached when `_place` fails —
+                # passed none, so a dropped slot position could reach the coverage ledger with
+                # nothing to identify it and degrade from `dropped` to `missing`.
+                #
+                # I reverted this once, having "measured `main`" and found the record already
+                # carried `location_slot.length`. That measurement was of the OTHER call site:
+                # my test part only ever reached the corridor path. Instrumenting which line
+                # fires shows 12 nameless position drops across nist_ctc_03 and nist_ctc_04,
+                # all from here (#1231 review, finding 1).
+                _record_slot_drop(ctx, dwg, "position", i, name, s, pos.id)
         elif s.kind == "pocket" and s.frame.axis != "z":
             # Side-/front-opening pockets need two in-plane coordinates in their
             # end-on view.  The compiler approves one entry PER coordinate, each with its
@@ -568,10 +571,14 @@ def render_slots(dwg, plan, a, *, ctx, only=None) -> int:
                     # `pos is None`, which is why passing `pos.id` here raises — and it places
                     # one entry per in-plane coordinate, so `entry` is the measurement being
                     # dropped. It previously passed none, unlike the width/length drops above.
-                    # Honest about the evidence: NO test observes this. Reverting it passes the
-                    # full tier. It is kept because the branch demonstrably executes and naming
-                    # the dropped measurement is correct by construction, not because anything
-                    # measured it (#1231 review, finding 5).
+                    #
+                    # No TEST observes this — reverting it passes the full tier — but the
+                    # product does: 29 `pocket_dim_dropped` records across nist_ctc_01 and both
+                    # nist_ctc_05 fixtures gain a measurement id. An earlier version of this
+                    # comment said it was kept as correct-by-construction "not because anything
+                    # measured it", which had the direction exactly backwards: the change I
+                    # called unobservable fixes 29 records, while the one I reverted as
+                    # non-reproducing was leaving 12 broken (#1231 review, finding 3).
                     _record_slot_drop(ctx, dwg, "position", i, name, s, entry.id)
     return count
 

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -1152,6 +1152,19 @@ def _compile_slot_positions(model: PartModel) -> tuple[list[ApprovedDimension], 
                 kind="length",
                 role=f.LOCATION_STEM,  # the feature owns its name (#966)
                 axis=f.long_axis,
+                # The direction the measurement RUNS, which every sibling location role
+                # states and this one did not: `_compile_off_axis_hole_locations` passes
+                # `discriminator=meas`, a non-Z pocket the same. Without it the entry has the
+                # shape `render_locations` reads as "plan location, either ladder" — so on a
+                # Z-LONG slot (only nist_ctc_02 in the corpus) the Y location dim was minted
+                # claiming `location_slot.length`, a Z extent of 94.1, while drawing 430 (#1219).
+                #
+                # `axis` stays the long axis. For a SlotFeature `frame.axis` IS the long axis —
+                # measured, they are equal for all 25 slots in the fixture corpus — so passing
+                # `f.frame.axis` here to "match the siblings" would be a no-op dressed up as a
+                # fix. The field genuinely means the feature normal elsewhere and the long axis
+                # here; that inconsistency is real, and naming it beats papering over it.
+                discriminator=f.long_axis,
             )
         )
     return approved, omissions

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -1152,12 +1152,15 @@ def _compile_slot_positions(model: PartModel) -> tuple[list[ApprovedDimension], 
                 kind="length",
                 role=f.LOCATION_STEM,  # the feature owns its name (#966)
                 axis=f.long_axis,
-                # The direction the measurement RUNS, which every sibling location role
-                # states and this one did not: `_compile_off_axis_hole_locations` passes
-                # `discriminator=meas`, a non-Z pocket the same. Without it the entry has the
-                # shape `render_locations` reads as "plan location, either ladder" — so on a
-                # Z-LONG slot (only nist_ctc_02 in the corpus) the Y location dim was minted
-                # claiming `location_slot.length`, a Z extent of 94.1, while drawing 430 (#1219).
+                # The direction the measurement RUNS, which this entry's DIRECTIONAL siblings
+                # state and it did not: `_compile_off_axis_hole_locations` passes
+                # `discriminator=meas`, a non-Z pocket the same. (Not "every sibling" — the
+                # Z-normal pocket ladder above deliberately passes none, and its comment says
+                # why.) That is the stronger framing: `discriminator=None` on a location entry
+                # MEANS "feeds both plan ladders", which is exactly what `render_locations`
+                # acted on — so on a Z-LONG slot (only nist_ctc_02 in the corpus) both ladders
+                # took it, and the Y one minted a dim claiming `location_slot.length`, a Z
+                # extent of 94.1, while drawing 430 (#1219).
                 #
                 # `axis` stays the long axis. For a SlotFeature `frame.axis` IS the long axis,
                 # and structurally so: all three construction sites — `detect.py:344`,

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -1159,11 +1159,14 @@ def _compile_slot_positions(model: PartModel) -> tuple[list[ApprovedDimension], 
                 # Z-LONG slot (only nist_ctc_02 in the corpus) the Y location dim was minted
                 # claiming `location_slot.length`, a Z extent of 94.1, while drawing 430 (#1219).
                 #
-                # `axis` stays the long axis. For a SlotFeature `frame.axis` IS the long axis —
-                # measured, they are equal for all 25 slots in the fixture corpus — so passing
-                # `f.frame.axis` here to "match the siblings" would be a no-op dressed up as a
-                # fix. The field genuinely means the feature normal elsewhere and the long axis
-                # here; that inconsistency is real, and naming it beats papering over it.
+                # `axis` stays the long axis. For a SlotFeature `frame.axis` IS the long axis,
+                # and structurally so: all three construction sites — `detect.py:344`,
+                # `detect.py:367`, `declare.py:1158` — pass `axis=long_axis` unconditionally,
+                # so passing `f.frame.axis` here to "match the siblings" would be a no-op
+                # dressed up as a fix. (A draft justified this by counting slots in the corpus,
+                # which is both weaker and, at "25", wrong: there are 24.) The field genuinely
+                # means the feature normal elsewhere and the long axis here; that inconsistency
+                # is real, and naming it beats papering over it.
                 discriminator=f.long_axis,
             )
         )

--- a/tests/test_issue_1217_the_facility_is_shared.py
+++ b/tests/test_issue_1217_the_facility_is_shared.py
@@ -51,15 +51,11 @@ _NON_MEASURING_ANNOTATIONS = ("detail_caption",)
 #:
 #: Pinned exactly, per part and name, so a fourth occurrence fails rather than being absorbed —
 #: this register is a defect ledger, not an exemption list, and it should shrink to nothing.
-#: Claims the drawing does NOT bear out, pinned the same way and for the same reason. One entry:
-#: `m_locy7` on nist_ctc_02 claims `location_slot.length` (94.1) and renders 430.0, which is
-#: **#1219** and reproduces identically on `main`. It is registered rather than tolerated because
-#: the fast sweep asserts `not unconfirmed` outright and the slow sweep must not be the weaker
-#: gate — a wrong id on a CTC-only path would otherwise survive exactly as one did in fast-tier
-#: code until round 2 of this PR's review (#1225 review, round 3, finding 1).
-_UNCONFIRMED_CLAIMS = {
-    ("nist_ctc_02_asme1_ap203.stp", "m_locy7", "location_slot.length"),
-}
+#: Empty, and that is the point. It held one entry — `m_locy7` on nist_ctc_02 claiming
+#: `location_slot.length` (94.1) while rendering 430.0 — until #1219 was fixed, at which point
+#: the entry had to go. Kept as an empty set rather than deleted so the next such defect is
+#: registered with an issue number instead of the assertion below being softened.
+_UNCONFIRMED_CLAIMS: set[tuple[str, str, str]] = set()
 
 _UNPLANNED_VALUES = {
     ("grm03_thumbwheel_drive_screw.step", "m_steplen0"),
@@ -340,7 +336,10 @@ class TestNoMeasuredAnnotationEscapesUnclaimed:
             self._corpus((fixture,), parts=False)
         )
         escapes = [e for e in escapes if e not in _UNPLANNED_VALUES]
+        seen = {u[:3] for u in unconfirmed}
         unconfirmed = [u for u in unconfirmed if u[:3] not in _UNCONFIRMED_CLAIMS]
+        stale = {r for r in _UNCONFIRMED_CLAIMS if r[0] == fixture.rsplit("/", 1)[-1]} - seen
+        assert not stale, f"{stale} no longer occurs — delete the entry, do not carry it"
         assert unclaimed > 40, f"only {unclaimed} unclaimed annotations examined; too few"
         assert readable > 40, f"only {readable} claimed annotations render a readable number"
         assert claims > 100, f"only {claims} claims verified; `not unconfirmed` means little"

--- a/tests/test_issue_1219_location_claims_its_own_axis.py
+++ b/tests/test_issue_1219_location_claims_its_own_axis.py
@@ -1,0 +1,177 @@
+"""#1219 — a location dimension must claim a measurement that runs where it draws.
+
+`render_locations` draws the plan X/Y ladders: a datum→feature offset in the page plane. It
+selects what to draw from `plan.locations` with ``if loc.axis != "z": continue``, reading `axis`
+as "this feature opens along Z, so its position is an in-plane pair".
+
+`_compile_slot_positions` did not use `axis` that way. It passed the slot's LONG axis and no
+discriminator at all, which is indistinguishable from the plan-location shape — so a slot that
+happens to run along Z fell into BOTH ladders, and each minted a dimension claiming
+`location_slot.length`, a measurement running along Z:
+
+    without the fix:  m_locx2 location_slot.length value_absent
+                      m_locy1 location_slot.length value_absent   + `claimed_value_absent` lint
+    with the fix:     (none)
+
+Found by the claim verifier (#1218) on `nist_ctc_02`, where only the Y ladder showed it — the X
+one merged the slot's ordinate into a neighbour's. The synthetic part below shows both, builds in
+about a second, and does not need a slow-tier CTC fixture.
+
+Two halves to the fix, and a guard for each: the compiler states the direction its measurement
+runs (`discriminator`), and `render_locations` leaves `location_slot` entries to `render_slots`,
+which draws that measurement and is the only annotation entitled to claim it. Before, whether a
+slot got a spurious plan-location dim depended on which way it happened to run — X- and Y-long
+slots were filtered out by `loc.axis != "z"` and Z-long ones were not.
+"""
+
+from __future__ import annotations
+
+import pytest
+from build123d import Align, Box, Cylinder, Pos
+
+from draftwright.builder import build_drawing
+from draftwright.linting.evidence import verify_measurement_claims
+from draftwright.model.compiled import compile_dimensions
+from draftwright.model.ir import SlotFeature
+
+_C = (Align.CENTER, Align.CENTER, Align.CENTER)
+_CTC02 = "tests/fixtures/nist_ctc_02_asme1_ap203.stp"
+_SLOT_POSITION = f"{SlotFeature.LOCATION_STEM}.length"
+
+
+def _z_long_slot_and_located_holes():
+    """A Z-long slot AND two located holes — both are needed to reach the defect.
+
+    The holes are not decoration. `render_locations` takes its datum from ``approved[0]``, so a
+    slot on its own is measured from itself, the offset is zero, and the ladder draws nothing at
+    all. Only once another location entry establishes the bounding-box corner datum does the
+    slot's ordinate become a drawable offset — which is why this reproduces and a bare slotted
+    block does not.
+    """
+    return (
+        Box(140, 60, 80, align=_C)
+        - Pos(35, 0, 10) * Box(14, 90, 80, align=_C)
+        - Pos(-50, 18, 0) * Cylinder(5, 120, align=_C)
+        - Pos(-20, -18, 0) * Cylinder(5, 120, align=_C)
+    )
+
+
+def _drawing():
+    return build_drawing(_z_long_slot_and_located_holes(), title="T", number="N-1")
+
+
+def _claims(drawing):
+    return verify_measurement_claims(drawing.registry, compile_dimensions(drawing.model()))
+
+
+def _ladder(drawing):
+    return sorted(n for n in drawing.registry.names() if n.startswith(("m_locx", "m_locy")))
+
+
+class TestThePartReallyContainsTheDefectsShape:
+    """Preconditions. Each assertion below is worthless on a part that cannot fail."""
+
+    def test_the_slot_is_recognised_and_runs_along_z(self):
+        slots = [f for f in _drawing().model().features if isinstance(f, SlotFeature)]
+        assert slots, "no slot recognised; nothing here exercises the defect"
+        assert any(s.long_axis == "z" for s in slots), [s.long_axis for s in slots]
+
+    def test_the_plan_ladder_actually_draws(self):
+        # An X- or Y-long slot never reached the ladder, so a part whose ladder is empty would
+        # pass every assertion below without touching the code path at all.
+        drawing = _drawing()
+        names = _ladder(drawing)
+        assert len(names) >= 4, names
+        assert [n for n in names if drawing.registry.measurement_of(n)], (
+            "no plan-location annotation claims anything; the ladder is not being exercised"
+        )
+
+    def test_the_slot_position_is_compiled(self):
+        plan = compile_dimensions(_drawing().model())
+        assert [loc for loc in plan.locations if loc.role == SlotFeature.LOCATION_STEM], (
+            "no slot position compiled; there is no measurement to mis-bind"
+        )
+
+
+class TestTheSlotPositionIsClaimedOnlyByWhatDrawsIt:
+    def test_no_plan_ladder_annotation_claims_the_slot_position(self):
+        # The defect, stated exactly: without the fix, m_locx2 and m_locy1 both claim it.
+        drawing = _drawing()
+        offenders = {
+            name: [str(i.parameter) for i in drawing.registry.measurement_of(name)]
+            for name in _ladder(drawing)
+            if any(
+                str(i.parameter) == _SLOT_POSITION for i in drawing.registry.measurement_of(name)
+            )
+        }
+        assert not offenders, (
+            f"{offenders} are plan-plane offsets claiming the slot's position, which runs along "
+            "the slot's long axis. Give the compiled entry a `discriminator` so it cannot be "
+            "read as a plan location (#1219)."
+        )
+
+    def test_nothing_on_the_sheet_claims_a_value_it_does_not_render(self):
+        outcomes = _claims(_drawing())
+        assert len(outcomes) > 5, f"only {len(outcomes)} claims; too few to mean anything"
+        assert not [o for o in outcomes if o.state != "confirmed"], [
+            (o.annotation, o.parameter_id, o.state) for o in outcomes if o.state != "confirmed"
+        ]
+
+    def test_the_compiled_entry_states_the_direction_it_runs(self):
+        # The compiler half of the fix. Without a discriminator the entry has the same shape as
+        # a plan-location pair, and both ladders take it.
+        plan = compile_dimensions(_drawing().model())
+        entries = [loc for loc in plan.locations if loc.role == SlotFeature.LOCATION_STEM]
+        assert entries, "no slot position compiled; the loop below is vacuous"
+        for loc in entries:
+            assert loc.discriminator is not None, (
+                f"a {loc.role!r} entry with no discriminator reads as a plan location"
+            )
+
+    def test_no_plan_ladder_annotation_is_drawn_without_a_claim(self):
+        # The RENDERER half, which the two assertions above do not reach: once the compiled
+        # entry carries a discriminator the ladder mints no claim from it, but it still drew a
+        # dimension — an unbacked plan offset for the slot, with nothing behind it. Reverting
+        # only the renderer skip leaves every claim correct and every one of these annotations
+        # silent, which is how that mutation survived until this test existed.
+        drawing = _drawing()
+        names = _ladder(drawing)
+        assert names, "no plan-location annotations at all; the assertion below is vacuous"
+        unclaimed = [n for n in names if not drawing.registry.measurement_of(n)]
+        assert not unclaimed, (
+            f"{unclaimed} draw a plan offset and claim nothing. `render_slots` owns the slot's "
+            "position; the plan ladder must not mint a second, uncompiled dimension for it."
+        )
+
+    def test_an_x_long_slot_behaves_the_same_way(self):
+        # The incoherence the renderer half removes: before, a slot got a spurious plan-location
+        # dim or not depending on which way it ran. Both must now be silent in the ladder.
+        part = Box(90, 50, 12, align=_C) - Pos(0, 0, 4) * Box(120, 10, 6, align=_C)
+        drawing = build_drawing(part, title="T", number="N-1")
+        assert not [
+            n
+            for n in _ladder(drawing)
+            if any(str(i.parameter) == _SLOT_POSITION for i in drawing.registry.measurement_of(n))
+        ]
+
+
+class TestTheReportedFixture:
+    """`nist_ctc_02` as filed. Slow-tier: CTC builds are slow-tier by policy (#153)."""
+
+    @pytest.mark.slow
+    def test_no_claim_on_the_reported_fixture_is_unconfirmed(self):
+        drawing = build_drawing(_CTC02, title="T", number="N-1")
+        outcomes = verify_measurement_claims(drawing.registry, compile_dimensions(drawing.model()))
+        assert len(outcomes) > 100, f"only {len(outcomes)} claims; too few to mean anything"
+        assert not [o for o in outcomes if o.state != "confirmed"], [
+            (o.annotation, o.parameter_id, o.state) for o in outcomes if o.state != "confirmed"
+        ]
+
+    @pytest.mark.slow
+    def test_the_slot_position_is_claimed_by_the_annotation_that_draws_it(self):
+        drawing = build_drawing(_CTC02, title="T", number="N-1")
+        claims = [c for c in _claims(drawing) if c.parameter_id == _SLOT_POSITION]
+        assert claims, "the fixture compiles no slot position; the loop below is vacuous"
+        for claim in claims:
+            assert claim.annotation.startswith("m_slot"), claim
+            assert claim.state == "confirmed", claim

--- a/tests/test_issue_1219_location_claims_its_own_axis.py
+++ b/tests/test_issue_1219_location_claims_its_own_axis.py
@@ -14,8 +14,23 @@ happens to run along Z fell into BOTH ladders, and each minted a dimension claim
     with the fix:     (none)
 
 Found by the claim verifier (#1218) on `nist_ctc_02`, where only the Y ladder showed it — the X
-one merged the slot's ordinate into a neighbour's. The synthetic part below shows both, builds in
-about a second, and does not need a slow-tier CTC fixture.
+one merged the slot's ordinate into a neighbour's. The synthetic part below shows both and does
+not need a slow-tier CTC fixture.
+
+**The dimension it was drawing was not the slot's position at all.** `model/detect.py::_convert_slot`
+builds a slot's frame as the part's BOUNDING-BOX CENTRE, overwriting only the long-axis
+component, so the compiled entry's other two coordinates are the part centreline. Measured on
+`main`, moving the slot along its width axis leaves the drawn labels unchanged::
+
+    slot x=35  w_center=35.0  ladder m_locx2='70' m_locy1='30'
+    slot x=50  w_center=50.0  ladder m_locx2='70' m_locy1='30'
+    slot x=20  w_center=20.0  ladder m_locx2='70' m_locy1='30'
+
+70 and 30 are half of 140 and 60 — the part's own centre, from the datum. On `nist_ctc_02` the
+same holds: `430` is half the part's Y extent, not the slot at y=390. #1219's own parenthetical
+("correct — the slot sits at y=390") is therefore wrong, and so was the first draft of this
+docstring. The ladder was not mislabelling the slot's position; it was drawing the part's
+centreline and attributing it to the slot.
 
 Two halves to the fix, and a guard for each: the compiler states the direction its measurement
 runs (`discriminator`), and `render_locations` leaves `location_slot` entries to `render_slots`,
@@ -56,8 +71,29 @@ def _z_long_slot_and_located_holes():
     )
 
 
-def _drawing():
-    return build_drawing(_z_long_slot_and_located_holes(), title="T", number="N-1")
+def _x_long_slots_and_located_holes():
+    """Two X-long slots and two located holes — the same shape with the slot running the OTHER
+    way. Before the fix these were filtered out by `loc.axis != "z"` and got no plan-location
+    dim; the point of the renderer half is that every slot is now handled the one way."""
+    return (
+        Box(120, 70, 14, align=_C)
+        - Pos(-25, 0, 0) * Box(30, 10, 40, align=_C)
+        - Pos(25, 0, 0) * Box(30, 10, 40, align=_C)
+        - Pos(-45, 25, 0) * Cylinder(4, 40, align=_C)
+        - Pos(40, -25, 0) * Cylinder(4, 40, align=_C)
+    )
+
+
+#: One build per part, shared. `test_issue_1217` established this for the same reason
+#: (#1225 review, findings 1 and 10); nothing here mutates a drawing.
+_BUILT: dict[str, object] = {}
+
+
+def _drawing(which: str = "z"):
+    if which not in _BUILT:
+        make = {"z": _z_long_slot_and_located_holes, "x": _x_long_slots_and_located_holes}[which]
+        _BUILT[which] = build_drawing(make(), title="T", number="N-1")
+    return _BUILT[which]
 
 
 def _claims(drawing):
@@ -143,16 +179,72 @@ class TestTheSlotPositionIsClaimedOnlyByWhatDrawsIt:
             "position; the plan ladder must not mint a second, uncompiled dimension for it."
         )
 
+    def test_x_long_slots_really_exist_on_the_other_part(self):
+        # Precondition. The first version of the test below used a part that recognised NO slot
+        # and whose ladder was empty, so `assert not []` passed against completely unfixed code
+        # — the exact failure this file's other precondition class exists to prevent, in this
+        # file (#1231 review, finding 2).
+        drawing = _drawing("x")
+        slots = [f for f in drawing.model().features if isinstance(f, SlotFeature)]
+        assert slots, "no slot recognised; the assertion below cannot fail"
+        assert all(s.long_axis == "x" for s in slots), [s.long_axis for s in slots]
+        assert _ladder(drawing), "no plan-location annotations; the ladder is not exercised"
+
     def test_an_x_long_slot_behaves_the_same_way(self):
         # The incoherence the renderer half removes: before, a slot got a spurious plan-location
-        # dim or not depending on which way it ran. Both must now be silent in the ladder.
-        part = Box(90, 50, 12, align=_C) - Pos(0, 0, 4) * Box(120, 10, 6, align=_C)
-        drawing = build_drawing(part, title="T", number="N-1")
+        # dim or not depending on which way it ran. Both must now be silent in the ladder, and
+        # every plan-location annotation must still carry a claim.
+        drawing = _drawing("x")
         assert not [
             n
             for n in _ladder(drawing)
             if any(str(i.parameter) == _SLOT_POSITION for i in drawing.registry.measurement_of(n))
         ]
+        assert not [n for n in _ladder(drawing) if not drawing.registry.measurement_of(n)]
+
+
+class TestADroppedSlotPositionSaysWhichMeasurementItLost:
+    """A property worth pinning, and NOT a guard for anything this change did.
+
+    A review reported that a dropped slot position names no measurement, unlike a dropped width
+    or length. Measured on `main`, it does — the corridor's own drop path supplies
+    `location_slot.length` — so the finding did not reproduce and the `_record_slot_drop` call
+    keeps its original arguments. These tests pass on `main` too.
+
+    They stay because the property is real and nothing else asserted it: a coverage ledger that
+    cannot tell a dropped measurement from an unplanned one reports `missing` where it should
+    report `dropped`.
+    """
+
+    def _part(self):
+        # Two Z-long slots and a hole, sized so the position dims cannot all be placed — the
+        # drop path has to actually run for this to assert anything.
+        return (
+            Box(160, 70, 80, align=_C)
+            - Pos(-40, 0, 10) * Box(14, 100, 80, align=_C)
+            - Pos(40, 0, 10) * Box(14, 100, 80, align=_C)
+            - Pos(0, 25, 0) * Cylinder(5, 120, align=_C)
+        )
+
+    def test_the_drop_path_really_runs(self):
+        # Precondition: without a dropped position dim there is nothing to inspect.
+        issues = build_drawing(self._part(), title="T", number="N-1").lint()
+        assert [i for i in issues if i.code == "slot_dim_dropped" and "position" in i.message], (
+            "no slot position dim was dropped; the assertion below is vacuous"
+        )
+
+    def test_it_names_the_measurement_it_dropped(self):
+        issues = build_drawing(self._part(), title="T", number="N-1").lint()
+        for issue in issues:
+            if issue.code != "slot_dim_dropped" or "position" not in issue.message:
+                continue
+            assert issue.measurement_ids, (
+                f"{issue.message!r} records no measurement, so the coverage ledger cannot tell "
+                "a dropped slot position from one that was never planned"
+            )
+            assert {str(m.parameter) for m in issue.measurement_ids} == {_SLOT_POSITION}, [
+                str(m.parameter) for m in issue.measurement_ids
+            ]
 
 
 class TestTheReportedFixture:

--- a/tests/test_issue_1219_location_claims_its_own_axis.py
+++ b/tests/test_issue_1219_location_claims_its_own_axis.py
@@ -204,47 +204,46 @@ class TestTheSlotPositionIsClaimedOnlyByWhatDrawsIt:
 
 
 class TestADroppedSlotPositionSaysWhichMeasurementItLost:
-    """A property worth pinning, and NOT a guard for anything this change did.
+    """`render_slots` has TWO drop paths, and only one of them named its measurement.
 
-    A review reported that a dropped slot position names no measurement, unlike a dropped width
-    or length. Measured on `main`, it does — the corridor's own drop path supplies
-    `location_slot.length` — so the finding did not reproduce and the `_record_slot_drop` call
-    keeps its original arguments. These tests pass on `main` too.
+    The corridor path (`_far_or_drop`) passes `approved.id` and is already covered by
+    `tests/test_slot_completeness.py::test_a_real_placement_failure_retains_the_dropped_measurement`,
+    which also pins the ledger consequence: emptying `measurement_ids` degrades the outcome from
+    `dropped` to `missing`. The NON-corridor path — the `else` after `_place` fails — passed
+    nothing, and nothing covered it.
 
-    They stay because the property is real and nothing else asserted it: a coverage ledger that
-    cannot tell a dropped measurement from an unplanned one reports `missing` where it should
-    report `dropped`.
+    I reverted this fix once, on the strength of "measured `main`, the record already carries
+    `location_slot.length`". That measurement was of the corridor path: my synthetic part never
+    reached the other one. Instrumenting which line fires shows 12 nameless position drops across
+    `nist_ctc_03` and `nist_ctc_04`, every one from the uncovered branch (#1231 review, finding 1).
+
+    So these use `nist_ctc_04`, which is where the uncovered path actually runs. Slow-tier: CTC
+    builds are slow-tier by policy (#153).
     """
 
-    def _part(self):
-        # Two Z-long slots and a hole, sized so the position dims cannot all be placed — the
-        # drop path has to actually run for this to assert anything.
-        return (
-            Box(160, 70, 80, align=_C)
-            - Pos(-40, 0, 10) * Box(14, 100, 80, align=_C)
-            - Pos(40, 0, 10) * Box(14, 100, 80, align=_C)
-            - Pos(0, 25, 0) * Cylinder(5, 120, align=_C)
-        )
+    FIXTURE = "tests/fixtures/nist_ctc_04_asme1_ap203.stp"
 
-    def test_the_drop_path_really_runs(self):
-        # Precondition: without a dropped position dim there is nothing to inspect.
-        issues = build_drawing(self._part(), title="T", number="N-1").lint()
-        assert [i for i in issues if i.code == "slot_dim_dropped" and "position" in i.message], (
-            "no slot position dim was dropped; the assertion below is vacuous"
-        )
+    @pytest.mark.slow
+    def test_the_uncovered_drop_path_really_runs(self):
+        # Precondition, and specifically that position drops HAPPEN here — the earlier version
+        # of this test asserted only "some drop occurred", which the corridor path satisfies.
+        issues = build_drawing(self.FIXTURE, title="T", number="N-1").lint()
+        drops = [i for i in issues if i.code == "slot_dim_dropped" and "position" in i.message]
+        assert len(drops) >= 5, f"only {len(drops)} position drops; too few to mean anything"
 
-    def test_it_names_the_measurement_it_dropped(self):
-        issues = build_drawing(self._part(), title="T", number="N-1").lint()
-        for issue in issues:
-            if issue.code != "slot_dim_dropped" or "position" not in issue.message:
-                continue
-            assert issue.measurement_ids, (
-                f"{issue.message!r} records no measurement, so the coverage ledger cannot tell "
-                "a dropped slot position from one that was never planned"
-            )
-            assert {str(m.parameter) for m in issue.measurement_ids} == {_SLOT_POSITION}, [
-                str(m.parameter) for m in issue.measurement_ids
-            ]
+    @pytest.mark.slow
+    def test_every_dropped_position_names_the_measurement_it_lost(self):
+        issues = build_drawing(self.FIXTURE, title="T", number="N-1").lint()
+        nameless = [
+            i.message
+            for i in issues
+            if i.code == "slot_dim_dropped" and "position" in i.message and not i.measurement_ids
+        ]
+        assert not nameless, (
+            f"{nameless} record no measurement, so the coverage ledger cannot tell a dropped "
+            "slot position from one that was never planned — it reports `missing` where it "
+            "should report `dropped`."
+        )
 
 
 class TestTheReportedFixture:


### PR DESCRIPTION
Closes #1219.

## The defect

`render_locations` draws the plan X/Y ladders — a datum→feature offset in the page plane — and
picks what to draw with `if loc.axis != "z": continue`, reading `axis` as *"this feature opens
along Z, so its position is an in-plane pair"*.

`_compile_slot_positions` did not use `axis` that way. It passed the slot's **long** axis and no
discriminator at all, which is exactly the plan-location shape. So a slot that happened to run
along Z fell into **both** ladders, and each minted a dimension claiming `location_slot.length` —
a measurement running along Z — on an annotation drawing an offset along X or Y.

Whether a slot got a spurious plan-location dim therefore depended on which way it happened to
run. The false claim is the symptom; that incoherence is the defect.

**And the dimension it drew was not the slot's position at all.** `_convert_slot` builds a slot's
frame as the part's **bounding-box centre**, overwriting only the long-axis component, so the
entry's other two coordinates are the part centreline. Measured on `main`, moving the slot along
its width axis leaves the labels unchanged:

```
slot x=35  w_center=35.0  ladder m_locx2='70' m_locy1='30'
slot x=50  w_center=50.0  ladder m_locx2='70' m_locy1='30'
slot x=20  w_center=20.0  ladder m_locx2='70' m_locy1='30'
```

70 and 30 are half of 140 and 60. On `nist_ctc_02`, `430` is half the part's Y extent, not the
slot at y=390 — so **#1219's own parenthetical, "(correct — the slot sits at y=390)", is wrong**.
The ladder was drawing the part's centreline and attributing it to the slot. Nothing is lost by
removing it: the slot's across-width position is still dimensioned by the shoulder dims, and its
long-axis position by `m_slot0_pos`.

```
without the fix:  m_locx2  location_slot.length  value_absent
                  m_locy1  location_slot.length  value_absent   + `claimed_value_absent` lint
with the fix:     (none)
```

## The fix — two halves

- **Compiler**: state the direction the measurement runs (`discriminator`), as every sibling
  location role already does (`_compile_off_axis_hole_locations` passes `discriminator=meas`; a
  non-Z pocket the same).
- **Renderer**: `render_locations` leaves `location_slot` entries to `render_slots`, which draws
  that measurement from the same entry and is the only annotation entitled to claim it.

An earlier draft called these "each separately load-bearing". **That was false.** Deleting the
discriminator and deselecting the one test that asserts the field is non-`None` passes the entire
fast tier, and giving it a *wrong* value (`"x"`, or `f.width_axis`) passes every test in the file
— the renderer skip precedes every read of it for that role. The line stays as intent-stating
defence-in-depth, and the claim is withdrawn. The renderer half is the one that does the work.

`axis` stays the long axis. For a `SlotFeature`, `frame.axis` **is** the long axis — measured,
equal at all three construction sites, which pass `axis=long_axis` unconditionally — so
passing `f.frame.axis` "to match the siblings"
would have been a no-op dressed up as a fix. I wrote that version first; the measurement caught
it. The field means the feature normal elsewhere and the long axis here, and naming that beats
papering over it. This is **structural**, not a corpus observation: all three `SlotFeature`
construction sites pass `axis=long_axis` unconditionally. (An earlier draft argued it by counting
slots — a weaker argument, and the count it gave, 25, was wrong: there are 24.)

## Effect on the reported fixture

`nist_ctc_02` keeps **all 170 annotations** and exactly one label changes:

```
labels only BEFORE: ['430']      <- the slot's unbacked plan offset
labels only AFTER : ['447.6']    <- a real hole location the solve had squeezed out
names gone: []   names new: []
```

A `location_ref_dropped` warning was already reporting that loss (its count goes 6 → 5), and
hole coverage improves: `location.location.y` moves `dropped` → `placed`, completeness
0.7970 → 0.8045. `location_slot.length` was *already* claimed by `m_slot0_pos` and confirmed on
`main`; what changes is that `m_locy7` stops **also** claiming it.

**The blast radius is wider than that one fixture, and that is the point.** On a part with two
Z-long slots, withdrawing two false `placed` credits moves fidelity 0.80 → 1.00 (four
`claimed_value_absent` gone) and completeness 0.80 → 0.60, with a new `slot_requirement_missing`.
That is the correct answer — the withdrawn credits pointed at annotations measuring the part
centreline — but a drawing can score *lower* on completeness after this change, and it should be
expected rather than come as a surprise.

## Verification

- Regression test is **synthetic and fast (~4 s)**, not the CTC fixture. It needs *both* a Z-long
  slot and two located holes: `render_locations` takes its datum from `approved[0]`, so a slot
  alone is measured from itself, the offset is zero and the ladder draws nothing. Two earlier
  candidate fixtures asserted nothing at all, which their own precondition tests caught. It also
  shows **both** ladders taking the entry, where the reported fixture showed only Y.
- **Mutations, substitution asserted applied each time.** Dropping the discriminator → KILLED.
  Reverting the renderer skip → KILLED, *but only after a fourth test was added*: with the
  discriminator in place the ladder mints no claim from a slot entry while still **drawing** an
  unbacked dimension for it, so the three claim-shaped assertions all passed on that mutant.
- The `_UNCONFIRMED_CLAIMS` register in #1225's ratchet held one entry for this defect. It is
  empty now, kept as an empty set with an assertion that a registered entry which no longer
  occurs must be deleted rather than carried.
- Full fast tier **4,295 passed**, 5 skipped, 2 xfailed. Slow tier **7 passed** across the three
  files this touches. `scripts/pr-check --static` exit 0 (read from `$?`).

## Architectural fit

Sits at the ADR 0010 provenance seam and the ADR 0016 Amdt 1 compiled-plan boundary: the point of
the change is that a renderer stops emitting a dimension the compiler never approved, and stops
attaching a compiled id to an annotation that draws something else. No IR shape change, no new
module edges.


---

## Review

Two adversarial rounds. The first found the fix sound and loses nothing — verified independently by
moving the slot and watching the removed labels not move — and found four things wrong with the
prose and one vacuous test. All are fixed:

- `test_an_x_long_slot_behaves_the_same_way` used a part recognising **no slot**, with an empty
  ladder, so `assert not []` passed against completely unfixed code. It now uses two real X-long
  slots with both preconditions asserted. Note it is a consistency check, not a discriminator:
  reverting the renderer half still passes it, correctly, since X-long slots were never admitted
  by the filter.
- "each separately load-bearing", the `m_slot0_pos` claim, and the slot count: corrected above.
- **A reported defect I wrongly declared non-reproducing.** The review asked for a one-word
  `pos.id` on a dropped slot position. I made the change, "measured `main`", saw the record
  already carrying `location_slot.length`, and reverted it. `render_slots` has **two** drop
  paths, and I had measured the other one — my synthetic part never reached the branch in
  question. Instrumenting the caller's line number over the corpus: **12 nameless position drops
  across nist_ctc_03 and nist_ctc_04**, all from the branch I had just un-fixed. Restored; all 92
  position drops now carry a measurement.

  The **inverse error** sat in the same commit: I kept `entry.id` in the pocket branch with a
  comment saying nothing measured it. It fixes **29** `pocket_dim_dropped` records (9 + 10 + 10
  nameless on `main` across nist_ctc_01 and both nist_ctc_05, 0 now). Both conclusions were
  exactly inverted, and both because I tested a part I had built rather than the corpus.

  Round 2 also showed "nothing else asserted it" was false —
  `test_slot_completeness.py::test_a_real_placement_failure_retains_the_dropped_measurement`
  pins the property and the `dropped` → `missing` ledger consequence. What it does not cover is
  the non-corridor path, so the two retained tests now point at **nist_ctc_04**, where that path
  runs, slow-marked, with a precondition asserting *position* drops specifically.
- One build per part instead of seven: 7.7 s → 2.2 s.




---

## Corpus effect, measured across all 16 fixtures

Round 3 ran a whole-corpus before/after that no earlier round had. **Eleven of sixteen fixtures
are byte-identical** in lint codes and annotation names; the five that move all improve:

```
nist_ctc_02_ap203  claimed_value_absent 1->0  fidelity 0.95->1.00  completeness 0.7970->0.8045
nist_ctc_02_ap242  claimed_value_absent 2->0  fidelity 0.90->1.00  completeness 0.8571->0.8647
nist_ctc_03_ap203  slot_requirement_missing 2->0
nist_ctc_04_ap203  slot_requirement_missing 5->0
nist_ctc_04_ap242  slot_requirement_missing 5->0
```

The `slot_requirement_missing` clearances are the drop-provenance half: **62 anonymous
`_record_slot_drop` invocations go to 0** — which surface as **41 nameless lint issues of 65**
going to 0, since several calls collapse into one issue. Both units are quoted deliberately: a
reader reproducing through `lint()` gets 41, and would otherwise conclude the 62 was invented.
A drop the ledger can identify degrades to `dropped` rather than `missing`. No fixture regresses
on any code, score, or annotation name.



## Known follow-up, not fixed here

A deferred `locate(<Z-long slot>)` now silently adds nothing, where before it added a wrong
dimension. The deferred router admits any feature whose frame axis is `z` without checking
hole/pattern, while the live path raises for a `SlotFeature`. Dropping the wrong dimension is the
right outcome and the router's laxness is pre-existing, but the user's intent now vanishes with
neither a raise nor a lint. That is a router change, not a #1219 one.
