### PR TITLE
Close the ledger's three member-keying seams (#1229)

### DIFF
--- a/src/draftwright/evaluation/step_analysis.py
+++ b/src/draftwright/evaluation/step_analysis.py
@@ -23,6 +23,21 @@ than a single case. Two instances are known:
   without addressing #754 would make the number wrong.
 
 A new representation route must be admitted here or it registers as a false loss.
+
+**Every draftwright import in this module is deliberately inside a function body** — there are
+no module-level ones at all, which is the #313 lazy-load pattern rather than an accident. It is
+load-bearing and measurable::
+
+    import draftwright.evaluation.step_analysis   0.014 s
+    import draftwright.builder                    1.781 s
+    import draftwright.linting.evidence           1.816 s
+    import draftwright.linting.hole_coverage      1.956 s
+    import draftwright.model.compiled             1.397 s
+
+Every one of them pulls build123d transitively, so hoisting any turns importing this module
+into a two-second operation for a caller that only wants to read a benchmark case. #1229 filed
+three of them as "unexplained, hoist or justify"; measuring is what showed the filing was wrong
+and this note is the justification it asked for. Keep new engine imports inside the bodies too.
 """
 
 from __future__ import annotations

--- a/src/draftwright/evaluation/step_analysis.py
+++ b/src/draftwright/evaluation/step_analysis.py
@@ -25,20 +25,22 @@ than a single case. Two instances are known:
 A new representation route must be admitted here or it registers as a false loss.
 
 **Every draftwright import in this module is deliberately inside a function body** — there are
-no module-level ones at all (six in-function), which is the #313 lazy-load pattern rather than
-an accident. It is load-bearing: importing this module costs ~0.01 s, and hoisting ANY engine
-import makes it ~2 s, because every one pulls build123d transitively. Measured in one process,
-the cost is essentially all build123d and is paid once::
+no module-level ones at all — five in-function, plus one `from build123d import import_step` —
+which is the #313 lazy-load pattern rather than an accident. It is load-bearing: importing this module costs ~0.01 s, and hoisting ANY engine import makes it
+one to two seconds, because every one pulls build123d transitively. Measured in a single process,
+the cost is essentially all build123d and is paid once — the draftwright modules themselves are
+free once it is loaded::
 
-    build123d                          2.256 s
-    draftwright.linting.hole_coverage  0.046 s   (after build123d)
-    draftwright.model.compiled         0.026 s
-    draftwright.linting.evidence       0.000 s
-    draftwright.builder                0.016 s
+    build123d                          (the whole cost)
+    draftwright.linting.hole_coverage  ~0.02-0.05 s   (after build123d)
+    draftwright.model.compiled         ~0.01-0.03 s
+    draftwright.linting.evidence        0.000 s
+    draftwright.builder                ~0.01-0.02 s
 
-(An earlier version of this note listed four figures of 1.4-2.0 s, one per module, from four
-separate cold processes — the same one-time cost measured four times and presented as if the
-modules differed. They do not.)
+Absolute seconds are deliberately not quoted for build123d: measurements on two machines gave
+1.35 s and 2.26 s. The SHAPE is the point and it reproduces. (An earlier version listed four
+figures of 1.4-2.0 s, one per module, from four separate cold processes — the same one-time cost
+measured four times and presented as if the modules differed. They do not.)
 
 #1229 filed three of these imports as "unexplained, hoist or justify"; measuring is what showed
 the filing was wrong, and this note is the justification it asked for. Keep new engine imports

--- a/src/draftwright/evaluation/step_analysis.py
+++ b/src/draftwright/evaluation/step_analysis.py
@@ -25,8 +25,10 @@ than a single case. Two instances are known:
 A new representation route must be admitted here or it registers as a false loss.
 
 **Every draftwright import in this module is deliberately inside a function body** — there are
-no module-level ones at all — five in-function, plus one `from build123d import import_step` —
-which is the #313 lazy-load pattern rather than an accident. It is load-bearing: importing this module costs ~0.01 s, and hoisting ANY engine import makes it
+no module-level ones at all — eight in function bodies: five `draftwright`, two
+`b123d_recognisers` and one `from build123d import import_step` — which is the #313 lazy-load
+pattern rather than an accident. (`b123d_recognisers` counts: importing it puts build123d in
+`sys.modules`, so it carries the same cost.) It is load-bearing: importing this module costs ~0.01 s, and hoisting ANY engine import makes it
 one to two seconds, because every one pulls build123d transitively. Measured in a single process,
 the cost is essentially all build123d and is paid once — the draftwright modules themselves are
 free once it is loaded::

--- a/src/draftwright/evaluation/step_analysis.py
+++ b/src/draftwright/evaluation/step_analysis.py
@@ -25,19 +25,24 @@ than a single case. Two instances are known:
 A new representation route must be admitted here or it registers as a false loss.
 
 **Every draftwright import in this module is deliberately inside a function body** — there are
-no module-level ones at all, which is the #313 lazy-load pattern rather than an accident. It is
-load-bearing and measurable::
+no module-level ones at all (six in-function), which is the #313 lazy-load pattern rather than
+an accident. It is load-bearing: importing this module costs ~0.01 s, and hoisting ANY engine
+import makes it ~2 s, because every one pulls build123d transitively. Measured in one process,
+the cost is essentially all build123d and is paid once::
 
-    import draftwright.evaluation.step_analysis   0.014 s
-    import draftwright.builder                    1.781 s
-    import draftwright.linting.evidence           1.816 s
-    import draftwright.linting.hole_coverage      1.956 s
-    import draftwright.model.compiled             1.397 s
+    build123d                          2.256 s
+    draftwright.linting.hole_coverage  0.046 s   (after build123d)
+    draftwright.model.compiled         0.026 s
+    draftwright.linting.evidence       0.000 s
+    draftwright.builder                0.016 s
 
-Every one of them pulls build123d transitively, so hoisting any turns importing this module
-into a two-second operation for a caller that only wants to read a benchmark case. #1229 filed
-three of them as "unexplained, hoist or justify"; measuring is what showed the filing was wrong
-and this note is the justification it asked for. Keep new engine imports inside the bodies too.
+(An earlier version of this note listed four figures of 1.4-2.0 s, one per module, from four
+separate cold processes — the same one-time cost measured four times and presented as if the
+modules differed. They do not.)
+
+#1229 filed three of these imports as "unexplained, hoist or justify"; measuring is what showed
+the filing was wrong, and this note is the justification it asked for. Keep new engine imports
+inside the bodies too.
 """
 
 from __future__ import annotations

--- a/src/draftwright/linting/hole_coverage.py
+++ b/src/draftwright/linting/hole_coverage.py
@@ -782,8 +782,16 @@ def hole_requirement_outcomes(
     for countersink in recognition.countersinks:
         if attached_countersinks[countersink]:
             attached_countersinks[countersink] -= 1
-        elif any(countersink_matches_hole(countersink, hole) for hole in recognition.holes):
-            unmatched_countersinks.append(countersink)
+            continue
+        # Keep the hole the seat matched, rather than discarding it and re-deriving a position
+        # from the seat itself. `members` is published in `canonical_hole_sites` space, and the
+        # seat's own opening centre is NOT in that space (#1229).
+        seat_hole = next(
+            (hole for hole in recognition.holes if countersink_matches_hole(countersink, hole)),
+            None,
+        )
+        if seat_hole is not None:
+            unmatched_countersinks.append((countersink, seat_hole))
 
     ir_by_key: dict[tuple[str, tuple], list] = defaultdict(list)
     owners_by_exact_member: dict[tuple, list] = defaultdict(list)
@@ -1011,21 +1019,29 @@ def hole_requirement_outcomes(
     # IR/compiler provenance without guessing which face the single slot represents.
     # Keep both of its dimensional facts in the denominator as explicit unverifiable
     # outcomes instead of hiding the standalone recognition inventory as a duplicate.
-    for countersink in unmatched_countersinks:
+    for countersink, seat_hole in unmatched_countersinks:
         at = _point(countersink.location)
+        # `members` too, like the two sites above, which omitted it here — but the seat's own
+        # opening centre is the WRONG value. `members` is published in `canonical_hole_sites`
+        # space (a through hole's coordinate along its own axis is zeroed); a raw world
+        # coordinate is not, so whether it aliased another requirement's key depended on where
+        # the solid happened to sit. Measured on the `_two_face_countersunk_hole` fixture, the
+        # raw seat centre `(0, 0, 0)` collided exactly with the bore's canonical site — the
+        # non-canonical-key defect class `_members` was fixed for in #1223, re-opened inside
+        # the fix for it (#1229 review).
+        #
+        # The seat is physically on `seat_hole`, so its canonical site is both correct and in the
+        # published space: a consumer joining by site is told "this hole carries a second
+        # countersink requirement that cannot be verified", which is the informative answer.
+        #
+        # Scope, honestly: NO consumer reads this today. `_drawing_consumer_outcomes` filters on
+        # `parameter_id == "bore.diameter"` before it ever looks at `members`, so a countersink
+        # outcome could not reach a wrong join with the old value either — the protection came
+        # from a filter, not from the empty tuple. This makes the field correct for the next
+        # consumer rather than fixing a live mis-join, and saying so beats implying otherwise.
+        sites = canonical_hole_sites(seat_hole)
         outcomes.extend(
-            # `members` too, like the two sites above. It was omitted here, so these outcomes
-            # carried the field's `()` default and no site-keyed consumer could reach them —
-            # `canonical_hole_sites` would find no match and fall through to its "unknown"
-            # default, which is the silent join failure that helper exists to prevent, one
-            # branch below where it is enforced (#1229).
-            #
-            # The alternative was an explicit `members=()` saying "deliberately unjoinable".
-            # This is better: the seat HAS a location, and a consumer that can find it and be
-            # told `unverifiable` is strictly better informed than one that cannot find it at
-            # all and infers nothing. Unjoinable to IR PROVENANCE is what `unverifiable`
-            # already says; it does not mean the outcome has no position.
-            HoleRequirementOutcome("hole", at, 1, parameter, "unverifiable", members=(at,))
+            HoleRequirementOutcome("hole", at, 1, parameter, "unverifiable", members=sites)
             for parameter in ("countersink.diameter", "countersink.angle")
         )
     return outcomes

--- a/src/draftwright/linting/hole_coverage.py
+++ b/src/draftwright/linting/hole_coverage.py
@@ -122,7 +122,15 @@ def _members(source, *, rounded: bool = True) -> tuple[tuple[float, float, float
     if recognised is not None:
         points = tuple(hole.location for hole in recognised)
         axis = _axis_letter(HoleSpec.from_hole(recognised[0]).axis)
-        through = all(HoleSpec.from_hole(hole).bottom == "through" for hole in recognised)
+        # From the group's own spec, like `axis` above — NOT `all(...)` over the members.
+        # `bottom` is a `HoleSpec` field and patterns are built by grouping on `_spec_key`, so
+        # a group cannot mix through and blind: the `all()` was exactly equivalent while
+        # reading as if it handled a case the grouping forbids, next to a line deciding the
+        # same question the other way (#1229). Note this is NOT symmetric with `axis`: within
+        # a spec group the members share a ROUNDED axis but their raw axes still differ, which
+        # is why that one must come through the spec. `bottom` needs no such normalisation —
+        # it comes through the spec to say plainly which value defines the group.
+        through = HoleSpec.from_hole(recognised[0]).bottom == "through"
     elif hasattr(source, "location"):
         points = (source.location,)
         axis = _axis_letter(HoleSpec.from_hole(source).axis)
@@ -1006,7 +1014,18 @@ def hole_requirement_outcomes(
     for countersink in unmatched_countersinks:
         at = _point(countersink.location)
         outcomes.extend(
-            HoleRequirementOutcome("hole", at, 1, parameter, "unverifiable")
+            # `members` too, like the two sites above. It was omitted here, so these outcomes
+            # carried the field's `()` default and no site-keyed consumer could reach them —
+            # `canonical_hole_sites` would find no match and fall through to its "unknown"
+            # default, which is the silent join failure that helper exists to prevent, one
+            # branch below where it is enforced (#1229).
+            #
+            # The alternative was an explicit `members=()` saying "deliberately unjoinable".
+            # This is better: the seat HAS a location, and a consumer that can find it and be
+            # told `unverifiable` is strictly better informed than one that cannot find it at
+            # all and infers nothing. Unjoinable to IR PROVENANCE is what `unverifiable`
+            # already says; it does not mean the outcome has no position.
+            HoleRequirementOutcome("hole", at, 1, parameter, "unverifiable", members=(at,))
             for parameter in ("countersink.diameter", "countersink.angle")
         )
     return outcomes

--- a/src/draftwright/linting/hole_coverage.py
+++ b/src/draftwright/linting/hole_coverage.py
@@ -1025,10 +1025,15 @@ def hole_requirement_outcomes(
         # opening centre is the WRONG value. `members` is published in `canonical_hole_sites`
         # space (a through hole's coordinate along its own axis is zeroed); a raw world
         # coordinate is not, so whether it aliased another requirement's key depended on where
-        # the solid happened to sit. Measured on the `_two_face_countersunk_hole` fixture, the
-        # raw seat centre `(0, 0, 0)` collided exactly with the bore's canonical site — the
-        # non-canonical-key defect class `_members` was fixed for in #1223, re-opened inside
-        # the fix for it (#1229 review).
+        # the solid happened to sit. On `_two_face_countersunk_hole` the raw seat centre was
+        # `(0, 0, 6)` — already a different key from the bore's `(0, 0, 0)`, aliasing nothing as
+        # authored. Translate the solid by −6 and it becomes `(0, 0, 0)` and collides. A key
+        # whose meaning moves with the part is the non-canonical-key defect class `_members` was
+        # fixed for in #1223, re-opened inside the fix for it.
+        #
+        # An earlier version of this comment said the collision was present as authored. It was
+        # not: the harness that "measured" it pooled the members of the ATTACHED countersink
+        # outcome, which legitimately carries the bore's site, with the tail's (#1229 review r2).
         #
         # The seat is physically on `seat_hole`, so its canonical site is both correct and in the
         # published space: a consumer joining by site is told "this hole carries a second
@@ -1039,6 +1044,12 @@ def hole_requirement_outcomes(
         # outcome could not reach a wrong join with the old value either — the protection came
         # from a filter, not from the empty tuple. This makes the field correct for the next
         # consumer rather than fixing a live mis-join, and saying so beats implying otherwise.
+        #
+        # And note what the correct value implies: the tail's key is now IDENTICAL to the bore's
+        # own, by construction, so `(parameter_id, member)` no longer identifies one outcome —
+        # this fixture carries `countersink.diameter` twice on site `(0, 0, 0)`, once `placed`
+        # and once `unverifiable`. That is right (both ARE about that hole), but a consumer
+        # joining on site alone must disambiguate on `state` or `source_at`.
         sites = canonical_hole_sites(seat_hole)
         outcomes.extend(
             HoleRequirementOutcome("hole", at, 1, parameter, "unverifiable", members=sites)

--- a/src/draftwright/linting/hole_coverage.py
+++ b/src/draftwright/linting/hole_coverage.py
@@ -782,16 +782,8 @@ def hole_requirement_outcomes(
     for countersink in recognition.countersinks:
         if attached_countersinks[countersink]:
             attached_countersinks[countersink] -= 1
-            continue
-        # Keep the hole the seat matched, rather than discarding it and re-deriving a position
-        # from the seat itself. `members` is published in `canonical_hole_sites` space, and the
-        # seat's own opening centre is NOT in that space (#1229).
-        seat_hole = next(
-            (hole for hole in recognition.holes if countersink_matches_hole(countersink, hole)),
-            None,
-        )
-        if seat_hole is not None:
-            unmatched_countersinks.append((countersink, seat_hole))
+        elif any(countersink_matches_hole(countersink, hole) for hole in recognition.holes):
+            unmatched_countersinks.append(countersink)
 
     ir_by_key: dict[tuple[str, tuple], list] = defaultdict(list)
     owners_by_exact_member: dict[tuple, list] = defaultdict(list)
@@ -1019,40 +1011,37 @@ def hole_requirement_outcomes(
     # IR/compiler provenance without guessing which face the single slot represents.
     # Keep both of its dimensional facts in the denominator as explicit unverifiable
     # outcomes instead of hiding the standalone recognition inventory as a duplicate.
-    for countersink, seat_hole in unmatched_countersinks:
+    for countersink in unmatched_countersinks:
         at = _point(countersink.location)
-        # `members` too, like the two sites above, which omitted it here — but the seat's own
-        # opening centre is the WRONG value. `members` is published in `canonical_hole_sites`
-        # space (a through hole's coordinate along its own axis is zeroed); a raw world
-        # coordinate is not, so whether it aliased another requirement's key depended on where
-        # the solid happened to sit. On `_two_face_countersunk_hole` the raw seat centre was
-        # `(0, 0, 6)` — already a different key from the bore's `(0, 0, 0)`, aliasing nothing as
-        # authored. Translate the solid by −6 and it becomes `(0, 0, 0)` and collides. A key
-        # whose meaning moves with the part is the non-canonical-key defect class `_members` was
-        # fixed for in #1223, re-opened inside the fix for it.
+        # `members` is EMPTY, deliberately, and that is the answer to the question #1229 posed
+        # rather than a field left unfilled. It is worth recording how the other answer failed,
+        # because it looked obviously right twice.
         #
-        # An earlier version of this comment said the collision was present as authored. It was
-        # not: the harness that "measured" it pooled the members of the ATTACHED countersink
-        # outcome, which legitimately carries the bore's site, with the tail's (#1229 review r2).
+        # `members` is published in `canonical_hole_sites` space — a hole's coordinate along its
+        # own axis is zeroed — so a consumer joins on it to identify WHICH recognised hole an
+        # outcome accounts for. This tail has no such hole. That is the whole reason the outcome
+        # is `unverifiable`: the `HoleRecord` waist has one countersink slot, and a second seat
+        # cannot be joined to IR provenance without guessing which face the slot represents.
         #
-        # The seat is physically on `seat_hole`, so its canonical site is both correct and in the
-        # published space: a consumer joining by site is told "this hole carries a second
-        # countersink requirement that cannot be verified", which is the informative answer.
+        # Attempt 1 passed the seat's own opening centre. That is a raw world coordinate in a
+        # canonical field: on `_two_face_countersunk_hole` it read `(0, 0, 6)`, and translating
+        # the solid by −6 made it `(0, 0, 0)` and collide with the bore's key. A key whose
+        # meaning moves with the part is the defect `canonical_hole_sites` exists to prevent.
         #
-        # Scope, honestly: NO consumer reads this today. `_drawing_consumer_outcomes` filters on
-        # `parameter_id == "bore.diameter"` before it ever looks at `members`, so a countersink
-        # outcome could not reach a wrong join with the old value either — the protection came
-        # from a filter, not from the empty tuple. This makes the field correct for the next
-        # consumer rather than fixing a live mis-join, and saying so beats implying otherwise.
+        # Attempt 2 looked up the hole the seat matched and published ITS canonical site. That
+        # is in the right space, but `countersink_matches_hole` can accept more than one hole —
+        # its tolerances scale with diameter — so the lookup needs a rule for choosing among
+        # them, and `next()` silently chose "first". Which hole a seat physically sits on is the
+        # recogniser's question (ADR 0013), not a policy for draftwright to invent in a lint
+        # module; getting it wrong publishes a confident, canonical-looking key pointing at the
+        # wrong hole, which is worse than publishing none.
         #
-        # And note what the correct value implies: the tail's key is now IDENTICAL to the bore's
-        # own, by construction, so `(parameter_id, member)` no longer identifies one outcome —
-        # this fixture carries `countersink.diameter` twice on site `(0, 0, 0)`, once `placed`
-        # and once `unverifiable`. That is right (both ARE about that hole), but a consumer
-        # joining on site alone must disambiguate on `state` or `source_at`.
-        sites = canonical_hole_sites(seat_hole)
+        # So: none. `unverifiable` with no members says exactly what is true — this requirement
+        # is real, it is counted in the denominator, and it cannot be attributed. A consumer
+        # that finds nothing to join is correctly informed. Closing the gap properly means the
+        # waist carrying more than one countersink slot, which is #1229's real remainder.
         outcomes.extend(
-            HoleRequirementOutcome("hole", at, 1, parameter, "unverifiable", members=sites)
+            HoleRequirementOutcome("hole", at, 1, parameter, "unverifiable", members=())
             for parameter in ("countersink.diameter", "countersink.angle")
         )
     return outcomes

--- a/tests/test_issue_1143_hole_completeness.py
+++ b/tests/test_issue_1143_hole_completeness.py
@@ -2323,10 +2323,14 @@ def test_unmatched_second_face_countersink_fails_closed_in_hole_ledger():
     # seat is physically on the hole it matched, so its canonical site is the correct key.
     #
     # Assert the SPACE, not just presence. The first fix here passed the seat's own opening
-    # centre, which is a raw world coordinate: on this very fixture it happened to equal the
-    # bore's canonical site, and translating the solid pulled the two apart — a key whose
-    # meaning depends on where the part sits, which is the defect `canonical_hole_sites` exists
-    # to prevent (#1229 review).
+    # centre, a raw world coordinate. Measured on this fixture that was `(0, 0, 6)` — already a
+    # DIFFERENT key from the bore's `(0, 0, 0)`, so it aliased nothing as authored. Translate the
+    # solid by −6 and the seat centre becomes `(0, 0, 0)` and collides. Which requirement it
+    # aliases depends on where the solid sits, and that is the defect (#1229 review round 2).
+    #
+    # An earlier version of this comment said the collision was present as authored. It was not;
+    # the harness that "measured" it pooled the members of the ATTACHED countersink outcome,
+    # which legitimately carries the bore's site, with the tail's.
     sites = {site for hole in drawing.recognition().holes for site in canonical_hole_sites(hole)}
     assert sites, "no recognised hole sites; the assertion below is vacuous"
     for item in unverifiable:
@@ -2334,10 +2338,41 @@ def test_unmatched_second_face_countersink_fails_closed_in_hole_ledger():
         assert set(item.members) <= sites, (item.parameter_id, item.members, sites)
 
 
-def test_an_unmatched_countersinks_member_site_does_not_move_with_the_part():
-    """The property the raw opening centre broke: a canonical key is translation-invariant."""
-    from build123d import Pos
+def _two_holes_countersunk_on_both_faces():
+    """Two through holes, each countersunk on both faces, 30 mm apart."""
+    part = Box(90, 50, 12)
+    for x in (-15, 15):
+        part -= Pos(x, 0, 0) * Cylinder(3, 12)
+        part -= Pos(x, 0, 4) * Cone(3, 7, 4)
+        part -= Pos(x, 0, -4) * Cone(7, 3, 4)
+    return part
 
+
+def test_an_unmatched_countersink_is_attributed_to_the_hole_it_sits_on():
+    """WHICH hole, not just "a hole in the right space".
+
+    With one hole in the part, `set(members) <= {every hole site}` is satisfied by any hole at
+    all — measured, attributing every seat to `recognition.holes[-1]` survives the entire fast
+    tier. Two holes make the assertion discriminating (#1229 review round 2).
+    """
+    drawing = build_drawing(_two_holes_countersunk_on_both_faces(), page="A3")
+    by_site = {
+        site: hole for hole in drawing.recognition().holes for site in canonical_hole_sites(hole)
+    }
+    assert len(by_site) == 2, f"expected two distinct holes, got {sorted(by_site)}"
+
+    unverifiable = [item for item in _outcomes(drawing) if item.state == "unverifiable"]
+    assert len(unverifiable) == 4, [item.parameter_id for item in unverifiable]
+    for item in unverifiable:
+        # The seat's own x/y identify the hole it sits on; only its axial coordinate differs.
+        expected = next(s for s in by_site if s[:2] == item.source_at[:2])
+        assert item.members == (expected,), (item.parameter_id, item.source_at, item.members)
+
+
+def test_an_unmatched_countersinks_member_site_does_not_move_along_the_hole_axis():
+    """`canonical_hole_sites` zeroes a through hole's coordinate along its OWN axis, so the key
+    is invariant under translation along that axis — and only that one. A lateral offset moves
+    it, correctly, because it identifies a different hole position."""
     keys = []
     for dz in (0.0, -6.0):
         part = _two_face_countersunk_hole()
@@ -2345,6 +2380,9 @@ def test_an_unmatched_countersinks_member_site_does_not_move_with_the_part():
         unverifiable = [item for item in _outcomes(drawing) if item.state == "unverifiable"]
         assert unverifiable, f"dz={dz}: the unmatched-countersink tail did not fire"
         keys.append({member for item in unverifiable for member in item.members})
+    # Without this the assertion below compares two EMPTY sets and passes with `members=()`
+    # — measured: dropping `members` left this test in the passing column (#1229 review round 2).
+    assert keys[0], "no member sites at all; the comparison below would be vacuous"
     assert keys[0] == keys[1], keys
 
 

--- a/tests/test_issue_1143_hole_completeness.py
+++ b/tests/test_issue_1143_hole_completeness.py
@@ -2318,72 +2318,44 @@ def test_unmatched_second_face_countersink_fails_closed_in_hole_ledger():
         issue.code for issue in drawing.lint() if issue.code == "hole_requirement_unverifiable"
     ] == ["hole_requirement_unverifiable"] * 2
 
-    # The ledger publishes `members` in `canonical_hole_sites` space, and these outcomes had
-    # none at all — so the one consumer that joins by site could not reach them (#1229). The
-    # seat is physically on the hole it matched, so its canonical site is the correct key.
+    # `members` is EMPTY here, deliberately — the decision #1229 asked for, not an unfilled
+    # field. The tail exists precisely because the seat cannot be attributed to a hole: the
+    # `HoleRecord` waist has one countersink slot and a second seat cannot be joined to IR
+    # provenance without guessing which face it represents.
     #
-    # Assert the SPACE, not just presence. The first fix here passed the seat's own opening
-    # centre, a raw world coordinate. Measured on this fixture that was `(0, 0, 6)` — already a
-    # DIFFERENT key from the bore's `(0, 0, 0)`, so it aliased nothing as authored. Translate the
-    # solid by −6 and the seat centre becomes `(0, 0, 0)` and collides. Which requirement it
-    # aliases depends on where the solid sits, and that is the defect (#1229 review round 2).
-    #
-    # An earlier version of this comment said the collision was present as authored. It was not;
-    # the harness that "measured" it pooled the members of the ATTACHED countersink outcome,
-    # which legitimately carries the bore's site, with the tail's.
-    sites = {site for hole in drawing.recognition().holes for site in canonical_hole_sites(hole)}
-    assert sites, "no recognised hole sites; the assertion below is vacuous"
-    for item in unverifiable:
-        assert item.members, f"{item.parameter_id} carries no member site and cannot be joined"
-        assert set(item.members) <= sites, (item.parameter_id, item.members, sites)
+    # Two attempts to give it a key failed, both plausibly. The seat's own opening centre is a
+    # raw world coordinate in a canonical field — it read `(0, 0, 6)` here and became `(0, 0, 0)`,
+    # colliding with the bore's key, when the solid was translated by −6. Looking up the hole the
+    # seat matched is in the right space, but `countersink_matches_hole` can accept several holes
+    # and choosing among them is the recogniser's question, not a lint module's.
+    assert all(item.members == () for item in unverifiable), [
+        (item.parameter_id, item.members) for item in unverifiable
+    ]
 
 
-def _two_holes_countersunk_on_both_faces():
-    """Two through holes, each countersunk on both faces, 30 mm apart."""
-    part = Box(90, 50, 12)
-    for x in (-15, 15):
-        part -= Pos(x, 0, 0) * Cylinder(3, 12)
-        part -= Pos(x, 0, 4) * Cone(3, 7, 4)
-        part -= Pos(x, 0, -4) * Cone(7, 3, 4)
-    return part
+def test_an_unmatched_countersink_is_still_counted_and_still_unattributable():
+    """The point of `unverifiable`: counted in the denominator, deliberately not joined.
 
-
-def test_an_unmatched_countersink_is_attributed_to_the_hole_it_sits_on():
-    """WHICH hole, not just "a hole in the right space".
-
-    With one hole in the part, `set(members) <= {every hole site}` is satisfied by any hole at
-    all — measured, attributing every seat to `recognition.holes[-1]` survives the entire fast
-    tier. Two holes make the assertion discriminating (#1229 review round 2).
+    Guards against someone "fixing" the empty `members` by inventing an attribution. If the
+    `HoleRecord` waist ever grows a second countersink slot, this seat becomes attributable and
+    the whole tail should go — that is #1229's real remainder, and this test should fail loudly
+    when it happens rather than the tail quietly persisting.
     """
-    drawing = build_drawing(_two_holes_countersunk_on_both_faces(), page="A3")
-    by_site = {
-        site: hole for hole in drawing.recognition().holes for site in canonical_hole_sites(hole)
-    }
-    assert len(by_site) == 2, f"expected two distinct holes, got {sorted(by_site)}"
-
+    drawing = build_drawing(_two_face_countersunk_hole(), page="A3")
     unverifiable = [item for item in _outcomes(drawing) if item.state == "unverifiable"]
-    assert len(unverifiable) == 4, [item.parameter_id for item in unverifiable]
+    assert {item.parameter_id for item in unverifiable} == {
+        "countersink.angle",
+        "countersink.diameter",
+    }
+    assert _completeness(drawing)["unverifiable"] == 2
     for item in unverifiable:
-        # The seat's own x/y identify the hole it sits on; only its axial coordinate differs.
-        expected = next(s for s in by_site if s[:2] == item.source_at[:2])
-        assert item.members == (expected,), (item.parameter_id, item.source_at, item.members)
-
-
-def test_an_unmatched_countersinks_member_site_does_not_move_along_the_hole_axis():
-    """`canonical_hole_sites` zeroes a through hole's coordinate along its OWN axis, so the key
-    is invariant under translation along that axis — and only that one. A lateral offset moves
-    it, correctly, because it identifies a different hole position."""
-    keys = []
-    for dz in (0.0, -6.0):
-        part = _two_face_countersunk_hole()
-        drawing = build_drawing(Pos(0, 0, dz) * part if dz else part, page="A3")
-        unverifiable = [item for item in _outcomes(drawing) if item.state == "unverifiable"]
-        assert unverifiable, f"dz={dz}: the unmatched-countersink tail did not fire"
-        keys.append({member for item in unverifiable for member in item.members})
-    # Without this the assertion below compares two EMPTY sets and passes with `members=()`
-    # — measured: dropping `members` left this test in the passing column (#1229 review round 2).
-    assert keys[0], "no member sites at all; the comparison below would be vacuous"
-    assert keys[0] == keys[1], keys
+        assert item.members == (), (item.parameter_id, item.members)
+        assert item.source_at == (0.0, 0.0, 6.0), item.source_at
+        # `source_at` is the seat's own location and is NOT a canonical key — it is diagnostic
+        # only. That distinction is the whole of #1229 seam 1.
+        assert item.source_at not in {
+            site for hole in drawing.recognition().holes for site in canonical_hole_sites(hole)
+        }
 
 
 def test_unattached_external_countersink_false_positive_is_not_a_hole_requirement():

--- a/tests/test_issue_1143_hole_completeness.py
+++ b/tests/test_issue_1143_hole_completeness.py
@@ -15,7 +15,7 @@ from b123d_recognisers import (
 from build123d import Align, Box, Compound, Cone, Cylinder, Pos, Rot
 
 from draftwright import Sheet, build_drawing
-from draftwright.linting.hole_coverage import hole_requirement_outcomes
+from draftwright.linting.hole_coverage import canonical_hole_sites, hole_requirement_outcomes
 from draftwright.linting.issues import LintIssue
 from draftwright.model.compiled import compile_dimensions
 from draftwright.model.declare import hole as declare_hole
@@ -2317,6 +2317,35 @@ def test_unmatched_second_face_countersink_fails_closed_in_hole_ledger():
     assert [
         issue.code for issue in drawing.lint() if issue.code == "hole_requirement_unverifiable"
     ] == ["hole_requirement_unverifiable"] * 2
+
+    # The ledger publishes `members` in `canonical_hole_sites` space, and these outcomes had
+    # none at all — so the one consumer that joins by site could not reach them (#1229). The
+    # seat is physically on the hole it matched, so its canonical site is the correct key.
+    #
+    # Assert the SPACE, not just presence. The first fix here passed the seat's own opening
+    # centre, which is a raw world coordinate: on this very fixture it happened to equal the
+    # bore's canonical site, and translating the solid pulled the two apart — a key whose
+    # meaning depends on where the part sits, which is the defect `canonical_hole_sites` exists
+    # to prevent (#1229 review).
+    sites = {site for hole in drawing.recognition().holes for site in canonical_hole_sites(hole)}
+    assert sites, "no recognised hole sites; the assertion below is vacuous"
+    for item in unverifiable:
+        assert item.members, f"{item.parameter_id} carries no member site and cannot be joined"
+        assert set(item.members) <= sites, (item.parameter_id, item.members, sites)
+
+
+def test_an_unmatched_countersinks_member_site_does_not_move_with_the_part():
+    """The property the raw opening centre broke: a canonical key is translation-invariant."""
+    from build123d import Pos
+
+    keys = []
+    for dz in (0.0, -6.0):
+        part = _two_face_countersunk_hole()
+        drawing = build_drawing(Pos(0, 0, dz) * part if dz else part, page="A3")
+        unverifiable = [item for item in _outcomes(drawing) if item.state == "unverifiable"]
+        assert unverifiable, f"dz={dz}: the unmatched-countersink tail did not fire"
+        keys.append({member for item in unverifiable for member in item.members})
+    assert keys[0] == keys[1], keys
 
 
 def test_unattached_external_countersink_false_positive_is_not_a_hole_requirement():

--- a/tests/test_issue_1229_ledger_member_keying.py
+++ b/tests/test_issue_1229_ledger_member_keying.py
@@ -1,0 +1,164 @@
+"""#1229 — three seams in the hole-requirement ledger's member keying.
+
+All three were latent: none produced a wrong answer on any fixture. They are worth closing
+anyway because each is a place where the ledger's own join contract is stated in one place and
+quietly not honoured in another, which is how #1223's real defect (a consumer keying a different
+axis space from the ledger) got in.
+
+1. `hole_requirement_outcomes` builds `HoleRequirementOutcome` at three sites. Two passed
+   `members`; the `unmatched_countersinks` tail did not, so those outcomes carried the `()`
+   default and no site-keyed consumer could reach them — `canonical_hole_sites` would find no
+   match and fall through to its "unknown" default. That is the silent join failure the helper
+   exists to prevent, one branch below where it is enforced.
+
+2. `_members`' grouped branch decided `through` with `all(...)` over the members while the
+   single-record branch decided it per hole. Equivalent in fact, misleading as code — see
+   `TestAGroupCannotMixThroughAndBlind`, which measures the invariant that makes it so.
+
+3. The module-level imports in `evaluation/step_analysis.py`. Filed as "unexplained"; measuring
+   showed the filing was wrong — see that module's docstring, and
+   `TestTheEvaluationModuleStaysCheapToImport` here.
+
+The first guard is structural rather than behavioural on purpose. The countersink site is
+unreachable through the public API — it needs a part whose recognised countersinks outnumber the
+single `HoleRecord.csink` slot, and a plate countersunk on both faces does not do it (both seats
+are recognised, neither attaches, and `countersink_matches_hole` rejects both). A test that
+cannot reach the branch cannot pin it; a test that reads the source can, and it covers the two
+sites that were already correct plus any site added later.
+"""
+
+from __future__ import annotations
+
+import ast
+import importlib.util
+import inspect
+import subprocess
+import sys
+from pathlib import Path
+
+from b123d_recognisers import HoleSpec
+
+from draftwright.linting import hole_coverage
+
+_SOURCE = Path(inspect.getfile(hole_coverage))
+
+
+class TestEveryOutcomeSiteKeysItsMembers:
+    """The ledger is joined by member site. An outcome with none cannot be joined at all."""
+
+    def _construction_sites(self) -> list[ast.Call]:
+        tree = ast.parse(_SOURCE.read_text())
+        return [
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "HoleRequirementOutcome"
+        ]
+
+    def test_the_source_really_contains_several_sites(self):
+        # Precondition. An AST guard that matches nothing is a broken harness reporting success.
+        sites = self._construction_sites()
+        assert len(sites) >= 3, f"found {len(sites)} construction sites; the guard is not looking"
+
+    def test_every_site_passes_members(self):
+        missing = [
+            node.lineno
+            for node in self._construction_sites()
+            if not any(kw.arg == "members" for kw in node.keywords)
+        ]
+        assert not missing, (
+            f"{_SOURCE.name} lines {missing} build a HoleRequirementOutcome without `members`. "
+            "A site-keyed consumer cannot reach it, so it falls through `canonical_hole_sites` "
+            "to an 'unknown' default — the silent join failure that helper exists to prevent "
+            "(#1229). Pass the outcome's own site."
+        )
+
+    def test_the_countersink_tail_keys_its_seat(self):
+        # The site that was wrong, named directly, so a future edit that drops it again fails
+        # here with the reason rather than only on the generic guard above.
+        source = _SOURCE.read_text()
+        tail = source[source.index("for countersink in unmatched_countersinks:") :]
+        call = tail[: tail.index("return outcomes")]
+        assert "members=(at,)" in call, (
+            "the unmatched-countersink outcomes must carry their seat's location; "
+            "'unverifiable' means unjoinable to IR provenance, not position-less"
+        )
+
+
+class TestAGroupCannotMixThroughAndBlind:
+    """Why `_members` may read `bottom` off one member rather than folding over all of them.
+
+    `bottom` is a `HoleSpec` field and hole patterns are built by grouping on `_spec_key`, so
+    the members of a group share it by construction. This measures that rather than asserting
+    it — the equivalence is the whole reason the `all(...)` was safe, and if the recogniser ever
+    groups more loosely, this fails before the ledger starts keying blind holes as through.
+
+    Be exact about what the change to `_members` did and did not do. Reverting it to read
+    `recognised[0].bottom` off the raw record SURVIVES the suite, and correctly:
+    `HoleSpec.from_hole` copies `bottom` across verbatim, so the spec adds no normalisation
+    here. It is expressive, not behavioural — it names the field that defines the group. That
+    is NOT true of `axis` on the line above, where the spec's 6-dp rounding is load-bearing and
+    reverting it changes the reported coordinates (#1223 review). Two adjacent lines, one
+    equivalent mutant and one real one; worth not confusing them.
+    """
+
+    def test_bottom_is_part_of_the_spec(self):
+        assert "bottom" in {f.name for f in __import__("dataclasses").fields(HoleSpec)}, (
+            "HoleSpec no longer carries `bottom`, so a spec group may mix through and blind "
+            "and `_members` must fold over the members again (#1229)"
+        )
+
+    def test_every_recognised_group_is_uniform_in_bottom(self):
+        from build123d import Align, Box, Cylinder, Pos
+
+        from draftwright.builder import build_drawing
+
+        centre = (Align.CENTER, Align.CENTER, Align.CENTER)
+        part = Box(120, 80, 12, align=centre)
+        for x, y in ((-40, -20), (0, -20), (40, -20), (-40, 20), (0, 20), (40, 20)):
+            part -= Pos(x, y, 0) * Cylinder(4, 40, align=centre)
+        drawing = build_drawing(part, title="T", number="N-1")
+        recognition = drawing.recognition()
+        groups = list(getattr(recognition, "hole_patterns", ()))
+        assert groups, "no hole pattern recognised; the assertion below is vacuous"
+        checked = 0
+        for group in groups:
+            bottoms = {HoleSpec.from_hole(h).bottom for h in group.holes}
+            checked += len(group.holes)
+            assert len(bottoms) == 1, (group, bottoms)
+        assert checked >= 3, f"only {checked} grouped holes examined"
+
+
+class TestTheEvaluationModuleStaysCheapToImport:
+    """#1229's third item, inverted: the in-function imports are load-bearing, not strays."""
+
+    def test_importing_the_evaluation_module_does_not_pull_the_engine(self):
+        # A subprocess, because the engine is already imported in this one. Asserting on
+        # `sys.modules` in-process would pass no matter what the module does.
+        code = (
+            "import sys, draftwright.evaluation.step_analysis;"
+            "print(int(any(m.startswith('build123d') for m in sys.modules)))"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True, check=True
+        )
+        assert result.stdout.strip() == "0", (
+            "importing draftwright.evaluation.step_analysis now pulls build123d, which takes "
+            "~1.8 s. Its draftwright imports are deliberately inside function bodies (#313); "
+            "see that module's docstring for the measurements (#1229)."
+        )
+
+    def test_the_module_has_no_module_level_draftwright_import(self):
+        spec = importlib.util.find_spec("draftwright.evaluation.step_analysis")
+        assert spec is not None and spec.origin is not None
+        tree = ast.parse(Path(spec.origin).read_text())
+        offenders = [
+            node.lineno
+            for node in tree.body
+            if isinstance(node, ast.ImportFrom)
+            and (node.module or "").startswith(("draftwright", "build123d"))
+        ]
+        assert not offenders, (
+            f"module-level engine import at line(s) {offenders}; keep them in function bodies"
+        )

--- a/tests/test_issue_1229_ledger_member_keying.py
+++ b/tests/test_issue_1229_ledger_member_keying.py
@@ -7,9 +7,11 @@ axis space from the ledger) got in.
 
 1. `hole_requirement_outcomes` builds `HoleRequirementOutcome` at three sites. Two passed
    `members`; the `unmatched_countersinks` tail did not, so those outcomes carried the `()`
-   default and no site-keyed consumer could reach them — `canonical_hole_sites` would find no
-   match and fall through to its "unknown" default. That is the silent join failure the helper
-   exists to prevent, one branch below where it is enforced.
+   default and could not be joined by site at all. Fixed in `hole_coverage.py`, tested in
+   `test_issue_1143_hole_completeness.py`. The first fix passed the seat's own opening centre —
+   a RAW world coordinate in a field published in `canonical_hole_sites` space, which aliased
+   the bore's own key on the fixture and moved when the part moved. It now carries the canonical
+   site of the hole the seat matched.
 
 2. `_members`' grouped branch decided `through` with `all(...)` over the members while the
    single-record branch decided it per hole. Equivalent in fact, misleading as code — see
@@ -19,71 +21,28 @@ axis space from the ledger) got in.
    showed the filing was wrong — see that module's docstring, and
    `TestTheEvaluationModuleStaysCheapToImport` here.
 
-The first guard is structural rather than behavioural on purpose. The countersink site is
-unreachable through the public API — it needs a part whose recognised countersinks outnumber the
-single `HoleRecord.csink` slot, and a plate countersunk on both faces does not do it (both seats
-are recognised, neither attaches, and `countersink_matches_hole` rejects both). A test that
-cannot reach the branch cannot pin it; a test that reads the source can, and it covers the two
-sites that were already correct plus any site added later.
+Seam 1 is tested where it belongs — `tests/test_issue_1143_hole_completeness.py::
+test_unmatched_second_face_countersink_fails_closed_in_hole_ledger`, which has exercised that
+branch since #1151 and now also asserts the member sites and their space.
+
+I first claimed the branch was unreachable and shipped an AST guard over the construction sites
+instead. That was wrong three ways, and the correction is worth keeping written down: the branch
+is reachable; a fixture and a passing test for it were already in the repo, findable by one grep;
+and the guard was not load-bearing anyway — it checked for the `members` KEYWORD, so it survived
+`members=()`, survived an aliased constructor two lines below, and could be pushed out of range
+by a comment. The behavioural test kills all of those. A structural guard is not a substitute for
+a reachable test; it is what you write when there is genuinely no way in, and I did not check.
 """
 
 from __future__ import annotations
 
 import ast
 import importlib.util
-import inspect
 import subprocess
 import sys
 from pathlib import Path
 
 from b123d_recognisers import HoleSpec
-
-from draftwright.linting import hole_coverage
-
-_SOURCE = Path(inspect.getfile(hole_coverage))
-
-
-class TestEveryOutcomeSiteKeysItsMembers:
-    """The ledger is joined by member site. An outcome with none cannot be joined at all."""
-
-    def _construction_sites(self) -> list[ast.Call]:
-        tree = ast.parse(_SOURCE.read_text())
-        return [
-            node
-            for node in ast.walk(tree)
-            if isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id == "HoleRequirementOutcome"
-        ]
-
-    def test_the_source_really_contains_several_sites(self):
-        # Precondition. An AST guard that matches nothing is a broken harness reporting success.
-        sites = self._construction_sites()
-        assert len(sites) >= 3, f"found {len(sites)} construction sites; the guard is not looking"
-
-    def test_every_site_passes_members(self):
-        missing = [
-            node.lineno
-            for node in self._construction_sites()
-            if not any(kw.arg == "members" for kw in node.keywords)
-        ]
-        assert not missing, (
-            f"{_SOURCE.name} lines {missing} build a HoleRequirementOutcome without `members`. "
-            "A site-keyed consumer cannot reach it, so it falls through `canonical_hole_sites` "
-            "to an 'unknown' default — the silent join failure that helper exists to prevent "
-            "(#1229). Pass the outcome's own site."
-        )
-
-    def test_the_countersink_tail_keys_its_seat(self):
-        # The site that was wrong, named directly, so a future edit that drops it again fails
-        # here with the reason rather than only on the generic guard above.
-        source = _SOURCE.read_text()
-        tail = source[source.index("for countersink in unmatched_countersinks:") :]
-        call = tail[: tail.index("return outcomes")]
-        assert "members=(at,)" in call, (
-            "the unmatched-countersink outcomes must carry their seat's location; "
-            "'unverifiable' means unjoinable to IR provenance, not position-less"
-        )
 
 
 class TestAGroupCannotMixThroughAndBlind:
@@ -109,25 +68,50 @@ class TestAGroupCannotMixThroughAndBlind:
             "and `_members` must fold over the members again (#1229)"
         )
 
-    def test_every_recognised_group_is_uniform_in_bottom(self):
+    @staticmethod
+    def _mixed_part():
+        """Three THROUGH and three BLIND holes of the same diameter on the same axis.
+
+        The first version of this test used six identical through holes, so `len(bottoms) == 1`
+        held by construction and the assertion could not fail however the recogniser grouped
+        (#1229 review). This part can exhibit the defect: if grouping ever stopped keying on
+        `bottom`, these six would land in one group with two bottoms.
+        """
         from build123d import Align, Box, Cylinder, Pos
 
+        centre = (Align.CENTER, Align.CENTER, Align.CENTER)
+        part = Box(160, 60, 20, align=centre)
+        for x in (-60, -40, -20):
+            part -= Pos(x, 0, 0) * Cylinder(4, 60, align=centre)
+        for x in (20, 40, 60):
+            part -= Pos(x, 0, 5) * Cylinder(4, 12, align=centre)
+        return part
+
+    def test_the_part_really_mixes_through_and_blind(self):
+        # The precondition. Without both kinds present the guard below is the tautology the
+        # first version of it was.
         from draftwright.builder import build_drawing
 
-        centre = (Align.CENTER, Align.CENTER, Align.CENTER)
-        part = Box(120, 80, 12, align=centre)
-        for x, y in ((-40, -20), (0, -20), (40, -20), (-40, 20), (0, 20), (40, 20)):
-            part -= Pos(x, y, 0) * Cylinder(4, 40, align=centre)
-        drawing = build_drawing(part, title="T", number="N-1")
-        recognition = drawing.recognition()
+        recognition = build_drawing(self._mixed_part(), title="T", number="N-1").recognition()
+        assert {HoleSpec.from_hole(h).bottom for h in recognition.holes} >= {"through", "flat"}, (
+            sorted({HoleSpec.from_hole(h).bottom for h in recognition.holes})
+        )
+
+    def test_every_recognised_group_is_uniform_in_bottom(self):
+        from draftwright.builder import build_drawing
+
+        recognition = build_drawing(self._mixed_part(), title="T", number="N-1").recognition()
         groups = list(getattr(recognition, "hole_patterns", ()))
-        assert groups, "no hole pattern recognised; the assertion below is vacuous"
+        assert len(groups) >= 2, (
+            "the mixed part produced fewer than two groups; either grouping no longer splits on "
+            "`bottom` — the thing this guards — or the fixture stopped recognising"
+        )
         checked = 0
         for group in groups:
             bottoms = {HoleSpec.from_hole(h).bottom for h in group.holes}
             checked += len(group.holes)
             assert len(bottoms) == 1, (group, bottoms)
-        assert checked >= 3, f"only {checked} grouped holes examined"
+        assert checked >= 6, f"only {checked} grouped holes examined"
 
 
 class TestTheEvaluationModuleStaysCheapToImport:
@@ -153,11 +137,21 @@ class TestTheEvaluationModuleStaysCheapToImport:
         spec = importlib.util.find_spec("draftwright.evaluation.step_analysis")
         assert spec is not None and spec.origin is not None
         tree = ast.parse(Path(spec.origin).read_text())
+        # BOTH `from x import y` and plain `import x`. Matching only `ImportFrom` left the
+        # test named for this property unable to see the commonest form; a mutation adding
+        # `import draftwright.linting.hole_coverage` was caught only by the subprocess test
+        # beside it (#1229 review).
         offenders = [
             node.lineno
             for node in tree.body
-            if isinstance(node, ast.ImportFrom)
-            and (node.module or "").startswith(("draftwright", "build123d"))
+            if (
+                isinstance(node, ast.ImportFrom)
+                and (node.module or "").startswith(("draftwright", "build123d"))
+            )
+            or (
+                isinstance(node, ast.Import)
+                and any(a.name.startswith(("draftwright", "build123d")) for a in node.names)
+            )
         ]
         assert not offenders, (
             f"module-level engine import at line(s) {offenders}; keep them in function bodies"

--- a/tests/test_issue_1229_ledger_member_keying.py
+++ b/tests/test_issue_1229_ledger_member_keying.py
@@ -6,20 +6,26 @@ quietly not honoured in another, which is how #1223's real defect (a consumer ke
 axis space from the ledger) got in.
 
 1. `hole_requirement_outcomes` builds `HoleRequirementOutcome` at three sites. Two passed
-   `members`; the `unmatched_countersinks` tail did not, so those outcomes carried the `()`
-   default and could not be joined by site at all. Fixed in `hole_coverage.py`, tested in
-   `test_issue_1143_hole_completeness.py`. The first fix passed the seat's own opening centre —
-   a RAW world coordinate in a field published in `canonical_hole_sites` space, which aliased
-   the bore's own key on the fixture and moved when the part moved. It now carries the canonical
-   site of the hole the seat matched.
+   `members`; the `unmatched_countersinks` tail did not. The answer is that it SHOULD be empty,
+   explicitly — see `hole_coverage.py` and
+   `test_issue_1143_hole_completeness.py::test_an_unmatched_countersink_is_still_counted_and_still_unattributable`.
+
+   Two attempts to give it a key failed first. The seat's own opening centre is a raw world
+   coordinate in a canonical field: measured, it was `(0, 0, 6)` on the fixture — aliasing
+   nothing as authored — and became `(0, 0, 0)` and collided with the bore's key once the solid
+   was translated by −6. (An earlier draft of this paragraph said it collided as authored; the
+   harness that "measured" that had pooled the ATTACHED seat's members, which legitimately carry
+   the bore's site, with the tail's.) Looking up the hole the seat matched is in the right space,
+   but `countersink_matches_hole` can accept more than one hole, so it needs a rule for choosing
+   — and which hole a seat sits on is the recogniser's question, not a lint module's.
 
 2. `_members`' grouped branch decided `through` with `all(...)` over the members while the
    single-record branch decided it per hole. Equivalent in fact, misleading as code — see
    `TestAGroupCannotMixThroughAndBlind`, which measures the invariant that makes it so.
 
-3. The module-level imports in `evaluation/step_analysis.py`. Filed as "unexplained"; measuring
-   showed the filing was wrong — see that module's docstring, and
-   `TestTheEvaluationModuleStaysCheapToImport` here.
+3. The IN-FUNCTION imports in `evaluation/step_analysis.py` — the module has no module-level
+   engine imports at all, which is the seam. Filed as "unexplained"; measuring showed the filing
+   was wrong — see that module's docstring, and `TestTheEvaluationModuleStaysCheapToImport`.
 
 Seam 1 is tested where it belongs — `tests/test_issue_1143_hole_completeness.py::
 test_unmatched_second_face_countersink_fails_closed_in_hole_ledger`, which has exercised that
@@ -44,14 +50,26 @@ from pathlib import Path
 
 from b123d_recognisers import HoleSpec
 
+_ENGINE = ("draftwright", "build123d", "b123d_recognisers")
+
 
 class TestAGroupCannotMixThroughAndBlind:
     """Why `_members` may read `bottom` off one member rather than folding over all of them.
 
-    `bottom` is a `HoleSpec` field and hole patterns are built by grouping on `_spec_key`, so
-    the members of a group share it by construction. This measures that rather than asserting
-    it — the equivalence is the whole reason the `all(...)` was safe, and if the recogniser ever
-    groups more loosely, this fails before the ledger starts keying blind holes as through.
+    `bottom` is a `HoleSpec` field and hole patterns are built by grouping on `_spec_key`, so the
+    members of a group share it by construction. This measures that rather than asserting it.
+
+    The fixture is INTERLEAVED — through at x=−60/−20/20, blind at −40/0/40, one pitch — because
+    the first two attempts were tautologies. Six identical through holes cannot mix by
+    construction; and three-through-then-three-blind split positionally at the gap between them,
+    so the assertion held however the spec key was mutated. Interleaved, only the spec key can
+    separate them: neutering it collapses all six into one `LinearArray` carrying
+    `{'through', 'flat'}`, which fails this test (#1229 review rounds 2 and 3).
+
+    Note `bottom` is not the only field doing the work — `HoleSpec.from_hole` sets
+    `depth = None if bottom == "through" else hole.depth`, so `depth is None` iff the hole is
+    through, and either field separates the two kinds. The invariant `_members` relies on is the
+    GROUPING, which is what this asserts.
 
     Be exact about what the change to `_members` did and did not do. Reverting it to read
     `recognised[0].bottom` off the raw record SURVIVES the suite, and correctly:
@@ -62,29 +80,28 @@ class TestAGroupCannotMixThroughAndBlind:
     equivalent mutant and one real one; worth not confusing them.
     """
 
-    def test_bottom_is_part_of_the_spec(self):
-        assert "bottom" in {f.name for f in __import__("dataclasses").fields(HoleSpec)}, (
-            "HoleSpec no longer carries `bottom`, so a spec group may mix through and blind "
-            "and `_members` must fold over the members again (#1229)"
-        )
+    def test_the_spec_separates_through_from_blind(self):
+        fields = {f.name for f in __import__("dataclasses").fields(HoleSpec)}
+        assert {"bottom", "depth"} <= fields, sorted(fields)
 
     @staticmethod
     def _mixed_part():
-        """Three THROUGH and three BLIND holes of the same diameter on the same axis.
+        """Through and blind holes of one diameter, INTERLEAVED at one pitch on one axis.
 
-        The first version of this test used six identical through holes, so `len(bottoms) == 1`
-        held by construction and the assertion could not fail however the recogniser grouped
-        (#1229 review). This part can exhibit the defect: if grouping ever stopped keying on
-        `bottom`, these six would land in one group with two bottoms.
+        Interleaving is the point. Six identical through holes cannot mix by construction, and
+        three-through-then-three-blind split positionally at the gap regardless of the spec key —
+        both earlier versions of this fixture were tautologies. Here only the spec key separates
+        them: neutering it yields one `LinearArray` of six with `{'through', 'flat'}`, measured.
         """
         from build123d import Align, Box, Cylinder, Pos
 
         centre = (Align.CENTER, Align.CENTER, Align.CENTER)
         part = Box(160, 60, 20, align=centre)
-        for x in (-60, -40, -20):
-            part -= Pos(x, 0, 0) * Cylinder(4, 60, align=centre)
-        for x in (20, 40, 60):
-            part -= Pos(x, 0, 5) * Cylinder(4, 12, align=centre)
+        for i, x in enumerate((-60, -40, -20, 0, 20, 40)):
+            if i % 2 == 0:
+                part -= Pos(x, 0, 0) * Cylinder(4, 60, align=centre)  # through
+            else:
+                part -= Pos(x, 0, 10) * Cylinder(4, 20, align=centre)  # blind
         return part
 
     def test_the_part_really_mixes_through_and_blind(self):
@@ -130,9 +147,9 @@ class TestTheEvaluationModuleStaysCheapToImport:
             [sys.executable, "-c", code], capture_output=True, text=True, check=True
         )
         assert result.stdout.strip() == "0", (
-            "importing draftwright.evaluation.step_analysis now pulls build123d, which takes "
-            "~1.8 s. Its draftwright imports are deliberately inside function bodies (#313); "
-            "see that module's docstring for the measurements (#1229)."
+            "importing draftwright.evaluation.step_analysis now pulls build123d, which costs "
+            "one to two seconds. Its engine imports are deliberately inside function bodies "
+            "(#313); see that module's docstring for the shape (#1229)."
         )
 
     def test_the_module_has_no_module_level_draftwright_import(self):
@@ -146,13 +163,13 @@ class TestTheEvaluationModuleStaysCheapToImport:
         offenders = [
             node.lineno
             for node in tree.body
-            if (
-                isinstance(node, ast.ImportFrom)
-                and (node.module or "").startswith(("draftwright", "build123d"))
-            )
+            # `b123d_recognisers` too: measured, importing it puts build123d in `sys.modules`,
+            # so it carries the same cost the note is about and the guard missed it entirely
+            # (#1229 review round 3).
+            if (isinstance(node, ast.ImportFrom) and (node.module or "").startswith(_ENGINE))
             or (
                 isinstance(node, ast.Import)
-                and any(a.name.startswith(("draftwright", "build123d")) for a in node.names)
+                and any(a.name.startswith(_ENGINE) for a in node.names)
             )
         ]
         assert not offenders, (

--- a/tests/test_issue_1229_ledger_member_keying.py
+++ b/tests/test_issue_1229_ledger_member_keying.py
@@ -102,9 +102,11 @@ class TestAGroupCannotMixThroughAndBlind:
 
         recognition = build_drawing(self._mixed_part(), title="T", number="N-1").recognition()
         groups = list(getattr(recognition, "hole_patterns", ()))
+        # `>= 2` says only that the part still recognises as patterns — it carries NO
+        # information about `bottom`, since these six also split positionally at the 40 mm gap.
+        # The load-bearing assertion is `len(bottoms) == 1` inside the loop (#1229 review r2).
         assert len(groups) >= 2, (
-            "the mixed part produced fewer than two groups; either grouping no longer splits on "
-            "`bottom` — the thing this guards — or the fixture stopped recognising"
+            f"the mixed part produced {len(groups)} group(s); it stopped recognising"
         )
         checked = 0
         for group in groups:


### PR DESCRIPTION
Closes #1229.

Three latent seams in the hole-requirement ledger's member keying. None produced a wrong answer
on any fixture; each is a place where the ledger's join contract is stated in one spot and quietly
not honoured in another — which is how #1223's real defect got in, *inside the helper written to
prevent it*.

## 1. The countersink tail built outcomes with no `members` — and the answer is that it should

Two of the three `HoleRequirementOutcome` sites pass `members`; the `unmatched_countersinks` tail
did not. The issue asked whether an outcome that cannot be joined to IR provenance should carry a
site that invites a join. **It should not**, and the field is now `members=()` explicitly, with
the reasoning in place.

Two attempts to give it a key failed first, both plausible-looking:

- **The seat's own opening centre** is a raw world coordinate in a field published in
  `canonical_hole_sites` space. Measured, it was `(0, 0, 6)` on the fixture — aliasing nothing as
  authored — and became `(0, 0, 0)`, colliding with the bore's key, once the solid was translated
  by −6. A key whose meaning moves with the part is the defect `canonical_hole_sites` exists to
  prevent.
- **The matched hole's canonical site** is in the right space, but `countersink_matches_hole`
  accepts more than one hole (its tolerances scale with diameter), so the lookup needs a rule for
  choosing among them and `next()` silently chose "first". Review constructed a part where that
  publishes a confident, canonical-looking key pointing at the **wrong** hole.

Which hole a seat physically sits on is the recogniser's question (**ADR 0013**), not a policy for
a lint module to invent. `unverifiable` with no members says what is true: the requirement is
real, it is counted in the denominator, and it cannot be attributed. Closing the gap properly
means the `HoleRecord` waist carrying more than one countersink slot — this issue's real
remainder, and the new test asserts it so the tail cannot quietly outlive its reason.

Tested where it belongs, in `test_issue_1143_hole_completeness.py`, whose
`_two_face_countersunk_hole` fixture has exercised this branch since **#1151**. My first version
claimed the branch was unreachable and shipped an AST guard instead; it was reachable, a passing
test existed one grep away, and the guard was not load-bearing anyway — it checked for the
`members` *keyword*, so it survived `members=()`, an aliased constructor, and a comment pushing it
out of range.

## 2. `_members` folded `through` over the group

`all(...)` over the members, two lines below a branch deciding the same field per hole. It reads
as if it handles a case the grouping forbids. **Stated plainly: reverting it survives the suite.**
`HoleSpec.from_hole` copies `bottom` verbatim, so the change is expressive, not behavioural —
unlike `axis` one line above, where the spec's 6-dp rounding is load-bearing.

The guard for it was a tautology *twice*: six identical through holes cannot mix; three-through-
then-three-blind split positionally at the gap regardless of the spec key. It is now
**interleaved** — through at −60/−20/20, blind at −40/0/40, one pitch — and measured, neutering
`_spec_key` collapses all six into one `LinearArray` carrying `{'through', 'flat'}` and the test
fails.

## 3. The "unexplained" lazy imports — my filing was wrong

`evaluation/step_analysis.py` has **no** module-level engine imports at all: eight live in
function bodies (5 `draftwright`, 2 `b123d_recognisers`, 1 `build123d`). Every one pulls build123d
transitively, so hoisting any turns importing the module from ~0.01 s into one to two seconds.
That is the **#313** lazy-load pattern applied deliberately; what was missing was the note, now in
the docstring. Absolute seconds are deliberately not quoted — two machines gave 1.35 s and 2.26 s
for the same import, and the shape is the point.

A subprocess test asserts build123d stays out of `sys.modules`; asserting that in-process would
pass regardless. The AST guard beside it now covers `import x` as well as `from x import y`, and
`b123d_recognisers` as well as the other two.

## Verification

- **Mutations, substitution asserted applied each time:** inventing an attribution → KILLED;
  `members` dropped → KILLED; neutering `_spec_key` → KILLED; hoisting a `b123d_recognisers`
  import → KILLED; `through` from the raw record → **SURVIVED**, an equivalent mutant as above.
- Full fast tier **4,292 passed**, 5 skipped, 2 xfailed. `scripts/pr-check --static` exit 0 (read
  from `$?`) — its exit code caught a name collision the tests did not.

## Review history

Three adversarial rounds, each of which found something real, and the pattern is worth stating:
the implementation has been small throughout; what kept failing review was confident prose about
it. Round 1 found the "unreachable" claim false and disproved by a test already in the repo.
Round 2 found the collision measurement false and *inverted* — the probe had pooled the attached
seat's members with the tail's — and found the attribution untested. Round 3 found the retraction
of that claim applied to two of the places it appeared while asserting all of them were fixed, and
found the replacement guard was a fresh tautology.
