### PR TITLE
Give the overall height an identity where there is no envelope feature (#1230)

### DIFF
--- a/src/draftwright/linting/evidence.py
+++ b/src/draftwright/linting/evidence.py
@@ -172,6 +172,19 @@ def compiled_values(plan) -> dict:
             values[approved.id].append(approved)
     for approved in getattr(plan, "locations", ()):
         values[approved.id].append(approved)
+    # Contingency FALLBACKS count as approved. A contingency is a ladder the compiler approved
+    # and held, to be released by the build if the primary does not fit — `orchestrator.py`
+    # releases `step_length`'s on a turned part whose step chain cannot tile the height. The
+    # renderer then legitimately draws that rung and claims its id.
+    #
+    # This function is handed a FRESHLY compiled plan (`drawing.py`'s `_lint` calls
+    # `compile_dimensions(model)`), which has no record of what the build released — so a claim
+    # on a released fallback read as `unresolved`, i.e. "the compiler did not approve this",
+    # about a measurement the compiler demonstrably did approve. Latent until #1230 gave the
+    # overall-height rung an identity: with `id=None` the rung made no claim and nothing asked.
+    for contingency in getattr(plan, "contingencies", ()):
+        for approved in getattr(contingency.fallback, "rungs", ()):
+            values[approved.id].append(approved)
     return {key: tuple(entries) for key, entries in values.items()}
 
 

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -869,6 +869,22 @@ def _compile_overall_height(
         # for: declaring `.envelope()` is how the overall height becomes nameable (#876).
         # This is the one place the fallback lives, so refusing it is one branch rather
         # than a rule every renderer has to remember.
+        # `feature=None` here, while the APPROVED rung below now carries a minted envelope
+        # identity (#1230). The two halves of a documented-joinable pair therefore disagree for
+        # this one measurement: `Drawing.measurement_keys` says it is "deliberately the SAME row
+        # shape … so a drawn measurement and a suppressed one are directly comparable", and
+        # `audit._correspondence` keys on the feature string — so it attributes a lost `dim_od`
+        # and `ldr_z0` but not a lost `dim_height` (#1233 review, F3/R4).
+        #
+        # Not closed here, and the reason is measured rather than chosen. Passing the same
+        # identity to both omissions is three lines and does work — but `height.length` is the
+        # ONLY producer of `feature=None` rows in the public ledger (zero featureless rows across
+        # the whole detected corpus; on `test_real_mixed_featureless_and_feature_suppressions_
+        # have_a_total_order`'s own fixture it is the single one). Giving it a feature deletes
+        # the last real source of the mixed `None`/`str` case that #1077's guard exists to sort,
+        # leaving that test asserting something no build can produce. Whether `feature=None`
+        # should stay representable in the public ledger is a question about the ledger's shape,
+        # not about this rung. Tracked on #1230.
         return (
             None,
             None,

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -56,6 +56,7 @@ from draftwright._geometry import _fmt
 from draftwright.model.ir import (
     EnvelopeFeature,
     Feature,
+    Frame,
     HoleFeature,
     PartModel,
     PatternFeature,
@@ -871,13 +872,38 @@ def _compile_overall_height(
             ],
         )
     value = float(env.height) if env is not None else float(bb.size.Z)
+    # A model with no `EnvelopeFeature` still gets an identity for its overall height, from a
+    # bounding-box envelope minted here. Without it `_dim_id` returns None, the rung carries no
+    # id, and `render_height_ladder` — which already threads `measurement=mid` correctly — has
+    # nothing to thread: `dim_height` reached every such sheet printing a real number that no
+    # compiled entry claimed. That is an ADR 0016 Amdt 1 breach in the one direction the ADR
+    # cares about, and it is a PLAN-content gap, so it cannot be closed at the renderer (#1230).
+    #
+    # The discriminator is having no envelope feature, NOT being rotational: `grm03` is neither
+    # rotational nor enveloped and escaped, while `if_step_flat_across_cylinder` is rotational,
+    # HAS an envelope, and never did.
+    #
+    # Minted from the bbox rather than added to `model.features`: this feature names the
+    # measurement, it is not a new recognised feature, and `DimensionId` compares features
+    # STRUCTURALLY — so re-planning the same part yields an equal id, which is the stability the
+    # identity model needs. The value is unchanged; only its identity is new.
+    identity = env
+    if identity is None:
+        identity = EnvelopeFeature(
+            frame=Frame(origin=(0.0, 0.0, 0.0), axis="z"),
+            width=float(bb.size.X),
+            height=float(bb.size.Z),
+            depth=float(bb.size.Y),
+            bbox_min=(float(bb.min.X), float(bb.min.Y), float(bb.min.Z)),
+            bbox_max=(float(bb.max.X), float(bb.max.Y), float(bb.max.Z)),
+        )
     env_ref = FeatureRef(env) if env is not None else None
     x, y = float(bb.max.X), float(bb.min.Y)
     ladder = ApprovedLadder(
         "overall_height",
         (
             ApprovedDimension(
-                id=_dim_id(env, "height.length"),
+                id=_dim_id(identity, "height.length"),
                 value_text=_fmt(value),
                 value=value,
                 span=((x, y, float(bb.min.Z)), (x, y, float(bb.max.Z))),

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -56,7 +56,6 @@ from draftwright._geometry import _fmt
 from draftwright.model.ir import (
     EnvelopeFeature,
     Feature,
-    Frame,
     HoleFeature,
     PartModel,
     PatternFeature,
@@ -619,8 +618,16 @@ class RenderableDimensionPlan:
             # boundary #946 is about: this is the right side of it.
             #
             # `ref is None` is the model-level case: the overall height of a part with no
-            # envelope feature belongs to the part, not to any feature, and says so rather
-            # than having one invented for it.
+            # envelope feature belongs to the part, not to any feature.
+            #
+            # Note the deliberate asymmetry with `id`, since the two now disagree. #1230 gives
+            # that rung a `DimensionId` whose feature IS a bounding-box envelope, minted for
+            # identity so the annotation can claim something; `ref` stays None, because a
+            # FeatureRef is what a script addresses and there is no such feature to address.
+            # Identity and addressability are different questions here, and this is the one
+            # place where the answers differ — worth stating rather than leaving the reader to
+            # find a comment that says no feature is ever invented, eight lines from where one
+            # is (#1233 review).
             if lad.kind not in _LADDER_ROLE:
                 continue
             out.append(AddressableIntent(lad.ref, _LADDER_ROLE[lad.kind]))
@@ -875,13 +882,21 @@ def _compile_overall_height(
     # A model with no `EnvelopeFeature` still gets an identity for its overall height, from a
     # bounding-box envelope minted here. Without it `_dim_id` returns None, the rung carries no
     # id, and `render_height_ladder` — which already threads `measurement=mid` correctly — has
-    # nothing to thread: `dim_height` reached every such sheet printing a real number that no
-    # compiled entry claimed. That is an ADR 0016 Amdt 1 breach in the one direction the ADR
-    # cares about, and it is a PLAN-content gap, so it cannot be closed at the renderer (#1230).
+    # nothing to thread, so `dim_height` reached the sheet claiming nothing and the verifier was
+    # blind to it. A PLAN-content gap, not closable at the renderer (#1230).
+    #
+    # Be exact about which ADR: this is **ADR 0010 provenance / ADR 0016 identity**, NOT an
+    # ADR 0016 Amdt 1 breach, which an earlier version of this comment asserted three times.
+    # Amendment 1 is about renderers emitting content the plan does not contain. The plan DID
+    # contain this: the rung existed with the right value, and `from_model` builds the label
+    # from the compiler's own `rendered_label`. Nothing was renderer-derived. What was missing
+    # was the identity, so nothing could claim it (#1233 review).
     #
     # The discriminator is having no envelope feature, NOT being rotational: `grm03` is neither
-    # rotational nor enveloped and escaped, while `if_step_flat_across_cylinder` is rotational,
-    # HAS an envelope, and never did.
+    # rotational nor enveloped and escaped. (`if_step_flat_across_cylinder` was cited as the
+    # other half of that contrast and does not earn it — it is rotational and enveloped, but its
+    # overall-height ladder is None and it draws no `dim_height` at all, so it discriminates
+    # nothing. The mechanism is the evidence: `_dim_id` returns None iff the feature is None.)
     #
     # Minted from the bbox rather than added to `model.features`: this feature names the
     # measurement, it is not a new recognised feature, and `DimensionId` compares features
@@ -889,14 +904,17 @@ def _compile_overall_height(
     # identity model needs. The value is unchanged; only its identity is new.
     identity = env
     if identity is None:
-        identity = EnvelopeFeature(
-            frame=Frame(origin=(0.0, 0.0, 0.0), axis="z"),
-            width=float(bb.size.X),
-            height=float(bb.size.Z),
-            depth=float(bb.size.Y),
-            bbox_min=(float(bb.min.X), float(bb.min.Y), float(bb.min.Z)),
-            bbox_max=(float(bb.max.X), float(bb.max.Y), float(bb.max.Z)),
-        )
+        # Through `_envelope_from_bbox`, the one shared constructor — NOT hand-rolled here.
+        # The first version of this hardcoded `Frame(origin=(0, 0, 0))`, which is the bbox
+        # centre only for a part centred on the origin. That is #976's signature, and this
+        # would have been its FIFTH instance: `sheet_emit` already paid for it once, and its
+        # own comment calls the hand-rolled version "the fourth instance of #977's signature".
+        # Measured, the literal made the direct and mirrored paths mint UNEQUAL ids for the
+        # same measurement on an off-centre part — breaking exactly the ADR 0011 round trip
+        # `mirror_model` exists for (#1233 review).
+        from draftwright.model.declare import _envelope_from_bbox
+
+        identity = _envelope_from_bbox(bb)
     env_ref = FeatureRef(env) if env is not None else None
     x, y = float(bb.max.X), float(bb.min.Y)
     ladder = ApprovedLadder(

--- a/tests/test_issue_1217_claimed_representations.py
+++ b/tests/test_issue_1217_claimed_representations.py
@@ -315,6 +315,45 @@ class TestEveryOutcomeReachesLint:
         plan = SimpleNamespace(groups=(), ladders=(SimpleNamespace(rungs=(rung,)),), locations=())
         assert compiled_values(plan) == {"rung": (rung,)}
 
+    def test_the_minted_height_identity_uses_the_shared_constructor(self):
+        """#976's signature, guarded at last.
+
+        `_compile_overall_height` mints an `EnvelopeFeature` for the overall height of a part
+        that has none, so the rung has an identity to claim (#1230). Hand-rolling that with
+        `Frame(origin=(0, 0, 0))` is the bbox CENTRE only for a part centred on the origin — the
+        defect `detect`, `sheet.envelope()` and `sheet_emit` have each been corrected for, and it
+        went in here a fifth time.
+
+        Nothing caught it: restoring the literal passed 4,302 fast and 44 slow tests, on a corpus
+        that already contains an off-centre envelope-less part (grm03's bbox centre is
+        `(11.75, 0, 0)`). The #1217 ratchet checks that a claim EXISTS, never that its identity
+        is right — so this asserts the identity (#1233 review round 2).
+        """
+        from build123d import Align, Cylinder, Pos
+
+        from draftwright.builder import build_drawing
+        from draftwright.model.compiled import compile_dimensions
+        from draftwright.model.declare import _envelope_from_bbox
+        from draftwright.model.ir import EnvelopeFeature
+
+        centre = (Align.CENTER, Align.CENTER, Align.CENTER)
+        # Offset in Y, so the bbox centre is NOT the origin and the two differ.
+        part = Pos(0, 6, 0) * (Cylinder(20, 60, align=centre) - Cylinder(6, 70, align=centre))
+        model = build_drawing(part, title="T", number="N-1").model()
+        assert not [f for f in model.features if isinstance(f, EnvelopeFeature)], (
+            "the part grew an envelope feature; it can no longer exercise the minted path"
+        )
+        rung = compile_dimensions(model).ladder("overall_height").rungs[0]
+        assert rung.id is not None, "the overall height rung carries no identity"
+        assert rung.id.feature == _envelope_from_bbox(model.bbox), (
+            f"{rung.id.feature.frame} is not the shared constructor's; a hand-rolled envelope "
+            "puts the frame at the origin instead of the bbox centre, so the direct and mirrored "
+            "paths mint unequal ids for the same measurement (#976)"
+        )
+        assert rung.id.feature.frame.origin[1] != 0.0, (
+            "the fixture is centred in Y after all, so this assertion cannot fail"
+        )
+
     def test_contingency_fallbacks_are_part_of_the_expected_set(self):
         # The fourth branch, added for #1230, and it had the same hole as the ladders one: the
         # only thing catching it was an unrelated parametrized case in `test_sheet_emit`.

--- a/tests/test_issue_1217_claimed_representations.py
+++ b/tests/test_issue_1217_claimed_representations.py
@@ -315,6 +315,25 @@ class TestEveryOutcomeReachesLint:
         plan = SimpleNamespace(groups=(), ladders=(SimpleNamespace(rungs=(rung,)),), locations=())
         assert compiled_values(plan) == {"rung": (rung,)}
 
+    def test_contingency_fallbacks_are_part_of_the_expected_set(self):
+        # The fourth branch, added for #1230, and it had the same hole as the ladders one: the
+        # only thing catching it was an unrelated parametrized case in `test_sheet_emit`.
+        #
+        # A contingency is a ladder the compiler approved and HELD, released by the build when
+        # the primary does not fit. `drawing._lint` verifies against a freshly compiled plan
+        # that has no record of the release, so a claim on a released fallback read as
+        # "the compiler did not approve this" about something it demonstrably did.
+        from draftwright.linting.evidence import compiled_values
+
+        rung = SimpleNamespace(id="fallback", value_text="40", value=40.0, span=None, axis=None)
+        plan = SimpleNamespace(
+            groups=(),
+            ladders=(),
+            locations=(),
+            contingencies=(SimpleNamespace(fallback=SimpleNamespace(rungs=(rung,))),),
+        )
+        assert compiled_values(plan) == {"fallback": (rung,)}
+
 
 class TestTheAcceptanceSetIsNarrowedWhereItCanBe:
     def test_a_repeat_count_cannot_confirm_a_diameter(self):

--- a/tests/test_issue_1217_the_facility_is_shared.py
+++ b/tests/test_issue_1217_the_facility_is_shared.py
@@ -54,10 +54,18 @@ _UNCONFIRMED_CLAIMS: set[tuple[str, str, str]] = set()
 #:     placement decision rather than a property of the part: the renderer groups steps whose
 #:     projected length falls below `2 * draft.arrow_length`, so the grouping moves with page
 #:     scale and font size. ADR 0016 cannot be satisfied by emitting it from the planner.
-#:   * Not drawing it fails `test_subfloor_head_gets_detail_view`, which pins the block as
-#:     deliberate: it LOCATES the head on the main view while DETAIL A breaks it down, "with
-#:     axial coverage satisfied across the two views". Measured, removing it leaves grm03
-#:     reporting `axial_length_missing` — a real coverage gap traded for a provenance one.
+#:   * Not drawing it leaves grm03 reporting `axial_length_missing` — a real coverage gap
+#:     traded for a provenance one. `test_subfloor_head_gets_detail_view` also fails, though
+#:     that test pins the block's PRESENCE, not its value: drawing it with an empty label passes
+#:     it. The load-bearing constraint is `lint_axial_coverage`; an earlier version of this note
+#:     presented the two as independent reasons and they are one (#1233 review).
+#:
+#: Be honest about the second bullet too: "the compiler cannot authorise it" overstates. The
+#: compiler could approve one candidate per contiguous step run — `hhi - hlo` IS a property of
+#: the part — and let the renderer select the one matching the grouping it chose, which is
+#: ADR 0014's collect-then-solve shape used everywhere else in this engine. What is true is
+#: that the SELECTION is placement-dependent, not that the aggregate is unapprovable. Whether
+#: that is worth building is a maintainer's call, which is why #1230 stays open for it.
 #:
 #: Registered with the reason rather than fixed badly. Pinned exactly, per part and name, so a
 #: second occurrence fails rather than being absorbed.

--- a/tests/test_issue_1217_the_facility_is_shared.py
+++ b/tests/test_issue_1217_the_facility_is_shared.py
@@ -34,33 +34,35 @@ _C = (Align.CENTER, Align.CENTER, Align.CENTER)
 #: so a second such case has to be argued rather than absorbed.
 _NON_MEASURING_ANNOTATIONS = ("detail_caption",)
 
-#: Annotations that render a real measured value carrying no compiled identity to thread — the
-#: `ctx.place` seam cannot fix these because there is no id to pass. All three are #1230:
-#:
-#:   * `m_steplen0` on grm03 — a synthetic step head-block drawing the SUM of two steps
-#:     (0.5 + 2.0 = 2.5). No plan entry holds 2.5, and claiming the two members would be a
-#:     false claim: the annotation does not draw either of them.
-#:   * `dim_height` on grm03 and on the bored tube — measured, `plan.ladder("overall_height")`
-#:     yields a rung with `id=None` whenever the model has NO `EnvelopeFeature`, and a rung
-#:     carrying an `EnvelopeFeature` id when it has one (`compiled.py` builds the id from that
-#:     feature, and `_dim_id` returns None for a missing one). "Rotational" is the wrong rule
-#:     and an earlier draft used it: grm03 is not rotational — it recognises as four steps, a
-#:     boss and a hole with no envelope — while `if_step_flat_across_cylinder` IS rotational,
-#:     HAS an envelope, and does not escape. Deciding what the rung means where there is no
-#:     envelope is a modelling call, not a threading edit (#1225 review, finding 7).
-#:
-#: Pinned exactly, per part and name, so a fourth occurrence fails rather than being absorbed —
-#: this register is a defect ledger, not an exemption list, and it should shrink to nothing.
-#: Empty, and that is the point. It held one entry — `m_locy7` on nist_ctc_02 claiming
-#: `location_slot.length` (94.1) while rendering 430.0 — until #1219 was fixed, at which point
-#: the entry had to go. Kept as an empty set rather than deleted so the next such defect is
-#: registered with an issue number instead of the assertion below being softened.
+#: Claims the drawing does NOT bear out. Empty, and that is the point: it held one entry —
+#: `m_locy7` on nist_ctc_02 claiming `location_slot.length` (94.1) while rendering 430.0 — until
+#: #1219 was fixed, at which point the entry had to go. Kept as an empty set rather than deleted
+#: so the next such defect is registered with an issue number instead of the assertion below
+#: being softened.
 _UNCONFIRMED_CLAIMS: set[tuple[str, str, str]] = set()
 
+#: Annotations that render a real measured value carrying no compiled identity to thread — the
+#: `ctx.place` seam cannot fix these because there is no id to pass. ONE entry now: the two
+#: `dim_height` entries were deleted when #1230 gave the overall-height rung an identity minted
+#: from the bounding box, so a part with no `EnvelopeFeature` has something true to claim.
+#:
+#: What remains is `m_steplen0` on grm03 — the synthetic step head-block, drawing the SUM of two
+#: steps (0.5 + 2.0 = 2.5). It resists a fix in BOTH directions, which is why it stays:
+#:
+#:   * Claiming the two members would be a FALSE claim — the annotation draws neither 0.5 nor 2.0.
+#:   * The compiler cannot authorise the aggregate, because WHICH steps form a head block is a
+#:     placement decision rather than a property of the part: the renderer groups steps whose
+#:     projected length falls below `2 * draft.arrow_length`, so the grouping moves with page
+#:     scale and font size. ADR 0016 cannot be satisfied by emitting it from the planner.
+#:   * Not drawing it fails `test_subfloor_head_gets_detail_view`, which pins the block as
+#:     deliberate: it LOCATES the head on the main view while DETAIL A breaks it down, "with
+#:     axial coverage satisfied across the two views". Measured, removing it leaves grm03
+#:     reporting `axial_length_missing` — a real coverage gap traded for a provenance one.
+#:
+#: Registered with the reason rather than fixed badly. Pinned exactly, per part and name, so a
+#: second occurrence fails rather than being absorbed.
 _UNPLANNED_VALUES = {
     ("grm03_thumbwheel_drive_screw.step", "m_steplen0"),
-    ("grm03_thumbwheel_drive_screw.step", "dim_height"),
-    ("bored tube", "dim_height"),
 }
 
 

--- a/tests/test_issue_1217_the_facility_is_shared.py
+++ b/tests/test_issue_1217_the_facility_is_shared.py
@@ -54,11 +54,16 @@ _UNCONFIRMED_CLAIMS: set[tuple[str, str, str]] = set()
 #:     placement decision rather than a property of the part: the renderer groups steps whose
 #:     projected length falls below `2 * draft.arrow_length`, so the grouping moves with page
 #:     scale and font size. ADR 0016 cannot be satisfied by emitting it from the planner.
-#:   * Not drawing it leaves grm03 reporting `axial_length_missing` — a real coverage gap
-#:     traded for a provenance one. `test_subfloor_head_gets_detail_view` also fails, though
-#:     that test pins the block's PRESENCE, not its value: drawing it with an empty label passes
-#:     it. The load-bearing constraint is `lint_axial_coverage`; an earlier version of this note
-#:     presented the two as independent reasons and they are one (#1233 review).
+#:   * Not drawing it fails `test_subfloor_head_gets_detail_view`, at the line that finds the
+#:     block by name — its PRESENCE is what is pinned, not its value: drawing it with an empty
+#:     label passes that test. Presence is the whole of the constraint.
+#:
+#:     Two earlier versions of this bullet were wrong, in opposite directions. The first paired
+#:     the test with `axial_length_missing` as independent reasons; the second kept
+#:     `axial_length_missing` as "the load-bearing constraint" and dropped the test. Measured,
+#:     grm03 reports `axial_length_missing` IDENTICALLY with and without the block — the block
+#:     carries no claim, so it never counted toward axial coverage and there is no trade at all
+#:     (#1233 review round 2).
 #:
 #: Be honest about the second bullet too: "the compiler cannot authorise it" overstates. The
 #: compiler could approve one candidate per contiguous step run — `hhi - hlo` IS a property of

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -9862,7 +9862,6 @@ class TestDiameterStepAnchor:
         # (axial mid 30, radial y=20), not a hybrid that takes the axial from the
         # long step and the radial from the bucket's first (short) step — which
         # would land the arrow off the selected step's silhouette.
-        from types import SimpleNamespace
 
         from draftwright.annotations.from_model import _diameter_step_anchor
         from draftwright.model.compiled import compile_dimensions
@@ -9871,14 +9870,15 @@ class TestDiameterStepAnchor:
 
         short = self._step("x", (0.0, 0.0, 0.0), -2.5, 2.5)  # len 5, centre x=0
         long = self._step("x", (30.0, 20.0, 0.0), 20.0, 40.0)  # len 20, centre x=30, y=20
-        # A full bbox, not just the fields one caller happens to read: `_compile_overall_height`
-        # now mints a bounding-box envelope for the height's identity (#1230) and reads X and Y
-        # too. A stub that models only today's reads breaks on any honest extension.
-        bbox = SimpleNamespace(
-            size=SimpleNamespace(X=80.0, Y=30.0, Z=20.0),
-            max=SimpleNamespace(X=40.0, Y=15.0, Z=20.0),
-            min=SimpleNamespace(X=-40.0, Y=0.0, Z=0.0),
-        )
+        # A real BoundBox, not a namespace modelling whichever fields one caller happens to
+        # read. `_compile_overall_height` now mints the height's identity from the bbox (#1230)
+        # via `_envelope_from_bbox`, which calls `center()`. Two successive stub versions broke
+        # here — the first lacked X and Y, the second added them but asserted an impossible
+        # geometry (`size.Y=30` with `max.Y-min.Y=15`) and still had no `center()`. A stub of a
+        # value type should be the value type (#1233 review).
+        from build123d import Box, Location
+
+        bbox = (Location((0, 7.5, 10)) * Box(80, 15, 20)).bounding_box()
         model = PartModel(bbox=bbox, orientation="x", features=[short, long])
         groups = plan_dimensions(model)
         plan = compile_dimensions(model, groups=groups)

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -9871,10 +9871,13 @@ class TestDiameterStepAnchor:
 
         short = self._step("x", (0.0, 0.0, 0.0), -2.5, 2.5)  # len 5, centre x=0
         long = self._step("x", (30.0, 20.0, 0.0), 20.0, 40.0)  # len 20, centre x=30, y=20
+        # A full bbox, not just the fields one caller happens to read: `_compile_overall_height`
+        # now mints a bounding-box envelope for the height's identity (#1230) and reads X and Y
+        # too. A stub that models only today's reads breaks on any honest extension.
         bbox = SimpleNamespace(
-            size=SimpleNamespace(Z=20.0),
-            max=SimpleNamespace(X=40.0, Z=20.0),
-            min=SimpleNamespace(Y=0.0, Z=0.0),
+            size=SimpleNamespace(X=80.0, Y=30.0, Z=20.0),
+            max=SimpleNamespace(X=40.0, Y=15.0, Z=20.0),
+            min=SimpleNamespace(X=-40.0, Y=0.0, Z=0.0),
         )
         model = PartModel(bbox=bbox, orientation="x", features=[short, long])
         groups = plan_dimensions(model)


### PR DESCRIPTION
Closes the `dim_height` half of #1230. The head-block half is answered too, and the answer is
"it stays registered", with the reasons — corrected twice — written down.

## `dim_height`: the renderer was never at fault

`render_height_ladder` already threads `measurement=mid` from the rung's own id. The rung had no
id: `_compile_overall_height` mints it with `_dim_id(env, "height.length")`, and `_dim_id` returns
`None` when the feature is missing. So on every part with **no `EnvelopeFeature`** the sheet
printed a real overall height that claimed nothing, and the verifier was blind to it:

```
#1227 bored tube -> ladder: [('60', None)]
grm03            -> ladder: [('10', None)]
plain box        -> ladder: [('20', DimensionId(feature=EnvelopeFeature(...), 'height.length'))]
```

**Which ADR:** this is **ADR 0010 provenance / ADR 0016 identity**, *not* an ADR 0016 Amdt 1
breach — a claim an earlier version of this PR made three times. Amendment 1 is about renderers
emitting content the plan does not contain. The plan contained it: the rung existed with the right
value, and `from_model` builds the label from the compiler's own `rendered_label`. Nothing was
renderer-derived. What was missing was the identity.

The compiler already computed the *value* from the bounding box for exactly these parts — its own
docstring says *"the COMPILER may do that; a renderer may not"*. It now mints the identity too,
**through `_envelope_from_bbox`**, the one shared constructor used by `detect`, `sheet.envelope()`
and `sheet_emit.mirror_model`. The first version hand-rolled `Frame(origin=(0,0,0))`, which is the
bbox centre only for a part centred on the origin — #976's signature, and this would have been its
fifth instance. Measured, the literal made the direct and mirrored paths mint **unequal ids** for
the same measurement on an off-centre part, breaking the ADR 0011 round trip `mirror_model` exists
for.

The discriminator is **having no envelope feature**, not being rotational. `grm03` is neither
rotational nor enveloped and escaped. (`if_step_flat_across_cylinder` was cited as the contrasting
half and does not earn it — it is rotational and enveloped, but its overall-height ladder is `None`
and it draws no `dim_height` at all, so it discriminates nothing. The mechanism is the evidence:
`_dim_id` returns `None` iff the feature is `None`.)

`ref` deliberately stays `None` while `id` gains a feature: a `FeatureRef` is what a script
addresses, and there is no such feature to address. That asymmetry is now stated at the comment
that previously said no feature is ever invented for this rung.

## A latent hazard this surfaced

The groove fixture then reported `claimed_measurement_not_compiled`. `drawing._lint` verifies
against a **freshly compiled** plan, which has no record of what the build released — and the
orchestrator releases `step_length`'s contingency on a turned part whose step chain cannot tile the
height, after which the renderer legitimately draws that fallback rung and claims its id.
`compiled_values` now indexes contingency fallbacks. Invisible until now, because with `id=None`
the rung made no claim and nothing asked.

## The head block stays registered

Removing it fails `test_subfloor_head_gets_detail_view` at the line that finds the block by name —
its **presence** is what is pinned, not its value; an empty label passes that test.

Two earlier versions of this reasoning were wrong in opposite directions, and both are recorded in
the register comment. The first paired the test with `axial_length_missing` as independent reasons;
the second kept `axial_length_missing` as "the load-bearing constraint" and dropped the test.
**Measured, grm03 reports `axial_length_missing` identically with and without the block** — it
carries no claim, so it never counted toward axial coverage. There is no trade.

"The compiler cannot authorise it" is also too strong: it could approve one candidate per
contiguous step run (`hhi - hlo` *is* a property of the part) and let the renderer select, which is
ADR 0014's collect-then-solve shape. What is true is that the **selection** is placement-dependent
— the grouping keys on `2 * draft.arrow_length`, so it moves with page scale and font size.

## What this does not close

- **grm03's overall height duplicates its OD.** `dim_height` is 10 and `m_dia_x1` is ø10 — the Z
  extent *is* the max step diameter, so the sheet states one requirement twice.
  `rotational_od_conveys_height` cannot suppress it because grm03 has no `RotationalFeature`.
  Giving the number an identity confirms it without making it correct; recorded on #1230.
- **`suppressions()` and `measurement_keys()` no longer join for this measurement.** The drawn side
  gains an identity, the suppressed side stays `feature=None`, so `audit` attributes a lost
  `dim_od` and `ldr_z0` but not a lost `dim_height`. Passing the identity to both omissions is
  three lines and works — but `height.length` is the **only** producer of `feature=None` ledger
  rows (zero across the detected corpus), so doing it deletes the last real source of the mixed
  `None`/`str` case #1077's guard exists to sort. That is a question about the ledger's shape;
  recorded at the site and on #1230.

## Verification

- **Mutations, substitution asserted applied each time:** reverting the minted identity → KILLED;
  dropping contingency fallbacks from `compiled_values` → KILLED (by the new unit test *and* the
  groove lint case); restoring the hand-rolled `Frame(origin=(0,0,0))` → KILLED **by the guard
  added in round 2** — it passed 4,302 fast and 44 slow tests before that.
- Full fast tier **4,303 passed**, 5 skipped, 2 xfailed. Slow tier 44 passed.
  `scripts/pr-check --static` exit 0 (read from `$?`).
- Corpus sweep, all 16 fixtures: exactly one difference — grm03's `dim_height` gains its claim. No
  label, lint-code, score or annotation-set regression anywhere.

## Review history

Two adversarial rounds. Round 1 found the hand-rolled envelope (#976's fifth recurrence), the wrong
ADR citation baked into a source comment, a contradicted comment eight lines from the new code, a
stub bbox asserting impossible geometry, and the missing test for the new `compiled_values` branch.
Round 2 found that the #976 fix had **no guard at all**, that my correction of the head-block
reasoning had replaced one false claim with another, that the seam above was left half-closed, and
that this body still carried every round-1 error.
