### PR TITLE
A starved overall extent falls through to the above strip (#1236)

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -80,6 +80,7 @@ from draftwright.annotations._common import (
     register_corridor,
     strip_free_span,
     strip_obstacles,
+    strip_occupants,
 )
 from draftwright.annotations.leaders import (
     _GREEDY_MATERIAL_LOOKAHEAD,
@@ -3323,7 +3324,7 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
         footprint=None,
         measurement=None,
     ):
-        def _report(nm, _view=view, _strip=strip, _mid=measurement):
+        def _report(nm, _view=view, _strip=strip, _above=above_strip, _mid=measurement):
             # An overall extent is the one dimension every drawing must carry, and until
             # #1216 review r9 its drop was the only one in the engine that reported NOTHING:
             # `on_drop` was `lambda _nm: None`, so a starved strip removed the width from the
@@ -3347,14 +3348,18 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
             #
             # `measurement=` so the report is joined to the measurement it is about, rather
             # than being an unattributed issue that any absence-shaped code could stand in for.
-            msg = full_strip_message(
-                f"overall {'width' if nm.endswith('width') else 'depth'} dimension not placed "
-                f"({_view}-view below and above strips full)",
-                dwg,
-                _strip,
-                _view,
-                "y",
+            # Both strips were tried, so both sets of blockers are named — a message that
+            # says "below and above strips full" and then lists only the below occupants
+            # half-attributes the refusal (#1239 review F3). `full_strip_message` extends a
+            # single-strip message; two strips are composed here from the same helper it uses.
+            which = "width" if nm.endswith("width") else "depth"
+            msg = (
+                f"overall {which} dimension not placed ({_view}-view below and above strips full)"
             )
+            for side_name, side_strip in (("below", _strip), ("above", _above)):
+                occupants = strip_occupants(dwg, side_strip, _view, "y") if side_strip else []
+                if occupants:
+                    msg = f"{msg[:-1]}; {side_name} occupied by: {', '.join(occupants)})"
             ctx.record_issue("error", "overall_dim_withheld", msg, measurement=_mid)
 
         def _drop(nm, _view=view, _above=above_strip, _mid=measurement, _xs=xs, _label=label):

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -3310,16 +3310,24 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
         return 0
     n = 0
 
-    def _queue(name, strip, view, tier, distance, build, footprint=None, measurement=None):
-        def _drop(nm, _view=view, _strip=strip, _mid=measurement):
+    def _queue(
+        name,
+        strip,
+        above_strip,
+        view,
+        tier,
+        distance,
+        xs,
+        label,
+        build,
+        footprint=None,
+        measurement=None,
+    ):
+        def _report(nm, _view=view, _strip=strip, _mid=measurement):
             # An overall extent is the one dimension every drawing must carry, and until
             # #1216 review r9 its drop was the only one in the engine that reported NOTHING:
             # `on_drop` was `lambda _nm: None`, so a starved strip removed the width from the
-            # sheet and the build, the lint and the score all stayed clean. Reproduced on an
-            # 80x80 plate with a hexagonal boss, where the A/F callout's leader spans the
-            # whole plan-below corridor: `m_env_width` is force-kept and mandatory and still
-            # solves to `strip_full`, leaving the part's width undimensioned and unremarked.
-            # Live on three CTC fixtures; the placement fix is #1236.
+            # sheet and the build, the lint and the score all stayed clean.
             #
             # NOT `placement_unsatisfiable`, which is what the height ladder records and what
             # this reported in its first cut. That code is a **required scale drop**
@@ -3333,24 +3341,69 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
             # code; neither raises through this one (#1216 review r9, F1).
             #
             # The SEVERITY is `error` and that is deliberate. `_is_required_scale_drop` never
-            # reads severity — it matches the code name and the `*_dropped` suffix — so the
-            # first fix for the above downgraded the one thing that was not causing it, and
-            # left a drawing with no overall width reporting `passed: True`. The part's
-            # principal extent is missing; that is an error, and `test_e2e_standards` carries
-            # a named quarantine for the three CTC fixtures where it is already true (#1236)
-            # rather than the finding being priced below the gate (#1216 review r10, F5).
+            # reads severity — it matches the code name and the `*_dropped` suffix — so an
+            # earlier fix downgraded the one thing that was not causing the raise, and left a
+            # drawing with no overall width reporting `passed: True` (#1216 review r10, F5).
             #
             # `measurement=` so the report is joined to the measurement it is about, rather
             # than being an unattributed issue that any absence-shaped code could stand in for.
             msg = full_strip_message(
                 f"overall {'width' if nm.endswith('width') else 'depth'} dimension not placed "
-                f"({_view}-view below strip full)",
+                f"({_view}-view below and above strips full)",
                 dwg,
                 _strip,
                 _view,
                 "y",
             )
             ctx.record_issue("error", "overall_dim_withheld", msg, measurement=_mid)
+
+        def _drop(nm, _view=view, _above=above_strip, _mid=measurement, _xs=xs, _label=label):
+            # Opposite-strip fallthrough (#1236). A feature leader placed before the drain —
+            # a polygonal boss's A/F callout on CTC-01, slot width dims on CTC-04 — can span
+            # the whole below corridor, and no corridor-side fix reaches it: the leader is not
+            # a corridor candidate, so registration ORDER cannot arbitrate against it, and a
+            # reserved band would tax every drawing's leader placement to protect a rare
+            # starvation. What the engine already does for a starved slot or plate dim is
+            # retry on the opposite strip (`_far_or_drop`, `render_plates`); the overall
+            # extent now does the same. An overall dimension above the view is ordinary
+            # drafting; a missing one is not.
+            #
+            # DEFERRED to ctx.post_drain, the #684 rule: this drop fires mid-drain, and
+            # placing onto the above strip immediately could occupy space a not-yet-solved
+            # corridor's force candidate needs. Post-drain, the above strip's occupants are
+            # final and `place_strip_candidates` spaces into what is genuinely free.
+            def _retry():
+                bounds = dwg.view_bounds(_view)
+                if _above is not None and bounds is not None:
+                    lift = bounds[3] + _WITNESS_LIFT_MM
+                    if not place_strip_candidates(
+                        dwg,
+                        _above,
+                        _view,
+                        "y",
+                        [
+                            (
+                                nm,
+                                lambda pos, _l=lift: _dim(
+                                    (_xs[0], _l, 0),
+                                    (_xs[1], _l, 0),
+                                    "above",
+                                    pos - _l,
+                                    dwg.draft,
+                                    label=_label,
+                                ),
+                            )
+                        ],
+                        tier,
+                        ctx=ctx,
+                        measurements={nm: _mid},
+                        trace=ctx.trace,
+                        trace_label=f"{nm}_above_fallthrough",
+                    ):
+                        return  # placed above — the measurement is on the sheet
+                _report(nm)
+
+            ctx.post_drain.append(_retry)
 
         register_corridor(
             ctx,
@@ -3380,9 +3433,12 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
         _queue(
             "m_env_width",
             a.pv_zones.below,
+            a.pv_zones.above,
             "plan",
             _SLOT_DIM_WIDTH,
             abs(x1 - x0),
+            (p1[0], p2[0]),
+            _env_label(width, dwg.draft),
             lambda pos, _p1=p1, _p2=p2, _w=witness, _v=_env_label(width, dwg.draft): _dim(
                 (_p1[0], _w, 0),
                 (_p2[0], _w, 0),
@@ -3415,9 +3471,12 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
         _queue(
             "m_env_depth",
             a.sv_zones.below,
+            a.sv_zones.above,
             "side",
             _SLOT_DIM_DEPTH,
             abs(y1 - y0),
+            (p1[0], p2[0]),
+            _env_label(depth, dwg.draft),
             lambda pos, _p1=p1, _p2=p2, _w=witness, _v=_env_label(depth, dwg.draft): _dim(
                 (_p1[0], _w, 0),
                 (_p2[0], _w, 0),

--- a/tests/test_e2e_standards.py
+++ b/tests/test_e2e_standards.py
@@ -47,31 +47,11 @@ def _assert_meets_standards(dwg, svg_path, dxf_path):
     assert any(isinstance(a, TitleBlock) for a in dwg.items), "no title block"
     assert len(dwg.items) >= 2, "expected dimensions + title block"
 
-    # Lint: no error-severity issues (warnings tolerated).
-    #
-    # ONE quarantined exception, #1236: a feature leader or a slot dim can fill a view's below
-    # corridor and starve the mandatory overall extent out of it, so CTC-01 and CTC-04 draw no
-    # overall width. That is a real defect and it is not new — it became visible only when
-    # #1216 gave the drop a lint code, because `render_envelope`'s candidate carried
-    # `on_drop=lambda _nm: None` and the dimension had been vanishing in silence.
-    #
-    # Quarantined rather than priced down. Reporting it below error severity would have kept
-    # this assertion green without listing anything, and a drawing missing its principal extent
-    # would report `passed: True` — moving the evidence under the gate instead of recording
-    # that the gate is failed for a known, filed reason (#1216 review r10, F5).
-    #
-    # Matched on the code AND the message, so any OTHER placement error on these fixtures still
-    # fails here. The ratchet that stops this quarantine outliving the defect is
-    # `test_issue_1215_no_approved_tolerance_is_dropped.py::test_a_starved_overall_extent_is_reported`,
-    # which asserts the extent is still absent and so fails the day #1236 is fixed.
-    errors = [
-        i
-        for i in dwg.lint()
-        if i.severity == "error"
-        and not (
-            i.code == "overall_dim_withheld" and "overall width dimension not placed" in i.message
-        )
-    ]
+    # Lint: no error-severity issues (warnings tolerated). This briefly carried a named
+    # quarantine for #1236 — CTC-01/04's overall width starved out of the below corridor by a
+    # feature leader — removed when the opposite-strip fallthrough landed and all ten CTC
+    # fixtures drew both extents again.
+    errors = [i for i in dwg.lint() if i.severity == "error"]
     assert not errors, f"lint errors: {[(i.code, i.message) for i in errors]}"
 
     data = Path(svg_path).read_text(encoding="utf-8")

--- a/tests/test_issue_1215_no_approved_tolerance_is_dropped.py
+++ b/tests/test_issue_1215_no_approved_tolerance_is_dropped.py
@@ -551,48 +551,69 @@ def _starved_extent_plate():
     return plate + boss.part
 
 
-def test_a_starved_overall_extent_is_reported():
-    """The overall extents were the only dimensions in the engine whose drop said nothing.
+def test_a_starved_overall_extent_recovers_to_the_above_strip():
+    """#1236: a feature leader spanning the below corridor must not cost the part its width.
 
-    Their corridor candidate carried `on_drop=lambda _nm: None` while every neighbouring pass
-    recorded `placement_unsatisfiable`, so a starved strip removed the part's width from the
-    sheet and the build issues, the lint and the score all stayed clean (#1216 review r9).
-
-    This asserts the REPORT, not the placement. Whether a feature leader may starve a mandatory
-    extent is an ADR 0014 question and is filed separately; it cannot be looked at at all while
-    the drop is invisible.
+    The hex boss's A/F leader fills the plan-below corridor, so `m_env_width` — force-kept,
+    mandatory — solves to `strip_full` there. For three review rounds that was the end of it:
+    the drop was first silent, then reported. Now it does what a starved slot or plate dim has
+    always done — retries on the opposite strip after every corridor has drained — because no
+    corridor-side fix reaches a leader (it is not a corridor candidate, so ordering cannot
+    arbitrate against it) and an overall dimension above the view is ordinary drafting.
     """
     drawing = build_drawing(_starved_extent_plate(), title="T", number="N")
-    # The precondition: this fixture really does lose the width dimension.
+    assert "m_env_width" in drawing.registry.names(), (
+        "the width no longer recovers: the fallthrough regressed, or the fixture stopped "
+        "starving the below strip and this test asserts nothing"
+    )
+    # It really is ABOVE the view — the precondition that the below strip was starved, and
+    # the fallthrough (not the ordinary corridor) placed it.
+    bounds = drawing.view_bounds("plan")
+    box = drawing.registry.named("m_env_width").label_bbox
+    assert box[1] > bounds[3], (
+        f"m_env_width's label sits at {box}, not above the plan view (top {bounds[3]}) — the "
+        "below strip stopped starving, so this fixture no longer reaches the fallthrough"
+    )
+    assert not [i for i in drawing.lint() if i.code == "overall_dim_withheld"]
+    assert not [i for i in drawing.lint() if i.severity == "error"]
+
+
+def test_a_doubly_starved_extent_is_still_reported(monkeypatch):
+    """Both strips full: the fallthrough fails and the drop must be reported, not vanish.
+
+    Constructed by refusing the fallthrough's own placement call (matched on its trace label,
+    every other call passes through untouched), because a fixture that genuinely fills BOTH
+    strips of a view would be an elaborate layout accident waiting to rot. The assertions are
+    the #1216 requirements: error severity so `passed` fails, the measurement attributed, the
+    occupants named — and NOT `placement_unsatisfiable`, which `builder._is_required_scale_drop`
+    matches by name and which made `build_drawing(scale=...)` raise (#1216 review r9/r10).
+    """
+    from draftwright.annotations import _common as common_mod
+    from draftwright.annotations import from_model as fm
+
+    real = common_mod.place_strip_candidates
+
+    def refuse_fallthrough(*args, **kwargs):
+        if str(kwargs.get("trace_label", "")).endswith("_above_fallthrough"):
+            return [name for name, _build in args[4]]
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(fm, "place_strip_candidates", refuse_fallthrough)
+    drawing = build_drawing(_starved_extent_plate(), title="T", number="N")
     assert "m_env_width" not in drawing.registry.names(), (
-        "precondition: this part now places its overall width, so the fixture no longer "
-        "reaches the starved-strip path"
+        "precondition: the refusal did not apply — the fallthrough placed the width anyway, "
+        "so nothing below tests the report"
     )
     reported = [i for i in drawing.lint() if i.code == "overall_dim_withheld"]
-    # Error severity, so a drawing missing its principal extent does not report `passed: True`.
-    # The scale gate keys on the CODE, not on this (#1216 review r10, F5).
-    assert all(i.severity == "error" for i in reported), [i.severity for i in reported]
-    summary = drawing.lint_summary()
-    assert summary["passed"] is False
-    # And it COUNTS as missing geometry. `_GEOMETRY_AWARE_CODES` exists so a lost requirement
-    # cannot report `geometry_issues: 0` alongside a drawing that lacks it; both withholding
-    # codes replace a silence rather than a different finding, so the count must include them
-    # (#1216 review r10, F4). Without the registration this drawing reported 0.
-    assert summary["geometry_issues"] >= 1, summary
-    assert any("width" in str(i.message) for i in reported), (
-        "the overall width never reached the sheet and nothing said so: "
-        f"{[(i.code, i.severity) for i in drawing.lint()]}"
+    assert reported, (
+        f"both strips full and nothing said so: {[(i.severity, i.code) for i in drawing.lint()]}"
     )
-    # It names what filled the strip, which is the whole point of reporting it,
+    assert all(i.severity == "error" for i in reported)
     assert any("occupied by" in str(i.message) for i in reported)
-    # and it carries the measurement, so a guard can ask about THIS extent rather than
-    # accepting any absence-shaped code in the build (#1216 review r9).
     assert any(getattr(i, "measurement_ids", ()) for i in reported)
-    # NOT `placement_unsatisfiable`: that code is a required scale drop, and reporting through
-    # it made `build_drawing(scale=...)` raise on parts that had always built. Asserted here so
-    # the code cannot drift back.
     assert not [i for i in drawing.lint() if i.code == "placement_unsatisfiable"]
-    build_drawing(_starved_extent_plate(), scale=1.0, title="T", number="N")
+    assert drawing.lint_summary()["passed"] is False
+    build_drawing(_starved_extent_plate(), scale=1.0, title="T", number="N")  # must not raise
 
 
 def _blind_plate_for_table():

--- a/tests/test_issue_1215_no_approved_tolerance_is_dropped.py
+++ b/tests/test_issue_1215_no_approved_tolerance_is_dropped.py
@@ -594,8 +594,15 @@ def test_a_doubly_starved_extent_is_still_reported(monkeypatch):
     real = common_mod.place_strip_candidates
 
     def refuse_fallthrough(*args, **kwargs):
-        if str(kwargs.get("trace_label", "")).endswith("_above_fallthrough"):
-            return [name for name, _build in args[4]]
+        # Exact names, not a suffix: the slot fallthrough's label `slot_above_fallthrough`
+        # also ends `_above_fallthrough`, so a suffix match would refuse a different pass on a
+        # slotted fixture and the docstring's "every other call passes through untouched"
+        # would be false (#1239 review F2).
+        if kwargs.get("trace_label") in (
+            "m_env_width_above_fallthrough",
+            "m_env_depth_above_fallthrough",
+        ):
+            return args[4]  # the (name, build) pairs, unplaced — the real return shape
         return real(*args, **kwargs)
 
     monkeypatch.setattr(fm, "place_strip_candidates", refuse_fallthrough)


### PR DESCRIPTION
A feature leader placed before the drain — the polygonal boss's A/F callout on
CTC-01, slot width dims on CTC-04 — can span a view's whole below corridor, and
`m_env_width`, force-kept and mandatory, still solved to `strip_full`: the part
shipped without its principal extent. #1216 made that drop visible; this makes
it recover.

Of the three options the issue sketched, the opposite-strip fallthrough is the
one that fits the existing architecture, and the other two fail for stated
reasons rather than taste:

- ORDERING cannot help: the starving leader is not a corridor candidate — it is
  placed by `_leader_callout_pass` before the drain — so no registration order
  or priority arbitrates against it.
- A RESERVED BAND would tax every drawing's leader placement to protect a rare
  starvation, and deciding its width re-opens exactly the budget-by-prediction
  ADR 0014 Amdt 3 forbids.
- The FALLTHROUGH is what the engine already does for a starved slot
  (`_far_or_drop`) and plate dim: retry on the opposite strip, deferred to
  `ctx.post_drain` per the #684 rule so a mid-drain placement cannot occupy
  space a not-yet-solved corridor's force candidate needs. An overall dimension
  above the view is ordinary drafting; a missing one is not.

If the above strip also refuses, the drop reports exactly as before — error
`overall_dim_withheld`, measurement attributed, occupants named, never
`placement_unsatisfiable` (the scale-gate code, #1216 r9/r10).

Relation to ADR 0018 (asked in review of the plan): 0018 is the structural
answer to this failure class — layout candidates validated against requirement
survival would reject the starving arrangement before placement. It is accepted
with nothing implemented, so this fix stays strictly inside ADR 0014: a
within-layout recovery that remains correct under 0018, whose "did the
requirement survive" input is what ADR 0019's outcome ledger will compute.

Verified:
- CTC-01 AP203/AP242 and CTC-04 AP203/AP242 all draw `m_env_width` +
  `m_env_depth`; no error-severity lint on any of the ten CTC fixtures, so the
  #1236 quarantine in `_assert_meets_standards` is DELETED, not narrowed.
- `_starved_extent_plate` places its width ABOVE the plan view (label box
  y > view top asserted — the precondition that the below strip still starves).
- The both-strips-full branch is tested by refusing the fallthrough's own
  placement call (matched on its trace label; a fixture genuinely filling both
  strips of one view would be a layout accident waiting to rot): error
  severity, attribution, named occupants, `passed` False, and
  `build_drawing(scale=1.0)` does not raise.
- Mutations killed: fallthrough removed -> the recovery test fails; the r10
  battery re-run where touched.
- Golden placements unchanged: the fallthrough engages only on a drop that was
  previously terminal.

4384 passed (fast), 44 passed (slow), pr-check --static exit 0.

Closes #1236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTXU3X3YFa1HPRdmUgCw22