### PR TITLE
Make the above strips and the iso view visible to each other (#1240)

### DIFF
--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -982,6 +982,40 @@ def occupancy_boxes(o, stroke_pad=None):
 _STROKE_PAD = 1.2
 
 
+#: Annotations whose Compound bounding box spans the whole page. They carry no ``.segments``
+#: to decompose, so :func:`annotation_obstacle_boxes` falls back to the full geometry box and
+#: they swallow the sheet — any occupancy test that includes them is a silent no-op. Filtered
+#: by `late_furniture_obstacles` (#1145), by three checks in `linting/structural`, and — since
+#: #1240 review round 2 — by `annotation_ink_obstacles`, because the iso fit had picked
+#: `strip_obstacles` instead and `--frame` therefore disabled the fit entirely.
+_PAGE_SPANNING_RIDERS = ("is_sheet_frame", "is_zone_grid")
+
+
+def is_page_spanning_rider(annotation) -> bool:
+    """Is *annotation* one of the page-spanning riders (see :data:`_PAGE_SPANNING_RIDERS`)?
+
+    One predicate, because the filter has been written out by hand in five places and the
+    sixth site got it wrong: the fit's obstacle set omitted it and a framed sheet's iso stopped
+    growing, silently, with the whole fast tier green (#1240 review r2).
+    """
+    return any(getattr(annotation, rider, False) for rider in _PAGE_SPANNING_RIDERS)
+
+
+def annotation_ink_obstacles(dwg, *, named=False):
+    """Every placed annotation's decomposed ink, minus the page-spanning riders.
+
+    What a placement or fit outside the strip system needs: the same occupancy
+    :func:`strip_obstacles` computes, without the frame/zone-grid boxes that would make the
+    test vacuous — and WITHOUT the views that :func:`late_furniture_obstacles` adds, which the
+    iso fit must not see (it would treat itself as an obstacle and never grow).
+    """
+    return [
+        (name, box) if named else box
+        for name, box in strip_obstacles(dwg, named=True)
+        if not is_page_spanning_rider(dwg.get_annotation(name))
+    ]
+
+
 def late_furniture_obstacles(dwg, *, named=False):
     """Everything a POST-FIT placement must keep clear of, as AABBs.
 
@@ -1012,7 +1046,7 @@ def late_furniture_obstacles(dwg, *, named=False):
     ]
     for annotation_name, box in strip_obstacles(dwg, named=True):
         annotation = dwg.get_annotation(annotation_name)
-        if any(getattr(annotation, rider, False) for rider in ("is_sheet_frame", "is_zone_grid")):
+        if is_page_spanning_rider(annotation):
             continue
         obstacles.append((f"annotation:{annotation_name}", box))
 

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -328,7 +328,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # that the iso has been projected and fitted.  Always apply so that any
     # future allocations are bounded; warn when the cursor has already passed
     # the limit (dims already placed may overlap the iso view).
-    _iso_x0, _iso_y0, _, _iso_y1 = _iso_bbox(dwg)
+    _iso_x0, _iso_y0, _iso_x1, _iso_y1 = _iso_bbox(dwg)
     _iso_x_limit = _iso_x0 - 4
     # Only tighten a right strip when the iso shares the strip's y-range: a strip
     # that abuts the iso horizontally would otherwise lose annotation space, while
@@ -345,6 +345,28 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
             _right_strips.append(_rs)
     for _rs in _right_strips:
         _rs.outer_limit = min(_rs.outer_limit, _iso_x_limit)
+
+    # The same guard for the page-reaching ABOVE strips (#1240). The right strips have been
+    # iso-clamped since the zone carve; the above strips had only the per-pass m_locy clamp,
+    # so every other above-strip resident — GD&T frames, grid pitch dims, #1236's overall-
+    # extent fallthrough — could stack under the iso unchecked: `strip_obstacles` is
+    # annotations-only by documented design (views enter `late_furniture_obstacles`, not the
+    # strip carve), so nothing else stood between them. Same x/y transposition of the same
+    # rule, same overlap guard, same reason for it: clamping a strip the iso does not
+    # horizontally overlap would cost annotation space for nothing. The m_locy clamp stays —
+    # it fires earlier (a 14 mm approach buffer, not bbox overlap) and is strictly tighter.
+    _iso_y_limit = _iso_y0 - 4
+    for _as, _x0, _x1 in (
+        (a.pv_zones.above, a.PV_X - a.fv_hw, a.PV_X + a.fv_hw),
+        (a.sv_zones.above, a.SV_X - a.sv_hw, a.SV_X + a.sv_hw),
+    ):
+        # Clamp only when the iso is actually IN the strip's path — x-overlapping AND above
+        # the strip anchor. The right-strip block's warning transposes exactly: an iso that
+        # x-overlaps the view from BELOW it (a lower-right zone beside a wide plan) would
+        # otherwise push the outer_limit beneath the anchor and break every allocation — four
+        # hole/slot fixtures lost their location dims to precisely that in the first cut.
+        if _x0 < _iso_x1 and _iso_x0 < _x1 and _iso_y_limit > _as.anchor:
+            _as.outer_limit = min(_as.outer_limit, _iso_y_limit)
 
     # Per-hole annotations from the feature records (#91, #92, #95): each
     # hole is annotated in the view its axis is normal to.

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -460,8 +460,6 @@ def _assemble(
         _fv_ol = a.fv_zones.right.outer_limit
         _pv_ol = a.pv_zones.right.outer_limit
         _sv_ol = a.sv_zones.right.outer_limit
-        _pv_a_ol = a.pv_zones.above.outer_limit
-        _sv_a_ol = a.sv_zones.above.outer_limit
         # The orchestrator RETURNS the omission ledger rather than writing a drawing private,
         # so `annotations/` stays off the state bus (#639/#830). Filled at the single site
         # below, not here — see there (#996 / ADR 0005 §2).
@@ -486,16 +484,19 @@ def _assemble(
         # strips after the build).
         _ix1 = _iso_bbox(dwg)[2]
         _iso_y_lim = _iy0 - 4
-        for _strip, _ol, _x0, _x1 in (
-            (a.pv_zones.above, _pv_a_ol, a.PV_X - a.fv_hw, a.PV_X + a.fv_hw),
-            (a.sv_zones.above, _sv_a_ol, a.SV_X - a.sv_hw, a.SV_X + a.sv_hw),
+        for _strip, _x0, _x1 in (
+            (a.pv_zones.above, a.PV_X - a.fv_hw, a.PV_X + a.fv_hw),
+            (a.sv_zones.above, a.SV_X - a.sv_hw, a.SV_X + a.sv_hw),
         ):
-            # Same anchor guard as the initial clamp: an iso x-overlapping the view from
-            # BELOW must not push the limit beneath the anchor and kill the strip.
+            # TIGHTEN ONLY — no restore-from-snapshot, unlike the right strips above. Their
+            # snapshot exists to give back space `_auto_annotate` took against a transient,
+            # possibly-overflowing iso; the above strips have no such pre-existing
+            # over-tightening to undo, and restoring would DISCARD the `m_locy` approach-buffer
+            # clamp (`from_model`), which is a different constraint that must survive
+            # (#1240 review F4). Same anchor guard as the initial clamp: an iso x-overlapping
+            # the view from BELOW must not push the limit beneath the anchor and kill the strip.
             if _x0 < _ix1 and _ix0 < _x1 and _iso_y_lim > _strip.anchor:
-                _strip.outer_limit = min(_ol, _iso_y_lim)
-            else:
-                _strip.outer_limit = _ol
+                _strip.outer_limit = min(_strip.outer_limit, _iso_y_lim)
     else:
         # Fit + label the iso as the auto path does (annotate defaults True): the NTS
         # note is sheet furniture — like the title block below — that states the iso is

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -43,7 +43,7 @@ from draftwright._core import (
 )
 from draftwright._warnings import ScaleCompletenessWarning
 from draftwright.analysis import Analysis, _analyse
-from draftwright.annotations._common import SolveTrace, place_iso_nts_note
+from draftwright.annotations._common import SolveTrace, place_iso_nts_note, strip_obstacles
 from draftwright.annotations.gears import render_gear_tables
 from draftwright.annotations.orchestrator import (
     _auto_annotate,
@@ -460,11 +460,16 @@ def _assemble(
         _fv_ol = a.fv_zones.right.outer_limit
         _pv_ol = a.pv_zones.right.outer_limit
         _sv_ol = a.sv_zones.right.outer_limit
+        _pv_a_ol = a.pv_zones.above.outer_limit
+        _sv_a_ol = a.sv_zones.above.outer_limit
         # The orchestrator RETURNS the omission ledger rather than writing a drawing private,
         # so `annotations/` stays off the state bus (#639/#830). Filled at the single site
         # below, not here — see there (#996 / ADR 0005 §2).
         _diagnostics = _auto_annotate(dwg, a, detail_view=detail_view)
-        _nts_bb = _fit_iso_view(dwg, a)
+        # The placed annotations are the fit's obstacles (#1240): the grow branch may not
+        # invade ink that placed legally against the pre-fit iso. Computed HERE because the
+        # fit sits below the occupancy model and must not own an obstacle set (#1197).
+        _nts_bb = _fit_iso_view(dwg, a, obstacles=strip_obstacles(dwg))
         _ix0, _iy0, _, _iy1 = _iso_bbox(dwg)
         _final_iso_x_lim = _ix0 - 4
         a.fv_zones.right.outer_limit = min(_fv_ol, _final_iso_x_lim)
@@ -475,12 +480,28 @@ def _assemble(
             a.sv_zones.right.outer_limit = min(_sv_ol, _final_iso_x_lim)
         else:
             a.sv_zones.right.outer_limit = _sv_ol
+        # Mirror for the ABOVE strips (#1240): restore, then re-cap below the FINAL iso only
+        # where the fitted iso horizontally overlaps that view — the transposition of the
+        # right-strip re-cap above, for the same customer (deferred edits place through these
+        # strips after the build).
+        _ix1 = _iso_bbox(dwg)[2]
+        _iso_y_lim = _iy0 - 4
+        for _strip, _ol, _x0, _x1 in (
+            (a.pv_zones.above, _pv_a_ol, a.PV_X - a.fv_hw, a.PV_X + a.fv_hw),
+            (a.sv_zones.above, _sv_a_ol, a.SV_X - a.sv_hw, a.SV_X + a.sv_hw),
+        ):
+            # Same anchor guard as the initial clamp: an iso x-overlapping the view from
+            # BELOW must not push the limit beneath the anchor and kill the strip.
+            if _x0 < _ix1 and _ix0 < _x1 and _iso_y_lim > _strip.anchor:
+                _strip.outer_limit = min(_ol, _iso_y_lim)
+            else:
+                _strip.outer_limit = _ol
     else:
         # Fit + label the iso as the auto path does (annotate defaults True): the NTS
         # note is sheet furniture — like the title block below — that states the iso is
         # not to scale. Suppressing it here silently diverged the emitted-script drawing
         # (auto_dims=False) from the direct CLI, which always labels it (script↔CLI parity).
-        _nts_bb = _fit_iso_view(dwg, a)
+        _nts_bb = _fit_iso_view(dwg, a, obstacles=strip_obstacles(dwg))
         _add_title_block(dwg, a)
         if a.frame:  # sheet border (#767) — auto path adds it via the orchestrator
             _add_sheet_frame(dwg, a)

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -43,7 +43,11 @@ from draftwright._core import (
 )
 from draftwright._warnings import ScaleCompletenessWarning
 from draftwright.analysis import Analysis, _analyse
-from draftwright.annotations._common import SolveTrace, place_iso_nts_note, strip_obstacles
+from draftwright.annotations._common import (
+    SolveTrace,
+    annotation_ink_obstacles,
+    place_iso_nts_note,
+)
 from draftwright.annotations.gears import render_gear_tables
 from draftwright.annotations.orchestrator import (
     _auto_annotate,
@@ -467,7 +471,14 @@ def _assemble(
         # The placed annotations are the fit's obstacles (#1240): the grow branch may not
         # invade ink that placed legally against the pre-fit iso. Computed HERE because the
         # fit sits below the occupancy model and must not own an obstacle set (#1197).
-        _nts_bb = _fit_iso_view(dwg, a, obstacles=strip_obstacles(dwg))
+        #
+        # `annotation_ink_obstacles`, NOT `strip_obstacles`: the sheet frame and zone grid are
+        # registered annotations whose Compound bbox spans the page, so the raw strip set made
+        # the iso overlap an "obstacle" at every factor and `--frame` disabled the fit
+        # altogether — no growth, no NTS caption, fast tier green. It also broke script/CLI
+        # parity, since the `auto_dims=False` branch below computes its obstacles before the
+        # frame is added and so kept growing (#1240 review r2).
+        _nts_bb = _fit_iso_view(dwg, a, obstacles=annotation_ink_obstacles(dwg))
         _ix0, _iy0, _, _iy1 = _iso_bbox(dwg)
         _final_iso_x_lim = _ix0 - 4
         a.fv_zones.right.outer_limit = min(_fv_ol, _final_iso_x_lim)
@@ -502,7 +513,7 @@ def _assemble(
         # note is sheet furniture — like the title block below — that states the iso is
         # not to scale. Suppressing it here silently diverged the emitted-script drawing
         # (auto_dims=False) from the direct CLI, which always labels it (script↔CLI parity).
-        _nts_bb = _fit_iso_view(dwg, a, obstacles=strip_obstacles(dwg))
+        _nts_bb = _fit_iso_view(dwg, a, obstacles=annotation_ink_obstacles(dwg))
         _add_title_block(dwg, a)
         if a.frame:  # sheet border (#767) — auto path adds it via the orchestrator
             _add_sheet_frame(dwg, a)

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -54,6 +54,7 @@ from draftwright.annotations._common import (
     _register_hole_table_coverage,
     carve_free_position,
     late_furniture_obstacles,
+    strip_obstacles,
 )
 from draftwright.annotations.balloons import render_balloons
 from draftwright.annotations.leaders import drain_feature_leaders
@@ -2616,7 +2617,10 @@ class Drawing:
                     _project_iso(self, a, a.SCALE)
                 _resolve_details(self, a, ctx=ctx)
                 if "iso" in self.views:
-                    _fit_iso_view(self, a)
+                    # Obstacles as on the build path (#1240) — inert today, since a details
+                    # refit disables the grow branch, but the call must not drift from the
+                    # builder's shape or the next grow-path change silently loses the cap.
+                    _fit_iso_view(self, a, obstacles=strip_obstacles(self))
 
         def _s_tabulate():
             # Dense-scattered plan-view holes escalate to the hole TABLE + balloon ring —

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -52,9 +52,9 @@ from draftwright._core import (
 from draftwright.annotations._common import (
     PlacementContext,
     _register_hole_table_coverage,
+    annotation_ink_obstacles,
     carve_free_position,
     late_furniture_obstacles,
-    strip_obstacles,
 )
 from draftwright.annotations.balloons import render_balloons
 from draftwright.annotations.leaders import drain_feature_leaders
@@ -2620,7 +2620,7 @@ class Drawing:
                     # Obstacles as on the build path (#1240) — inert today, since a details
                     # refit disables the grow branch, but the call must not drift from the
                     # builder's shape or the next grow-path change silently loses the cap.
-                    _fit_iso_view(self, a, obstacles=strip_obstacles(self))
+                    _fit_iso_view(self, a, obstacles=annotation_ink_obstacles(self))
 
         def _s_tabulate():
             # Dense-scattered plan-view holes escalate to the hole TABLE + balloon ring —

--- a/src/draftwright/projection.py
+++ b/src/draftwright/projection.py
@@ -34,6 +34,7 @@ from draftwright._core import (
 )
 from draftwright._geometry import (
     MaterialField,
+    _boxes_overlap,
     material_field,
 )
 
@@ -358,30 +359,55 @@ def _project_iso(dwg, a: Analysis, scale, shape_s=None):
     )
 
 
-def _iso_grow_cap(bb, cx, cy, obstacles) -> float:
-    """The largest scale factor about ``(cx, cy)`` at which *bb* still avoids every obstacle.
+#: Bisection steps for :func:`_largest_clear_factor`. Each step is one re-projection plus a
+#: bbox read — measured at 0.3-0.5 ms on the parts in this suite — so eight steps resolve the
+#: factor to ~0.4 % of the growth corridor for a few milliseconds on the one path that grows.
+_ISO_CLEAR_STEPS = 8
 
-    Pure interval arithmetic, no occupancy knowledge — the obstacle boxes are the CALLER's
-    statement of what is already on the sheet, because this module sits below the occupancy
-    model and every hand-rolled obstacle set it has owned was wrong (#1197). Scaling about the
-    centre is monotone per axis, so overlap with a box begins at ``max(fx, fy)`` — the factor
-    at which BOTH axes first overlap — and the admissible cap is the minimum of that over the
-    obstacles. A box already straddling the centre on both axes returns 0.0 (no growth);
-    no obstacles returns ``inf`` (#1240).
+
+def _largest_clear_factor(dwg, a, hi, obstacles) -> float:
+    """The largest factor in ``[1, hi]`` whose RE-PROJECTED iso clears every obstacle.
+
+    **Measured, not predicted** — ADR 0014 Amendment 3, and this function is the second time
+    that amendment has been learned the hard way. Its first version computed the answer from a
+    linear model: re-projection at factor *f* maps each bbox edge *e* to ``c + f*(e-c)`` about
+    the page centre. That is false. `_project_iso` scales the part about the WORLD ORIGIN, so a
+    solid carrying a non-identity Location — every authored `build123d` part, since the
+    primitives are centred by construction — has its projected bbox TRANSLATE as it scales:
+
+        Cylinder(20, 60) at f=1.3, y edges predicted [86.15, 179.85], measured [93.49, 187.20]
+
+    a 7.3 mm drift against a 0.98 clearance margin worth 0.75 mm. The prediction's "capped"
+    iso grew straight through the obstacle it was capped by, worst exactly where growth is
+    largest. STEP-imported solids arrive with identity Location and ARE linear, which is why
+    all ten CTC fixtures agreed with the model and the defect survived two hunts (#1240 review
+    F1).
+
+    Bisection on the real projection has no model to be wrong about. The drawing is left
+    projected at an arbitrary probe scale; the caller re-projects at the returned factor.
     """
+    if not obstacles or hi <= 1.0:
+        return float(hi)
 
-    def _onset(lo, hi, c, olo, ohi) -> float:
-        # The factor at which [c + f*(lo-c), c + f*(hi-c)] begins to overlap [olo, ohi].
-        if ohi <= c:
-            return (c - ohi) / (c - lo) if lo < c else math.inf
-        if olo >= c:
-            return (olo - c) / (hi - c) if hi > c else math.inf
-        return 0.0  # the obstacle straddles the centre on this axis
+    def clear(factor) -> bool:
+        _project_iso(dwg, a, a.SCALE * factor)
+        box = _iso_bbox(dwg)
+        return not any(_boxes_overlap(box, obstacle) for obstacle in obstacles)
 
-    cap = math.inf
-    for ox0, oy0, ox1, oy1 in obstacles:
-        cap = min(cap, max(_onset(bb[0], bb[2], cx, ox0, ox1), _onset(bb[1], bb[3], cy, oy0, oy1)))
-    return cap
+    if clear(hi):
+        return float(hi)
+    if not clear(1.0):
+        # Already overlapping at sheet scale: growth is not what put it there and shrinking is
+        # not this branch's job. Report no growth and leave the conflict to lint.
+        return 1.0
+    lo = 1.0
+    for _ in range(_ISO_CLEAR_STEPS):
+        mid = (lo + hi) / 2
+        if clear(mid):
+            lo = mid
+        else:
+            hi = mid
+    return lo
 
 
 def _fit_iso_view(dwg, a: Analysis, obstacles=()):
@@ -453,15 +479,23 @@ def _fit_iso_view(dwg, a: Analysis, obstacles=()):
         # 0.88 — which turned any obstacle in the middle of the growth corridor into a veto:
         # the capped factor fell under the 5 % no-op threshold and the iso stayed at sheet
         # scale instead of growing up to the box.
-        grow = needed * 0.90
-        cap = _iso_grow_cap(bb, a.ISO_X, a.ISO_Y, obstacles)
-        if cap < math.inf:
-            grow = min(grow, cap * 0.98)
-        factor = math.floor(grow * 10000) / 10000
+        factor = math.floor(needed * 0.90 * 10000) / 10000
         factor = max(factor, 1.0)  # grow branch must never shrink
         factor = min(factor, _ISO_MAX_GROW)  # never dwarf the dimensioned views
+        if obstacles and factor > 1.0:
+            factor = _largest_clear_factor(dwg, a, factor, obstacles)
+            _project_iso(dwg, a, a.SCALE)  # undo the probes; the tail re-projects if it grows
+            factor = math.floor(factor * 10000) / 10000
     else:
         # Iso overflows; shrink to just fit with 2 % safety margin.
+        #
+        # NOT obstacle-checked, and deliberately not justified by "shrinking about the centre
+        # cannot create an overlap absent at 1.0" — the first version of this said that, and it
+        # rests on the same false linear model `_largest_clear_factor` exists to replace: the
+        # shrink translates too (a tall cylinder's bbox measured 3.5 mm below prediction at
+        # f=0.905). The real reason is that this branch has no choice: the iso OVERFLOWS its
+        # page region, so it must shrink whatever else is nearby, and a resulting collision is
+        # reported by `view_annotation_overlap` rather than prevented here (#1240 review F3).
         factor = math.floor(needed * 0.98 * 10000) / 10000
     if abs(factor - 1.0) < 0.05:
         return  # within 5 % of sheet scale — no rescale, no NTS label

--- a/src/draftwright/projection.py
+++ b/src/draftwright/projection.py
@@ -378,19 +378,22 @@ def _largest_clear_factor(dwg, a, hi, obstacles, base_box) -> float:
     about the page centre. That is false. The projected bbox is affine in *f* but carries a
     translation term as well as the scale, so the model drifts linearly with the factor:
 
-        Cylinder(20, 60)          f=1.2  +4.899 mm   f=1.3  +7.348 mm   (top edge)
+        Cylinder(20, 60)          f=1.2  +4.899 mm   f=1.3  +7.348 mm   (top edge, macOS)
         Box(40, 30, 8)            f=1.2  +0.490 mm   f=1.3  +0.735 mm
         nist_ctc_01_asme1_ap203   f=1.2  -0.816 mm   f=1.3  -1.225 mm
 
     against a clearance margin worth well under a millimetre. The prediction's "capped" iso
     grew straight through the obstacle it was capped by, worst exactly where growth is largest.
 
-    The size of the drift tracks how far the part sits from the origin it is scaled about, and
-    an authored `build123d` primitive — centred by construction, so carrying a non-identity
-    Location — drifts hardest. But it is NOT a property only authored parts have: the second
-    version of this docstring claimed "STEP-imported solids arrive with identity Location and
-    ARE linear", and CTC-01 above has an identity Location and drifts 1.2 mm. A false
-    explanation for why the first defect escaped, written into its fix (#1240 review r2, F3).
+    The drift tracks the Location the engine gives `a.part` — the offset between the origin the
+    part is scaled about and the point the view is centred on. Two attempts to say more than
+    that were wrong and are worth recording, because both were written INTO a fix for the
+    previous one: "scales the part about the WORLD ORIGIN" (wrong mechanism), and
+    "STEP-imported solids arrive with identity Location and ARE linear" — CTC-01 above has an
+    identity input Location and drifts 1.2 mm (#1240 review r2, F3). The measured amount is
+    also platform-dependent: `Cylinder(20, 60)` drifts 7.35 mm on macOS and exactly zero on
+    Linux, which is why the guard for this is driven by a synthetic projection rather than by
+    any real part's incidental placement.
 
     Bisection on the real projection has no model to be wrong about. `lo` is only ever assigned
     a factor measured clear, so the result is always genuinely clear — but it is not

--- a/src/draftwright/projection.py
+++ b/src/draftwright/projection.py
@@ -359,47 +359,70 @@ def _project_iso(dwg, a: Analysis, scale, shape_s=None):
     )
 
 
-#: Bisection steps for :func:`_largest_clear_factor`. Each step is one re-projection plus a
-#: bbox read — measured at 0.3-0.5 ms on the parts in this suite — so eight steps resolve the
-#: factor to ~0.4 % of the growth corridor for a few milliseconds on the one path that grows.
-_ISO_CLEAR_STEPS = 8
+#: Bisection steps for :func:`_largest_clear_factor`. Five halvings of a corridor at most
+#: 0.3 wide resolve the factor to ~0.01 — under 1 % of the growth available, ~1 mm on a
+#: 130 mm iso, and far below the ~1.2 mm the obstacle boxes are already inflated by
+#: (`_STROKE_PAD`). Each step is one re-projection plus a bbox read, and that is NOT free on a
+#: real part: measured 0.28 ms on `Cylinder(20, 60)` but **14.2 ms** on CTC-01 AP203, so the
+#: search costs ~85 ms there. The first version of this comment said "0.3-0.5 ms … a few
+#: milliseconds", having measured only the trivial parts (#1240 review r2, F4).
+_ISO_CLEAR_STEPS = 5
 
 
-def _largest_clear_factor(dwg, a, hi, obstacles) -> float:
-    """The largest factor in ``[1, hi]`` whose RE-PROJECTED iso clears every obstacle.
+def _largest_clear_factor(dwg, a, hi, obstacles, base_box) -> float:
+    """A factor in ``[1, hi]`` whose RE-PROJECTED iso clears every obstacle, as large as this
+    search finds.
 
-    **Measured, not predicted** — ADR 0014 Amendment 3, and this function is the second time
-    that amendment has been learned the hard way. Its first version computed the answer from a
-    linear model: re-projection at factor *f* maps each bbox edge *e* to ``c + f*(e-c)`` about
-    the page centre. That is false. `_project_iso` scales the part about the WORLD ORIGIN, so a
-    solid carrying a non-identity Location — every authored `build123d` part, since the
-    primitives are centred by construction — has its projected bbox TRANSLATE as it scales:
+    **Measured, not predicted** — ADR 0014 Amendment 3. Its first version computed the answer
+    from a linear model: re-projection at factor *f* maps each bbox edge *e* to ``c + f*(e-c)``
+    about the page centre. That is false. The projected bbox is affine in *f* but carries a
+    translation term as well as the scale, so the model drifts linearly with the factor:
 
-        Cylinder(20, 60) at f=1.3, y edges predicted [86.15, 179.85], measured [93.49, 187.20]
+        Cylinder(20, 60)          f=1.2  +4.899 mm   f=1.3  +7.348 mm   (top edge)
+        Box(40, 30, 8)            f=1.2  +0.490 mm   f=1.3  +0.735 mm
+        nist_ctc_01_asme1_ap203   f=1.2  -0.816 mm   f=1.3  -1.225 mm
 
-    a 7.3 mm drift against a 0.98 clearance margin worth 0.75 mm. The prediction's "capped"
-    iso grew straight through the obstacle it was capped by, worst exactly where growth is
-    largest. STEP-imported solids arrive with identity Location and ARE linear, which is why
-    all ten CTC fixtures agreed with the model and the defect survived two hunts (#1240 review
-    F1).
+    against a clearance margin worth well under a millimetre. The prediction's "capped" iso
+    grew straight through the obstacle it was capped by, worst exactly where growth is largest.
 
-    Bisection on the real projection has no model to be wrong about. The drawing is left
-    projected at an arbitrary probe scale; the caller re-projects at the returned factor.
+    The size of the drift tracks how far the part sits from the origin it is scaled about, and
+    an authored `build123d` primitive — centred by construction, so carrying a non-identity
+    Location — drifts hardest. But it is NOT a property only authored parts have: the second
+    version of this docstring claimed "STEP-imported solids arrive with identity Location and
+    ARE linear", and CTC-01 above has an identity Location and drifts 1.2 mm. A false
+    explanation for why the first defect escaped, written into its fix (#1240 review r2, F3).
+
+    Bisection on the real projection has no model to be wrong about. `lo` is only ever assigned
+    a factor measured clear, so the result is always genuinely clear — but it is not
+    necessarily the LARGEST such factor: with several obstacles the clear set can be
+    non-contiguous, and a bisection that lands in a lower island stays there. Conservative in
+    the safe direction, and not worth exact interval arithmetic over an affine model this
+    function exists because a model was wrong (#1240 review r2, F5).
+
+    *base_box* is the iso bbox at sheet scale, which the caller has already measured. The
+    drawing is left projected at an arbitrary probe scale; the caller re-projects.
     """
     if not obstacles or hi <= 1.0:
         return float(hi)
 
+    def hits(box) -> bool:
+        return any(_boxes_overlap(box, obstacle) for obstacle in obstacles)
+
     def clear(factor) -> bool:
         _project_iso(dwg, a, a.SCALE * factor)
-        box = _iso_bbox(dwg)
-        return not any(_boxes_overlap(box, obstacle) for obstacle in obstacles)
+        return not hits(_iso_bbox(dwg))
 
+    # *base_box* is the caller's already-measured f=1 bbox, so the f=1 reading costs nothing.
+    # Passed in rather than read off `dwg`: reading it here would silently depend on the
+    # drawing being projected at sheet scale on entry, and the first version did exactly that
+    # — a caller (this file's own test) that had probed the projection first got 1.0 back for
+    # every input.
+    if hits(base_box):
+        # Already overlapping before any growth: growth is not what put it there, and shrinking
+        # is not this branch's job. Report no growth and leave the conflict to lint.
+        return 1.0
     if clear(hi):
         return float(hi)
-    if not clear(1.0):
-        # Already overlapping at sheet scale: growth is not what put it there and shrinking is
-        # not this branch's job. Report no growth and leave the conflict to lint.
-        return 1.0
     lo = 1.0
     for _ in range(_ISO_CLEAR_STEPS):
         mid = (lo + hi) / 2
@@ -449,6 +472,7 @@ def _fit_iso_view(dwg, a: Analysis, obstacles=()):
             region_left = max(region_left, sec_right + 4)
     region = (region_left, a.iso_bottom_limit, a.iso_right_limit, a.iso_top_limit)
     bb = _iso_bbox(dwg)
+    probed = False  # did the obstacle search leave the iso projected at a probe scale?
     ratios = [
         avail / extent
         for extent, avail in (
@@ -483,9 +507,9 @@ def _fit_iso_view(dwg, a: Analysis, obstacles=()):
         factor = max(factor, 1.0)  # grow branch must never shrink
         factor = min(factor, _ISO_MAX_GROW)  # never dwarf the dimensioned views
         if obstacles and factor > 1.0:
-            factor = _largest_clear_factor(dwg, a, factor, obstacles)
-            _project_iso(dwg, a, a.SCALE)  # undo the probes; the tail re-projects if it grows
-            factor = math.floor(factor * 10000) / 10000
+            searched = _largest_clear_factor(dwg, a, factor, obstacles, bb)
+            factor = math.floor(searched * 10000) / 10000
+            probed = True
     else:
         # Iso overflows; shrink to just fit with 2 % safety margin.
         #
@@ -498,6 +522,10 @@ def _fit_iso_view(dwg, a: Analysis, obstacles=()):
         # reported by `view_annotation_overlap` rather than prevented here (#1240 review F3).
         factor = math.floor(needed * 0.98 * 10000) / 10000
     if abs(factor - 1.0) < 0.05:
+        # Undo the probes ONLY here: every other exit re-projects at `factor` below, so the
+        # restore would be a wasted projection — and on CTC-01 a projection is 14 ms.
+        if probed:
+            _project_iso(dwg, a, a.SCALE)
         return  # within 5 % of sheet scale — no rescale, no NTS label
     _project_iso(dwg, a, a.SCALE * factor)
     bb = _iso_bbox(dwg)

--- a/src/draftwright/projection.py
+++ b/src/draftwright/projection.py
@@ -358,7 +358,33 @@ def _project_iso(dwg, a: Analysis, scale, shape_s=None):
     )
 
 
-def _fit_iso_view(dwg, a: Analysis):
+def _iso_grow_cap(bb, cx, cy, obstacles) -> float:
+    """The largest scale factor about ``(cx, cy)`` at which *bb* still avoids every obstacle.
+
+    Pure interval arithmetic, no occupancy knowledge — the obstacle boxes are the CALLER's
+    statement of what is already on the sheet, because this module sits below the occupancy
+    model and every hand-rolled obstacle set it has owned was wrong (#1197). Scaling about the
+    centre is monotone per axis, so overlap with a box begins at ``max(fx, fy)`` — the factor
+    at which BOTH axes first overlap — and the admissible cap is the minimum of that over the
+    obstacles. A box already straddling the centre on both axes returns 0.0 (no growth);
+    no obstacles returns ``inf`` (#1240).
+    """
+
+    def _onset(lo, hi, c, olo, ohi) -> float:
+        # The factor at which [c + f*(lo-c), c + f*(hi-c)] begins to overlap [olo, ohi].
+        if ohi <= c:
+            return (c - ohi) / (c - lo) if lo < c else math.inf
+        if olo >= c:
+            return (olo - c) / (hi - c) if hi > c else math.inf
+        return 0.0  # the obstacle straddles the centre on this axis
+
+    cap = math.inf
+    for ox0, oy0, ox1, oy1 in obstacles:
+        cap = min(cap, max(_onset(bb[0], bb[2], cx, ox0, ox1), _onset(bb[1], bb[3], cy, oy0, oy1)))
+    return cap
+
+
+def _fit_iso_view(dwg, a: Analysis, obstacles=()):
     """Scale the iso view to fill its page zone; return its bbox when the result is
     NOT to sheet scale and therefore needs an NTS caption, else ``None``.
 
@@ -415,15 +441,28 @@ def _fit_iso_view(dwg, a: Analysis):
         # already-fitting orientation view at its current scale.
         return
     if needed >= 1.0:
-        # Iso fits; grow to 90 % of zone — leaves comfortable breathing room.
-        margin_pct = 0.90
-    else:
-        # Iso overflows; shrink to just fit with 2 % safety margin.
-        margin_pct = 0.98
-    factor = math.floor(needed * margin_pct * 10000) / 10000
-    if needed >= 1.0:
+        # Iso fits; grow to 90 % of zone — leaves comfortable breathing room — capped by the
+        # caller's obstacle boxes (#1240): the zone is the largest view-free rectangle, and
+        # annotations are free to live in it — the above strips run into it — so growing to
+        # the zone edge could grow ONTO a placed annotation, invisibly to both sides
+        # (annotations avoid the iso at its pre-fit size; the fit never saw annotations).
+        #
+        # The two margins guard DIFFERENT edges and must not compound: 0.90 is breathing room
+        # from the zone boundary, 0.98 (the shrink branch's own figure) is clearance off an
+        # obstacle's edge. The first cut multiplied the obstacle cap by both — an effective
+        # 0.88 — which turned any obstacle in the middle of the growth corridor into a veto:
+        # the capped factor fell under the 5 % no-op threshold and the iso stayed at sheet
+        # scale instead of growing up to the box.
+        grow = needed * 0.90
+        cap = _iso_grow_cap(bb, a.ISO_X, a.ISO_Y, obstacles)
+        if cap < math.inf:
+            grow = min(grow, cap * 0.98)
+        factor = math.floor(grow * 10000) / 10000
         factor = max(factor, 1.0)  # grow branch must never shrink
         factor = min(factor, _ISO_MAX_GROW)  # never dwarf the dimensioned views
+    else:
+        # Iso overflows; shrink to just fit with 2 % safety margin.
+        factor = math.floor(needed * 0.98 * 10000) / 10000
     if abs(factor - 1.0) < 0.05:
         return  # within 5 % of sheet scale — no rescale, no NTS label
     _project_iso(dwg, a, a.SCALE * factor)

--- a/tests/test_issue_1240_iso_above_strip_visibility.py
+++ b/tests/test_issue_1240_iso_above_strip_visibility.py
@@ -18,17 +18,41 @@ apart from a sweep that tests nothing.
 
 from __future__ import annotations
 
-import math
-
+import pytest
 from build123d import Box, Cylinder, Pos
 
 from draftwright._core import _iso_bbox
 from draftwright.builder import build_drawing
-from draftwright.projection import _iso_grow_cap
+from draftwright.projection import _largest_clear_factor
 
 
 def _overlap(a, b) -> bool:
     return a[0] < b[2] and b[0] < a[2] and a[1] < b[3] and b[1] < a[3]
+
+
+def _built_with_analysis(part, **kwargs):
+    """A built drawing and its `Analysis`, captured at the fit seam.
+
+    NOT `drawing._analysis`: `test_private_test_attr_reads` ratchets test-side reads of
+    `Drawing` privates strictly downward, and adding three would have grown the ceiling.
+    `_fit_iso_view` is handed the Analysis by the builder anyway, so a spy there gets the same
+    object without reaching through the drawing.
+    """
+    from draftwright import builder as builder_mod
+
+    captured: dict = {}
+    real = builder_mod._fit_iso_view
+
+    def spy(dwg, analysis, obstacles=()):
+        captured["analysis"] = analysis
+        return real(dwg, analysis, obstacles=obstacles)
+
+    builder_mod._fit_iso_view = spy
+    try:
+        drawing = build_drawing(part, **kwargs)
+    finally:
+        builder_mod._fit_iso_view = real
+    return drawing, captured["analysis"]
 
 
 def _plate_with_locations():
@@ -39,25 +63,60 @@ def _plate_with_locations():
     return part
 
 
-def test_the_grow_cap_geometry():
-    """`_iso_grow_cap` — pure interval arithmetic, hand-checked.
+def test_the_clear_factor_search_measures_the_real_projection(monkeypatch):
+    """`_largest_clear_factor` must not believe a linear model of re-projection.
 
-    bb (90,90)-(110,110) about centre (100,100): each edge is 10 from the centre.
+    Its first version predicted the grown bbox as a scale about the page centre. `_project_iso`
+    scales the part about the WORLD ORIGIN, so a solid with a non-identity Location — every
+    authored `build123d` primitive — translates as it grows, and the prediction is wrong by
+    millimetres exactly where growth is largest (#1240 review F1):
+
+        Cylinder(20, 60) at f=1.3 — predicted y [86.15, 179.85], measured [93.49, 187.20]
+
+    So this asserts the property a model cannot give: at the returned factor, the ACTUAL
+    re-projected bbox clears the obstacle — checked here on the drifting part, with the
+    drift itself asserted so the test fails if the fixture stops exercising it.
     """
-    bb = (90.0, 90.0, 110.0, 110.0)
-    # No obstacles: unbounded.
-    assert _iso_grow_cap(bb, 100, 100, []) == math.inf
-    # A box whose left edge is 30 right of centre: x-onset at f=3; y straddles → onset 0.
-    assert _iso_grow_cap(bb, 100, 100, [(130, 90, 140, 110)]) == 3.0
-    # Same box, but y-separated too (above by 20 → y-onset f=2): overlap needs BOTH, so the
-    # cap is max(3, 2) = 3 — the later axis governs.
-    assert _iso_grow_cap(bb, 100, 100, [(130, 120, 140, 130)]) == 3.0
-    # A box straddling the centre on both axes: no growth at all.
-    assert _iso_grow_cap(bb, 100, 100, [(95, 95, 105, 105)]) == 0.0
-    # Below the centre: y-onset (100-80)/(100-90) = 2; x straddles → cap 2.
-    assert _iso_grow_cap(bb, 100, 100, [(90, 70, 110, 80)]) == 2.0
-    # Several obstacles: the nearest governs.
-    assert _iso_grow_cap(bb, 100, 100, [(130, 90, 140, 110), (90, 70, 110, 80)]) == 2.0
+    from draftwright._core import _iso_bbox as core_iso_bbox
+    from draftwright.projection import _project_iso
+
+    drawing, analysis = _built_with_analysis(Cylinder(20, 60), title="T", number="N")
+    _project_iso(drawing, analysis, analysis.SCALE)
+    base = core_iso_bbox(drawing)
+    centre_y = (base[1] + base[3]) / 2
+
+    # The precondition: this part really does drift off the linear model.
+    _project_iso(drawing, analysis, analysis.SCALE * 1.3)
+    grown = core_iso_bbox(drawing)
+    predicted_top = centre_y + 1.3 * (base[3] - centre_y)
+    assert abs(grown[3] - predicted_top) > 1.0, (
+        f"the fixture stopped drifting (measured top {grown[3]:.2f} vs predicted "
+        f"{predicted_top:.2f}) — a linear cap would now be correct and this asserts nothing"
+    )
+
+    # An obstacle in the growth corridor, placed against the MEASURED trajectory.
+    obstacle = (base[0], grown[3] - 6.0, base[2], grown[3] - 2.0)
+    factor = _largest_clear_factor(drawing, analysis, 1.3, [obstacle])
+    assert 1.0 < factor < 1.3, f"expected a bounded factor, got {factor}"
+
+    _project_iso(drawing, analysis, analysis.SCALE * factor)
+    actual = core_iso_bbox(drawing)
+    assert not _overlap(actual, obstacle), (
+        f"at the returned factor {factor:.4f} the REAL bbox {actual} still hits {obstacle}"
+    )
+    # And a linear cap would have overshot — the defect this replaces, stated as a number.
+    linear = centre_y + factor * (base[3] - centre_y)
+    assert actual[3] > linear, (
+        f"no drift at the chosen factor ({actual[3]:.2f} vs linear {linear:.2f}), so this "
+        "test no longer distinguishes measurement from prediction"
+    )
+
+
+def test_the_clear_factor_search_degenerate_inputs():
+    """No obstacles and a non-growing ceiling are returned untouched, without projecting."""
+    drawing, analysis = _built_with_analysis(Box(40, 30, 8), title="T", number="N")
+    assert _largest_clear_factor(drawing, analysis, 1.3, []) == 1.3
+    assert _largest_clear_factor(drawing, analysis, 1.0, [(0.0, 0.0, 1e4, 1e4)]) == 1.0
 
 
 def test_iso_growth_is_capped_by_a_planted_annotation_box(monkeypatch):
@@ -184,4 +243,76 @@ def test_the_above_strip_is_clamped_below_an_overlapping_iso(monkeypatch):
     assert boxes_in(clamped, band), (
         "nothing placed in the above strip at all — the clamp killed the strip rather than "
         "bounding it, or the fixture stopped using it"
+    )
+
+
+@pytest.mark.slow  # CTC fixture build (#153)
+def test_the_iso_no_longer_grows_over_ctc_01s_pocket_position_dim():
+    """The one NATURAL case in the corpus, found only by the #1240 review.
+
+    Both hunts for a reproducing fixture reported none, and the PR said so — but they searched
+    for *strip* collisions and this is the other direction: on `main`, CTC-01 AP203's iso grows
+    over `m_pocket0_pos_long`'s witness lines. It escaped every sweep because
+    `view_annotation_overlap` compares projected EDGES, not bboxes, so the drawing linted clean
+    while the boxes genuinely overlapped (#1240 review F2).
+
+    Asserted against the whole fixture rather than that one name: any annotation ink inside the
+    final iso bbox is the defect, whichever annotation it belongs to.
+    """
+    from draftwright._geometry import _boxes_overlap
+    from draftwright.annotations._common import annotation_obstacle_boxes
+
+    drawing = build_drawing("tests/fixtures/nist_ctc_01_asme1_ap203.stp")
+    assert "iso" in drawing.views, "precondition: the fixture has no iso view"
+    iso = _iso_bbox(drawing)
+    intruders = sorted(
+        {
+            name
+            for name, obj in drawing.iter_annotations()
+            if not getattr(obj, "is_sheet_frame", False)
+            and not getattr(obj, "is_zone_grid", False)
+            for box in annotation_obstacle_boxes(drawing, obj)
+            if _boxes_overlap(box, iso)
+        }
+    )
+    assert not intruders, f"the iso grew over placed annotation ink: {intruders}"
+
+
+def test_the_post_fit_recap_only_ever_tightens(monkeypatch):
+    """The builder's re-cap must not hand back space another pass took.
+
+    It mirrors the right-strip re-cap, which restores from a pre-`_auto_annotate` snapshot to
+    give back space taken against a transient iso. Transposed literally, that would DISCARD the
+    `m_locy` approach-buffer clamp, which is a different constraint (#1240 review F4). The
+    above-strip re-cap therefore tightens only.
+
+    The re-cap branch is guarded on the iso x-overlapping the view, which no natural layout
+    does — the first version of this test asserted tightening on a fixture where the branch
+    never ran, and a mutation replacing `min(current, limit)` with `limit` PASSED. The iso bbox
+    is planted at the builder's own binding so the branch executes.
+    """
+    from draftwright import builder as builder_mod
+
+    part = _plate_with_locations()
+    baseline = build_drawing(part, title="T", number="N")
+    pv = baseline.view_bounds("plan")
+    # An iso spanning the plan's x-range, well above it: the re-cap branch's guards both pass.
+    fake = (pv[0] + 5, pv[3] + 40, pv[2] - 5, pv[3] + 90)
+    planted = pv[3] + 20.0  # tighter than the fake iso's limit (fake[1] - 4)
+    assert planted < fake[1] - 4, "precondition: the planted limit is not the tighter one"
+
+    monkeypatch.setattr(builder_mod, "_iso_bbox", lambda dwg: fake)
+    real_annotate = builder_mod._auto_annotate
+
+    def clamp_after(dwg, a, **kwargs):
+        result = real_annotate(dwg, a, **kwargs)
+        a.pv_zones.above.outer_limit = min(a.pv_zones.above.outer_limit, planted)
+        return result
+
+    monkeypatch.setattr(builder_mod, "_auto_annotate", clamp_after)
+    _drawing, analysis = _built_with_analysis(part, title="T", number="N")
+    final = analysis.pv_zones.above.outer_limit
+    assert final <= planted, (
+        f"the re-cap loosened a limit set during annotation: {final} > {planted} — it is "
+        "restoring from the snapshot instead of tightening"
     )

--- a/tests/test_issue_1240_iso_above_strip_visibility.py
+++ b/tests/test_issue_1240_iso_above_strip_visibility.py
@@ -1,0 +1,187 @@
+"""#1240 — the above strips and the iso view must see each other.
+
+`strip_obstacles` is annotations-only by documented design (views enter
+`late_furniture_obstacles`), so strip placement never saw the iso; and `_fit_iso_view`
+re-scales the iso AFTER `_auto_annotate` from the compose-time zone, so the fit never saw
+annotations. Two blindnesses, one per direction. The right strips have been iso-clamped since
+the zone carve; the above strips had only the per-pass `m_locy` special case.
+
+**No natural fixture reaches the collision** — this was hunted hard, in the #1239 review
+(forced-fallthrough sweep over six synthetic parts and all ten CTC fixtures) and again when
+this was fixed (deep-Y parts, wide-X parts, pinned pages, forced starvation): compose plus
+page/scale selection kept the iso zone horizontally separated from every populated above strip
+every time. So these tests construct the geometry at the seam instead — a planted iso bbox for
+the clamp, a planted obstacle box for the grow cap — and each carries a control proving the
+un-fixed behaviour differs, since a sweep that finds nothing cannot (#1216's lesson) be told
+apart from a sweep that tests nothing.
+"""
+
+from __future__ import annotations
+
+import math
+
+from build123d import Box, Cylinder, Pos
+
+from draftwright._core import _iso_bbox
+from draftwright.builder import build_drawing
+from draftwright.projection import _iso_grow_cap
+
+
+def _overlap(a, b) -> bool:
+    return a[0] < b[2] and b[0] < a[2] and a[1] < b[3] and b[1] < a[3]
+
+
+def _plate_with_locations():
+    """Holes at distinct x/y so location dims populate the plan/side above strips."""
+    part = Box(120, 70, 12)
+    for x, y in ((-40, 20), (-10, -15), (25, 5), (45, -25)):
+        part -= Pos(x, y, 0) * Cylinder(3.5, 40)
+    return part
+
+
+def test_the_grow_cap_geometry():
+    """`_iso_grow_cap` — pure interval arithmetic, hand-checked.
+
+    bb (90,90)-(110,110) about centre (100,100): each edge is 10 from the centre.
+    """
+    bb = (90.0, 90.0, 110.0, 110.0)
+    # No obstacles: unbounded.
+    assert _iso_grow_cap(bb, 100, 100, []) == math.inf
+    # A box whose left edge is 30 right of centre: x-onset at f=3; y straddles → onset 0.
+    assert _iso_grow_cap(bb, 100, 100, [(130, 90, 140, 110)]) == 3.0
+    # Same box, but y-separated too (above by 20 → y-onset f=2): overlap needs BOTH, so the
+    # cap is max(3, 2) = 3 — the later axis governs.
+    assert _iso_grow_cap(bb, 100, 100, [(130, 120, 140, 130)]) == 3.0
+    # A box straddling the centre on both axes: no growth at all.
+    assert _iso_grow_cap(bb, 100, 100, [(95, 95, 105, 105)]) == 0.0
+    # Below the centre: y-onset (100-80)/(100-90) = 2; x straddles → cap 2.
+    assert _iso_grow_cap(bb, 100, 100, [(90, 70, 110, 80)]) == 2.0
+    # Several obstacles: the nearest governs.
+    assert _iso_grow_cap(bb, 100, 100, [(130, 90, 140, 110), (90, 70, 110, 80)]) == 2.0
+
+
+def test_iso_growth_is_capped_by_a_planted_annotation_box(monkeypatch):
+    """The fit must not grow onto ink the caller reports — and must still grow up to it.
+
+    The box is planted from MEASURED geometry, not guessed: a spy on the fit captures the
+    pre-fit bbox, the control build gives the grown one, and the box goes at the midpoint of
+    the growth corridor with its y-range straddling the iso centre (so the x onset alone
+    governs). The first version of this test planted "just inside the grown corner", which
+    OVERLAPPED the pre-fit bbox — the cap correctly refused all growth and the test read
+    that as a failure.
+    """
+    from draftwright import builder as builder_mod
+    from draftwright import projection as projection_mod
+
+    part = Box(40, 30, 8) - Pos(-10, 5, 0) * Cylinder(3, 20) - Pos(10, -5, 0) * Cylinder(3, 20)
+
+    prefit: list = []
+    real_fit = projection_mod._fit_iso_view
+
+    def spy_fit(dwg, a, obstacles=()):
+        prefit.append(_iso_bbox(dwg))
+        return real_fit(dwg, a, obstacles=obstacles)
+
+    monkeypatch.setattr(builder_mod, "_fit_iso_view", spy_fit)
+
+    control = build_drawing(part, title="T", number="N")
+    grown = _iso_bbox(control)
+    pre = prefit[0]
+    cx, cy = (grown[0] + grown[2]) / 2, (grown[1] + grown[3]) / 2  # scaling preserves centre
+    control_factor = (cx - grown[0]) / (cx - pre[0])
+    assert control_factor > 1.15, (
+        f"precondition: the control iso grew only {control_factor:.2f}x, leaving no corridor "
+        "to plant an obstacle in"
+    )
+    # Midpoint of the growth corridor in factor space, thin, y-straddling the centre.
+    fx_target = (1 + control_factor) / 2
+    planted_right = cx - fx_target * (cx - pre[0])
+    planted = (planted_right - 3.0, cy - 2.0, planted_right, cy + 2.0)
+    assert _overlap(planted, grown) and not _overlap(planted, pre), (
+        f"precondition: the box {planted} is not strictly inside the growth corridor "
+        f"(pre {pre}, grown {grown})"
+    )
+
+    real = builder_mod.strip_obstacles
+
+    def with_planted(dwg, *args, **kwargs):
+        return list(real(dwg, *args, **kwargs)) + [planted]
+
+    monkeypatch.setattr(builder_mod, "strip_obstacles", with_planted)
+    prefit.clear()
+    capped = build_drawing(part, title="T", number="N")
+    capped_bb = _iso_bbox(capped)
+    assert not _overlap(planted, capped_bb), (
+        f"the fit grew onto a reported obstacle: iso={capped_bb} obstacle={planted}"
+    )
+    assert capped_bb[0] >= planted[2] - 1e-6, (
+        f"the iso's left edge {capped_bb[0]:.2f} crossed the obstacle's right edge "
+        f"{planted[2]:.2f}"
+    )
+    # And the cap allowed growth rather than giving up: strictly wider than pre-fit, strictly
+    # narrower than the unobstructed control.
+    assert capped_bb[0] < prefit[0][0] - 0.25, (
+        f"no growth at all (left edge {capped_bb[0]:.2f} vs pre-fit {prefit[0][0]:.2f}) — the "
+        "cap is behaving as a veto, or the margins swallowed the corridor"
+    )
+    assert capped_bb[0] > grown[0], "the cap did not bind — the obstacle was not the constraint"
+
+
+def test_the_above_strip_is_clamped_below_an_overlapping_iso(monkeypatch):
+    """Strip placement must not stack under an iso that horizontally overlaps its view.
+
+    A fake iso bbox is planted directly over the plan view, low enough that the location
+    dims' natural stack would enter it (the control asserts they DO without the clamp —
+    the defect, reproduced). With the clamp, nothing may be placed inside it.
+    """
+    from draftwright.annotations import orchestrator as orch
+    from draftwright.annotations._common import annotation_obstacle_boxes
+
+    part = _plate_with_locations()
+
+    # Geometry first: where does the plan's above stack sit unclamped?
+    base = build_drawing(part, title="T", number="N")
+    pv = base.view_bounds("plan")
+    assert pv is not None
+    # The fake iso spans the plan's x-range with its bottom between the natural stack's
+    # second and third tiers (measured: tier tops sit ~11/21/30/40 mm above the view top).
+    # The clamp (bottom - 4) then admits tier 1 and refuses tier 3+ — so the un-clamped
+    # control MUST enter the box (precondition) while a clamped build keeps a live,
+    # non-empty strip below it (the last assertion, which a bottom set too low turns into
+    # "the clamp emptied the strip", the first version's failure).
+    fake = (pv[0] + 5, pv[3] + 24, pv[2] - 5, pv[3] + 70)
+
+    real = orch._iso_bbox
+
+    def fake_iso(dwg):
+        return fake
+
+    monkeypatch.setattr(orch, "_iso_bbox", fake_iso)
+    clamped = build_drawing(part, title="T", number="N")
+    monkeypatch.setattr(orch, "_iso_bbox", real)
+
+    def boxes_in(drawing, region):
+        hits = []
+        for name, obj in drawing.iter_annotations():
+            if getattr(obj, "is_sheet_frame", False) or getattr(obj, "is_zone_grid", False):
+                continue
+            for box in annotation_obstacle_boxes(drawing, obj):
+                if _overlap(box, region):
+                    hits.append(name)
+        return sorted(set(hits))
+
+    # The precondition, on the UN-clamped build: the natural stack enters the fake region —
+    # otherwise the clamp assertion below is vacuous.
+    assert boxes_in(base, fake), (
+        f"precondition: no annotation enters {fake} even without the clamp, so this fixture "
+        "does not reach the defect"
+    )
+    assert not boxes_in(clamped, fake), (
+        f"annotations placed under the (planted) iso despite the clamp: {boxes_in(clamped, fake)}"
+    )
+    # The clamp must not have simply emptied the strip: something still placed below it.
+    band = (pv[0], pv[3], pv[2], fake[1])
+    assert boxes_in(clamped, band), (
+        "nothing placed in the above strip at all — the clamp killed the strip rather than "
+        "bounding it, or the fixture stopped using it"
+    )

--- a/tests/test_issue_1240_iso_above_strip_visibility.py
+++ b/tests/test_issue_1240_iso_above_strip_visibility.py
@@ -64,18 +64,73 @@ def _plate_with_locations():
 
 
 def test_the_clear_factor_search_measures_the_real_projection(monkeypatch):
-    """`_largest_clear_factor` must not believe a linear model of re-projection.
+    """The search must not believe a page-centre linear model of re-projection.
 
-    Its first version predicted the grown bbox as a scale about the page centre. `_project_iso`
-    scales the part about the WORLD ORIGIN, so a solid with a non-identity Location — every
-    authored `build123d` primitive — translates as it grows, and the prediction is wrong by
-    millimetres exactly where growth is largest (#1240 review F1):
+    Its first version predicted the grown bbox as a scale about the page centre. The real
+    projected bbox is affine in the factor but carries a TRANSLATION term as well, so the
+    prediction drifts — measured on macOS at +7.35 mm for `Cylinder(20, 60)` at f=1.3 — and the
+    "capped" iso grew through the obstacle it was capped by.
 
-        Cylinder(20, 60) at f=1.3 — predicted y [86.15, 179.85], measured [93.49, 187.20]
+    Driven against a SYNTHETIC projection rather than a real part. The first version of this
+    test used `Cylinder(20, 60)`, whose drift comes from the Location the engine gives
+    `a.part` — and that is platform-dependent: 7.35 mm on macOS, exactly **zero** on Linux, so
+    CI failed on its own "the fixture stopped drifting" precondition (which is the precondition
+    doing its job, and the fixture failing at it). A fake map pins the contract the search
+    exists to satisfy, identically everywhere:
 
-    So this asserts the property a model cannot give: at the returned factor, the ACTUAL
-    re-projected bbox clears the obstacle — checked here on the drifting part, with the
-    drift itself asserted so the test fails if the fixture stops exercising it.
+        half(f) = 10 f              — a scale about the centre, which a linear model gets right
+        drift(f) = 25 (f - 1)       — a translation, which it does not
+
+    so the top edge is `100 + 35f - 25`, reaching the obstacle at f = 1.1428 while a
+    page-centre model puts it at f = 1.5 and would return the full 1.3.
+    """
+    from draftwright import projection as projection_mod
+
+    centre, half_at_one, drift_rate = 100.0, 10.0, 25.0
+    state = {"factor": 1.0}
+
+    def fake_project(_dwg, analysis, scale):
+        state["factor"] = scale / analysis.SCALE
+
+    def fake_bbox(_dwg):
+        factor = state["factor"]
+        half = half_at_one * factor
+        drift = drift_rate * (factor - 1.0)
+        return (centre - half, centre - half + drift, centre + half, centre + half + drift)
+
+    monkeypatch.setattr(projection_mod, "_project_iso", fake_project)
+    monkeypatch.setattr(projection_mod, "_iso_bbox", fake_bbox)
+
+    drawing, analysis = _built_with_analysis(Box(40, 30, 8), title="T", number="N")
+    base = fake_bbox(drawing)
+    obstacle = (centre - 5.0, 115.0, centre + 5.0, 118.0)
+    assert not _overlap(base, obstacle), "precondition: the obstacle is not clear at f=1"
+
+    # The precondition that makes this a test of measurement: a page-centre model says the
+    # whole corridor is clear, so a predictive search would return `hi` unchanged.
+    predicted_top_at_hi = centre + half_at_one * 1.3
+    assert predicted_top_at_hi < obstacle[1], (
+        f"the linear model already hits the obstacle ({predicted_top_at_hi} >= {obstacle[1]}), "
+        "so this fixture cannot tell measurement from prediction"
+    )
+
+    factor = _largest_clear_factor(drawing, analysis, 1.3, [obstacle], base)
+    assert 1.10 < factor < 1.15, (
+        f"expected the search to stop near the true onset 1.1428, got {factor} — 1.3 means it "
+        "predicted rather than measured"
+    )
+    state["factor"] = factor
+    assert not _overlap(fake_bbox(drawing), obstacle), (
+        f"the returned factor {factor} does not actually clear the obstacle"
+    )
+
+
+def test_the_returned_factor_clears_the_obstacle_on_a_real_projection():
+    """The same contract end-to-end, with no dependence on how much a part drifts.
+
+    Whatever the platform makes of the projection, the factor the search returns must leave the
+    REAL re-projected bbox clear of the obstacle. That is true with or without drift, so unlike
+    the synthetic test above it carries no precondition that can go platform-specific.
     """
     from draftwright._core import _iso_bbox as core_iso_bbox
     from draftwright.projection import _project_iso
@@ -83,32 +138,18 @@ def test_the_clear_factor_search_measures_the_real_projection(monkeypatch):
     drawing, analysis = _built_with_analysis(Cylinder(20, 60), title="T", number="N")
     _project_iso(drawing, analysis, analysis.SCALE)
     base = core_iso_bbox(drawing)
-    centre_y = (base[1] + base[3]) / 2
-
-    # The precondition: this part really does drift off the linear model.
     _project_iso(drawing, analysis, analysis.SCALE * 1.3)
     grown = core_iso_bbox(drawing)
-    predicted_top = centre_y + 1.3 * (base[3] - centre_y)
-    assert abs(grown[3] - predicted_top) > 1.0, (
-        f"the fixture stopped drifting (measured top {grown[3]:.2f} vs predicted "
-        f"{predicted_top:.2f}) — a linear cap would now be correct and this asserts nothing"
-    )
+    assert grown[3] > base[3], "precondition: this part's iso does not grow upward at all"
 
-    # An obstacle in the growth corridor, placed against the MEASURED trajectory.
     obstacle = (base[0], grown[3] - 6.0, base[2], grown[3] - 2.0)
+    _project_iso(drawing, analysis, analysis.SCALE)  # the search's documented entry state
     factor = _largest_clear_factor(drawing, analysis, 1.3, [obstacle], base)
-    assert 1.0 < factor < 1.3, f"expected a bounded factor, got {factor}"
 
     _project_iso(drawing, analysis, analysis.SCALE * factor)
-    actual = core_iso_bbox(drawing)
-    assert not _overlap(actual, obstacle), (
-        f"at the returned factor {factor:.4f} the REAL bbox {actual} still hits {obstacle}"
-    )
-    # And a linear cap would have overshot — the defect this replaces, stated as a number.
-    linear = centre_y + factor * (base[3] - centre_y)
-    assert actual[3] > linear, (
-        f"no drift at the chosen factor ({actual[3]:.2f} vs linear {linear:.2f}), so this "
-        "test no longer distinguishes measurement from prediction"
+    assert not _overlap(core_iso_bbox(drawing), obstacle), (
+        f"at the returned factor {factor:.4f} the real bbox {core_iso_bbox(drawing)} still "
+        f"hits {obstacle}"
     )
 
 

--- a/tests/test_issue_1240_iso_above_strip_visibility.py
+++ b/tests/test_issue_1240_iso_above_strip_visibility.py
@@ -96,7 +96,7 @@ def test_the_clear_factor_search_measures_the_real_projection(monkeypatch):
 
     # An obstacle in the growth corridor, placed against the MEASURED trajectory.
     obstacle = (base[0], grown[3] - 6.0, base[2], grown[3] - 2.0)
-    factor = _largest_clear_factor(drawing, analysis, 1.3, [obstacle])
+    factor = _largest_clear_factor(drawing, analysis, 1.3, [obstacle], base)
     assert 1.0 < factor < 1.3, f"expected a bounded factor, got {factor}"
 
     _project_iso(drawing, analysis, analysis.SCALE * factor)
@@ -114,9 +114,12 @@ def test_the_clear_factor_search_measures_the_real_projection(monkeypatch):
 
 def test_the_clear_factor_search_degenerate_inputs():
     """No obstacles and a non-growing ceiling are returned untouched, without projecting."""
+    from draftwright._core import _iso_bbox as core_iso_bbox
+
     drawing, analysis = _built_with_analysis(Box(40, 30, 8), title="T", number="N")
-    assert _largest_clear_factor(drawing, analysis, 1.3, []) == 1.3
-    assert _largest_clear_factor(drawing, analysis, 1.0, [(0.0, 0.0, 1e4, 1e4)]) == 1.0
+    base = core_iso_bbox(drawing)
+    assert _largest_clear_factor(drawing, analysis, 1.3, [], base) == 1.3
+    assert _largest_clear_factor(drawing, analysis, 1.0, [(0.0, 0.0, 1e4, 1e4)], base) == 1.0
 
 
 def test_iso_growth_is_capped_by_a_planted_annotation_box(monkeypatch):
@@ -161,12 +164,12 @@ def test_iso_growth_is_capped_by_a_planted_annotation_box(monkeypatch):
         f"(pre {pre}, grown {grown})"
     )
 
-    real = builder_mod.strip_obstacles
+    real = builder_mod.annotation_ink_obstacles
 
     def with_planted(dwg, *args, **kwargs):
         return list(real(dwg, *args, **kwargs)) + [planted]
 
-    monkeypatch.setattr(builder_mod, "strip_obstacles", with_planted)
+    monkeypatch.setattr(builder_mod, "annotation_ink_obstacles", with_planted)
     prefit.clear()
     capped = build_drawing(part, title="T", number="N")
     capped_bb = _iso_bbox(capped)
@@ -316,3 +319,46 @@ def test_the_post_fit_recap_only_ever_tightens(monkeypatch):
         f"the re-cap loosened a limit set during annotation: {final} > {planted} — it is "
         "restoring from the snapshot instead of tightening"
     )
+
+
+@pytest.mark.parametrize(
+    "options",
+    [{}, {"frame": True}, {"frame": True, "zones": True}, {"frame": True, "auto_dims": False}],
+    ids=["plain", "frame", "frame+zones", "frame+script-path"],
+)
+def test_the_page_spanning_riders_do_not_neutralise_the_iso_fit(options):
+    """`--frame` must not disable the fit (#1240 review r2, F1).
+
+    The sheet frame and zone grid are registered annotations whose Compound bbox spans the
+    page — they carry no `.segments`, so the obstacle decomposition falls back to the full
+    geometry box. Handing the raw `strip_obstacles` set to the fit therefore made the iso
+    overlap an "obstacle" at every factor: `--frame` silently disabled growth and the NTS
+    caption with it, on 17 of 20 corpus fixtures, with the whole fast tier green. It also broke
+    script/CLI parity, because the `auto_dims=False` path computes its obstacles BEFORE the
+    frame is added and so kept growing — the one thing that branch's comment exists to protect.
+
+    `tests/test_iso_nts_caption_placement.py` makes the same point about the same riders for
+    the caption; this is the fit's copy of it, and the reason there is now one predicate
+    (`is_page_spanning_rider`) rather than a sixth hand-rolled filter.
+
+    All four configurations must agree: the riders are furniture, not obstacles.
+    """
+    part = Box(40, 30, 8) - Pos(-10, 5, 0) * Cylinder(3, 20) - Pos(10, -5, 0) * Cylinder(3, 20)
+    plain = build_drawing(part, title="T", number="N")
+    plain_iso = _iso_bbox(plain)
+    # The precondition: this part's iso GROWS, so a veto is observable at all.
+    assert "note_iso_nts" in plain.registry.names(), (
+        "precondition: the fixture's iso no longer grows, so no configuration can lose the fit"
+    )
+
+    drawing = build_drawing(part, title="T", number="N", **options)
+    iso = _iso_bbox(drawing)
+    # SIZE, not position: a frame legitimately shifts the layout (measured: the framed iso sits
+    # 3 mm lower). What the riders must not do is change how far the fit GROWS.
+    plain_size = (plain_iso[2] - plain_iso[0], plain_iso[3] - plain_iso[1])
+    size = (iso[2] - iso[0], iso[3] - iso[1])
+    assert size == pytest.approx(plain_size, abs=1e-6), (
+        f"{options} changed the fitted iso size: {size} vs {plain_size} — a page-spanning "
+        "rider is being treated as an obstacle, so the fit is vetoed"
+    )
+    assert "note_iso_nts" in drawing.registry.names(), f"{options} lost the NTS caption"

--- a/tests/test_private_test_imports.py
+++ b/tests/test_private_test_imports.py
@@ -42,6 +42,12 @@ _ALLOW: frozenset[tuple[str, str]] = frozenset(
         # (#733): the sequence pin test exists precisely to guard it, so its white-box
         # read is the point, not a coupling smell.
         ("orchestrator", "_PASS_SEQUENCE"),
+        # #1240: the iso/above-strip clamp has NO natural fixture — compose plus page/scale
+        # selection keeps the iso x-separated from populated above strips on every real
+        # layout tried (two independent sweeps) — so the guard test plants a fake iso bbox
+        # by patching the orchestrator's binding. White-box by necessity, documented in
+        # tests/test_issue_1240_iso_above_strip_visibility.py's module docstring.
+        ("orchestrator", "_iso_bbox"),
         # Pure label/format helpers — legitimate unit tests (formatting logic, not coupling).
         ("from_model", "_chamfer_label"),
         ("from_model", "_fillet_label"),


### PR DESCRIPTION
Two blindnesses, one per direction, found in #1239's review (F1):

- `strip_obstacles` is annotations-only by documented design (views enter
  `late_furniture_obstacles`), so strip placement never saw the iso. The RIGHT
  strips have been iso-clamped since the zone carve; the above strips had only
  the per-pass m_locy special case, so every other above-strip resident — GD&T,
  grid pitch dims, #1236's overall-extent fallthrough — could stack under the
  iso unchecked.
- `_fit_iso_view` re-scales the iso AFTER `_auto_annotate` from the compose-time
  zone, so the grow branch could grow onto ink that placed legally against the
  pre-fit iso.

The fix keeps each side at its DAG rank:

- The initial right-strip clamp in `_auto_annotate` gains its above-strip
  transposition (pv/sv above, x-overlap guarded), and builder's post-fit re-cap
  mirrors it for the strips deferred edits use. The m_locy clamp stays — it
  fires earlier (approach buffer, not bbox overlap) and is strictly tighter.
- `_fit_iso_view(dwg, a, obstacles=())` caps the GROW factor by caller-passed
  boxes via `_iso_grow_cap` — pure interval arithmetic about the projection
  centre; overlap with a box begins at max(fx, fy), the factor at which BOTH
  axes first overlap. The obstacle list is computed by the CALLER (builder /
  the finalize refit) because the fit sits below the occupancy model and every
  hand-rolled obstacle set it has owned was wrong (#1197). The shrink branch is
  untouched: shrinking about the centre cannot create an overlap absent at 1.0.

Two defects in my own first cut, both caught by execution and worth recording:

- The clamp lacked the anchor guard the right-strip block's comment warns
  about: an iso x-overlapping a view from BELOW it pushed outer_limit beneath
  the strip anchor and broke every allocation — four hole/slot fixtures lost
  their location dims. Clamp only when `iso_y0 - 4 > strip.anchor`.
- The grow cap multiplied BOTH margins (0.98 obstacle clearance x 0.90 zone
  breathing room = 0.88), turning any mid-corridor obstacle into a veto: the
  capped factor fell under the 5% no-op threshold and the iso stayed at sheet
  scale instead of growing up to the box. The margins guard different edges
  and are now applied separately.

**Correction (review F2): one natural case does exist, in the direction I was not
searching.** The hunts looked for *strip* collisions and found none; the cap binds on
**CTC-01 AP203**, where on `main` the iso grows over `m_pocket0_pos_long`'s witness lines and
on this branch it does not. It escaped every sweep because `view_annotation_overlap` compares
projected EDGES, not bboxes, so that drawing lints clean while the boxes genuinely overlap. So
this PR does change CTC-01 AP203's iso and NTS-note placement — for the better — and a
slow-tier test now asserts no annotation ink inside the final iso bbox.

No natural fixture reaches the *strip* collision — hunted in #1239's review (forced
fallthrough over six synthetics and all ten CTC fixtures) and again here
(deep-Y, wide-X, pinned pages, forced starvation): compose plus page/scale
selection kept the iso x-separated from populated above strips every time. The
guard tests therefore construct the geometry at the seam — a planted iso bbox
for the clamp (via the ratcheted, rationale-pinned orchestrator patch), a
planted obstacle box in the measured growth corridor for the cap — each with a
control proving the un-fixed behaviour differs, plus a pure unit test of the
cap arithmetic. Mutations killed: clamp removed, cap removed, builder not
passing obstacles.

4387 passed (fast), 44 passed (slow), pr-check --static exit 0.

Closes #1240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTXU3X3YFa1HPRdmUgCw22


---

## Review round 1 (see commit `0b82fc7`)

Found a correctness defect in the headline mechanism, plus the false claim corrected above.
Both were invisible to my evidence for one reason: **every fixture I hunted on was a STEP
import.**

**F1 — the cap's model of re-projection was false.** It predicted the grown bbox as a scale
about the page centre; `_project_iso` scales the part about the **world origin**, so a solid
with a non-identity Location — every authored `build123d` part, since the primitives are
centred by construction — *translates* as it grows:

```
Cylinder(20, 60) at f=1.3
  predicted y [86.15, 179.85]   measured y [93.49, 187.20]   drift +7.35 mm
```

against a 0.98 clearance worth 0.75 mm. The "capped" iso grew straight through the obstacle it
was capped by, worst exactly where growth is largest. STEP imports arrive with identity
Location and are exactly linear — which is why all ten CTC fixtures agreed with the model.

Replaced by `_largest_clear_factor`: **bisection on the real re-projected bbox**, eight steps
at a measured 0.3–0.5 ms each, on the one path that grows. ADR 0014 Amdt 3 — budgets must
measure, not predict — learned here rather than read, for the second time.

**F3** — the shrink branch's stated justification rested on the same false model (a tall
cylinder's shrink measured 3.5 mm below prediction). The branch is unchanged; the reason is
now the real one: an overflowing iso must shrink regardless, and a resulting collision is
lint's to report.

**F4** — the post-fit re-cap was untested and, transposed literally from the right strips,
discarded the `m_locy` clamp by restoring from a snapshot. It tightens only now. My first test
for it asserted on a fixture where the guarded branch never ran (the mutation replacing
`min(current, limit)` with `limit` **passed**), so it plants the iso bbox at the builder's own
binding to reach the branch.

Also: three test-side `drawing._analysis` reads would have grown the #741 ratchet's ceiling —
the Analysis is captured at the fit seam, which is handed it anyway.

**Mutations killed, all five**: clamp removed, cap removed, builder not passing obstacles, the
linear model restored inside the search, re-cap restoring the snapshot.
**4389 passed** (fast), **45 passed** (slow), `pr-check --static` exit 0.
