### PR TITLE
Render an authored envelope tolerance on all three extents (#1215)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -4026,6 +4026,11 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                 "representative step-height dimension dropped (front-view right strip full)",
                 rep.id,
                 rep.value,
+                # NO tolerance, deliberately. `N× rise` states one value for the whole run, so
+                # a ± here would claim the author's tolerance of every level at once — the same
+                # rule the turned-step collapse follows (#28 / P2a). The plain rungs below each
+                # state their own measurement and do carry it (#1234 review r5).
+                None,
             )
         )
     elif rungs:
@@ -4078,6 +4083,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                     "step-height dimension dropped (front-view right strip full)",
                     rung.id,
                     None,  # no `N×` prefix: the label states the span itself
+                    rung.tolerance,
                 )
             )
 
@@ -4093,19 +4099,24 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                 "overall height dimension dropped (front-view right strip full)",
                 height.id,
                 None,  # no `N×` prefix
+                height.tolerance,
             )
         )
 
-    # An authored `envelope().tolerance(..., on="height")` reaches the sheet here, composed into
-    # the LABEL like every other toleranced Dimension in this module. Passing it as
-    # `Dimension(tolerance=...)` renders nothing, because an explicit label discards it — see
-    # `_env_label` (#1215, #1234 review). Keyed by name because only the overall rung has one;
-    # a step rung's tolerance is a separate question.
-    _tolerances = {"dim_height": overall.rungs[0].tolerance} if overall is not None else {}
+    # Authored tolerances reach the sheet here, composed into the LABEL like every other
+    # toleranced Dimension in this module. Passing one as `Dimension(tolerance=...)` renders
+    # nothing, because an explicit label discards it — see `_env_label` (#1215).
+    #
+    # Keyed per rung, not just the overall height. An earlier version said "a step rung's
+    # tolerance is a separate question"; it is only separate for the `N× rise` REPRESENTATIVE,
+    # where a ± would claim the tolerance of every level. A plain ladder's rungs each state
+    # their own measurement, and `.tolerance()` on a step level was being dropped exactly as
+    # the envelope's was (#1234 review r5).
+    _tolerances = {c[0]: c[8] for c in chain}
 
     names = [c[0] for c in chain]
     solved: dict[str, float] = {}
-    for k, (name, zbase, ztop, label, _tsize, drop_msg, mid, per_unit) in enumerate(chain):
+    for k, (name, zbase, ztop, label, _tsize, drop_msg, mid, per_unit, _rt) in enumerate(chain):
 
         def _build(
             pos,

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -3227,12 +3227,21 @@ def render_plates(dwg, plan, a, *, ctx) -> int:
 
 
 def _env_label(approved, draft) -> str:
-    """The string an envelope extent's Dimension will RENDER, tolerance included.
+    """An envelope extent's label, authored tolerance included (#1215).
 
-    `Dimension` formats its own tolerance and leaves `label` untouched, so the annotation's
-    `label` attribute stays the bare value while the sheet shows the suffix. Anything measuring
-    the drawn width — the corridor footprint — needs this, and `_tol_suffix` is documented as
-    matching helpers' `_format_label` byte for byte, same precision rounding included (#1215).
+    Composed here, exactly as `render_boss_heights` and the plate-thickness and channel-width
+    dims already do — `pd.value_text + _tol_suffix(pd.tolerance, draft)`.
+
+    NOT passed as `Dimension(tolerance=...)`, which is what the first version of this fix did
+    and why it rendered nothing: helpers' `Dimension` does
+    `rendered = label if label is not None else draft._number_with_units(measured, tolerance)`,
+    so an explicit label DISCARDS the tolerance. Every dimension here passes a label, because
+    the compiler owns the value text. Measured then: `label`, glyph count and label width were
+    byte-identical with and without a tolerance, and the exported SVG had the same 115 paths
+    (#1234 review).
+
+    `_tol_suffix` also renders a `FitClass`, which the ink path's `_number_with_units` raises
+    on — so composing the label is the only route that satisfies #1215's fit-class line.
     """
     return f"{approved.value_text}{_tol_suffix(approved.tolerance, draft)}"
 
@@ -3284,14 +3293,13 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
             "plan",
             _SLOT_DIM_WIDTH,
             abs(x1 - x0),
-            lambda pos, _p1=p1, _p2=p2, _w=witness, _v=width.value_text, _t=width.tolerance: _dim(
+            lambda pos, _p1=p1, _p2=p2, _w=witness, _v=_env_label(width, dwg.draft): _dim(
                 (_p1[0], _w, 0),
                 (_p2[0], _w, 0),
                 "below",
                 _w - pos,
                 dwg.draft,
                 label=_v,
-                tolerance=_t,
             ),
             # The footprint must measure the string the Dimension will RENDER, not the bare
             # value: helpers' `_format_label` appends the same suffix `_tol_suffix` builds, so
@@ -3321,14 +3329,13 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
             "side",
             _SLOT_DIM_DEPTH,
             abs(y1 - y0),
-            lambda pos, _p1=p1, _p2=p2, _w=witness, _v=depth.value_text, _t=depth.tolerance: _dim(
+            lambda pos, _p1=p1, _p2=p2, _w=witness, _v=_env_label(depth, dwg.draft): _dim(
                 (_p1[0], _w, 0),
                 (_p2[0], _w, 0),
                 "below",
                 _w - pos,
                 dwg.draft,
                 label=_v,
-                tolerance=_t,
             ),
             footprint=lambda pos, _p1=p1, _p2=p2, _w=witness, _v=_env_label(depth, dwg.draft): (
                 dim_footprint((_p1[0], _w, 0), (_p2[0], _w, 0), "below", _w - pos, dwg.draft, _v)
@@ -4074,11 +4081,11 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
             )
         )
 
-    # An authored `envelope().tolerance(..., on="height")` reaches the sheet here. The rung
-    # carries it and `Dimension` formats its own, exactly as the width/depth extents do in
-    # `render_envelope` — the two paths have to agree, and they used to differ only because
-    # this one dropped the field on the floor (#1215). Keyed by name because only the overall
-    # rung has one; a step rung's tolerance is a separate question.
+    # An authored `envelope().tolerance(..., on="height")` reaches the sheet here, composed into
+    # the LABEL like every other toleranced Dimension in this module. Passing it as
+    # `Dimension(tolerance=...)` renders nothing, because an explicit label discards it — see
+    # `_env_label` (#1215, #1234 review). Keyed by name because only the overall rung has one;
+    # a step rung's tolerance is a separate question.
     _tolerances = {"dim_height": overall.rungs[0].tolerance} if overall is not None else {}
 
     names = [c[0] for c in chain]
@@ -4107,8 +4114,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                 "right",
                 pos - base,
                 draft,
-                label=label,
-                tolerance=_tol,
+                label=label + _tol_suffix(_tol, draft),
             )
             if per_unit is not None:
                 # What this dimension's `N× v` label actually measures. Lint reads it in

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -3242,6 +3242,12 @@ def _env_label(approved, draft) -> str:
 
     `_tol_suffix` also renders a `FitClass`, which the ink path's `_number_with_units` raises
     on — so composing the label is the only route that satisfies #1215's fit-class line.
+
+    One consequence worth naming: every `_dim` call site in this package passes a label, so
+    helpers' own `_number_with_units` formatting is unreachable. That is why the sheet is
+    internally consistent on limit-pair ORDER — `_tol_suffix` renders `+upper -lower` for an
+    envelope extent and a hole callout alike, while `_number_with_units` would render the
+    opposite. The consistency is real but it rests on that unreachability (#1234 review r2).
     """
     return f"{approved.value_text}{_tol_suffix(approved.tolerance, draft)}"
 
@@ -3301,17 +3307,16 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
                 dwg.draft,
                 label=_v,
             ),
-            # The footprint must measure the string the Dimension will RENDER, not the bare
-            # value: helpers' `_format_label` appends the same suffix `_tol_suffix` builds, so
-            # a toleranced envelope dim is wider than `value_text` and the corridor would
-            # otherwise reserve too little (#1215).
+            # The footprint measures the string the Dimension will RENDER, because a footprint
+            # that does not model the ink is wrong by construction. That is the whole
+            # justification — no test observes it, and two earlier versions of this comment
+            # invented a failure mode that does not occur.
             #
-            # Honest about the evidence: NO test observes this. Reverting it to `value_text`
-            # passes the suite, and on a sparse part every annotation's bounding box is
-            # byte-identical with and without a tolerance — the extra width only tips a
-            # fit/no-fit decision on a strip already close to full, which I could not construct
-            # reliably. It is kept because a footprint that does not model the ink is wrong by
-            # construction, not because anything measured it.
+            # Measured: `dim_footprint` is span-dominated, so for these extents the hull is
+            # IDENTICAL with and without the suffix. It differs only inside the outside-arrow
+            # flip regime (span ~8-20 mm), and there the toleranced footprint reserves LESS in
+            # the strip-depth direction, not more — the opposite of "reserves too little"
+            # (#1234 review r2).
             footprint=lambda pos, _p1=p1, _p2=p2, _w=witness, _v=_env_label(width, dwg.draft): (
                 dim_footprint((_p1[0], _w, 0), (_p2[0], _w, 0), "below", _w - pos, dwg.draft, _v)
             ),
@@ -3417,7 +3422,17 @@ def _draw_step_chain(
     gap = draft.font_size + 4 * draft.pad_around_text
     horizontal = abs(segs[0].pb[0] - segs[0].pa[0]) >= abs(segs[0].pb[1] - segs[0].pa[1])
     vals = [seg.value for seg in segs]
-    labels = [seg.label if seg.label is not None else _fmt(seg.value) for seg in segs]
+    # The suffix rides the LABEL, for the reason `_env_label` documents: helpers discard
+    # `tolerance=` whenever an explicit label is given, and one always is here. This site
+    # passed `tolerance=seg.tolerance` to `_dim` and rendered nothing — the same defect #1215
+    # fixed for the envelope, ninety lines away, with four tests asserting the discarded kwarg.
+    # The file already contradicted itself: `label_widths` below sizes the staggering decision
+    # with `_fmt(seg.value) + _tol_suffix(...)`, i.e. it measured a string this line refused to
+    # draw (#1234 review round 2).
+    labels = [
+        seg.label if seg.label is not None else _fmt(seg.value) + _tol_suffix(seg.tolerance, draft)
+        for seg in segs
+    ]
     mean_v = sum(vals) / len(vals)
     if (
         allow_collapse
@@ -3509,7 +3524,6 @@ def _draw_step_chain(
                         dist,
                         draft,
                         label=labels[i],
-                        tolerance=seg.tolerance,
                     ),
                     seg.measurements,
                 )
@@ -4125,8 +4139,8 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
             return dim
 
         # The footprint measures the RENDERED string, so it carries the same suffix the
-        # Dimension will draw — otherwise a toleranced overall height reserves the width of the
-        # bare value and the corridor packs the strip too tightly (#1215).
+        # Dimension draws. Correctness, not a measured failure mode — see the note in
+        # `render_envelope`; the invented "packs the strip too tightly" claim is withdrawn.
         def _foot(
             pos,
             zbase=zbase,

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -3226,6 +3226,17 @@ def render_plates(dwg, plan, a, *, ctx) -> int:
     return n
 
 
+def _env_label(approved, draft) -> str:
+    """The string an envelope extent's Dimension will RENDER, tolerance included.
+
+    `Dimension` formats its own tolerance and leaves `label` untouched, so the annotation's
+    `label` attribute stays the bare value while the sheet shows the suffix. Anything measuring
+    the drawn width — the corridor footprint — needs this, and `_tol_suffix` is documented as
+    matching helpers' `_format_label` byte for byte, same precision rounding included (#1215).
+    """
+    return f"{approved.value_text}{_tol_suffix(approved.tolerance, draft)}"
+
+
 def render_envelope(dwg, plan, a, *, ctx) -> int:
     """Overall width (plan, below) + depth (side, below) envelope dims via the IR,
     registered into the same below-strip corridor as feature/location/GD&T/PMI candidates.
@@ -3273,16 +3284,28 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
             "plan",
             _SLOT_DIM_WIDTH,
             abs(x1 - x0),
-            lambda pos, _p1=p1, _p2=p2, _w=witness, _v=width.value_text: _dim(
+            lambda pos, _p1=p1, _p2=p2, _w=witness, _v=width.value_text, _t=width.tolerance: _dim(
                 (_p1[0], _w, 0),
                 (_p2[0], _w, 0),
                 "below",
                 _w - pos,
                 dwg.draft,
                 label=_v,
+                tolerance=_t,
             ),
-            footprint=lambda pos, _p1=p1, _p2=p2, _w=witness, _v=width.value_text: dim_footprint(
-                (_p1[0], _w, 0), (_p2[0], _w, 0), "below", _w - pos, dwg.draft, _v
+            # The footprint must measure the string the Dimension will RENDER, not the bare
+            # value: helpers' `_format_label` appends the same suffix `_tol_suffix` builds, so
+            # a toleranced envelope dim is wider than `value_text` and the corridor would
+            # otherwise reserve too little (#1215).
+            #
+            # Honest about the evidence: NO test observes this. Reverting it to `value_text`
+            # passes the suite, and on a sparse part every annotation's bounding box is
+            # byte-identical with and without a tolerance — the extra width only tips a
+            # fit/no-fit decision on a strip already close to full, which I could not construct
+            # reliably. It is kept because a footprint that does not model the ink is wrong by
+            # construction, not because anything measured it.
+            footprint=lambda pos, _p1=p1, _p2=p2, _w=witness, _v=_env_label(width, dwg.draft): (
+                dim_footprint((_p1[0], _w, 0), (_p2[0], _w, 0), "below", _w - pos, dwg.draft, _v)
             ),
             measurement=width.id,
         )
@@ -3298,16 +3321,17 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
             "side",
             _SLOT_DIM_DEPTH,
             abs(y1 - y0),
-            lambda pos, _p1=p1, _p2=p2, _w=witness, _v=depth.value_text: _dim(
+            lambda pos, _p1=p1, _p2=p2, _w=witness, _v=depth.value_text, _t=depth.tolerance: _dim(
                 (_p1[0], _w, 0),
                 (_p2[0], _w, 0),
                 "below",
                 _w - pos,
                 dwg.draft,
                 label=_v,
+                tolerance=_t,
             ),
-            footprint=lambda pos, _p1=p1, _p2=p2, _w=witness, _v=depth.value_text: dim_footprint(
-                (_p1[0], _w, 0), (_p2[0], _w, 0), "below", _w - pos, dwg.draft, _v
+            footprint=lambda pos, _p1=p1, _p2=p2, _w=witness, _v=_env_label(depth, dwg.draft): (
+                dim_footprint((_p1[0], _w, 0), (_p2[0], _w, 0), "below", _w - pos, dwg.draft, _v)
             ),
             measurement=depth.id,
         )
@@ -4050,18 +4074,42 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
             )
         )
 
+    # An authored `envelope().tolerance(..., on="height")` reaches the sheet here. The rung
+    # carries it and `Dimension` formats its own, exactly as the width/depth extents do in
+    # `render_envelope` — the two paths have to agree, and they used to differ only because
+    # this one dropped the field on the floor (#1215). Keyed by name because only the overall
+    # rung has one; a step rung's tolerance is a separate question.
+    _tolerances = {"dim_height": overall.rungs[0].tolerance} if overall is not None else {}
+
     names = [c[0] for c in chain]
     solved: dict[str, float] = {}
     for k, (name, zbase, ztop, label, _tsize, drop_msg, mid, per_unit) in enumerate(chain):
 
-        def _build(pos, name=name, zbase=zbase, ztop=ztop, label=label, k=k, per_unit=per_unit):
+        def _build(
+            pos,
+            name=name,
+            zbase=zbase,
+            ztop=ztop,
+            label=label,
+            k=k,
+            per_unit=per_unit,
+            _tol=_tolerances.get(name),
+        ):
             base = edge2
             for pn in reversed(names[:k]):  # nearest already-built predecessor's line
                 if pn in solved:
                     base = solved[pn]
                     break
             solved[name] = pos
-            dim = _dim((base, zbase, 0), (base, ztop, 0), "right", pos - base, draft, label=label)
+            dim = _dim(
+                (base, zbase, 0),
+                (base, ztop, 0),
+                "right",
+                pos - base,
+                draft,
+                label=label,
+                tolerance=_tol,
+            )
             if per_unit is not None:
                 # What this dimension's `N× v` label actually measures. Lint reads it in
                 # preference to parsing the label, because `N× v` is drawn under two
@@ -4070,7 +4118,16 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                 dim._dw_label_value = per_unit
             return dim
 
-        def _foot(pos, zbase=zbase, ztop=ztop, label=label, k=k):
+        # The footprint measures the RENDERED string, so it carries the same suffix the
+        # Dimension will draw — otherwise a toleranced overall height reserves the width of the
+        # bare value and the corridor packs the strip too tightly (#1215).
+        def _foot(
+            pos,
+            zbase=zbase,
+            ztop=ztop,
+            label=label + _tol_suffix(_tolerances.get(name), draft),
+            k=k,
+        ):
             # Predecessor-aware prediction (#689 review): the conservative edge-anchored
             # witness can falsely exhaust the strip when an inner obstacle sits in the
             # already-traversed region. Use the same solved map the build chain uses.

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -4217,7 +4217,10 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
     for i, rung in enumerate(short_rungs):
         name = f"dim_step_{i}"
         zbase, ztop = _zspan(rung)
-        label = rung.final_label
+        # Same composition as the main chain: this is the SHORT-RISE escape, solved in the left
+        # strip because external arrows would swamp the right one. It is the same measurement
+        # by another route, and it dropped the tolerance (#1234 review r6).
+        label = rung.final_label + _tol_suffix(rung.tolerance, draft)
 
         def _build_left(pos, zbase=zbase, ztop=ztop, label=label):
             return _dim(
@@ -4336,7 +4339,11 @@ def render_step_positions(dwg, plan, frame, *, ctx) -> int:
         edge = p1[1]
         name = f"dim_shoulder_{axis}{i}"
 
-        def _build(pos, p1=p1, p2=p2, edge=edge, label=rung.final_label, direction=direction):
+        # The compiler's label plus its tolerance — a shoulder states a position the author can
+        # tolerance like any other (#1234 review r6).
+        shoulder_label = rung.final_label + _tol_suffix(rung.tolerance, draft)
+
+        def _build(pos, p1=p1, p2=p2, edge=edge, label=shoulder_label, direction=direction):
             return _dim(
                 (p1[0], edge, 0),
                 (p2[0], edge, 0),

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -3425,7 +3425,8 @@ def _draw_step_chain(
     # The suffix rides the LABEL, for the reason `_env_label` documents: helpers discard
     # `tolerance=` whenever an explicit label is given, and one always is here. This site
     # passed `tolerance=seg.tolerance` to `_dim` and rendered nothing — the same defect #1215
-    # fixed for the envelope, ninety lines away, with four tests asserting the discarded kwarg.
+    # fixed for the envelope, ninety lines away, with three tests reading the discarded kwarg
+    # (two asserting a value, one asserting its absence).
     # The file already contradicted itself: `label_widths` below sizes the staggering decision
     # with `_fmt(seg.value) + _tol_suffix(...)`, i.e. it measured a string this line refused to
     # draw (#1234 review round 2).

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -138,11 +138,20 @@ def callout_from_spec(spec, draft, count) -> HoleCallout | None:
         # diameter carrying tolerance/fit text, "8 ±0.05"); no tolerance → empty suffix.
         dia += _tol_suffix(spec.get("tolerance"), draft)
 
-    depth = f(spec["depth"])
-    cbore_dia = f(spec["cbore_dia"])
-    cbore_depth = f(spec["cbore_depth"])
-    csink_dia = f(spec.get("csink_dia"))
-    csink_angle = f(spec.get("csink_angle"))
+    def ft(value, key):
+        """A formatted term with its own authored tolerance baked in.
+
+        Every term of a compound callout can be toleranced, not just the bore. `.get()`
+        because hand-built specs in tests omit the keys (#1234 review r7).
+        """
+        text = f(value)
+        return None if text is None else text + _tol_suffix(spec.get(key), draft)
+
+    depth = ft(spec["depth"], "depth_tol")
+    cbore_dia = ft(spec["cbore_dia"], "cbore_dia_tol")
+    cbore_depth = ft(spec["cbore_depth"], "cbore_depth_tol")
+    csink_dia = ft(spec.get("csink_dia"), "csink_dia_tol")
+    csink_angle = ft(spec.get("csink_angle"), "csink_angle_tol")
     suffix = spec["suffix"]
     callout = HoleCallout(
         dia,

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -1214,7 +1214,7 @@ def _add_furniture(
             members[0],
             members[-1],
             len(members),
-            pitch.value_text,
+            pitch.value_text + _tol_suffix(pitch.tolerance, dwg.draft),
             to_page,
             f"dim_pitch_{view}{j}",
             feature=feat,
@@ -1394,7 +1394,7 @@ def _add_grid_pitch_dims(
             members[lo],
             members[hi],
             n,
-            pitch.value_text,
+            pitch.value_text + _tol_suffix(pitch.tolerance, dwg.draft),
             to_page,
             f"{name_prefix}_{view}{j}_{sub}",
             feature=feature,
@@ -1470,6 +1470,11 @@ def _place_pitch_dim(
         side, reach = max(cands, key=lambda c: c[0][0] * pref[0] + c[0][1] * pref[1])
     fallback_sides = [(side, reach)] + [c for c in cands if c[0] != side]
 
+    # `pitch_text` arrives already carrying its authored tolerance (composed at the call
+    # sites), because an explicit label discards a forwarded `tolerance=` — #1215's mechanism.
+    # A uniform array's ± applies to each identical gap, so `4× 20 ±0.05` is coherent; that is
+    # unlike the STEP representative, whose levels merely fall within 10% of each other, where
+    # a ± would claim the tolerance of values that differ (#1234 review r6).
     label = f"{n - 1}× {pitch_text}"
 
     def _make(off, side_vec=side, label_offset_x=0.0):
@@ -1744,7 +1749,7 @@ def render_pocket_patterns(dwg, plan, a, *, ctx, only=None) -> int:
                 members[0],
                 members[-1],
                 len(members),
-                pitch.value_text,
+                pitch.value_text + _tol_suffix(pitch.tolerance, dwg.draft),
                 to_page,
                 f"dim_pocketpat_pitch_{view}{i}",
                 feature=g.ref,
@@ -1863,7 +1868,7 @@ def render_slot_patterns(dwg, plan, a, *, ctx, only=None) -> int:
                 members[0],
                 members[-1],
                 len(members),
-                pitch.value_text,
+                pitch.value_text + _tol_suffix(pitch.tolerance, dwg.draft),
                 to_page,
                 f"dim_slotpat_pitch_{view}{i}",
                 feature=g.ref,

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -862,7 +862,23 @@ def _overall_height_name(dwg, a: Analysis) -> str | None:
     **unambiguous**: zero or several surviving candidates (e.g. a hand-authored
     twin of the height dim, or a square part whose depth label equals its height)
     return ``None``, and the caller simply proceeds without a demotion retry."""
+    # Compare the VALUE, not the whole label. An authored `envelope().tolerance(..., on=
+    # "height")` composes a suffix into `dim_height`'s label (#1215), so `'10'` becomes
+    # `'10 ±0.1'` and an exact-equality match against a re-derived numeric silently found
+    # nothing — in both the canonical branch and the generalised fallback. The failure is
+    # quiet by design ("no demotion, the safe outcome"), so a toleranced part would simply
+    # stop retrying and drop its detail view instead (#1234 review r4).
     height_label = _fmt(a.z_size)
+
+    def _is_height(obj) -> bool:
+        label = getattr(obj, "label", None)
+        if label is None:
+            return False
+        # The suffix is appended, so the value is the leading token. `_tol_suffix` emits
+        # " ±t", " +hi -lo" and a fit class's " h6" — all space-separated — and a bare label
+        # has no space, so splitting once is exact for every form.
+        return str(label).split(" ", 1)[0] == height_label
+
     # The auto pass names the overall height `dim_height`; subject it to the SAME
     # demotion-safety guards as the generalised names (user review, #661): never
     # demote a PINNED dim (a pin is the user's "this stays put", ADR 0012), and
@@ -874,7 +890,7 @@ def _overall_height_name(dwg, a: Analysis) -> str | None:
     if (
         canonical is not None
         and not dwg.registry.is_pinned("dim_height")
-        and getattr(canonical, "label", None) == height_label
+        and _is_height(canonical)
     ):
         return "dim_height"
     candidates = []
@@ -884,7 +900,7 @@ def _overall_height_name(dwg, a: Analysis) -> str | None:
         for name, obj in dwg.annotations_of(feat).items():
             if dwg.registry.is_pinned(name):
                 continue
-            if getattr(obj, "label", None) != height_label:
+            if not _is_height(obj):
                 continue
             box = _anno_box(obj)
             if box is not None and (box[3] - box[1]) > (box[2] - box[0]):

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -42,6 +42,7 @@ from draftwright._core import (
     _largest_empty_rect,
     _legible_steps,
     _log,
+    _tol_suffix,
 )
 from draftwright._geometry import _leader_ink_polygons, _stroke_polygon
 from draftwright.annotations._common import carve_free_segments, strip_obstacles
@@ -1035,7 +1036,14 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx, plan) -> None:
         placed = 0
         for i, z in enumerate(det_kept):
             rung = rung_by_level[z]
-            label = rung.final_label  # the compiler's label, not a second derivation
+            # The compiler's label plus its tolerance — NOT a second derivation of the value.
+            # Before #1215 the tolerance was dropped everywhere, so the sheet was at least
+            # self-consistent. Composing it on the main view alone made a toleranced staircase
+            # contradict itself: the levels the legibility gate moved here are dimensioned ONLY
+            # in the detail, so three of five authored ± requirements vanished while two showed
+            # — a machinist reads the bare ones as falling under the general block
+            # (#1234 review r6).
+            label = rung.final_label + _tol_suffix(rung.tolerance, dwg.draft)
             try:
                 if has_level_supports:
                     source_x = source_x_by_z[z]

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -872,13 +872,14 @@ def _overall_height_name(dwg, a: Analysis) -> str | None:
     height_label = _fmt(a.z_size)
 
     def _is_height(obj) -> bool:
-        label = getattr(obj, "label", None)
-        if label is None:
-            return False
+        # No `is None` guard: a missing label stringifies to "None", which cannot equal a
+        # formatted number, so that branch had no outcome of its own — only an uncoverable
+        # partial, which codecov correctly flagged (#1234 review r6).
+        #
         # The suffix is appended, so the value is the leading token. `_tol_suffix` emits
         # " ±t", " +hi -lo" and a fit class's " h6" — all space-separated — and a bare label
         # has no space, so splitting once is exact for every form.
-        return str(label).split(" ", 1)[0] == height_label
+        return str(getattr(obj, "label", None)).split(" ", 1)[0] == height_label
 
     # The auto pass names the overall height `dim_height`; subject it to the SAME
     # demotion-safety guards as the generalised names (user review, #661): never

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -271,26 +271,40 @@ def _est_planned_bore_callout_width(
         token_w.append(
             _text_width(f"{_fmt(bore)}{_tol_suffix(spec['tolerance'], draft)}", font_size)
         )
+
+        # Every term's tolerance, not just the bore's. The estimator has to measure the string
+        # the callout will DRAW: reserving the bare width of a toleranced recess made the
+        # placement check reject a callout the reservation said would fit, and the whole
+        # annotation was dropped with `callout_dropped: no room beside the view` — a wrong
+        # drawing produced from a right one (#1234 review r7).
+        def _term(value, tol_key):
+            return _text_width(f"{_fmt(value)}{_tol_suffix(spec.get(tol_key), draft)}", font_size)
+
         if spec["through"]:
             token_w.append(_text_width("THRU", font_size))
         elif depth is not None:
             token_w.append(sym_w)  # depth symbol
-            token_w.append(_text_width(_fmt(depth), font_size))
+            token_w.append(_term(depth, "depth_tol"))
         if cbore_dia is not None:
             token_w.append(sym_w)  # counterbore/spotface symbol
             token_w.append(sym_w)  # ⌀
-            token_w.append(_text_width(_fmt(cbore_dia), font_size))
+            token_w.append(_term(cbore_dia, "cbore_dia_tol"))
             if cbore_depth is not None:
                 token_w.append(sym_w)  # depth symbol
-                token_w.append(_text_width(_fmt(cbore_depth), font_size))
+                token_w.append(_term(cbore_depth, "cbore_depth_tol"))
         csink_dia = spec["csink_dia"]
         if csink_dia is not None:
             token_w.append(sym_w)  # countersink symbol
             token_w.append(sym_w)  # ⌀
-            token_w.append(_text_width(_fmt(csink_dia), font_size))
+            token_w.append(_term(csink_dia, "csink_dia_tol"))
             csink_angle = spec["csink_angle"]
             if csink_angle is not None:
-                token_w.append(_text_width(f"× {_fmt(csink_angle)}°", font_size))
+                token_w.append(
+                    _text_width(
+                        f"× {_fmt(csink_angle)}{_tol_suffix(spec.get('csink_angle_tol'), draft)}°",
+                        font_size,
+                    )
+                )
         if suffix is not None:
             token_w.append(_text_width(suffix, font_size))
 

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -992,7 +992,12 @@ class Drawing:
             slot: strip slot depth (mm); the perpendicular space reserved per dim.
             feature: optional source IR feature to attribute this dim to, so
                 :meth:`drop` / :meth:`annotations_of` can find it (#398).
-            **kwargs: forwarded to ``Dimension`` (e.g. ``label=``, ``tolerance=``).
+            **kwargs: forwarded to ``Dimension`` (e.g. ``label=``). NOT ``tolerance=``:
+                this method injects a ``label`` when none is given, and helpers do
+                ``rendered = label if label is not None else …``, so an explicit label
+                DISCARDS the tolerance and it never reaches the sheet. Compose the suffix
+                into the label instead — ``_tol_suffix`` is what the renderers use
+                (#1234 review, verified: ``tolerance=(0.1, 0.2)`` renders a bare ``90``).
 
         Deprecated for normal editable scripts: prefer :meth:`dimension` for
         feature-backed linear dimensions and :meth:`locate` for feature-backed

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -46,6 +46,7 @@ from draftwright._core import (
     _fmt,
     _log,
     _tag_sequence,
+    _tol_suffix,
     place_annotation,
 )
 from draftwright.annotations._common import (
@@ -992,12 +993,11 @@ class Drawing:
             slot: strip slot depth (mm); the perpendicular space reserved per dim.
             feature: optional source IR feature to attribute this dim to, so
                 :meth:`drop` / :meth:`annotations_of` can find it (#398).
-            **kwargs: forwarded to ``Dimension`` (e.g. ``label=``). NOT ``tolerance=``:
-                this method injects a ``label`` when none is given, and helpers do
-                ``rendered = label if label is not None else …``, so an explicit label
-                DISCARDS the tolerance and it never reaches the sheet. Compose the suffix
-                into the label instead — ``_tol_suffix`` is what the renderers use
-                (#1234 review, verified: ``tolerance=(0.1, 0.2)`` renders a bare ``90``).
+            **kwargs: forwarded to ``Dimension`` (e.g. ``label=``). ``tolerance=`` is
+                folded into the injected label rather than forwarded, because helpers do
+                ``rendered = label if label is not None else …`` — an explicit label
+                DISCARDS a forwarded tolerance, and this method always supplies one. Pass
+                your own ``label=`` and the tolerance is yours to compose (#1234).
 
         Deprecated for normal editable scripts: prefer :meth:`dimension` for
         feature-backed linear dimensions and :meth:`locate` for feature-backed
@@ -1069,7 +1069,15 @@ class Drawing:
         # an explicit label.
         if "label" not in kwargs:
             page_len = math.hypot(p2[0] - p1[0], p2[1] - p1[1])
-            kwargs["label"] = _fmt(page_len / self.scale)
+            # The suffix goes into the LABEL, and it has to. Injecting a label is exactly what
+            # makes `tolerance=` unreachable: helpers do
+            # `rendered = label if label is not None else …`, so an explicit label discards it.
+            # Both public verbs that reach here — the deprecated `place_dim` and the preferred
+            # `dimension` — documented `tolerance=` as forwarded while it silently vanished
+            # (#1234 review r3). Composing it here closes both.
+            kwargs["label"] = _fmt(page_len / self.scale) + _tol_suffix(
+                kwargs.pop("tolerance", None), draft
+            )
         return self._add(
             _dim(p1, p2, side, max(dist, 4.0), draft, **kwargs), name, feature=feature
         )

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -994,10 +994,10 @@ class Drawing:
             feature: optional source IR feature to attribute this dim to, so
                 :meth:`drop` / :meth:`annotations_of` can find it (#398).
             **kwargs: forwarded to ``Dimension`` (e.g. ``label=``). ``tolerance=`` is
-                folded into the injected label rather than forwarded, because helpers do
-                ``rendered = label if label is not None else …`` — an explicit label
-                DISCARDS a forwarded tolerance, and this method always supplies one. Pass
-                your own ``label=`` and the tolerance is yours to compose (#1234).
+                folded into the label rather than forwarded — your own ``label=`` included —
+                because helpers do ``rendered = label if label is not None else …``, so an
+                explicit label DISCARDS a forwarded tolerance and a label is always
+                present here (#1234).
 
         Deprecated for normal editable scripts: prefer :meth:`dimension` for
         feature-backed linear dimensions and :meth:`locate` for feature-backed
@@ -1067,17 +1067,22 @@ class Drawing:
         # no label is given, which is scale-too-big at non-1:1 scales. Supply the
         # real-world length (page distance ÷ drawing scale) unless the caller set
         # an explicit label.
+        # The suffix goes into the LABEL, and it has to. Injecting a label is exactly what makes
+        # `tolerance=` unreachable: helpers do
+        # `rendered = label if label is not None else …`, so an explicit label discards it.
+        # Both public verbs that reach here — the deprecated `place_dim` and the preferred
+        # `dimension` — documented `tolerance=` as forwarded while it silently vanished
+        # (#1234 review r3). Composing it here closes both.
+        #
+        # Popped UNCONDITIONALLY, and composed onto whichever label is used. Doing it only in
+        # the inject branch left the defect alive for a caller passing BOTH `label=` and
+        # `tolerance=`: the tolerance stayed in kwargs and `Dimension` discarded it, which is
+        # the very thing being fixed, surviving in one branch (#1234 review r4).
+        tolerance = kwargs.pop("tolerance", None)
         if "label" not in kwargs:
             page_len = math.hypot(p2[0] - p1[0], p2[1] - p1[1])
-            # The suffix goes into the LABEL, and it has to. Injecting a label is exactly what
-            # makes `tolerance=` unreachable: helpers do
-            # `rendered = label if label is not None else …`, so an explicit label discards it.
-            # Both public verbs that reach here — the deprecated `place_dim` and the preferred
-            # `dimension` — documented `tolerance=` as forwarded while it silently vanished
-            # (#1234 review r3). Composing it here closes both.
-            kwargs["label"] = _fmt(page_len / self.scale) + _tol_suffix(
-                kwargs.pop("tolerance", None), draft
-            )
+            kwargs["label"] = _fmt(page_len / self.scale)
+        kwargs["label"] = f"{kwargs['label']}{_tol_suffix(tolerance, draft)}"
         return self._add(
             _dim(p1, p2, side, max(dist, 4.0), draft, **kwargs), name, feature=feature
         )

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1254,9 +1254,18 @@ class Drawing:
             for k, v in it.kwargs.items()
             if k not in {"param", "role", "side", "view", "name", "pin", "priority", "slot"}
         }
+        # The same composition as `_place_dim`, and for the same reason: this is the DEFERRED
+        # twin of that function, so a tolerance reaching it must go into the label or helpers
+        # discard it. Without this the identical public call rendered `80 +0.2 -0.1` live and a
+        # bare `80` the moment the author added `pin=True` or `priority=` — a divergence #1215
+        # INTRODUCED, since before it neither path rendered anything. `pin=True` is ADR 0012's
+        # first-class corridor candidate, so it was the going-forward surface that lost the
+        # requirement (#1234 review r4).
+        tolerance = dim_kwargs.pop("tolerance", None)
         if "label" not in dim_kwargs:
             page_len = math.hypot(p2[0] - p1[0], p2[1] - p1[1])
             dim_kwargs["label"] = _fmt(page_len / self.scale)
+        dim_kwargs["label"] = f"{dim_kwargs['label']}{_tol_suffix(tolerance, self.draft)}"
         slot = it.kwargs.get("slot", 8.0)
         axis = "y" if side in ("above", "below") else "x"
         ax = 1 if axis == "y" else 0
@@ -1341,7 +1350,9 @@ class Drawing:
         ``"side"``) where the span projects non-degenerate — a length along the turning
         axis vanishes in its end-on view, so the view follows the geometry. Pass ``view=``
         to force one of those three (a non-orthographic view foreshortens the span and is
-        rejected). ``side`` defaults to ``"above"``; ``kwargs`` forward to the dimension.
+        rejected). ``side`` defaults to ``"above"``; ``kwargs`` forward to the dimension —
+        except ``tolerance=``, which is folded into the label (see :meth:`place_dim`),
+        because helpers discard a forwarded tolerance whenever a label is present.
         In deferred mode, ``pin=True`` anchors the dimension at its natural slot coordinate
         inside the shared corridor solve, and ``priority=`` controls over-capacity survival.
         Live placement still uses the single-position escape hatch and pins only the placed

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1079,7 +1079,11 @@ class Drawing:
         # `tolerance=`: the tolerance stayed in kwargs and `Dimension` discarded it, which is
         # the very thing being fixed, surviving in one branch (#1234 review r4).
         tolerance = kwargs.pop("tolerance", None)
-        if "label" not in kwargs:
+        # `.get(...) is None`, not `not in`: an explicit `label=None` is helpers' documented
+        # "auto", and testing membership composed the suffix onto the literal `None`, so the
+        # sheet printed the string "None". A public API made to print garbage by the fix for a
+        # public API that printed nothing (#1234 review r5).
+        if kwargs.get("label") is None:
             page_len = math.hypot(p2[0] - p1[0], p2[1] - p1[1])
             kwargs["label"] = _fmt(page_len / self.scale)
         kwargs["label"] = f"{kwargs['label']}{_tol_suffix(tolerance, draft)}"
@@ -1262,7 +1266,7 @@ class Drawing:
         # first-class corridor candidate, so it was the going-forward surface that lost the
         # requirement (#1234 review r4).
         tolerance = dim_kwargs.pop("tolerance", None)
-        if "label" not in dim_kwargs:
+        if dim_kwargs.get("label") is None:  # `None` is "auto"; see `_place_dim` (#1234 r5)
             page_len = math.hypot(p2[0] - p1[0], p2[1] - p1[1])
             dim_kwargs["label"] = _fmt(page_len / self.scale)
         dim_kwargs["label"] = f"{dim_kwargs['label']}{_tol_suffix(tolerance, self.draft)}"

--- a/src/draftwright/model/callout.py
+++ b/src/draftwright/model/callout.py
@@ -339,6 +339,22 @@ def hole_callout_spec(group: DimensionGroup) -> dict | None:
         return None
     _refuse_headless_callout(group)  # every segment, not just the head — see the docstring
     cbore_dia, cbore_depth = _recess(group)
+    # The recess and countersink terms carry their own authored tolerances. Only the bore's
+    # was threaded, so `s.hole(...).cbore(...).tolerance(0.05)` — which `_decorated` folds onto
+    # EVERY parameter of that kind — printed `⌀8 ±0.1 THRU ⌴ ⌀14`: one ± shown, one silently
+    # gone, and a machinist reads the bare ⌀14 as falling under the general block
+    # (#1215, #1234 review r7).
+    #
+    # Through `_recess_plan` rather than a second lookup, so the tolerance comes from the SAME
+    # segment that won the counterbore/spotface precedence — resolving them independently is
+    # the #920 defect that paired one role's ⌀ with the other's depth.
+    recess_dia_pd, recess_depth_pd = _recess_plan(group)
+    csink_dia_pd = _planned(group, "diameter", "countersink")
+    csink_angle_pd = _planned(group, "angle", "countersink")
+
+    def _tol_of(planned):
+        return planned.param.tolerance if planned is not None else None
+
     bore_pd = _planned(group, "diameter", "bore")
     bore = _first(group, "diameter", "bore")
     if bore is None:
@@ -373,6 +389,11 @@ def hole_callout_spec(group: DimensionGroup) -> dict | None:
         "csink_angle": _first(group, "angle", "countersink"),
         "suffix": suffix,
         "tolerance": bore_tol,  # P2a: ± on the bore ⌀, baked into the callout string below
+        # ...and one per remaining term, baked in the same way (#1234 review r7).
+        "cbore_dia_tol": _tol_of(recess_dia_pd),
+        "cbore_depth_tol": _tol_of(recess_depth_pd),
+        "csink_dia_tol": _tol_of(csink_dia_pd),
+        "csink_angle_tol": _tol_of(csink_angle_pd),
         # Exact compiler identities printed by this compound callout. Count and THRU are
         # non-dimensional facts carried separately as structured callout coverage; neither
         # rendered text nor an invented dimensional identity certifies them.

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -940,11 +940,14 @@ def _compile_overall_height(
     # A part with no `EnvelopeFeature` has nothing to key a decoration on, and #876 already
     # says declaring `.envelope()` is how the overall height becomes nameable, so `None` here
     # is the right answer rather than a gap (#1215).
+    # `next()` with no default, deliberately: `EnvelopeFeature.parameters()` always returns a
+    # `height` role, so a guard for its absence is a branch no test can take — and one that
+    # would silently drop an authored tolerance if the contract ever changed. Raising is the
+    # honest failure.
     height_tol = None
     if env is not None:
-        height_param = next((pm for pm in env.parameters() if pm.role == "height"), None)
-        if height_param is not None:
-            height_tol = _decorated(model, env, height_param).tolerance
+        height_param = next(pm for pm in env.parameters() if pm.role == "height")
+        height_tol = _decorated(model, env, height_param).tolerance
     ladder = ApprovedLadder(
         "overall_height",
         (

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -955,6 +955,14 @@ def _compile_overall_height(
                 span=((x, y, float(bb.min.Z)), (x, y, float(bb.max.Z))),
                 ref=env_ref,
                 tolerance=height_tol,
+                # `rendered_label` is the BARE value while `tolerance` is set beside it, so for
+                # a toleranced rung this field is not the "complete compiler-owned label" its
+                # own docstring promises — the renderer composes the suffix. It has to:
+                # `_tol_suffix` lives in `_core` at rank 1 and this module is rank 0, so the
+                # compiler cannot build the string. Today the overall-height rung has exactly
+                # one consumer (`render_height_ladder`), which does compose it; a second
+                # consumer trusting the docstring would silently drop the tolerance
+                # (#1234 review, F8/finding 6).
                 rendered_label=_fmt(value),
             ),
         ),

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -741,6 +741,20 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
         )
         return ((x, y, step.base), (x, y, z)), bounds
 
+    # An authored `.tolerance(...)` on a step level, through the one owner. The PLAIN ladder
+    # rungs carry it; the `N× rise` representative below deliberately does not, because a ±
+    # on a collapsed representative would claim it of every level (#28 / P2a).
+    #
+    # The seventh site of #1215's discard, and the last: a bare `.tolerance()` on a step level
+    # reached `model.decorations` and was dropped here, so `dim_step_0` printed `14` where the
+    # author wrote `14 ±0.05`. `sheet.py` promises a bare tolerance "folds onto every parameter
+    # of that kind" (#1234 review r5).
+    step_height_param = next((pm for pm in step.parameters() if pm.role == "step_height"), None)
+    step_tol = (
+        _decorated(model, step, step_height_param).tolerance
+        if step_height_param is not None
+        else None
+    )
     heights = []
     for z in sorted(step.levels):
         span, support_bounds = _height_evidence(z)
@@ -749,6 +763,7 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
                 id=_dim_id(step, "step_height.length"),
                 value_text=_fmt(z - step.base),
                 value=z - step.base,
+                tolerance=step_tol,
                 span=span,
                 ref=step_ref,
                 rendered_label=_fmt(z - step.base),

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -69,6 +69,7 @@ from draftwright.model.ir import (
 from draftwright.model.planner import (
     _AUTHORED_OMISSION,
     DimensionId,
+    _decorated,
     authored_location_omitted,
     location_datum,
     plan_dimensions,
@@ -933,6 +934,17 @@ def _compile_overall_height(
         identity = _envelope_from_bbox(bb)
     env_ref = FeatureRef(env) if env is not None else None
     x, y = float(bb.max.X), float(bb.min.Y)
+    # An authored `envelope().tolerance(...)` on the height, through the one owner
+    # (`_decorated`) rather than read off `model.decorations` here — a second reader is how
+    # a decorated parameter and an undecorated one came to look interchangeable (#1154).
+    # A part with no `EnvelopeFeature` has nothing to key a decoration on, and #876 already
+    # says declaring `.envelope()` is how the overall height becomes nameable, so `None` here
+    # is the right answer rather than a gap (#1215).
+    height_tol = None
+    if env is not None:
+        height_param = next((pm for pm in env.parameters() if pm.role == "height"), None)
+        if height_param is not None:
+            height_tol = _decorated(model, env, height_param).tolerance
     ladder = ApprovedLadder(
         "overall_height",
         (
@@ -942,6 +954,7 @@ def _compile_overall_height(
                 value=value,
                 span=((x, y, float(bb.min.Z)), (x, y, float(bb.max.Z))),
                 ref=env_ref,
+                tolerance=height_tol,
                 rendered_label=_fmt(value),
             ),
         ),

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -815,6 +815,15 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
         hi[_di[axis]] = pos
         return (tuple(lo), tuple(hi))
 
+    # Shoulders carry their authored tolerance too. Without this the SAME `DimensionId` sat in
+    # `plan.groups` with a tolerance (via `_compile_groups`) and in `plan.ladders` without one,
+    # and `evidence.compiled_values` merges both into one multimap — a one-owner violation of
+    # the same shape as #1154, five lines below where #1215 added the height rungs'
+    # (#1234 review r6).
+    shoulder_param = next((pm for pm in step.parameters() if pm.role == "step_position"), None)
+    shoulder_tol = (
+        _decorated(model, step, shoulder_param).tolerance if shoulder_param is not None else None
+    )
     shoulders = [
         ApprovedDimension(
             id=_dim_id(step, "step_position.length"),
@@ -823,6 +832,7 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
             span=_shoulder_span(axis, pos),
             ref=step_ref,
             axis=axis,
+            tolerance=shoulder_tol,
             rendered_label=_fmt(abs(pos - step.datum[_di[axis]])),
         )
         for axis, pos in sorted(step.shoulders)

--- a/tests/test_issue_1154_one_owner_per_measurement.py
+++ b/tests/test_issue_1154_one_owner_per_measurement.py
@@ -561,13 +561,24 @@ class TestTheToleranceRuleIsAsymmetric:
         # author who toleranced the OVERALL THICKNESS got the duplicate `8` back — #1154's own
         # defect, re-opened by its fix (review r2). A tolerance on the owner is the same
         # requirement on the same two faces; it does not make them two facts.
-        assert self._z_hub_labels(on_envelope=True) == ["8"]
+        #
+        # The label gained its ± in #1215; the RULE is untouched. What this test guards is the
+        # COUNT — one label, not two — and that is unchanged.
+        assert self._z_hub_labels(on_envelope=True) == ["8 ±0.1"]
 
     def test_equal_tolerances_on_both_sides_still_keep_both(self):
         # The r2 correction then went one step too far and admitted "equal tolerances", on
-        # the premise that the receiving extent states the same requirement. Measured, an
-        # envelope decoration is not rendered on ANY axis while `render_boss_heights` appends
-        # `_tol_suffix`, so an identically toleranced boss height lost its ± anyway — the
-        # exact silent loss the tolerance rule was added to stop, re-created by the fix for
-        # its own over-correction (review r3). The rule is about the yielder alone.
-        assert self._z_hub_labels(on_boss=True, on_envelope=True) == ["8", "8 ±0.1"]
+        # the premise that the receiving extent states the same requirement.
+        #
+        # That premise was false when this was written, for a reason #1215 has since removed:
+        # an envelope decoration was not rendered on ANY axis, so an identically toleranced
+        # boss height lost its ± when consolidated away — the silent loss the tolerance rule
+        # exists to stop, re-created by the fix for its own over-correction (review r3).
+        #
+        # Now both extents state their tolerance, so the yielded fact would no longer be lost.
+        # The rule still refuses, and deliberately: #1154's own comment says the refusal must
+        # not DEPEND on the receiving extent being able to state a tolerance, so nothing here
+        # changes just because it now can. #1215's last acceptance line proposes revisiting
+        # whether transferring beats refusing; that is a separate decision, and this test keeps
+        # guarding the count either way.
+        assert self._z_hub_labels(on_boss=True, on_envelope=True) == ["8 ±0.1", "8 ±0.1"]

--- a/tests/test_issue_1215_envelope_tolerance.py
+++ b/tests/test_issue_1215_envelope_tolerance.py
@@ -72,6 +72,21 @@ class TestTheDecorationReachesAllThreeExtents:
         for axis in _AXES:
             assert _label(drawing, _ANNOTATION[axis]) == _BARE[axis], axis
 
+    def test_a_bare_tolerance_folds_onto_every_extent(self):
+        """`envelope().tolerance(0.05)` with no `on=` — the kind-keyed fallback in `_decorated`.
+
+        Untested until now, and the PR's central architectural argument rests on it: sourcing
+        the decoration through `_decorated` rather than reading `model.decorations` here. A
+        mutation dropping the kind-keyed lookup silently loses the ± on the HEIGHT alone and
+        passed the entire fast tier, because every other test passes `on=` (#1234 review r2).
+        """
+        sheet = Sheet(Box(30, 20, 10))
+        sheet.envelope().tolerance(0.05)
+        sheet.auto_dimensions()
+        drawing = sheet.build()
+        for axis in _AXES:
+            assert _label(drawing, _ANNOTATION[axis]) == f"{_BARE[axis]} ±0.1", axis
+
     def test_a_limit_pair_prints_both_limits(self):
         assert _label(_built("height", 0.1, 0.2), "dim_height") == "10 +0.2 -0.1"
 
@@ -88,16 +103,19 @@ class TestTheTwoPathsAgree:
         assert set(suffixes.values()) == {"±0.1"}, suffixes
 
 
-class TestTheTolerandeReachesTheInk:
+class TestTheToleranceReachesTheInk:
     """Labels are metadata. This is what the reader sees."""
 
-    def test_the_tolerance_reaches_the_exported_ink(self, tmp_path):
+    @pytest.mark.parametrize("axis", _AXES)
+    def test_the_tolerance_reaches_the_exported_ink(self, axis, tmp_path):
+        # All three axes, not just width: the HEIGHT is the path with two code changes
+        # (compiler rung + ladder renderer) and had no ink assertion at all (#1234 review r2).
         import re
 
         def measured(tolerance):
-            drawing = _built("width") if tolerance else _built(axis=None)
-            annotation = drawing.registry.named("m_env_width")
-            out = tmp_path / f"o{int(bool(tolerance))}.svg"
+            drawing = _built(axis) if tolerance else _built(axis=None)
+            annotation = drawing.registry.named(_ANNOTATION[axis])
+            out = tmp_path / f"{axis}{int(bool(tolerance))}.svg"
             drawing.export(str(out))
             paths = len(re.findall(r"<path", out.read_text()))
             return len(annotation.faces()), paths
@@ -106,6 +124,58 @@ class TestTheTolerandeReachesTheInk:
         tol_faces, tol_paths = measured(True)
         assert tol_faces > bare_faces, (bare_faces, tol_faces)
         assert tol_paths > bare_paths, (bare_paths, tol_paths)
+
+
+class TestTheCostOnACrowdedSheet:
+    """A longer label can overlap the view, and on this fixture it does. Pinned, not hidden.
+
+    `Sheet(Box(30, 20, 10)).envelope().tolerance(0.05, on="height")` — the fixture these tests
+    build — goes from an `info` to a `warning`:
+
+        before: view_annotation_inside_extents (info)
+        after : view_annotation_overlap (warning)  "line-work overlaps label of '10 ±0.1'"
+
+    The height dim is `side="right"`, so its label is ROTATED and the suffix grows it along the
+    dimension line — in Y, not into the reserved strip depth. Measured, `label_bbox` goes
+    y 73.36-76.64 -> 68.85-81.15 while the annotation's own `bounding_box()` is unchanged, which
+    is why a bbox comparison misses it. The corridor solve does not model a rotated label's
+    along-line growth, and `repair()` does not clear it.
+
+    That is a real cost of rendering the tolerance, and the lint is right to report it — the
+    label does overlap. It is pinned here so the next person sees a decision rather than a
+    surprise; fixing it means teaching the corridor about rotated labels, which is not this
+    change (#1234 review r2).
+    """
+
+    def test_the_toleranced_height_overlaps_the_view_on_this_fixture(self):
+        codes = {issue.code for issue in _built("height").lint()}
+        assert "view_annotation_overlap" in codes, codes
+
+    def test_the_untoleranced_fixture_does_not(self):
+        # The precondition: without this the assertion above could be pinning a pre-existing
+        # warning that has nothing to do with the tolerance.
+        codes = {issue.code for issue in _built(axis=None).lint()}
+        assert "view_annotation_overlap" not in codes, codes
+
+    def test_a_shorter_suffix_does_not_trip_it(self):
+        # It is length, not the presence of a suffix: a fit class renders `10 h6` and fits.
+        from draftwright.builder import build_drawing
+        from draftwright.fits import fit_class
+
+        sheet = Sheet(Box(30, 20, 10))
+        sheet.envelope()
+        sheet.auto_dimensions()
+        model = sheet.build().model()
+        envelope = next(f for f in model.features if f.kind == "envelope")
+        drawing = build_drawing(
+            Box(30, 20, 10),
+            model=model,
+            decorations={(envelope, "length", "height"): fit_class("h6", 10.0, "class")},
+            title="T",
+            number="N-1",
+        )
+        assert _label(drawing, "dim_height") == "10 h6"
+        assert "view_annotation_overlap" not in {issue.code for issue in drawing.lint()}
 
 
 class TestAFitClassRendersToo:
@@ -141,12 +211,16 @@ class TestAFitClassRendersToo:
     def test_the_ink_path_would_have_raised_on_it(self):
         # Why the label route is not merely a preference. If the tolerance were handed to the
         # Dimension instead, this is what the reader would get.
+        #
+        # `_number_with_units` is the INK path — the branch helpers take when `label is None`.
+        # An earlier version of this test asserted the same thing about `_format_label`, which
+        # is the lint-parity approximation; both raise, so the claim held, but the test did not
+        # test what its own comment said (#1234 review r2).
         import pytest as _pytest
-        from build123d_drafting.helpers import _format_label
 
         from draftwright.builder import build_drawing
         from draftwright.fits import fit_class
 
         draft = build_drawing(Box(30, 20, 10), title="T", number="N-1").draft
         with _pytest.raises(TypeError):
-            _format_label(30.0, draft, fit_class("h6", 30.0, "class"))
+            draft._number_with_units(30.0, fit_class("h6", 30.0, "class"))

--- a/tests/test_issue_1215_envelope_tolerance.py
+++ b/tests/test_issue_1215_envelope_tolerance.py
@@ -1,0 +1,145 @@
+"""#1215 — an authored envelope tolerance must render, on all three extents.
+
+`sheet.envelope().tolerance(0.05, on="height")` recorded the decoration on the model and it was
+never printed. Measured before the fix, on all three axes:
+
+    tolerance on height  -> {'dim_height': '10', 'm_env_depth': '20', 'm_env_width': '30'}
+    tolerance on width   -> {'dim_height': '10', 'm_env_depth': '20', 'm_env_width': '30'}
+    tolerance on depth   -> {'dim_height': '10', 'm_env_depth': '20', 'm_env_width': '30'}
+
+Two independent drops, which is why the issue says the two renderers need the same answer:
+
+* `render_envelope` built width/depth labels from `value_text` and passed no `tolerance=`;
+* `_compile_overall_height` built the ladder rung with no tolerance at all, so the height had
+  nothing to pass even if the renderer had asked.
+
+**Where the assertions look, and why.** `Dimension` formats its own tolerance and leaves `label`
+alone — measured, a `Dimension(label="30", tolerance=0.02)` still reports `label == "30"`. So the
+tolerance is NOT visible on the annotation's label, and a test reading `label` would pass against
+completely unfixed code. These read the `tolerance` the Dimension was constructed with, via the
+`_dw_spec` the repair loop already records.
+
+The suffix is `_tol_suffix`'s, which is documented as matching helpers' `_format_label` byte for
+byte — verified in `test_the_suffix_matches_what_the_helper_renders` rather than assumed, because
+the footprint depends on it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from build123d import Box
+
+from draftwright._core import _tol_suffix
+from draftwright.sheet import Sheet
+
+_AXES = ("width", "depth", "height")
+_ANNOTATION = {"width": "m_env_width", "depth": "m_env_depth", "height": "dim_height"}
+
+
+def _built(axis, tolerance=0.05):
+    sheet = Sheet(Box(30, 20, 10))
+    sheet.envelope().tolerance(tolerance, on=axis)
+    sheet.auto_dimensions()
+    return sheet.build()
+
+
+def _tolerance_of(drawing, name):
+    spec = getattr(drawing.registry.named(name), "_dw_spec", None)
+    assert spec is not None, f"{name} was not built through `_dim`, so it records no spec"
+    return spec.kwargs.get("tolerance")
+
+
+class TestTheDecorationReachesAllThreeExtents:
+    @pytest.mark.parametrize("axis", _AXES)
+    def test_the_decorated_extent_renders_its_tolerance(self, axis):
+        drawing = _built(axis)
+        assert _tolerance_of(drawing, _ANNOTATION[axis]) == 0.05
+
+    @pytest.mark.parametrize("axis", _AXES)
+    def test_the_other_two_extents_are_untouched(self, axis):
+        # The decoration is per-parameter. Without this a fix that tolerances every extent
+        # would pass the test above on all three.
+        drawing = _built(axis)
+        for other in _AXES:
+            if other == axis:
+                continue
+            assert _tolerance_of(drawing, _ANNOTATION[other]) is None, other
+
+    def test_an_undecorated_envelope_stays_bare(self):
+        # The precondition for both assertions above: they mean nothing if a plain envelope
+        # already carried a tolerance from somewhere.
+        #
+        # `envelope()` is still called — declaring the envelope is what puts the width and
+        # depth extents on the sheet at all. Measured, a bare `Sheet(Box(...)).auto_dimensions()`
+        # draws only `dim_height`; asserting over `_ANNOTATION` on that build fails looking up
+        # an annotation that does not exist, which is a broken precondition, not a passing one.
+        sheet = Sheet(Box(30, 20, 10))
+        sheet.envelope()
+        sheet.auto_dimensions()
+        drawing = sheet.build()
+        for name in _ANNOTATION.values():
+            assert name in drawing.registry.names(), f"{name} absent; nothing to assert about"
+            assert _tolerance_of(drawing, name) is None, name
+
+    def test_a_limit_pair_survives_as_a_pair(self):
+        # `_tol_value` keeps `(lower, upper)`; the renderers must not coerce it to a float.
+        drawing = _built("height", tolerance=None)
+        sheet = Sheet(Box(30, 20, 10))
+        sheet.envelope().tolerance(0.1, 0.2, on="height")
+        sheet.auto_dimensions()
+        drawing = sheet.build()
+        assert _tolerance_of(drawing, "dim_height") == (0.1, 0.2)
+
+
+class TestTheTwoPathsAgree:
+    """#1215's second acceptance line: the ladder path and the ordinary envelope path.
+
+    The height rides `render_height_ladder`, width and depth ride `render_envelope`. They took
+    the decoration from different places and only one of them looked.
+    """
+
+    def test_both_paths_carry_the_same_kind_of_value(self):
+        for axis in _AXES:
+            assert _tolerance_of(_built(axis), _ANNOTATION[axis]) == 0.05, axis
+
+    def test_the_label_itself_stays_bare_on_both_paths(self):
+        # Stated because it is surprising, and because it is why these tests read `_dw_spec`:
+        # `Dimension` renders the tolerance without touching `label`. A test asserting on the
+        # label would pass against unfixed code.
+        for axis in _AXES:
+            drawing = _built(axis)
+            label = str(getattr(drawing.registry.named(_ANNOTATION[axis]), "label", None))
+            assert "±" not in label, (axis, label)
+
+
+class TestTheFootprintMeasuresWhatIsDrawn:
+    def test_the_suffix_matches_what_the_helper_renders(self):
+        """The corridor reserves space using `_tol_suffix`; the sheet draws helpers'
+        `_format_label`. If they disagree a toleranced extent reserves the wrong width."""
+        from build123d_drafting.helpers import _format_label
+
+        from draftwright.builder import build_drawing
+
+        draft = build_drawing(Box(30, 20, 10), title="T", number="N-1").draft
+        for tolerance in (0.05, 0.5, (0.1, 0.2)):
+            expected = _format_label(30.0, draft, tolerance)
+            ours = f"{round(30.0, draft.decimal_precision):.{draft.decimal_precision}f}"
+            assert ours + _tol_suffix(tolerance, draft) == expected, tolerance
+
+
+class TestWhatThisDoesNotCover:
+    def test_an_envelope_cannot_take_a_fit_class(self):
+        """#1215's third acceptance line asks for `FitClass` rendering. It is unreachable.
+
+        `_Params` — the envelope handle — has no `fit()`, and `_Dim.fit` is diametral by
+        design ("a fit is diametral"), reading `self._sheet._features[self._i].diameter`. An
+        envelope's parameters are width/height/depth and it has no diameter, so no `FitClass`
+        can key onto one. `_tol_suffix` handles `FitClass` already, so the day an envelope
+        grows a diametral parameter the suffix is ready; nothing else here is.
+
+        Asserted rather than left as prose, so this stops being true loudly.
+        """
+        sheet = Sheet(Box(30, 20, 10))
+        handle = sheet.envelope()
+        assert not hasattr(handle, "fit"), "an envelope grew fit(); #1215's third line is now live"
+        assert "diameter" not in {p.role for p in sheet.features[0].parameters()}

--- a/tests/test_issue_1215_envelope_tolerance.py
+++ b/tests/test_issue_1215_envelope_tolerance.py
@@ -127,55 +127,53 @@ class TestTheToleranceReachesTheInk:
 
 
 class TestTheCostOnACrowdedSheet:
-    """A longer label can overlap the view, and on this fixture it does. Pinned, not hidden.
+    """A longer label grows ALONG the dimension line when the label is rotated.
 
-    `Sheet(Box(30, 20, 10)).envelope().tolerance(0.05, on="height")` — the fixture these tests
-    build — goes from an `info` to a `warning`:
+    The height dim is `side="right"`, so its label is rotated and the suffix extends it in Y —
+    the direction the corridor does not reserve, since the strip's depth runs in X. Measured on
+    `Sheet(Box(30, 20, 10)).envelope().tolerance(0.05, on="height")`:
 
-        before: view_annotation_inside_extents (info)
-        after : view_annotation_overlap (warning)  "line-work overlaps label of '10 ±0.1'"
+        label bbox height  3.273 -> 12.300
+        annotation bbox    (64.95, 85.05) -> unchanged
 
-    The height dim is `side="right"`, so its label is ROTATED and the suffix grows it along the
-    dimension line — in Y, not into the reserved strip depth. Measured, `label_bbox` goes
-    y 73.36-76.64 -> 68.85-81.15 while the annotation's own `bounding_box()` is unchanged, which
-    is why a bbox comparison misses it. The corridor solve does not model a rotated label's
-    along-line growth, and `repair()` does not clear it.
+    The annotation's own `bounding_box()` not moving is why a bbox comparison misses this
+    entirely, and why the corridor solve does not account for it.
 
-    That is a real cost of rendering the tolerance, and the lint is right to report it — the
-    label does overlap. It is pinned here so the next person sees a decision rather than a
-    surprise; fixing it means teaching the corridor about rotated labels, which is not this
-    change (#1234 review r2).
+    **What this class does NOT assert is the lint outcome.** On this machine the fixture goes
+    from `view_annotation_inside_extents` (info) to `view_annotation_overlap` (warning), and
+    `repair()` does not clear it. On CI it produces neither — `codes` is the empty set. I first
+    pinned the warning and it failed on three ubuntu shards: whether the taller label actually
+    crosses the front view's edge depends on the solved offset, which differs by platform. The
+    geometry is the durable fact; the lint code is not, and asserting it was pinning my own
+    machine (#1234 review r2, and its CI run).
     """
 
-    def test_the_toleranced_height_overlaps_the_view_on_this_fixture(self):
-        codes = {issue.code for issue in _built("height").lint()}
-        assert "view_annotation_overlap" in codes, codes
+    @staticmethod
+    def _label_box(drawing, name):
+        return getattr(drawing.registry.named(name), "label_bbox")
 
-    def test_the_untoleranced_fixture_does_not(self):
-        # The precondition: without this the assertion above could be pinning a pre-existing
-        # warning that has nothing to do with the tolerance.
-        codes = {issue.code for issue in _built(axis=None).lint()}
-        assert "view_annotation_overlap" not in codes, codes
+    def test_a_rotated_label_grows_along_the_dimension_line(self):
+        bare = self._label_box(_built(axis=None), "dim_height")
+        tol = self._label_box(_built("height"), "dim_height")
+        assert (tol[3] - tol[1]) > (bare[3] - bare[1]) * 2, (bare, tol)
+        # ...and NOT across it: the strip depth is unchanged, which is the whole problem.
+        assert round(tol[2] - tol[0], 3) == round(bare[2] - bare[0], 3), (bare, tol)
 
-    def test_a_shorter_suffix_does_not_trip_it(self):
-        # It is length, not the presence of a suffix: a fit class renders `10 h6` and fits.
-        from draftwright.builder import build_drawing
-        from draftwright.fits import fit_class
+    def test_the_annotations_own_bounding_box_does_not_move(self):
+        # Why this went unnoticed: the obvious check sees nothing.
+        def box(drawing):
+            b = drawing.registry.named("dim_height").bounding_box()
+            return (round(b.min.Y, 2), round(b.max.Y, 2))
 
-        sheet = Sheet(Box(30, 20, 10))
-        sheet.envelope()
-        sheet.auto_dimensions()
-        model = sheet.build().model()
-        envelope = next(f for f in model.features if f.kind == "envelope")
-        drawing = build_drawing(
-            Box(30, 20, 10),
-            model=model,
-            decorations={(envelope, "length", "height"): fit_class("h6", 10.0, "class")},
-            title="T",
-            number="N-1",
-        )
-        assert _label(drawing, "dim_height") == "10 h6"
-        assert "view_annotation_overlap" not in {issue.code for issue in drawing.lint()}
+        assert box(_built(axis=None)) == box(_built("height"))
+
+    def test_an_unrotated_extent_grows_the_other_way(self):
+        # The contrast that makes the rotation the cause rather than the suffix: `m_env_width`
+        # is horizontal, so its label grows in X — into the strip depth, which IS reserved.
+        bare = self._label_box(_built(axis=None), "m_env_width")
+        tol = self._label_box(_built("width"), "m_env_width")
+        assert (tol[2] - tol[0]) > (bare[2] - bare[0]), (bare, tol)
+        assert round(tol[3] - tol[1], 3) == round(bare[3] - bare[1], 3), (bare, tol)
 
 
 class TestAFitClassRendersToo:

--- a/tests/test_issue_1215_envelope_tolerance.py
+++ b/tests/test_issue_1215_envelope_tolerance.py
@@ -168,8 +168,14 @@ class TestTheCostOnACrowdedSheet:
         assert box(_built(axis=None)) == box(_built("height"))
 
     def test_an_unrotated_extent_grows_the_other_way(self):
-        # The contrast that makes the rotation the cause rather than the suffix: `m_env_width`
-        # is horizontal, so its label grows in X — into the strip depth, which IS reserved.
+        # The contrast that makes the ROTATION the cause rather than the suffix: `m_env_width`
+        # is horizontal, so its label grows in X while the height's grows in Y. Both grow along
+        # their own dimension line, and neither growth is into the reserved slot depth — an
+        # earlier version of this comment claimed X "IS reserved", which is false: `_queue`
+        # registers the envelope extents with `axis="y"`, so their reserved depth runs in Y.
+        # The lint fires for the height and not the width for a POSITIONAL reason — the height
+        # label sits inside the front view's extents, the width label in open space below the
+        # plan (#1234 review r3).
         bare = self._label_box(_built(axis=None), "m_env_width")
         tol = self._label_box(_built("width"), "m_env_width")
         assert (tol[2] - tol[0]) > (bare[2] - bare[0]), (bare, tol)

--- a/tests/test_issue_1215_envelope_tolerance.py
+++ b/tests/test_issue_1215_envelope_tolerance.py
@@ -238,6 +238,46 @@ class TestTheSuffixDoesNotBreakLabelIdentity:
         assert _overall_height_name(drawing, self._analysis_for(drawing)) == "dim_height"
 
 
+class TestTheGeneralisedFallbackMatchesToo:
+    """`_overall_height_name` has TWO branches and only the canonical one was covered.
+
+    Reverting the fallback's match to exact string equality passed the entire fast tier —
+    the r4 commit and its test docstring both claimed the break was fixed "in BOTH the
+    canonical branch and the generalised fallback", and the second half was prose. That is the
+    failure mode this PR's own commit messages indict twice, recurring a third time inside the
+    fix for it (#1234 review r5).
+
+    Removing `dim_height` forces the fallback, which searches envelope-attributed annotations
+    for a portrait-shaped one whose label states the height.
+    """
+
+    def test_the_fallback_finds_a_toleranced_height_under_another_name(self):
+        from draftwright.annotations.sections import _overall_height_name
+
+        drawing = _built("height")
+        assert _label(drawing, "dim_height") == "10 ±0.1"
+        envelope = next(f for f in drawing.model().features if f.kind == "envelope")
+        drawing.remove("dim_height")
+        assert "dim_height" not in drawing.registry.names()
+
+        drawing.place_dim(
+            (98, 70, 0),
+            (98, 80, 0),
+            "right",
+            "front",
+            drawing.draft,
+            name="dim_length7",
+            feature=envelope,
+            label="10",
+            tolerance=0.05,
+        )
+        assert str(drawing.get_annotation("dim_length7").label) == "10 ±0.1"
+        found = _overall_height_name(
+            drawing, TestTheSuffixDoesNotBreakLabelIdentity._analysis_for(drawing)
+        )
+        assert found == "dim_length7", found
+
+
 class TestAFitClassRendersToo:
     """#1215's third acceptance line, which I first asserted was unreachable. It is not.
 

--- a/tests/test_issue_1215_envelope_tolerance.py
+++ b/tests/test_issue_1215_envelope_tolerance.py
@@ -1,27 +1,26 @@
 """#1215 — an authored envelope tolerance must render, on all three extents.
 
-`sheet.envelope().tolerance(0.05, on="height")` recorded the decoration on the model and it was
-never printed. Measured before the fix, on all three axes:
+`sheet.envelope().tolerance(0.05, on="height")` recorded the decoration and never printed it:
 
     tolerance on height  -> {'dim_height': '10', 'm_env_depth': '20', 'm_env_width': '30'}
     tolerance on width   -> {'dim_height': '10', 'm_env_depth': '20', 'm_env_width': '30'}
     tolerance on depth   -> {'dim_height': '10', 'm_env_depth': '20', 'm_env_width': '30'}
 
-Two independent drops, which is why the issue says the two renderers need the same answer:
+Two independent drops: `render_envelope` composed its width/depth labels from `value_text` alone,
+and `_compile_overall_height` built the ladder rung with no tolerance, so the height had nothing
+to render even once its renderer asked.
 
-* `render_envelope` built width/depth labels from `value_text` and passed no `tolerance=`;
-* `_compile_overall_height` built the ladder rung with no tolerance at all, so the height had
-  nothing to pass even if the renderer had asked.
+**These tests assert the LABEL, and that is the whole point.** The first version of this fix
+passed `Dimension(tolerance=...)` and asserted on the constructor argument via `_dw_spec`. That
+renders nothing — helpers do
+`rendered = label if label is not None else draft._number_with_units(measured, tolerance)`, so an
+explicit label DISCARDS the tolerance, and every dimension here passes one because the compiler
+owns the value text. The tests passed, the sheet was unchanged, and one of them asserted
+`"±" not in label` — codifying the defect as intended behaviour, passing on unfixed code and
+failing on a working fix (#1234 review).
 
-**Where the assertions look, and why.** `Dimension` formats its own tolerance and leaves `label`
-alone — measured, a `Dimension(label="30", tolerance=0.02)` still reports `label == "30"`. So the
-tolerance is NOT visible on the annotation's label, and a test reading `label` would pass against
-completely unfixed code. These read the `tolerance` the Dimension was constructed with, via the
-`_dw_spec` the repair loop already records.
-
-The suffix is `_tol_suffix`'s, which is documented as matching helpers' `_format_label` byte for
-byte — verified in `test_the_suffix_matches_what_the_helper_renders` rather than assumed, because
-the footprint depends on it.
+`test_the_tolerance_reaches_the_exported_ink` is the backstop: labels are metadata, and glyph
+count is what the reader sees.
 """
 
 from __future__ import annotations
@@ -29,117 +28,125 @@ from __future__ import annotations
 import pytest
 from build123d import Box
 
-from draftwright._core import _tol_suffix
 from draftwright.sheet import Sheet
 
 _AXES = ("width", "depth", "height")
 _ANNOTATION = {"width": "m_env_width", "depth": "m_env_depth", "height": "dim_height"}
+_BARE = {"width": "30", "depth": "20", "height": "10"}
 
 
-def _built(axis, tolerance=0.05):
+def _built(axis=None, lo=0.05, hi=None):
     sheet = Sheet(Box(30, 20, 10))
-    sheet.envelope().tolerance(tolerance, on=axis)
+    params = sheet.envelope()
+    if axis is not None:
+        params.tolerance(lo, hi, on=axis) if hi is not None else params.tolerance(lo, on=axis)
     sheet.auto_dimensions()
     return sheet.build()
 
 
-def _tolerance_of(drawing, name):
-    spec = getattr(drawing.registry.named(name), "_dw_spec", None)
-    assert spec is not None, f"{name} was not built through `_dim`, so it records no spec"
-    return spec.kwargs.get("tolerance")
+def _label(drawing, name):
+    assert name in drawing.registry.names(), f"{name} absent; nothing to assert about"
+    return str(getattr(drawing.registry.named(name), "label", None))
 
 
 class TestTheDecorationReachesAllThreeExtents:
     @pytest.mark.parametrize("axis", _AXES)
-    def test_the_decorated_extent_renders_its_tolerance(self, axis):
-        drawing = _built(axis)
-        assert _tolerance_of(drawing, _ANNOTATION[axis]) == 0.05
+    def test_the_decorated_extent_prints_its_tolerance(self, axis):
+        assert _label(_built(axis), _ANNOTATION[axis]) == f"{_BARE[axis]} ±0.1"
 
     @pytest.mark.parametrize("axis", _AXES)
-    def test_the_other_two_extents_are_untouched(self, axis):
-        # The decoration is per-parameter. Without this a fix that tolerances every extent
-        # would pass the test above on all three.
+    def test_the_other_two_extents_stay_bare(self, axis):
+        # The decoration is per-parameter: a fix that tolerances every extent passes the test
+        # above on all three.
         drawing = _built(axis)
         for other in _AXES:
-            if other == axis:
-                continue
-            assert _tolerance_of(drawing, _ANNOTATION[other]) is None, other
+            if other != axis:
+                assert _label(drawing, _ANNOTATION[other]) == _BARE[other], other
 
-    def test_an_undecorated_envelope_stays_bare(self):
-        # The precondition for both assertions above: they mean nothing if a plain envelope
-        # already carried a tolerance from somewhere.
-        #
-        # `envelope()` is still called — declaring the envelope is what puts the width and
-        # depth extents on the sheet at all. Measured, a bare `Sheet(Box(...)).auto_dimensions()`
-        # draws only `dim_height`; asserting over `_ANNOTATION` on that build fails looking up
-        # an annotation that does not exist, which is a broken precondition, not a passing one.
-        sheet = Sheet(Box(30, 20, 10))
-        sheet.envelope()
-        sheet.auto_dimensions()
-        drawing = sheet.build()
-        for name in _ANNOTATION.values():
-            assert name in drawing.registry.names(), f"{name} absent; nothing to assert about"
-            assert _tolerance_of(drawing, name) is None, name
+    def test_an_undecorated_envelope_prints_no_tolerance(self):
+        # The precondition. `envelope()` is still called — declaring it is what puts the width
+        # and depth extents on the sheet at all; a bare `Sheet(Box(...)).auto_dimensions()`
+        # registers only `dim_height`, and asserting over `_ANNOTATION` there fails looking up
+        # an annotation that does not exist.
+        drawing = _built(axis=None)
+        for axis in _AXES:
+            assert _label(drawing, _ANNOTATION[axis]) == _BARE[axis], axis
 
-    def test_a_limit_pair_survives_as_a_pair(self):
-        # `_tol_value` keeps `(lower, upper)`; the renderers must not coerce it to a float.
-        drawing = _built("height", tolerance=None)
-        sheet = Sheet(Box(30, 20, 10))
-        sheet.envelope().tolerance(0.1, 0.2, on="height")
-        sheet.auto_dimensions()
-        drawing = sheet.build()
-        assert _tolerance_of(drawing, "dim_height") == (0.1, 0.2)
+    def test_a_limit_pair_prints_both_limits(self):
+        assert _label(_built("height", 0.1, 0.2), "dim_height") == "10 +0.2 -0.1"
 
 
 class TestTheTwoPathsAgree:
-    """#1215's second acceptance line: the ladder path and the ordinary envelope path.
+    """#1215's second acceptance line. The height rides `render_height_ladder`; width and depth
+    ride `render_envelope`. They took the decoration from different places and neither printed
+    it, so "they agree" was satisfied vacuously until both did."""
 
-    The height rides `render_height_ladder`, width and depth ride `render_envelope`. They took
-    the decoration from different places and only one of them looked.
+    def test_every_extent_prints_the_same_suffix_for_the_same_tolerance(self):
+        suffixes = {
+            axis: _label(_built(axis), _ANNOTATION[axis]).split(" ", 1)[1] for axis in _AXES
+        }
+        assert set(suffixes.values()) == {"±0.1"}, suffixes
+
+
+class TestTheTolerandeReachesTheInk:
+    """Labels are metadata. This is what the reader sees."""
+
+    def test_the_tolerance_reaches_the_exported_ink(self, tmp_path):
+        import re
+
+        def measured(tolerance):
+            drawing = _built("width") if tolerance else _built(axis=None)
+            annotation = drawing.registry.named("m_env_width")
+            out = tmp_path / f"o{int(bool(tolerance))}.svg"
+            drawing.export(str(out))
+            paths = len(re.findall(r"<path", out.read_text()))
+            return len(annotation.faces()), paths
+
+        bare_faces, bare_paths = measured(False)
+        tol_faces, tol_paths = measured(True)
+        assert tol_faces > bare_faces, (bare_faces, tol_faces)
+        assert tol_paths > bare_paths, (bare_paths, tol_paths)
+
+
+class TestAFitClassRendersToo:
+    """#1215's third acceptance line, which I first asserted was unreachable. It is not.
+
+    `build_drawing(decorations=...)` is public (ADR 0011's public-IR input) and `_Params`
+    forwards unknown attributes to the `Sheet`, so `not hasattr(handle, "fit")` proved only that
+    `Sheet` has no `fit` verb at all — not that an envelope cannot take one (#1234 review).
+
+    It also matters which mechanism renders it: `_tol_suffix` handles `FitClass`, while the ink
+    path's `_number_with_units` raises `TypeError: 'FitClass' object is not subscriptable`. So
+    composing the label is the only route that satisfies this line at all.
     """
 
-    def test_both_paths_carry_the_same_kind_of_value(self):
-        for axis in _AXES:
-            assert _tolerance_of(_built(axis), _ANNOTATION[axis]) == 0.05, axis
+    def test_a_fit_class_on_an_envelope_extent_renders_its_code(self):
+        from draftwright.builder import build_drawing
+        from draftwright.fits import fit_class
 
-    def test_the_label_itself_stays_bare_on_both_paths(self):
-        # Stated because it is surprising, and because it is why these tests read `_dw_spec`:
-        # `Dimension` renders the tolerance without touching `label`. A test asserting on the
-        # label would pass against unfixed code.
-        for axis in _AXES:
-            drawing = _built(axis)
-            label = str(getattr(drawing.registry.named(_ANNOTATION[axis]), "label", None))
-            assert "±" not in label, (axis, label)
+        sheet = Sheet(Box(30, 20, 10))
+        sheet.envelope()
+        sheet.auto_dimensions()
+        model = sheet.build().model()
+        envelope = next(f for f in model.features if f.kind == "envelope")
+        drawing = build_drawing(
+            Box(30, 20, 10),
+            model=model,
+            decorations={(envelope, "length", "width"): fit_class("h6", 30.0, "class")},
+            title="T",
+            number="N-1",
+        )
+        assert _label(drawing, "m_env_width") == "30 h6"
 
-
-class TestTheFootprintMeasuresWhatIsDrawn:
-    def test_the_suffix_matches_what_the_helper_renders(self):
-        """The corridor reserves space using `_tol_suffix`; the sheet draws helpers'
-        `_format_label`. If they disagree a toleranced extent reserves the wrong width."""
+    def test_the_ink_path_would_have_raised_on_it(self):
+        # Why the label route is not merely a preference. If the tolerance were handed to the
+        # Dimension instead, this is what the reader would get.
+        import pytest as _pytest
         from build123d_drafting.helpers import _format_label
 
         from draftwright.builder import build_drawing
+        from draftwright.fits import fit_class
 
         draft = build_drawing(Box(30, 20, 10), title="T", number="N-1").draft
-        for tolerance in (0.05, 0.5, (0.1, 0.2)):
-            expected = _format_label(30.0, draft, tolerance)
-            ours = f"{round(30.0, draft.decimal_precision):.{draft.decimal_precision}f}"
-            assert ours + _tol_suffix(tolerance, draft) == expected, tolerance
-
-
-class TestWhatThisDoesNotCover:
-    def test_an_envelope_cannot_take_a_fit_class(self):
-        """#1215's third acceptance line asks for `FitClass` rendering. It is unreachable.
-
-        `_Params` — the envelope handle — has no `fit()`, and `_Dim.fit` is diametral by
-        design ("a fit is diametral"), reading `self._sheet._features[self._i].diameter`. An
-        envelope's parameters are width/height/depth and it has no diameter, so no `FitClass`
-        can key onto one. `_tol_suffix` handles `FitClass` already, so the day an envelope
-        grows a diametral parameter the suffix is ready; nothing else here is.
-
-        Asserted rather than left as prose, so this stops being true loudly.
-        """
-        sheet = Sheet(Box(30, 20, 10))
-        handle = sheet.envelope()
-        assert not hasattr(handle, "fit"), "an envelope grew fit(); #1215's third line is now live"
-        assert "diameter" not in {p.role for p in sheet.features[0].parameters()}
+        with _pytest.raises(TypeError):
+            _format_label(30.0, draft, fit_class("h6", 30.0, "class"))

--- a/tests/test_issue_1215_envelope_tolerance.py
+++ b/tests/test_issue_1215_envelope_tolerance.py
@@ -182,6 +182,62 @@ class TestTheCostOnACrowdedSheet:
         assert round(tol[3] - tol[1], 3) == round(bare[3] - bare[1], 3), (bare, tol)
 
 
+class TestTheSuffixDoesNotBreakLabelIdentity:
+    """`_overall_height_name` matched `dim_height` by exact string equality against a re-derived
+    numeric label. Composing a suffix into that label broke it — in BOTH the canonical branch
+    and the generalised fallback — so a toleranced part silently stopped finding its own height
+    dim.
+
+    The consequence is quiet by design: the caller treats `None` as "no demotion, the safe
+    outcome", so a crowded part would drop its detail view instead of demoting the height, with
+    nothing red. That is why this is asserted directly rather than through a build — I could not
+    construct a part that reaches the #661 demotion retry, and neither could the review
+    (#1234 review r4). The mechanism is what is pinned.
+    """
+
+    @staticmethod
+    def _analysis_for(drawing):
+        """The only field `_overall_height_name` reads off the analysis is `z_size`.
+
+        Built from the public model rather than reaching for `drawing._analysis`: #741's guard
+        budgets test-side reads of `Drawing` privates and this would have added two, which is
+        reach-through where the public surface already answers the question.
+        """
+        from types import SimpleNamespace
+
+        return SimpleNamespace(z_size=drawing.model().bbox.size.Z)
+
+    def test_the_height_dim_is_still_found_when_it_carries_a_tolerance(self):
+        from draftwright.annotations.sections import _overall_height_name
+
+        for axis, expected in ((None, "10"), ("height", "10 ±0.1")):
+            drawing = _built(axis) if axis else _built(axis=None)
+            assert _label(drawing, "dim_height") == expected, axis
+            found = _overall_height_name(drawing, self._analysis_for(drawing))
+            assert found == "dim_height", (axis, found)
+
+    def test_a_fit_class_suffix_is_matched_too(self):
+        # The other suffix form `_tol_suffix` emits: a class code, not a ± pair.
+        from draftwright.annotations.sections import _overall_height_name
+        from draftwright.builder import build_drawing
+        from draftwright.fits import fit_class
+
+        sheet = Sheet(Box(30, 20, 10))
+        sheet.envelope()
+        sheet.auto_dimensions()
+        model = sheet.build().model()
+        envelope = next(f for f in model.features if f.kind == "envelope")
+        drawing = build_drawing(
+            Box(30, 20, 10),
+            model=model,
+            decorations={(envelope, "length", "height"): fit_class("h6", 10.0, "class")},
+            title="T",
+            number="N-1",
+        )
+        assert _label(drawing, "dim_height") == "10 h6"
+        assert _overall_height_name(drawing, self._analysis_for(drawing)) == "dim_height"
+
+
 class TestAFitClassRendersToo:
     """#1215's third acceptance line, which I first asserted was unreachable. It is not.
 

--- a/tests/test_issue_1215_no_approved_tolerance_is_dropped.py
+++ b/tests/test_issue_1215_no_approved_tolerance_is_dropped.py
@@ -23,15 +23,19 @@ precisely than the author wrote it — silently, which is the whole failure mode
 
 from __future__ import annotations
 
-import re
-
 import pytest
-from build123d import Box, Cylinder, Pos, Rot
+from build123d import Axis, Box, Cylinder, Pos, Rot
 
+from draftwright._core import _tol_suffix
 from draftwright.builder import build_drawing
 from draftwright.model.compiled import compile_dimensions
 
 _TOL = 0.05
+
+#: The draft the suffix is formatted against. `_tol_suffix` rounds to `decimal_precision`, so
+#: the expected text must come from the same draft the renderer used — a different precision
+#: would make the comparison a guess again.
+_DRAFT = build_drawing(Box(20, 20, 20), title="T", number="N").draft
 
 
 def _staircase():
@@ -78,6 +82,35 @@ def _short_first_rise():
     return part.part
 
 
+def _counterbored_plate():
+    """A counterbored through hole: the compound callout, whose recess terms are separate
+    parameters. Only the BORE's tolerance was threaded, so `⌀8 ±0.1 THRU ⌴ ⌀14` showed one ±
+    and silently lost the other (#1234 review r7)."""
+    from build123d import Cone
+
+    part = Box(140, 60, 12)
+    # Counterbored.
+    part -= Pos(-35, 0, 0) * Cylinder(4, 40)
+    part -= Pos(-35, 0, 3) * Cylinder(7, 6)
+    # Countersunk — the csink terms are separate parameters again, and a fixture without one
+    # leaves `csink_dia_tol` / `csink_angle_tol` unswept. This cone geometry is the one
+    # `tests/test_issue_1143_hole_completeness.py` uses; my first attempt built a cone the
+    # recogniser did not see as a countersink at all, so the sweep silently covered nothing.
+    part -= Pos(35, 0, 0) * Cylinder(3, 40)
+    part -= Pos(35, 0, 4) * Cone(3, 7, 4)
+    return part
+
+
+def _chamfered_block():
+    """Chamfers label as `C3` and fillets as `4× R5` — letters then digits, which the guard's
+    second predicate matched as if it were a fit class. Deleting the chamfer renderer's suffix
+    left the authored ± off the sheet with the guard green (#1234 review r7)."""
+    from build123d import chamfer
+
+    part = Box(60, 40, 20)
+    return chamfer(part.edges().filter_by(Axis.Z), 3)
+
+
 def _plate_with_holes():
     return Box(90, 60, 12) - Pos(-25, 12, 0) * Cylinder(4, 40) - Pos(25, -12, 0) * Cylinder(4, 40)
 
@@ -88,6 +121,8 @@ _PARTS = {
     "linear_pattern": _linear_pattern,
     "short_first_rise": _short_first_rise,
     "turned_shaft": _turned_shaft,
+    "chamfered_block": _chamfered_block,
+    "counterbored_plate": _counterbored_plate,
     "plate_with_holes": _plate_with_holes,
 }
 
@@ -111,19 +146,23 @@ def _approved_with_tolerance(plan):
     return approved
 
 
-#: The three shapes `_tol_suffix` emits: " ±t", " +hi -lo", and a fit class's " h6".
-_TOLERANCE_SHAPE = re.compile(r"±|[+-]\d|\b[A-Za-z]+\d+$")
+def _renders(label: str, approved) -> bool:
+    """Does this label carry the suffix the COMPILER says this measurement has?
 
+    Not a pattern match on the rendered string. Two earlier predicates were guessed and both
+    reported green over a live drop:
 
-def _renders_a_tolerance(label: str) -> bool:
-    """Does this label carry a tolerance SUFFIX?
+    * "contains a space" — every collapsed `4× 20` label has one, so the pattern-pitch site
+      was invisible;
+    * a regex for the three `_tol_suffix` shapes — its fit-class alternative (letters then
+      digits) matches `C3` on every chamfer and `4× R5` on every fillet, so deleting the
+      chamfer renderer's suffix left the authored ± off the sheet with the guard still green
+      (#1234 review r6, r7).
 
-    Not "does it contain a space" — that was the first version, and it made the guard blind to
-    the pattern-pitch site, because a collapsed `4× 20` label already has one. A predicate that
-    accepts the very labels most likely to hide a drop is worse than no predicate: it reports
-    green while the sweep covers nothing (#1234 review r6).
+    The plan already holds the tolerance, so the expected text is computable exactly. Comparing
+    to the compiler rather than to a guess is also the ADR 0016 Amdt 1 shape.
     """
-    return bool(_TOLERANCE_SHAPE.search(label.strip()))
+    return _tol_suffix(approved.tolerance, _DRAFT) in label
 
 
 def _drops(part_name, feature, param):
@@ -149,8 +188,16 @@ def _drops(part_name, feature, param):
         if not claimed or name in _DELIBERATELY_BARE:
             continue
         label = str(getattr(drawing.registry.named(name), "label", "") or "")
-        if any(mid in approved for mid in claimed) and not _renders_a_tolerance(label):
-            dropped.append(f"{part_name}/{feature.kind}.{param.role}: {name}={label!r}")
+        # PER ID, not "does it render some tolerance". One annotation can claim several
+        # approved-toleranced ids — a compound hole callout does — and rendering the suffix
+        # for one of them satisfied the whole check, hiding the others (#1234 review r7).
+        for mid in claimed:
+            got = approved.get(mid)
+            if got is not None and not _renders(label, got):
+                want = _tol_suffix(got.tolerance, _DRAFT)
+                dropped.append(
+                    f"{part_name}/{feature.kind}.{param.role}: {name}={label!r} want{want!r}"
+                )
     return dropped
 
 

--- a/tests/test_issue_1215_no_approved_tolerance_is_dropped.py
+++ b/tests/test_issue_1215_no_approved_tolerance_is_dropped.py
@@ -1,0 +1,189 @@
+"""Every tolerance the compiler approves must reach the annotation that claims it.
+
+`tests/test_compiled_plan_boundary.py` enforces one direction of ADR 0016 Amdt 1 — a renderer
+must not emit what the plan withheld. Nothing enforced the converse: **a renderer must emit
+everything the plan approved.**
+
+#1215 was one instance of the converse, and six review rounds found it one site at a time —
+envelope extents, the overall-height ladder, the turned-step chain, two public `Drawing` verbs,
+the deferred corridor route, prismatic step rungs, the detail-view redraw, the short-rise escape,
+step shoulders, and pattern pitch. Each round's fix was correct and each round's sweep was scoped
+to the shape of the site it had just seen.
+
+This is the general guard. It decorates **every parameter of every feature** on a set of parts,
+builds, and joins what the compiler approved against what the claiming annotation actually
+renders. It found three live sites in a single run — the ones rounds 6 was still discovering by
+hand — and it fails on any new one.
+
+Why the join is sound: `registry.measurement_of(name)` is the ADR 0010 seam, so an annotation
+that claims a `DimensionId` is asserting it draws that measurement. If the compiler attached a
+tolerance to that id and the label carries no suffix, the drawing states a requirement less
+precisely than the author wrote it — silently, which is the whole failure mode.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from build123d import Box, Cylinder, Pos, Rot
+
+from draftwright.builder import build_drawing
+from draftwright.model.compiled import compile_dimensions
+
+_TOL = 0.05
+
+
+def _staircase():
+    return Box(120, 60, 15) + Pos(-20, 0, 15) * Box(80, 60, 15) + Pos(-40, 0, 30) * Box(40, 60, 15)
+
+
+def _crowded_staircase():
+    """Tiers 3 mm apart: the legibility gate moves rungs into an enlarged DETAIL view.
+
+    The detail is the case that matters most — those rungs are dimensioned *only* there, so a
+    tolerance dropped in the redraw is absent from the drawing entirely while its siblings on
+    the main view show theirs.
+    """
+    part = Pos(0, 0, 3) * Box(20, 16, 6)
+    z = 6
+    for w in (16, 13, 10, 7, 5):
+        part += Pos(0, 0, z + 1.5) * Box(w, 12, 3)
+        z += 3
+    return part
+
+
+def _linear_pattern():
+    part = Box(140, 60, 12)
+    for x in (-40, -20, 0, 20, 40):
+        part -= Pos(x, 0, 0) * Cylinder(3, 40)
+    return part
+
+
+def _turned_shaft():
+    return Rot(0, 90, 0) * (Cylinder(8, 30) + Pos(0, 0, 30) * Cylinder(5, 20))
+
+
+def _short_first_rise():
+    """A 1 mm first rise: too short to dimension in the right strip, so it escapes to the LEFT
+    one (`_build_left`). That branch is live — instrumenting it records 18 hits across the fast
+    tier — but no fixture anywhere toleranced a part that reaches it, so the escape dropped its
+    suffix unobserved (#1234 review r6)."""
+    from build123d import BuildPart, BuildSketch, Plane, Polygon, extrude
+
+    with BuildPart() as part:
+        with BuildSketch(Plane.XZ):
+            Polygon((0, 0), (50, 0), (50, 1), (25, 1), (25, 20), (0, 20))
+        extrude(amount=30)
+    return part.part
+
+
+def _plate_with_holes():
+    return Box(90, 60, 12) - Pos(-25, 12, 0) * Cylinder(4, 40) - Pos(25, -12, 0) * Cylinder(4, 40)
+
+
+_PARTS = {
+    "staircase": _staircase,
+    "crowded_staircase": _crowded_staircase,
+    "linear_pattern": _linear_pattern,
+    "short_first_rise": _short_first_rise,
+    "turned_shaft": _turned_shaft,
+    "plate_with_holes": _plate_with_holes,
+}
+
+#: Parameters whose mark deliberately states no tolerance, with the reason. A collapsed
+#: representative is the case: `N× rise` stands for levels that merely fall within 10% of each
+#: other, so a ± would claim the author's tolerance of values that differ. (A pattern's `N× pitch`
+#: is NOT here — its gaps are identical by construction, so the ± applies to each one.)
+_DELIBERATELY_BARE = {"dim_step_typ", "m_steplen_typ"}
+
+
+def _approved_with_tolerance(plan):
+    approved = {}
+    for group in plan.groups:
+        for dim in group.dims:
+            if dim.tolerance is not None and dim.id is not None:
+                approved[dim.id] = dim
+    for ladder in plan.ladders:
+        for rung in ladder.rungs:
+            if rung.tolerance is not None and rung.id is not None:
+                approved[rung.id] = rung
+    return approved
+
+
+#: The three shapes `_tol_suffix` emits: " ±t", " +hi -lo", and a fit class's " h6".
+_TOLERANCE_SHAPE = re.compile(r"±|[+-]\d|\b[A-Za-z]+\d+$")
+
+
+def _renders_a_tolerance(label: str) -> bool:
+    """Does this label carry a tolerance SUFFIX?
+
+    Not "does it contain a space" — that was the first version, and it made the guard blind to
+    the pattern-pitch site, because a collapsed `4× 20` label already has one. A predicate that
+    accepts the very labels most likely to hide a drop is worse than no predicate: it reports
+    green while the sweep covers nothing (#1234 review r6).
+    """
+    return bool(_TOLERANCE_SHAPE.search(label.strip()))
+
+
+def _drops(part_name, feature, param):
+    """Annotations that claim an approved-toleranced id but render no suffix."""
+    base = build_drawing(_PARTS[part_name](), title="T", number="N")
+    model = base.model()
+    target = next((f for f in model.features if f.kind == feature.kind and f == feature), None)
+    if target is None:
+        return []
+    drawing = build_drawing(
+        _PARTS[part_name](),
+        model=model,
+        decorations={(target, param.kind, param.role): _TOL},
+        title="T",
+        number="N",
+    )
+    approved = _approved_with_tolerance(compile_dimensions(drawing.model()))
+    if not approved:
+        return []
+    dropped = []
+    for name in sorted(drawing.registry.names()):
+        claimed = drawing.registry.measurement_of(name)
+        if not claimed or name in _DELIBERATELY_BARE:
+            continue
+        label = str(getattr(drawing.registry.named(name), "label", "") or "")
+        if any(mid in approved for mid in claimed) and not _renders_a_tolerance(label):
+            dropped.append(f"{part_name}/{feature.kind}.{param.role}: {name}={label!r}")
+    return dropped
+
+
+@pytest.mark.parametrize("part_name", sorted(_PARTS))
+def test_no_approved_tolerance_is_dropped_by_a_renderer(part_name):
+    base = build_drawing(_PARTS[part_name](), title="T", number="N")
+    dropped: list[str] = []
+    for feature in base.model().features:
+        for param in feature.parameters():
+            dropped += _drops(part_name, feature, param)
+    assert not dropped, (
+        f"{dropped}\n\nThe compiler approved a tolerance on these measurements and the "
+        "annotation claiming them renders no suffix, so the drawing states the requirement "
+        "less precisely than the author wrote it. Compose `_tol_suffix` into the label at the "
+        "renderer — helpers discard a forwarded `tolerance=` whenever a label is present."
+    )
+
+
+def test_the_sweep_actually_decorates_something():
+    """The precondition. A sweep that approves no toleranced dimension asserts nothing, and
+    every part above must contribute — otherwise a fixture silently stops covering its site."""
+    for part_name in sorted(_PARTS):
+        base = build_drawing(_PARTS[part_name](), title="T", number="N")
+        model = base.model()
+        seen = 0
+        for feature in model.features:
+            for param in feature.parameters():
+                drawing = build_drawing(
+                    _PARTS[part_name](),
+                    model=model,
+                    decorations={(feature, param.kind, param.role): _TOL},
+                    title="T",
+                    number="N",
+                )
+                seen += len(_approved_with_tolerance(compile_dimensions(drawing.model())))
+        assert seen, f"{part_name} approves no toleranced dimension; it guards nothing"

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -319,9 +319,21 @@ class TestSheetTolerance:
     def _dias(self, dwg):
         return {n: dwg.get_annotation(n).label for n in dwg.annotations() if n.startswith("m_dia")}
 
-    def _steplen_tol(self, dwg, name):
-        o = dwg.get_annotation(name)
-        return o._dw_spec.kwargs.get("tolerance")
+    def _steplen_label(self, dwg, name):
+        """The step-length dim's rendered LABEL.
+
+        This used to read `_dw_spec.kwargs["tolerance"]` — the constructor argument. helpers do
+        `rendered = label if label is not None else ...`, so an explicit label DISCARDS
+        `tolerance=`, and these dims always pass one. Four tests here therefore asserted a
+        tolerance that never reached the sheet, including one named
+        `test_step_length_tolerance_reaches_dimension` (#1234 review round 2).
+        """
+        return str(getattr(dwg.get_annotation(name), "label", ""))
+
+    def _steplen_labels(self, dwg):
+        return {
+            self._steplen_label(dwg, n) for n in dwg.annotations() if n.startswith("m_steplen")
+        }
 
     def test_boss_diameter_tolerance_renders_on_leader(self):
         shaft = self._stepped_shaft()
@@ -345,8 +357,7 @@ class TestSheetTolerance:
         s.step(diameter=8, length=20, at=(0, 0, 0), axis="x").tolerance(0.0, 0.2)
         s.step(diameter=12, length=10, at=(15, 0, 0), axis="x")
         dwg = s.build()
-        tols = {self._steplen_tol(dwg, n) for n in dwg.annotations() if n.startswith("m_steplen")}
-        assert (0.0, 0.2) in tols
+        assert "20 +0.2 -0.0" in self._steplen_labels(dwg), self._steplen_labels(dwg)
 
     @staticmethod
     def _pocket_part():
@@ -414,9 +425,7 @@ class TestSheetTolerance:
         dwg = s.build()
         # the bare .tolerance() went to the length dim; the OD leader stays plain
         assert all("±" not in lbl and "+" not in lbl for lbl in self._dias(dwg).values())
-        assert 0.1 in {
-            self._steplen_tol(dwg, n) for n in dwg.annotations() if n.startswith("m_steplen")
-        }
+        assert "20 ±0.1" in self._steplen_labels(dwg), self._steplen_labels(dwg)
 
     def test_step_on_diameter_tolerances_the_od(self):
         shaft = self._stepped_shaft()
@@ -436,7 +445,7 @@ class TestSheetTolerance:
         dwg = s.build()
         assert all("±" not in lbl and "+" not in lbl for lbl in self._dias(dwg).values())
         assert all(
-            self._steplen_tol(dwg, n) is None
+            "±" not in self._steplen_label(dwg, n) and "+" not in self._steplen_label(dwg, n)
             for n in dwg.annotations()
             if n.startswith("m_steplen")
         )

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -486,6 +486,34 @@ class TestSheetTolerance:
         )
         assert str(dwg.get_annotation("u0").label) == "CUSTOM ±0.1"
 
+    @pytest.mark.parametrize("extra", [{}, {"pin": True}, {"priority": 5.0}])
+    def test_a_deferred_dimension_renders_its_tolerance(self, extra):
+        """The corridor route — `_queue_dimension_intent`, the deferred twin of `_place_dim`.
+
+        It injects a label of its own, so it discarded the tolerance the same way. Fixing only
+        the live path made the SAME public call diverge: `80 +0.2 -0.1` immediately, a bare `80`
+        the moment the author added `pin=True` — ADR 0012's first-class corridor candidate, so
+        the going-forward surface was the one losing the requirement. #1215 introduced that
+        divergence; before it, neither path rendered anything (#1234 review r4).
+        """
+        from build123d import Box
+
+        from draftwright.builder import build_drawing
+
+        dwg = build_drawing(Box(80, 50, 20), auto_dims=False, title="T", number="N-1")
+        envelope = next(f for f in dwg.model().features if f.kind == "envelope")
+        with dwg.deferred():
+            dwg.dimension(
+                envelope,
+                "length",
+                role="width",
+                side="below",
+                name="tst",
+                tolerance=(0.1, 0.2),
+                **extra,
+            )
+        assert str(dwg.get_annotation("tst").label) == "80 +0.2 -0.1"
+
     def test_step_on_diameter_tolerances_the_od(self):
         shaft = self._stepped_shaft()
         s = Sheet(shaft).auto_dimensions()

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -454,6 +454,38 @@ class TestSheetTolerance:
         for label in collapsed:
             assert "±" not in label and "+" not in label, label
 
+    def test_the_public_dimension_verbs_render_a_tolerance(self):
+        """Both verbs that route through `_place_dim`, and both label branches.
+
+        `Drawing.dimension` is the PREFERRED verb and discarded `tolerance=` outright — only
+        the deprecated `place_dim` got a caveat first. And composing the suffix solely in the
+        inject branch left a caller passing BOTH `label=` and `tolerance=` with the same silent
+        discard: the defect surviving in one branch of its own fix (#1234 review r3, r4).
+        """
+        from build123d import Box
+
+        from draftwright.builder import build_drawing
+
+        dwg = build_drawing(Box(90, 60, 20), title="T", number="N-1")
+        envelope = next(f for f in dwg.model().features if f.kind == "envelope")
+
+        injected = dwg.dimension(
+            envelope, "length", role="width", side="above", tolerance=(0.1, 0.2)
+        )
+        assert str(dwg.get_annotation(injected).label) == "90 +0.2 -0.1"
+
+        dwg.place_dim(
+            (10, 10, 0),
+            (60, 10, 0),
+            "below",
+            "plan",
+            dwg.draft,
+            name="u0",
+            label="CUSTOM",
+            tolerance=0.05,
+        )
+        assert str(dwg.get_annotation("u0").label) == "CUSTOM ±0.1"
+
     def test_step_on_diameter_tolerances_the_od(self):
         shaft = self._stepped_shaft()
         s = Sheet(shaft).auto_dimensions()

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -583,6 +583,26 @@ class TestSheetTolerance:
         dwg.place_dim((10, 10, 0), (60, 10, 0), "below", "plan", dwg.draft, name="u0", label=None)
         assert str(dwg.get_annotation("u0").label) == "50"
 
+    @pytest.mark.parametrize("extra", [{"pin": True}, {"priority": 5.0}])
+    def test_a_deferred_none_label_still_means_auto(self, extra):
+        """The deferred half of the `label=None` fix, which had nothing holding it.
+
+        Reverting only `_queue_dimension_intent` to `"label" not in dim_kwargs` passed the
+        entire fast tier — the commit said "both sites now test `kwargs.get("label") is None`",
+        and the code did while only one was tested (#1234 review r6).
+        """
+        from build123d import Box
+
+        from draftwright.builder import build_drawing
+
+        dwg = build_drawing(Box(80, 50, 20), auto_dims=False, title="T", number="N-1")
+        envelope = next(f for f in dwg.model().features if f.kind == "envelope")
+        with dwg.deferred():
+            dwg.dimension(
+                envelope, "length", role="width", side="below", name="tst", label=None, **extra
+            )
+        assert str(dwg.get_annotation("tst").label) == "80"
+
     def test_step_on_diameter_tolerances_the_od(self):
         shaft = self._stepped_shaft()
         s = Sheet(shaft).auto_dimensions()

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -514,6 +514,75 @@ class TestSheetTolerance:
             )
         assert str(dwg.get_annotation("tst").label) == "80 +0.2 -0.1"
 
+    @staticmethod
+    def _staircase():
+        from build123d import Box, Pos
+
+        return (
+            Box(120, 60, 15)
+            + Pos(-20, 0, 15) * Box(80, 60, 15)
+            + Pos(-40, 0, 30) * Box(40, 60, 15)
+        )
+
+    def test_a_step_level_tolerance_renders_on_every_rung(self):
+        """The seventh site of #1215's discard, and the last one the sweep found.
+
+        `sheet.py` promises a bare `.tolerance(...)` "folds onto every parameter of that kind";
+        a step level's rungs dropped it, so `dim_step_0` printed `15` where the author wrote
+        `15 ±0.05`. The compiler built the rungs with no tolerance and the renderer keyed its
+        suffix map to `dim_height` alone (#1234 review r5).
+        """
+        from draftwright.sheet import Sheet as _S
+
+        for tol, expected in ((None, {"15", "30"}), (0.05, {"15 ±0.1", "30 ±0.1"})):
+            sheet = _S(self._staircase(), title="T", number="N")
+            handle = sheet.step_level(self._staircase())
+            if tol is not None:
+                handle.tolerance(tol)
+            sheet.auto_dimensions()
+            dwg = sheet.build()
+            labels = {
+                str(dwg.get_annotation(n).label)
+                for n in dwg.annotations()
+                if n.startswith("dim_step_")
+            }
+            assert labels == expected, (tol, labels)
+
+    def test_the_representative_step_rung_carries_no_tolerance(self):
+        """`N× rise` states ONE value for the whole run, so a ± would claim the author's
+        tolerance of every level at once — the same rule the turned-step collapse follows."""
+        from build123d import Box, Pos
+
+        from draftwright.sheet import Sheet as _S
+
+        def uniform():
+            part = Box(120, 60, 10)
+            for i in range(1, 4):
+                part += Pos(-10 * i, 0, 10 * i) * Box(120 - 20 * i, 60, 10)
+            return part
+
+        sheet = _S(uniform(), title="T", number="N")
+        sheet.step_level(uniform()).tolerance(0.05)
+        sheet.auto_dimensions()
+        dwg = sheet.build()
+        rep = [n for n in dwg.annotations() if n.startswith("dim_step_typ")]
+        assert rep, sorted(dwg.annotations())
+        for name in rep:
+            label = str(dwg.get_annotation(name).label)
+            assert "×" in label and "±" not in label and "+" not in label, label
+
+    def test_an_explicit_none_label_still_means_auto(self):
+        """`label=None` is helpers' documented "auto". Composing the suffix onto whatever was
+        in `kwargs` printed the literal string `None` on the sheet — a public API made to print
+        garbage by the fix for a public API that printed nothing (#1234 review r5)."""
+        from build123d import Box
+
+        from draftwright.builder import build_drawing
+
+        dwg = build_drawing(Box(90, 60, 20), title="T", number="N-1")
+        dwg.place_dim((10, 10, 0), (60, 10, 0), "below", "plan", dwg.draft, name="u0", label=None)
+        assert str(dwg.get_annotation("u0").label) == "50"
+
     def test_step_on_diameter_tolerances_the_od(self):
         shaft = self._stepped_shaft()
         s = Sheet(shaft).auto_dimensions()

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -324,8 +324,9 @@ class TestSheetTolerance:
 
         This used to read `_dw_spec.kwargs["tolerance"]` — the constructor argument. helpers do
         `rendered = label if label is not None else ...`, so an explicit label DISCARDS
-        `tolerance=`, and these dims always pass one. Four tests here therefore asserted a
-        tolerance that never reached the sheet, including one named
+        `tolerance=`, and these dims always pass one. Three tests here read it — two asserting
+        a value, one asserting its absence — so a tolerance that never reached the sheet was
+        guarded as if it had, including one named
         `test_step_length_tolerance_reaches_dimension` (#1234 review round 2).
         """
         return str(getattr(dwg.get_annotation(name), "label", ""))
@@ -425,7 +426,33 @@ class TestSheetTolerance:
         dwg = s.build()
         # the bare .tolerance() went to the length dim; the OD leader stays plain
         assert all("±" not in lbl and "+" not in lbl for lbl in self._dias(dwg).values())
-        assert "20 ±0.1" in self._steplen_labels(dwg), self._steplen_labels(dwg)
+        labels = self._steplen_labels(dwg)
+        assert "20 ±0.1" in labels, labels
+        # PER-PARAMETER. A mutation taking the first non-None tolerance in the chain gave the
+        # UNDECORATED rung `10 ±0.1` too — a requirement the author never wrote — and passed the
+        # entire fast tier. The commit that introduced this fix asserted per-parameter behaviour
+        # in prose with nothing behind it (#1234 review r3).
+        assert "10" in labels, labels
+
+    def test_a_uniform_run_collapses_without_a_tolerance(self):
+        """`N× v` carries no ±, and now something says so.
+
+        A per-step tolerance on N collapsed equal steps would be a false claim: the label
+        states one representative value for the whole run. `_draw_step_chain` says exactly that
+        in a comment, and a mutation appending the suffix to the collapse label passed the whole
+        fast tier — the invariant was prose only (#1234 review r3).
+        """
+        from build123d import Cylinder, Rot
+
+        shaft = Rot(0, 90, 0) * Cylinder(4, 40)
+        s = Sheet(shaft).auto_dimensions()
+        for i in range(4):
+            s.step(diameter=8, length=10, at=(i * 10, 0, 0), axis="x").tolerance(0.1)
+        dwg = s.build()
+        collapsed = [lbl for lbl in self._steplen_labels(dwg) if "×" in lbl]
+        assert collapsed, self._steplen_labels(dwg)
+        for label in collapsed:
+            assert "±" not in label and "+" not in label, label
 
     def test_step_on_diameter_tolerances_the_od(self):
         shaft = self._stepped_shaft()


### PR DESCRIPTION
Closes #1215.

## The defect

`sheet.envelope().tolerance(0.05, on=...)` recorded the decoration and never printed it:

```
tolerance on height  -> {'dim_height': '10', 'm_env_depth': '20', 'm_env_width': '30'}
tolerance on width   -> {'dim_height': '10', 'm_env_depth': '20', 'm_env_width': '30'}
tolerance on depth   -> {'dim_height': '10', 'm_env_depth': '20', 'm_env_width': '30'}
```

## The mechanism, which is the whole story

`helpers.py:644`:

```python
rendered = label if label is not None else draft._number_with_units(measured, tolerance)
```

**An explicit `label=` discards `tolerance=`.** Every dimension in this engine passes a label,
because the compiler owns the value text — so any site that "forwards the tolerance" renders
nothing. The suffix has to be composed into the label, which is what `render_boss_heights`, the
plate-thickness dim and the channel-width dim already do, and what #1215 named as the model.

It is also forced: `_tol_suffix` lives in `_core` (rank 1) and `compiled` is rank 0, so the
compiler cannot build the string.

## Four sites, not one

The issue named two renderers. Successive review rounds found the same discard at four:

| site | symptom |
|---|---|
| `render_envelope` (width, depth) | composed labels from `value_text` alone |
| `_compile_overall_height` + ladder | rung carried no tolerance, so the height had nothing to render |
| `_draw_step_chain` | built bare labels **and** passed the discarded `tolerance=` |
| `_place_dim` → `place_dim` / **`Drawing.dimension`** | injects a label, so both public verbs silently dropped it |

The last is the preferred public verb, and its docstring advertised `tolerance=` as forwarded.
All four now render:

```
envelope   height -> '10 ±0.1'   width -> '30 ±0.1'   depth -> '20 ±0.1'
step chain 0.1    -> '20 ±0.1'   (0.0, 0.2) -> '20 +0.2 -0.0'
dimension() with tolerance=(0.1, 0.2) -> '90 +0.2 -0.1'
```

## Verified at the ink

Labels are metadata; these are glyphs on the exported sheet.

```
envelope, each of width/depth/height:  faces 9 -> 15,  SVG paths 115 -> 121
step chain, symmetric:                 faces 9 -> 15
step chain, limit pair:                faces 9 -> 20
the ± glyph alone:                     exactly 2 faces
```

The uniform-run collapse is deliberately untouched — `N× v` carries no ±, because a per-step
tolerance on N collapsed equal steps is a false claim about the run.

## A `FitClass` renders too, and only this way

`build_drawing(decorations=...)` is public (ADR 0011's public-IR input), so a fit class **can**
reach an envelope extent — an earlier version of this PR asserted it could not. It renders
`30 h6`. `_tol_suffix` handles `FitClass`; the ink path's `_number_with_units` raises
`TypeError: 'FitClass' object is not subscriptable`. Composing the label is the only route that
satisfies #1215's third acceptance line at all.

## Verification

- **Mutations, substitution asserted applied each time — killed:** each of the four sites
  reverted; the compiler rung's tolerance dropped; `_decorated` reduced to a role-keyed lookup
  (which silently loses a bare `.tolerance()` with no `on=`); a tolerance **leaking** across the
  step chain onto an undecorated rung; the collapse gaining a per-step ±; the ladder's tolerance
  map keyed to the wrong rung; the compiler picking the wrong role.
- **Two mutations survive, both documented:** the envelope and ladder **footprints** reverting to
  the bare value. The footprint must model the ink it measures — that is correctness by
  construction — but nothing observes it. Measured, `dim_footprint` is span-dominated and
  identical with or without the suffix for these extents; it differs only in the outside-arrow
  flip regime, and there the toleranced footprint reserves *less*, not more.
- Full fast tier **4,322 passed**, 5 skipped, 2 xfailed. Slow tier 44 passed.
  `scripts/pr-check --static` exit 0 (read from `$?`).

## Costs and follow-ups, recorded not hidden

- **A `view_annotation_overlap` warning appears on this PR's own fixture, on macOS.** The height
  dim is `side="right"`, so its label is rotated and the suffix grows it *along* the dimension
  line (label bbox height 3.27 → 12.30) while the annotation's own bounding box is unchanged —
  which is why a bbox check misses it. `repair()` does not clear it. The corridor solve does not
  model a rotated label's along-line growth; that is ADR 0014 work, not this change. The tests
  assert the geometry, **not** the lint code: a first attempt pinned the warning and failed on
  three ubuntu shards, where it does not occur.
- `ApprovedDimension.rendered_label` is documented as the complete compiler-owned label while a
  toleranced rung now carries the bare value beside a tolerance. Recorded at the site; today's
  single consumer composes the suffix.
- `sheet_emit` re-emits no `.tolerance()` for any feature, so decorations are outside the
  recognise→emit→declare loop entirely. Pre-existing, not this PR's debt.

## Two #1154 tests changed expectation; the rule did not

Both guard the consolidation **count** — one label, then two — and both counts are unchanged; only
the labels gained their ±. One justified itself on the premise that *"an envelope decoration is
not rendered on ANY axis"*, which is exactly what this fixes. The rule still refuses to transfer a
tolerance, deliberately: #1154's own comment says the refusal must not **depend** on the receiving
extent being able to state one. #1215's last acceptance line proposes revisiting that — a separate
decision, not taken here.

## Review history

Three adversarial rounds, and each found the same mistake one level further out.

**Round 1:** the fix rendered nothing. The tests asserted `_dw_spec.kwargs["tolerance"]` — the
argument helpers throw away — so twelve passed with the sheet unchanged, and one asserted
`"±" not in label`, passing on unfixed code and failing on a working fix. The measurement I had
taken (that `Dimension` leaves `label` untouched) was true and consistent with both "renders
separately" and "is discarded"; I never looked at the ink and picked the flattering reading.

**Round 2:** the identical bug was live 90 lines away in `_draw_step_chain`, guarded by three tests
reading the same discarded kwarg — one named `test_step_length_tolerance_reaches_dimension`. The
file already contradicted itself: `label_widths` sized the staggering decision *with* the suffix.

**Round 3:** two invariants I had asserted only in prose both survived the full suite as mutations,
and the same discard was still live in `Drawing.dimension`.
