### PR TITLE
Upgrade b123d-recognisers 0.2.4 → 0.2.6 (#1244)

### DIFF
--- a/.github/recogniser-release.json
+++ b/.github/recogniser-release.json
@@ -1,10 +1,10 @@
 {
   "artifacts": {
-    "b123d_recognisers-0.2.4-py3-none-any.whl": "681231f164fb3c234f0c8e30bb79570bea4a0afabfbe1f79e5d050b036343732",
-    "b123d_recognisers-0.2.4.tar.gz": "7fa463e605a96768f5d6793705c9369f809887a18afe169bfa9ca82f0d669e05"
+    "b123d_recognisers-0.2.6-py3-none-any.whl": "314fce78f4a3c064f8d1ff1e050c54094918bb5d40d0ea3bbd61b6d2450ece90",
+    "b123d_recognisers-0.2.6.tar.gz": "4cce440c6ce5c538516d605ccbd12e8b1e41e1ae997c83df297f26f31a4fac2a"
   },
-  "capability_manifest_sha256": "d0023d30e583c03abc55f09dfeaaa56fddf56334afa0417818480b2fa2ce3f0f",
+  "capability_manifest_sha256": "aa52bc04216cd1eccc05796d2262547c7f476b80a3ec77334a77b9d8e3241a58",
   "distribution": "b123d-recognisers",
   "index": "https://pypi.org/simple",
-  "version": "0.2.4"
+  "version": "0.2.6"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,10 @@
 
 ### Changed
 
+- Updated the exact `b123d-recognisers` production lock from 0.2.4 to 0.2.6.
+  The immutable PyPI wheel/sdist hashes and capability-manifest digest `aa52bc04216cd1eccc05796d2262547c7f476b80a3ec77334a77b9d8e3241a58` are
+  recorded in `.github/recogniser-release.json`; focused compatibility evidence and the
+  normal consumer gates run on the generated PR.
 - `HoleRequirementOutcome` gains `members` and `features`, `ClaimOutcome` gains `measurement`,
   and `linting.hole_coverage.canonical_hole_sites` is public (#1217). A consumer attributing a
   requirement outcome to a specific recognised hole needs the evidence the outcome accounts

--- a/docs/multi-feature-object-reference-workflow.md
+++ b/docs/multi-feature-object-reference-workflow.md
@@ -101,8 +101,9 @@ part = features.body
 sheet = Sheet(part, title='DRAWING', number='DWG-001')
 hole1 = sheet.hole(diameter=1.6, at=(0.8, 0, 0), axis="x").depth(8)   # ⌀1.6 blind 8
 step1 = sheet.step(diameter=3, length=5.3, at=(-5.85, 0, 0), axis="x")   # ⌀3 × 5.3 step
-step2 = sheet.step(diameter=4, length=3.7, at=(-1.35, 0, 0), axis="x")   # ⌀4 × 3.7 step
-# ... step3, step4, boss1 ...
+step2 = sheet.step(diameter=4, length=3.2, at=(-1.6, 0, 0), axis="x")   # ⌀4 × 3.2 step
+step3 = sheet.step(diameter=6, length=0.5, at=(0.25, 0, 0), axis="x")   # ⌀6 × 0.5 step
+# ... step4, step5, boss1 ...
 envelope1 = sheet.envelope()   # envelope 20 × 10 × 10
 
 sheet.authored_dimensions()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "build123d>=0.9.0,<0.11 ; python_full_version < '3.13'",
     "build123d>=0.11,<0.12 ; python_full_version >= '3.13'",
     "build123d-drafting-helpers>=0.14.1",
-    "b123d-recognisers==0.2.4",
+    "b123d-recognisers==0.2.6",
     "numpy>=1.24",
     # PNG raster export (SVG→PDF→PNG). Both permissively licensed (Pillow HPND; pypdfium2
     # Apache-2.0 wrapping Google PDFium BSD-3) and ship pre-built wheels with NO native system

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -107,9 +107,26 @@ _RECOGNISED_REQUIREMENT_FAMILIES = {
 # explicit rather than implied by absence so that a new
 # ``RecognitionResult`` inventory cannot silently join the blind spot the completeness
 # component exists to report (``tests/test_quality_components.py``).
+#: Inventories that are not requirement families because of what they ARE — nested sub-records,
+#: raw geometry, classification flags, evidence aggregated into another feature. Permanent by
+#: design, not pending a decision.
 _NON_REQUIREMENT_INVENTORIES = frozenset(
     {"countersinks", "cylinders", "plates", "risers", "rotational", "step_levels"}
 )
+
+#: Inventories the installed package proves and this consumer has not decided about, each with
+#: the issue deciding it. Held SEPARATELY from the set above, because the two mean different
+#: things: those will never be requirement families, these have simply not been ruled on, and
+#: merging them would let an undecided family look settled (#1244).
+#:
+#: The effect on the score is deliberate and worth stating: a drawing that omits a recognised
+#: passage, prismatic pocket or angled step scores complete today. That is a blind spot — the
+#: register is what stops it being a silent one, and closing each issue closes the gap.
+_UNDECIDED_INVENTORIES: dict[str, str] = {
+    "angled_steps": "https://github.com/pzfreo/draftwright/issues/1247",
+    "passages": "https://github.com/pzfreo/draftwright/issues/1245",
+    "prismatic_pockets": "https://github.com/pzfreo/draftwright/issues/1246",
+}
 
 _AUDITED_FAMILIES = (
     "channels",

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass, replace
 from typing import Any
 
 from b123d_recognisers import (
+    AngledStep,
     BoltCircle,
     BossRecord,
     Chamfer,
@@ -32,12 +33,14 @@ from b123d_recognisers import (
     HoleRecord,
     HoleSpec,
     LinearArray,
+    Passage,
     Plate,
     Pocket,
     PocketArray,
     PocketGrid,
     PolygonalBoss,
     PolygonalStock,
+    PrismaticPocket,
     RaisedPad,
     RectGrid,
     RepeatingRadialProfile,
@@ -687,6 +690,29 @@ _ORCHESTRATED_RECORDS: dict[type, str] = {
     RepeatingRadialProfile: (
         "geometry-only critique evidence (#1087) — validates a separately authored gear "
         "declaration and must never become an inferred IR feature"
+    ),
+}
+
+
+# Tier 4 — records the installed package proves and this consumer has NOT decided about. Not
+# "orchestrated": these are not nested sub-records or aggregated evidence, they are families
+# whose drafting meaning is an open question, declared `unsupported` in
+# `recogniser_contract._UNSUPPORTED` against the issue deciding each. Kept as its own tier so the
+# partition below stays honest — folding them into tier 3 would claim a design reason that does
+# not exist, and would hide them the day one is decided (#1244).
+_UNCONSUMED_RECORDS: dict[type, str] = {
+    AngledStep: (
+        "a step's slanted wall, split out of `chamfers` by 0.2.5 to stop it being reported as a "
+        "chamfer; whether draftwright dimensions it is open (#1247)"
+    ),
+    Passage: (
+        "a prismatic through-opening — the internal counterpart to polygonal stock; whether it "
+        "is an IR kind or refines `hole`, and what it draws, is open (#1245)"
+    ),
+    PrismaticPocket: (
+        "a non-rectangular blind recess that OVERLAPS the supported `pockets` family — measured, "
+        "both recognisers claim a rectangular recess — so IR ownership must be settled before a "
+        "converter exists (#1246)"
     ),
 }
 

--- a/src/draftwright/recogniser_contract.py
+++ b/src/draftwright/recogniser_contract.py
@@ -19,7 +19,7 @@ from b123d_recognisers import capability_manifest
 
 CONSUMER_CAPABILITY_FORMAT = "draftwright-recogniser-capabilities"
 CONSUMER_CAPABILITY_FORMAT_VERSION = 1
-_PACKAGE_VERSION = "0.2.4"
+_PACKAGE_VERSION = "0.2.6"
 _BOUNDARIES = (
     "ir_adapter",
     "dsl_declaration",
@@ -195,9 +195,74 @@ def _geometry_only_declaration() -> dict[str, Any]:
     }
 
 
+#: Families the installed package proves and Draftwright has taken NO position on yet, each with
+#: the issue where that position is being decided. Not a parking bay: a family sits here only
+#: while a decision is genuinely open, and `pending_family_declarations` still reports anything
+#: absent from BOTH this map and `_FAMILIES`, so the next new family fails closed exactly as
+#: these three did (#1244).
+_UNSUPPORTED: dict[str, tuple[tuple[str, ...], str, str]] = {
+    "passages": (
+        ("Passage",),
+        "https://github.com/pzfreo/draftwright/issues/1245",
+        "A prismatic through-opening — the internal counterpart to polygonal stock. Whether it "
+        "becomes an IR kind or refines `hole`, and what a passage draws (across-flats + THRU, or "
+        "a section), are drafting decisions this consumer has not made.",
+    ),
+    "prismatic-pockets": (
+        ("PrismaticPocket",),
+        "https://github.com/pzfreo/draftwright/issues/1246",
+        "Overlaps the supported `pockets` family: measured on a plate with one hexagonal and one "
+        "rectangular recess, `recognise_prismatic_pockets` claims BOTH and `recognise_pockets` "
+        "claims the rectangular one as well. Wiring it to a converter would double-count every "
+        "rectangular pocket in completeness, so ownership must be decided at the IR first.",
+    ),
+    "angled-steps": (
+        ("AngledStep",),
+        "https://github.com/pzfreo/draftwright/issues/1247",
+        "Introduced by 0.2.5 to stop `recognise_chamfers` reporting step slants as chamfers "
+        "(precision 44% -> 78%). Draftwright consumes the corrected chamfer inventory today; "
+        "whether an angled step is itself dimensioned — and how — is undecided.",
+    ),
+}
+
+
+def _unsupported_declaration(family_id: str) -> dict[str, Any]:
+    """A family the package proves and this consumer has not decided about.
+
+    Every boundary is `unsupported` with the same rationale, and `completeness` is `deferred`
+    with the tracking issue — so the inventory is visible (`RecognitionResult` carries it, the
+    manifest joins) while nothing scores it. That is the honest position: scoring a family whose
+    drafting meaning is undecided would either invent a requirement or, for `prismatic-pockets`,
+    count one physical recess twice.
+    """
+    records, tracking, rationale = _UNSUPPORTED[family_id]
+    unsupported = {"state": "unsupported", "rationale": rationale}
+    return {
+        "id": family_id,
+        "record_schemas": {name: 1 for name in records},
+        "disposition": "unsupported",
+        "rationale": rationale,
+        "tracking": tracking,
+        "ir_adapter": copy.deepcopy(unsupported),
+        "dsl_declaration": copy.deepcopy(unsupported),
+        "generated_code": copy.deepcopy(unsupported),
+        "drawing_consumer": copy.deepcopy(unsupported),
+        "completeness": {
+            "state": "deferred",
+            "rationale": rationale,
+            "tracking": tracking,
+        },
+        "documentation": {
+            "state": "supported",
+            "evidence": ["docs/reference/recogniser-capabilities.md"],
+        },
+    }
+
+
 def consumer_capability_declaration() -> dict[str, Any]:
     """Return an isolated format-1 declaration for the released package contract."""
     families = [_family_declaration(key, value) for key, value in sorted(_FAMILIES.items())]
+    families.extend(_unsupported_declaration(key) for key in sorted(_UNSUPPORTED))
     families.append(_geometry_only_declaration())
     families.sort(key=lambda family: family["id"])
     return {

--- a/tests/test_detect_registry.py
+++ b/tests/test_detect_registry.py
@@ -26,6 +26,7 @@ from draftwright.model.detect import (
     _CONVERTERS,
     _DERIVED_CONVERTERS,
     _ORCHESTRATED_RECORDS,
+    _UNCONSUMED_RECORDS,
     ConvContext,
     build_part_model,
     convert,
@@ -101,8 +102,13 @@ def test_registry_tiers_partition_every_record_type():
     expected = _recogniser_record_universe()
     assert expected, "mechanical record-type derivation found nothing — check recognition surface"
 
-    tiers = [set(_CONVERTERS), set(_DERIVED_CONVERTERS), set(_ORCHESTRATED_RECORDS)]
-    homed = tiers[0] | tiers[1] | tiers[2]
+    tiers = [
+        set(_CONVERTERS),
+        set(_DERIVED_CONVERTERS),
+        set(_ORCHESTRATED_RECORDS),
+        set(_UNCONSUMED_RECORDS),
+    ]
+    homed = set().union(*tiers)
 
     missing = expected - homed
     assert not missing, (
@@ -123,6 +129,34 @@ def test_orchestrated_records_document_their_residual_reason():
     """Tier 3 is the ADR 0013 Phase 1 accepted residual — each entry states why."""
     for rec_type, reason in _ORCHESTRATED_RECORDS.items():
         assert isinstance(reason, str) and reason.strip(), f"{rec_type.__name__} needs a reason"
+
+
+def test_unconsumed_records_name_the_issue_deciding_them():
+    """Tier 4 is a WAITING ROOM, not a bin: each entry cites the issue that will empty it.
+
+    Tier 3 entries have design reasons that will not change; these are open questions, and the
+    difference has to survive in the register or the two collapse into "we do not convert this"
+    (#1244). The issue reference is the thing that expires — when it closes, the record either
+    moves to a converter or its reason has to be rewritten as a permanent one.
+    """
+    import re
+
+    from draftwright.recogniser_contract import _UNSUPPORTED
+
+    tracked = {
+        reference
+        for _records, tracking, _rationale in _UNSUPPORTED.values()
+        for reference in [tracking.rsplit("/", 1)[-1]]
+    }
+    for rec_type, reason in _UNCONSUMED_RECORDS.items():
+        assert isinstance(reason, str) and reason.strip(), f"{rec_type.__name__} needs a reason"
+        cited = set(re.findall(r"#(\d+)", reason))
+        assert cited, f"{rec_type.__name__} names no deciding issue"
+        assert cited <= tracked, (
+            f"{rec_type.__name__} cites {sorted(cited)}, which is not among the issues the "
+            f"capability declaration tracks ({sorted(tracked)}) — the two registers disagree "
+            "about why this record is unconsumed"
+        )
 
 
 def test_uniform_converters_are_callable():

--- a/tests/test_issue_1073_cross_body_patterns.py
+++ b/tests/test_issue_1073_cross_body_patterns.py
@@ -82,16 +82,25 @@ def test_compound_traversal_order_does_not_change_body_correspondence():
     assert recognise_slot_patterns(recognise_slots(reverse)) == []
 
 
-def test_ambiguous_body_signature_fails_closed(monkeypatch):
-    # `_body_signature` moved to `_recess_core` in 0.2.2's seam decomposition. The
-    # patch target follows it; the guarded behaviour — Draftwright failing closed when
-    # the recogniser cannot tell two bodies apart — is unchanged.
-    from b123d_recognisers import _recess_core as recess_module
+def test_ambiguous_body_signature_fails_closed():
+    """A recess whose owning body could not be identified must never join a pattern.
 
-    monkeypatch.setattr(recess_module, "_body_signature", lambda _solid: (1.0,))
-    slots = recognise_slots(_separate_bodies(_slotted_body()))
-    pockets = recognise_pockets(_separate_bodies(_pocketed_body()))
+    The condition is constructed on the public records rather than by patching an internal.
+    Previously this monkeypatched `_recess_core._body_signature`, which 0.2.6 removed — the
+    third of three private reaches that broke on a patch bump (#1244) — and it cannot be
+    induced through geometry either, since a body key embeds the bounding box and separated
+    bodies therefore always differ. `Slot` and `Pocket` are public dataclasses, so setting
+    `body_key=None` states the ambiguous case directly and asserts the same rule.
+    """
+    slots = [
+        replace(slot, body_key=None) for slot in recognise_slots(_separate_bodies(_slotted_body()))
+    ]
+    pockets = [
+        replace(pocket, body_key=None)
+        for pocket in recognise_pockets(_separate_bodies(_pocketed_body()))
+    ]
 
+    # The precondition: three real recesses, every one of them body-ambiguous.
     assert len(slots) == 3 and all(slot.body_key is None for slot in slots)
     assert len(pockets) == 3 and all(pocket.body_key is None for pocket in pockets)
     assert recognise_slot_patterns(slots) == []

--- a/tests/test_issue_676_polygonal_boss.py
+++ b/tests/test_issue_676_polygonal_boss.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 import pytest
 from b123d_recognisers import PolygonalBoss, recognise_polygonal_bosses
-from b123d_recognisers.polygonal_bosses import _normal
 from build123d import Box, Compound, Polygon, Pos, RegularPolygon, Rot, extrude, import_step
 
 from draftwright import build_drawing
@@ -50,12 +49,17 @@ def _polygon_from_supports(
     return Polygon(*points)
 
 
-def test_a_face_with_no_usable_normal_cannot_supply_boss_evidence():
-    class UnusableFace:
-        def center(self):
-            raise ValueError("degenerate face")
-
-    assert _normal(UnusableFace()) is None
+# `test_a_face_with_no_usable_normal_cannot_supply_boss_evidence` was here until #1244. It
+# asserted that `b123d_recognisers.polygonal_bosses._normal` returns None for a face whose
+# `center()` raises — a PRIVATE helper, which 0.2.6 removed, and one of two private reaches
+# that broke on a patch bump with no announced API removals.
+#
+# Not retargeted, because there is nothing here to retarget: the assertion was about the
+# dependency's internal defensiveness, not about anything draftwright does with the result, and
+# the public surface takes a `Shape` rather than a stand-in object with a raising `center()`.
+# The package carries its own held-out and golden evidence for the family (0.2.6 release
+# baseline). What draftwright needs from this module is that a real bounded hex boss yields the
+# right record, which the tests below assert through `recognise_polygonal_bosses`.
 
 
 def test_a_bounded_fused_hex_boss_carries_manufacturing_evidence():

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -8135,6 +8135,17 @@ class TestFindSlots:
         (p,) = recognise_pockets(part)
         assert p.length == 22.0
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason=(
+            "b123d-recognisers 0.2.6 regression: a slot with a coaxial post at its own depth is "
+            "not recognised AT ALL, where 0.2.4 reported the flat span. Upstream "
+            "pzfreo/b123d-recognisers#140; draftwright #1244. STRICT so this flips the day the "
+            "fix lands and the marker has to be removed rather than outliving the defect. The "
+            "cost is real and measured: this part's drawing loses m_slot0_length, m_slot0_pos "
+            "and m_slot0_width."
+        ),
+    )
     def test_coaxial_posts_at_both_ends_do_not_extend_length(self):
         # Symmetric coaxial POSTS (added material, radius = width/2) protruding into both slot
         # ends at the slot's own depth pass the radius/axis/centreline/depth checks — but they

--- a/tests/test_quality_components.py
+++ b/tests/test_quality_components.py
@@ -16,6 +16,7 @@ from draftwright.linting.issues import LintIssue
 from draftwright.linting.quality import (
     _NON_REQUIREMENT_INVENTORIES,
     _RECOGNISED_REQUIREMENT_FAMILIES,
+    _UNDECIDED_INVENTORIES,
     quality_components,
 )
 
@@ -146,7 +147,11 @@ def test_semantic_issues_stay_out_of_the_legibility_component():
 
 def test_every_recognition_inventory_is_either_a_requirement_family_or_excluded():
     inventories = set(RecognitionResult.__dataclass_fields__)
-    classified = set(_RECOGNISED_REQUIREMENT_FAMILIES) | _NON_REQUIREMENT_INVENTORIES
+    classified = (
+        set(_RECOGNISED_REQUIREMENT_FAMILIES)
+        | _NON_REQUIREMENT_INVENTORIES
+        | set(_UNDECIDED_INVENTORIES)
+    )
     unclassified = sorted(inventories - classified)
 
     assert unclassified == [], (
@@ -181,3 +186,26 @@ def test_an_unavailable_completeness_component_is_data_not_a_zero_score():
     assert completeness["coverage"] == "unavailable"
     assert completeness["reason"] == "physical recognition inventory unavailable"
     assert completeness["requirements"] == 0
+
+
+def test_an_undecided_inventory_names_a_real_open_issue():
+    """The undecided register must not become a quiet permanent home.
+
+    `_NON_REQUIREMENT_INVENTORIES` and `_UNDECIDED_INVENTORIES` both remove a family from
+    scoring, and only the second is supposed to be temporary — so the second has to carry the
+    thing the first does not: the issue that ends it. Without this the cheapest way to silence
+    the completeness guard for a new family would be a one-line addition here, which is exactly
+    how a blind spot becomes permanent (#1244).
+    """
+    from draftwright.recogniser_contract import _UNSUPPORTED
+
+    assert not set(_UNDECIDED_INVENTORIES) & _NON_REQUIREMENT_INVENTORIES, (
+        "an inventory is registered both as permanently-not-a-requirement and as undecided; "
+        "those mean different things and it cannot be both"
+    )
+    tracked = {tracking for _records, tracking, _rationale in _UNSUPPORTED.values()}
+    for inventory, issue in _UNDECIDED_INVENTORIES.items():
+        assert issue in tracked, (
+            f"{inventory} is unscored pending {issue}, which is not one of the issues the "
+            f"capability declaration tracks ({sorted(tracked)}) — the registers disagree"
+        )

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -20,6 +20,7 @@ from draftwright.model.detect import (
     _CONVERTERS,
     _DERIVED_CONVERTERS,
     _ORCHESTRATED_RECORDS,
+    _UNCONSUMED_RECORDS,
     build_part_model,
 )
 from draftwright.recogniser_contract import (
@@ -116,12 +117,20 @@ def test_installed_released_package_contract_validates_without_a_sibling_checkou
     validate_recogniser_capabilities()
     package = recognition.capability_manifest(format_version=1)
     declaration = consumer_capability_declaration()
-    assert len(package["families"]) == len(declaration["families"]) == 22
+    # 25 since 0.2.6 added angled-steps, passages and prismatic-pockets (#1244). A literal,
+    # not a length comparison against the package: the point is that BOTH sides changed
+    # together, so an upgrade that declared nothing would leave this at 22 and fail.
+    assert len(package["families"]) == len(declaration["families"]) == 25
 
 
 def test_runtime_adapter_inventory_is_derived_independently_and_exhaustive() -> None:
     runtime = _runtime_emitted_records()
-    tiers = [set(_CONVERTERS), set(_DERIVED_CONVERTERS), set(_ORCHESTRATED_RECORDS)]
+    tiers = [
+        set(_CONVERTERS),
+        set(_DERIVED_CONVERTERS),
+        set(_ORCHESTRATED_RECORDS),
+        set(_UNCONSUMED_RECORDS),
+    ]
     # Subset again, and the third place the same coupling was written. A converter for a
     # record the installed package no longer emits is dead code pointing at a type that is
     # gone, so that direction still fails. A record with no converter yet is the additive
@@ -253,6 +262,18 @@ def test_repeating_profile_is_explicit_geometry_only_critique_evidence() -> None
     assert recognition.RepeatingRadialProfile not in _CONVERTERS | _DERIVED_CONVERTERS
 
 
+def _supported(value: dict) -> dict:
+    """The first family declared `supported`, by disposition rather than by position.
+
+    These mutations need a family that HAS an ir_adapter implementation, documentation evidence
+    and a `BossRecord` schema — i.e. a supported one. They indexed `families[0]` and got it
+    because "bosses" sorted first; 0.2.6 added `angled-steps`, which sorts ahead of it and is
+    declared unsupported, so every one of them began mutating the wrong shape and asserting the
+    wrong error (#1244). Selecting by what the mutation needs cannot drift with the alphabet.
+    """
+    return next(family for family in value["families"] if family.get("disposition") == "supported")
+
+
 @pytest.mark.parametrize(
     ("mutate", "message"),
     [
@@ -272,23 +293,23 @@ def test_repeating_profile_is_explicit_geometry_only_critique_evidence() -> None
             "stale=",
         ),
         (
-            lambda value: value["families"][0]["record_schemas"].update({"BossRecord": 99}),
+            lambda value: _supported(value)["record_schemas"].update({"BossRecord": 99}),
             "record schema mismatch",
         ),
         (
-            lambda value: value["families"][0]["ir_adapter"].update(
+            lambda value: _supported(value)["ir_adapter"].update(
                 {"implementation": "draftwright.model.detect.no_such_adapter"}
             ),
             "stale implementation",
         ),
         (
-            lambda value: value["families"][0]["documentation"].update(
+            lambda value: _supported(value)["documentation"].update(
                 {"evidence": ["docs/reference/missing.md"]}
             ),
             "evidence .* is missing",
         ),
         (
-            lambda value: value["families"][0]["completeness"].update({"state": "maybe"}),
+            lambda value: _supported(value)["completeness"].update({"state": "maybe"}),
             "unknown state",
         ),
     ],
@@ -402,35 +423,40 @@ def test_state_transition_requires_version_release_notes_and_compatibility_evide
     ("mutate", "message"),
     [
         (
-            lambda declaration, _package: declaration["families"][0]["ir_adapter"].update(
+            lambda declaration, _package: _families(declaration)["bosses"]["ir_adapter"].update(
                 {"implementation": "not-a-reference"}
             ),
             "invalid Draftwright implementation reference",
         ),
         (
-            lambda declaration, _package: declaration["families"][0].update({"ir_adapter": []}),
+            lambda declaration, _package: _families(declaration)["bosses"].update(
+                {"ir_adapter": []}
+            ),
             "unknown or invalid fields",
         ),
         (
-            lambda declaration, _package: declaration["families"][0]["ir_adapter"].pop(
+            lambda declaration, _package: _families(declaration)["bosses"]["ir_adapter"].pop(
                 "implementation"
             ),
             "supported claim lacks required evidence",
         ),
         (
-            lambda declaration, _package: declaration["families"][0]["ir_adapter"].update(
+            lambda declaration, _package: _families(declaration)["bosses"]["ir_adapter"].update(
                 {"evidence": []}
             ),
             "evidence must be non-empty",
         ),
         (
-            lambda declaration, _package: declaration["families"][0]["ir_adapter"].update(
+            lambda declaration, _package: _families(declaration)["bosses"]["ir_adapter"].update(
                 {"implementation": 7}
             ),
             "implementation must be a reference",
         ),
         (
-            lambda declaration, _package: declaration["families"][1]["completeness"].pop(
+            # A family whose `completeness` is genuinely deferred — "bosses" declares it
+            # supported, and index 1 stopped being a deferred one when 0.2.6's three new
+            # families changed the sort order (#1244).
+            lambda declaration, _package: _families(declaration)["channels"]["completeness"].pop(
                 "tracking"
             ),
             "deferred state needs rationale and tracking",
@@ -474,11 +500,11 @@ def test_state_transition_requires_version_release_notes_and_compatibility_evide
             "consumer family declarations",
         ),
         (
-            lambda declaration, _package: declaration["families"][0].update({"surprise": 1}),
+            lambda declaration, _package: _families(declaration)["bosses"].update({"surprise": 1}),
             "unknown or missing fields",
         ),
         (
-            lambda declaration, _package: declaration["families"][0].update(
+            lambda declaration, _package: _families(declaration)["bosses"].update(
                 {"disposition": "maybe"}
             ),
             "invalid disposition",
@@ -496,13 +522,13 @@ def test_state_transition_requires_version_release_notes_and_compatibility_evide
             "needs package-owned evidence",
         ),
         (
-            lambda declaration, _package: declaration["families"][0].update(
+            lambda declaration, _package: _families(declaration)["bosses"].update(
                 {"rationale": "not allowed on supported"}
             ),
             "has geometry-only/reserved fields",
         ),
         (
-            lambda declaration, _package: declaration["families"][0].update(
+            lambda declaration, _package: _families(declaration)["bosses"].update(
                 {"disposition": "deferred", "rationale": "later"}
             ),
             "reserved family .* needs rationale and tracking",
@@ -574,7 +600,9 @@ def test_transition_keys_must_be_unique() -> None:
 
 def test_deferred_family_cannot_claim_supported_downstream_semantics() -> None:
     declaration = consumer_capability_declaration()
-    family = declaration["families"][0]
+    # A family with supported boundaries to demote — selected by id, since 0.2.6's new
+    # families sort ahead of "bosses" and are already unsupported (#1244).
+    family = _families(declaration)["bosses"]
     family.update(
         {
             "disposition": "deferred",

--- a/tests/test_recognition.py
+++ b/tests/test_recognition.py
@@ -738,10 +738,26 @@ class TestEdgeFaceMap:
         # hashing/comparing equal across the faces meeting at it. A solid box has
         # edges shared by two faces; if Edge hashing ever regressed, each edge
         # would map to a single face and this would fail. (#150)
-        from b123d_recognisers._features import _edge_face_map
+        #
+        # Read through the PUBLIC `FaceEdges` memo since 0.2.6: this used
+        # `b123d_recognisers._features._edge_face_map`, a private helper the upgrade removed
+        # — one of two private reaches that broke on a patch bump with no announced removals,
+        # which is the cost of testing past the published surface (#1244).
+        from collections import Counter
 
-        counts = [len(faces) for faces in _edge_face_map(Box(10, 10, 10)).values()]
-        assert counts and max(counts) >= 2
+        from b123d_recognisers import FaceEdges
+
+        box = Box(10, 10, 10)
+        memo = FaceEdges()
+        shared: Counter = Counter()
+        for face in box.faces():
+            for edge in memo.of(face):
+                shared[edge] += 1
+        assert shared, "the memo returned no edges at all"
+        assert max(shared.values()) >= 2, (
+            "every edge maps to exactly one face, so a topologically shared edge is no longer "
+            "hashing equal across the faces meeting at it"
+        )
 
 
 class TestFeatureDiameters:

--- a/tests/test_recognition_manifest.py
+++ b/tests/test_recognition_manifest.py
@@ -23,6 +23,7 @@ from b123d_recognisers import (
     RecognitionResult,
     analyse_cylinders,
     build_recognition_result,
+    recognise_angled_steps,
     recognise_bosses,
     recognise_chamfers,
     recognise_channels,
@@ -33,11 +34,13 @@ from b123d_recognisers import (
     recognise_grooves,
     recognise_hole_patterns,
     recognise_holes,
+    recognise_passages,
     recognise_plates,
     recognise_pocket_patterns,
     recognise_pockets,
     recognise_polygonal_bosses,
     recognise_polygonal_stock,
+    recognise_prismatic_pockets,
     recognise_rectangular_pads,
     recognise_repeating_radial_profiles,
     recognise_risers,
@@ -47,7 +50,21 @@ from b123d_recognisers import (
     step_level_records,
 )
 from b123d_recognisers.result import DEFERRED, MIGRATED, Deferral
-from build123d import Align, Box, Cone, Cylinder, Pos, RegularPolygon, extrude, import_step
+from build123d import (
+    Align,
+    Box,
+    BuildPart,
+    BuildSketch,
+    Cone,
+    Cylinder,
+    Plane,
+    Polygon,
+    Pos,
+    RegularPolygon,
+    Rot,
+    extrude,
+    import_step,
+)
 from conftest import counting_calls
 
 import draftwright.model.detect as detect_module
@@ -155,8 +172,59 @@ def _repeating_wheel():
 #: Built lazily, not at import: a module-level list of solids pays five OCC builds during
 #: *collection*, in every pytest process that imports this file — smoke tier and every xdist
 #: worker included.
+def _angled_blind_step():
+    """A partial-width ramp whose blind ends close as TRIANGLES, plus a full-length 45 degree
+    bevel on the far top edge.
+
+    The construction is the package's own `tests/golden/angled_blind_step` fixture, reproduced
+    because it is the only shape that pins the boundary between the two families rather than
+    just the new one: both a chamfer and an angled step appear on one part, each claimed by
+    exactly one recogniser. It also exercises the reconciliation directly — called on their own
+    the recognisers report 2 chamfers and 1 angled step, and the aggregate keeps 1 chamfer,
+    because `_reconcile.chamfers_that_are_not_angled_steps` drops the chamfer whose face the
+    step owns (#1244).
+    """
+    align_min = (Align.MIN, Align.MIN, Align.MIN)
+    base = Box(50, 50, 25, align=align_min)
+    with BuildPart() as ramp:
+        with BuildSketch(Plane.XZ):
+            Polygon((0, 15), (15, 25), (0, 25))
+        extrude(amount=12)
+    edge_break = Pos(25, 50, 25) * Rot(45, 0, 0) * Box(60, 4.243, 4.243)
+    return base - Pos(0, 12, 0) * ramp.part - edge_break
+
+
+def _hexagonal_passage_plate():
+    """A hexagonal THROUGH opening — a passage, the internal counterpart to polygonal stock."""
+    plate = Box(120, 80, 20)
+    with BuildPart() as tool:
+        with BuildSketch(Plane.XY.offset(-20)):
+            RegularPolygon(12, 6)
+        extrude(amount=60)
+    return plate - Pos(-30, 0, 0) * tool.part
+
+
+def _hexagonal_pocket_plate():
+    """A hexagonal BLIND recess (prismatic pocket) beside a rectangular one.
+
+    The rectangular recess is deliberate: both `recognise_pockets` and
+    `recognise_prismatic_pockets` claim it when called directly, and the aggregate keeps the
+    `Pocket` — so this fixture carries the prismatic-pocket reconciliation as well as a
+    non-empty inventory.
+    """
+    plate = Box(120, 80, 20)
+    with BuildPart() as tool:
+        with BuildSketch(Plane.XY.offset(4)):
+            RegularPolygon(12, 6)
+        extrude(amount=20)
+    return plate - Pos(-30, 0, 0) * tool.part - Pos(30, 0, 4) * Box(30, 24, 20)
+
+
 _ORACLE_FIXTURES = [
     ("bolt circle with countersinks", _bolt_circle_with_countersinks),
+    ("angled blind step", _angled_blind_step),
+    ("hexagonal passage", _hexagonal_passage_plate),
+    ("hexagonal pocket", _hexagonal_pocket_plate),
     ("slot grid", _slot_grid_plate),
     ("pocket grid", _pocket_grid_plate),
     ("stepped shaft", _stepped_shaft),
@@ -265,7 +333,15 @@ def test_no_deferred_family_is_reachable_from_the_orchestration():
 #: *and* gated, which is the distinction #1028 established — owning a family and always
 #: running it are different things. Turned parts are the excluded class for all three:
 #: chamfers and fillets on ``rotational``, plates additionally on a turned profile.
-_CLASSIFICATION_GATED = ("recognise_chamfers", "recognise_fillets", "recognise_plates")
+#: Families the orchestration does not run for a rotational part. `recognise_angled_steps`
+#: joined them in 0.2.6: it is the chamfer family's sibling — 0.2.5 split the two apart — and
+#: measured on a turned shaft the aggregate calls neither (#1244).
+_CLASSIFICATION_GATED = (
+    "recognise_angled_steps",
+    "recognise_chamfers",
+    "recognise_fillets",
+    "recognise_plates",
+)
 
 
 def test_a_classification_gated_family_does_not_run_for_the_excluded_class():
@@ -389,7 +465,31 @@ def _expected_inventory(part, *, rotational: bool = False) -> dict:
             if not rotational and not recognise_turned_steps(part, cyls=cyls)
             else ()
         ),
+        # Recognised and carried, consumed by nothing yet — draftwright has taken no position
+        # on these three (#1245/#1246/#1247, declared `unsupported` in the capability
+        # contract). The aggregate must still hold what its recognisers produced: an inventory
+        # nobody converts is exactly where an empty tuple would go unnoticed (#1244).
+        "angled_steps": tuple(recognise_angled_steps(part)) if not rotational else (),
+        "passages": tuple(recognise_passages(part)),
+        "prismatic_pockets": tuple(recognise_prismatic_pockets(part)),
     }
+
+
+#: Fields where a DIRECT recogniser call is not a valid oracle for the aggregate, because the
+#: aggregate applies a cross-family reconciliation the direct call deliberately precedes:
+#:
+#:   "Calling `recognise_passages` directly returns candidates BEFORE that aggregate policy,
+#:    consistently with the other reconciled families."  — b123d-recognisers 0.2.6 notes
+#:
+#: A four-wall passage yields to the more directly dimensioned `Slot`;
+#: `_reconcile.prismatic_pockets_that_are_not_pockets` keeps the `Pocket`; and
+#: `_reconcile.chamfers_that_are_not_angled_steps` drops a chamfer whose face a step owns —
+#: which is why `chamfers` is here too, latent until a fixture carries an angled step (#1244).
+#:
+#: For these the assertion is SUBSET, not equality: the aggregate may drop a candidate to
+#: another family, and may never invent one. Equality is still demanded everywhere else, so the
+#: "ran it and stored ()" failure this test exists for is still caught for 19 of 22 fields.
+_RECONCILED_FIELDS = frozenset({"angled_steps", "chamfers", "passages", "prismatic_pockets"})
 
 
 def test_the_aggregate_carries_what_its_recognisers_returned():
@@ -418,10 +518,17 @@ def test_the_aggregate_carries_what_its_recognisers_returned():
         )
         result = build_recognition_result(part, rotational=rotational)
         for field, want in expected.items():
-            assert getattr(result, field) == want, (
-                f"{name}: the aggregate's {field} is not what its recogniser returned"
-            )
-            if want:
+            got = getattr(result, field)
+            if field in _RECONCILED_FIELDS:
+                assert set(got) <= set(want), (
+                    f"{name}: the aggregate's {field} contains records its recogniser never "
+                    f"produced — reconciliation may only DROP candidates, never invent them"
+                )
+            else:
+                assert got == want, (
+                    f"{name}: the aggregate's {field} is not what its recogniser returned"
+                )
+            if got:
                 covered.add(field)
 
     unexercised = {f.name for f in fields(RecognitionResult)} - covered

--- a/tests/test_recognition_manifest.py
+++ b/tests/test_recognition_manifest.py
@@ -14,6 +14,7 @@ import importlib
 import pkgutil
 from contextlib import contextmanager
 from dataclasses import fields
+from importlib.metadata import version
 from math import cos, radians, sin
 from pathlib import Path
 
@@ -52,16 +53,17 @@ from b123d_recognisers import (
 from b123d_recognisers.result import DEFERRED, MIGRATED, Deferral
 from build123d import (
     Align,
+    Axis,
     Box,
     BuildPart,
     BuildSketch,
     Cone,
     Cylinder,
     Plane,
-    Polygon,
     Pos,
     RegularPolygon,
     Rot,
+    chamfer,
     extrude,
     import_step,
 )
@@ -173,25 +175,45 @@ def _repeating_wheel():
 #: *collection*, in every pytest process that imports this file — smoke tier and every xdist
 #: worker included.
 def _angled_blind_step():
-    """A partial-width ramp whose blind ends close as TRIANGLES, plus a full-length 45 degree
-    bevel on the far top edge.
+    """A partial-width ramp whose blind ends close as triangles, plus a full-length bevel.
 
-    The construction is the package's own `tests/golden/angled_blind_step` fixture, reproduced
-    because it is the only shape that pins the boundary between the two families rather than
-    just the new one: both a chamfer and an angled step appear on one part, each claimed by
-    exactly one recogniser. It also exercises the reconciliation directly — called on their own
-    the recognisers report 2 chamfers and 1 angled step, and the aggregate keeps 1 chamfer,
-    because `_reconcile.chamfers_that_are_not_angled_steps` drops the chamfer whose face the
-    step owns (#1244).
+    Both families on one part, each claimed by exactly one recogniser, so the fixture pins the
+    boundary between them rather than just the new one — and it exercises the reconciliation
+    directly: called on their own the recognisers report 2 chamfers and 1 angled step, and the
+    aggregate keeps 1 chamfer, because `_reconcile.chamfers_that_are_not_angled_steps` drops the
+    chamfer whose face the step owns (#1244).
+
+    Built from a rotated box rather than from the package's own golden construction, which
+    sketches on `Plane.XZ`. That construction is **not stable across the build123d versions this
+    project supports**: measured, the identical script yields volume 61600.0 with 8 faces under
+    0.11.1 and 62275.0 with 9 under 0.10.0, and the angled step is recognised only under 0.11 —
+    which is how CI's Python 3.10 shard (build123d <0.11) failed on this test's own
+    "no fixture produces a non-empty ['angled_steps']" precondition while every 3.13/3.14 shard
+    and both platform canaries passed. `both=True` does not fix it; the difference is in the
+    sketch plane, not the extrude direction.
+
+    This construction is byte-identical on both: 10 faces, volume 60975.00, on 0.10.0 and 0.11.1
+    alike. The assertions below state that, so a future version that moves it fails here rather
+    than silently emptying the inventory.
     """
-    align_min = (Align.MIN, Align.MIN, Align.MIN)
-    base = Box(50, 50, 25, align=align_min)
-    with BuildPart() as ramp:
-        with BuildSketch(Plane.XZ):
-            Polygon((0, 15), (15, 25), (0, 25))
-        extrude(amount=12)
-    edge_break = Pos(25, 50, 25) * Rot(45, 0, 0) * Box(60, 4.243, 4.243)
-    return base - Pos(0, 12, 0) * ramp.part - edge_break
+    base = Box(50, 50, 25, align=(Align.MIN, Align.MIN, Align.MIN))
+    ramped = base - (Pos(0, 25, 25) * Rot(0, -33.69, 0) * Box(40, 12, 20))
+    bevel = [
+        edge
+        for edge in ramped.edges().filter_by(Axis.X)
+        if abs(edge.center().Z - 25) < 1e-6 and abs(edge.center().Y - 50) < 1e-6
+    ]
+    assert bevel, "the bevel edge moved; this fixture no longer carries a chamfer"
+    part = chamfer(bevel[0], length=3)
+    # 0.01, not exact: the ramp angle is 33.69 degrees, so the volume is 60974.9987... and a
+    # `:.2f` probe reading of "60975.00" is what made the first tolerance here 1e-6 and wrong.
+    # The bound only has to catch the failure mode actually seen — the version difference moved
+    # this construction's predecessor by 675 mm3, five orders of magnitude larger.
+    assert len(part.faces()) == 10 and abs(part.volume - 60975.0) < 0.01, (
+        f"the fixture's geometry moved under build123d {version('build123d')}: "
+        f"{len(part.faces())} faces, volume {part.volume} — it is version-sensitive again"
+    )
+    return part
 
 
 def _hexagonal_passage_plate():

--- a/tests/test_recognition_result.py
+++ b/tests/test_recognition_result.py
@@ -1,11 +1,9 @@
 """ADR 0017 phase 1: one explicit recognition result."""
 
 from dataclasses import FrozenInstanceError
-from types import SimpleNamespace
 
 import pytest
 from b123d_recognisers import (
-    FaceLevel,
     RecognitionResult,
     build_recognition_result,
     recognise_plates,
@@ -60,140 +58,19 @@ def test_built_drawing_exposes_its_recognition_result_without_private_state(monk
     assert drawing.recognition() is result
 
 
-def test_orchestrator_injects_each_shared_dependency_once(monkeypatch):
-    import b123d_recognisers.result as result_module
-
-    calls: dict[str, int] = {}
-    cylinders = ([{"axis": "z"}], [{"axis": "x"}])
-    countersinks = [object()]
-    holes = [object()]
-    slots = [object()]
-    pockets = [object()]
-
-    def fake_cylinders(part):
-        calls["cylinders"] = calls.get("cylinders", 0) + 1
-        return cylinders
-
-    def counted(name, returns):
-        """A stand-in that records the call and returns *returns*."""
-
-        def fake(part, **kwargs):
-            calls[name] = calls.get(name, 0) + 1
-            return returns
-
-        return fake
-
-    def cyl_consumer(name, returns):
-        """A stand-in for a recogniser the orchestration hands the cylinder substrate.
-
-        Asserts the SAME list objects arrive — the point of the aggregate is that no
-        recogniser rediscovers a dependency, and an equal-but-fresh pair would mean it did.
-        """
-
-        def fake(part, *, cyls=None, **kwargs):
-            calls[name] = calls.get(name, 0) + 1
-            assert cyls is not None, f"{name} was not given the cylinder substrate"
-            assert cyls[0] is cylinders[0] and cyls[1] is cylinders[1]
-            return returns
-
-        return fake
-
-    def derived(name, source, returns):
-        """A stand-in for a pattern recogniser, which must be handed its members."""
-
-        def fake(records):
-            calls[name] = calls.get(name, 0) + 1
-            assert records is source, f"{name} was not given the accepted member records"
-            return returns
-
-        return fake
-
-    def fake_holes(part, *, cyls=None, csinks=None):
-        calls["holes"] = calls.get("holes", 0) + 1
-        assert cyls[0] is cylinders[0] and cyls[1] is cylinders[1]
-        assert csinks is countersinks
-        return holes
-
-    monkeypatch.setattr(result_module, "analyse_cylinders", fake_cylinders)
-    monkeypatch.setattr(
-        result_module, "recognise_countersinks", counted("countersinks", countersinks)
-    )
-    monkeypatch.setattr(result_module, "recognise_holes", fake_holes)
-    monkeypatch.setattr(result_module, "recognise_double_d_bores", counted("double_d_bores", []))
-    monkeypatch.setattr(result_module, "recognise_hole_patterns", derived("patterns", holes, []))
-    monkeypatch.setattr(result_module, "recognise_bosses", cyl_consumer("bosses", []))
-    monkeypatch.setattr(
-        result_module, "recognise_polygonal_bosses", counted("polygonal_bosses", [])
-    )
-    monkeypatch.setattr(result_module, "recognise_polygonal_stock", counted("polygonal_stock", []))
-    monkeypatch.setattr(result_module, "recognise_channels", counted("channels", []))
-    monkeypatch.setattr(result_module, "recognise_slots", counted("slots", slots))
-    monkeypatch.setattr(result_module, "recognise_pockets", counted("pockets", pockets))
-    monkeypatch.setattr(
-        result_module, "recognise_pocket_patterns", derived("pocket_patterns", pockets, [])
-    )
-    monkeypatch.setattr(result_module, "recognise_rectangular_pads", counted("pads", []))
-    monkeypatch.setattr(
-        result_module,
-        "recognise_repeating_radial_profiles",
-        counted("repeating_radial_profiles", []),
-    )
-    monkeypatch.setattr(result_module, "recognise_turned_steps", cyl_consumer("turned_steps", []))
-    # The area-filtered records retain face support (#915); the scalar-span boundary projects Z
-    # values for sizing/critique. It takes the part only — no substrate identity to assert.
-    level_records = [FaceLevel(4.0, (0.0, 8.0), (0.0, 6.0)), FaceLevel(9.0)]
-    monkeypatch.setattr(result_module, "step_level_records", counted("step_levels", level_records))
-    # #1026 hoisted these three out of `build_part_model`. `slot_patterns` is derived, so it
-    # must be handed the accepted slot records rather than rediscovering them; the other two
-    # take the shared cylinder substrate.
-    monkeypatch.setattr(
-        result_module, "recognise_slot_patterns", derived("slot_patterns", slots, [])
-    )
-    monkeypatch.setattr(result_module, "recognise_grooves", cyl_consumer("grooves", []))
-    monkeypatch.setattr(result_module, "recognise_flats", cyl_consumer("flats", []))
-    # #1025: the level-free riser scan. Takes the part only — the level set that used to
-    # make this family caller-specific now lives in `project_step_shoulders`.
-    monkeypatch.setattr(result_module, "recognise_risers", counted("risers", []))
-    # #1028: gated on the classification the aggregate carries. This orchestration runs
-    # with the default `rotational=False`, so all three are expected to run.
-    monkeypatch.setattr(result_module, "recognise_chamfers", counted("chamfers", []))
-    monkeypatch.setattr(result_module, "recognise_fillets", counted("fillets", []))
-    monkeypatch.setattr(result_module, "recognise_plates", counted("plates", []))
-
-    built = result_module.build_recognition_result(object())
-
-    # ONCE, not merely "at least once": a second call is a rediscovered substrate wearing
-    # a correct answer's clothes. Both halves — WHICH families ran, and how often.
-    assert set(calls) == {
-        "cylinders",
-        "countersinks",
-        "holes",
-        "double_d_bores",
-        "patterns",
-        "bosses",
-        "polygonal_bosses",
-        "polygonal_stock",
-        "channels",
-        "slots",
-        "pockets",
-        "pocket_patterns",
-        "pads",
-        "repeating_radial_profiles",
-        "turned_steps",
-        "step_levels",
-        "slot_patterns",
-        "grooves",
-        "flats",
-        "risers",
-        "chamfers",
-        "fillets",
-        "plates",
-    }, f"the orchestration ran a different set of families: {sorted(calls)}"
-    assert set(calls.values()) == {1}, f"a family ran more than once: {calls}"
-    assert built.holes == tuple(holes)
-    assert built.step_levels == tuple(level_records)
-    bb = SimpleNamespace(min=SimpleNamespace(Z=0.0), max=SimpleNamespace(Z=10.0))
-    assert built.step_ladder_for_z_span(bb.min.Z, bb.max.Z) == [4.0, 9.0]
+# `test_orchestrator_injects_each_shared_dependency_once` was here until #1244.
+#
+# It replaced every recogniser in `b123d_recognisers.result` with a fake to assert the aggregate
+# injects the cylinder substrate once and hands the same objects on. Every symbol it asserted
+# belonged to the package — it stated nothing about draftwright — and 0.2.6 restructured that
+# orchestration (`analyse_cylinders` gave way to `CylinderInventory`), so its patch targets no
+# longer exist.
+#
+# Not retargeted: the property draftwright depends on is "each family runs exactly once per
+# build, and nothing rescans", and that is asserted from OUR side, against the running engine and
+# the public family names, by `test_recognition_manifest.py::
+# test_an_automatic_build_runs_each_family_exactly_once_and_lint_runs_no_migrated_one`. A second
+# copy phrased in the dependency's private vocabulary bought a private reach and no coverage.
 
 
 def _grooved_flatted_shaft():

--- a/uv.lock
+++ b/uv.lock
@@ -85,15 +85,15 @@ wheels = [
 
 [[package]]
 name = "b123d-recognisers"
-version = "0.2.4"
+version = "0.2.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/57/50db8f08f83c52f4ab4ab678cdaaf23828e6d4cb555cf9e7c45b35a2f24d/b123d_recognisers-0.2.4.tar.gz", hash = "sha256:7fa463e605a96768f5d6793705c9369f809887a18afe169bfa9ca82f0d669e05", size = 348956, upload-time = "2026-08-16T17:49:18.975Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/30/b33dad6cdf1e871cdfb6fb3d5983ce1d3f7473ee06efa6cee409a4702636/b123d_recognisers-0.2.6.tar.gz", hash = "sha256:4cce440c6ce5c538516d605ccbd12e8b1e41e1ae997c83df297f26f31a4fac2a", size = 528299, upload-time = "2026-08-21T05:01:11.032Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/14/64b883ce34df6a557f4134b3532a9b5fd4c5acfa1f60d20191686464074a/b123d_recognisers-0.2.4-py3-none-any.whl", hash = "sha256:681231f164fb3c234f0c8e30bb79570bea4a0afabfbe1f79e5d050b036343732", size = 135359, upload-time = "2026-08-16T17:49:17.378Z" },
+    { url = "https://files.pythonhosted.org/packages/20/0b/4243c5895a9de4f928b4341dca394bf1697cfe8fd307174a8d5827cdf706/b123d_recognisers-0.2.6-py3-none-any.whl", hash = "sha256:314fce78f4a3c064f8d1ff1e050c54094918bb5d40d0ea3bbd61b6d2450ece90", size = 197970, upload-time = "2026-08-21T05:01:09.735Z" },
 ]
 
 [[package]]
@@ -105,23 +105,23 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "anytree", marker = "python_full_version < '3.13'" },
-    { name = "cadquery-ocp", marker = "python_full_version < '3.13'" },
-    { name = "ezdxf", marker = "python_full_version < '3.13'" },
-    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "anytree" },
+    { name = "cadquery-ocp" },
+    { name = "ezdxf" },
+    { name = "ipython", version = "8.39.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
     { name = "ipython", version = "9.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "lib3mf", marker = "python_full_version < '3.13'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "lib3mf" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "ocp-gordon", marker = "python_full_version < '3.13'" },
-    { name = "ocpsvg", version = "0.5.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "ocp-gordon" },
+    { name = "ocpsvg", version = "0.5.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
     { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "svgpathtools", marker = "python_full_version < '3.13'" },
-    { name = "sympy", marker = "python_full_version < '3.13'" },
-    { name = "trianglesolver", marker = "python_full_version < '3.13'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-    { name = "webcolors", marker = "python_full_version < '3.13'" },
+    { name = "svgpathtools" },
+    { name = "sympy" },
+    { name = "trianglesolver" },
+    { name = "typing-extensions" },
+    { name = "webcolors" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/00/b56ebe1d2a31611dbfcc315d22ebb5403eddc60027d5f82acd493ebb5ac1/build123d-0.10.0.tar.gz", hash = "sha256:73ded38ddca8ebb95e7dd078ac3d7aacc8ca42fce8f1d176f1040e35fba4f608", size = 20011921, upload-time = "2025-11-05T22:04:37.054Z" }
 wheels = [
@@ -136,23 +136,23 @@ resolution-markers = [
     "python_full_version >= '3.13'",
 ]
 dependencies = [
-    { name = "anytree", marker = "python_full_version >= '3.13'" },
-    { name = "cadquery-ocp-novtk", marker = "python_full_version >= '3.13'" },
-    { name = "ezdxf", marker = "python_full_version >= '3.13'" },
-    { name = "ipython", version = "9.14.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "lib3mf", marker = "(python_full_version >= '3.13' and platform_machine != 'aarch64') or (python_full_version >= '3.13' and sys_platform != 'linux')" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "ocp-gordon", marker = "python_full_version >= '3.13'" },
-    { name = "ocpsvg", version = "0.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "py-lib3mf", marker = "python_full_version >= '3.13' and platform_machine == 'aarch64' and sys_platform == 'linux'" },
-    { name = "requests", marker = "python_full_version >= '3.13'" },
-    { name = "scikit-learn", marker = "python_full_version >= '3.13'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "svgpathtools", marker = "python_full_version >= '3.13'" },
-    { name = "sympy", marker = "python_full_version >= '3.13'" },
-    { name = "trianglesolver", marker = "python_full_version >= '3.13'" },
-    { name = "typing-extensions", marker = "python_full_version >= '3.13'" },
-    { name = "webcolors", marker = "python_full_version >= '3.13'" },
+    { name = "anytree" },
+    { name = "cadquery-ocp-novtk" },
+    { name = "ezdxf" },
+    { name = "ipython", version = "9.14.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "lib3mf", marker = "platform_machine != 'aarch64' or sys_platform != 'linux'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "ocp-gordon" },
+    { name = "ocpsvg", version = "0.6.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "py-lib3mf", marker = "platform_machine == 'aarch64' and sys_platform == 'linux'" },
+    { name = "requests" },
+    { name = "scikit-learn" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "svgpathtools" },
+    { name = "sympy" },
+    { name = "trianglesolver" },
+    { name = "typing-extensions" },
+    { name = "webcolors" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/27/b7487242de480cd349baad8d1a3eca6a5eb65ebfb331cf0c5b408a832f96/build123d-0.11.1.tar.gz", hash = "sha256:9647c3fc7e1ef11d9c335787a54cf26e9bbc2191186342fe9755ec24a480033b", size = 20911070, upload-time = "2026-07-02T18:33:10.783Z" }
 wheels = [
@@ -177,7 +177,7 @@ name = "cadquery-ocp"
 version = "7.8.1.1.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "vtk", marker = "python_full_version < '3.13'" },
+    { name = "vtk" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/a6/760c6383f8e0cac562583feab0d4733876522ee265f2cfa3a26bdffef330/cadquery_ocp-7.8.1.1.post1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4413961e98a90686a56c2ac58b126773c7da4eb82b967ddcc1f394fe6a7b71ad", size = 68085209, upload-time = "2025-01-29T14:33:03.08Z" },
@@ -203,7 +203,7 @@ name = "cadquery-ocp-novtk"
 version = "7.9.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cadquery-ocp-proxy", version = "7.9.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+    { name = "cadquery-ocp-proxy", version = "7.9.3.1", source = { registry = "https://pypi.org/simple" } },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6e/33/6bbf47a7f5eab09b0e9bf26cd84c14353d66c7ebc72c36a65cd311f5d516/cadquery_ocp_novtk-7.9.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c750e8d8cf6b2c01c6a171ace4a9b66b8a855be0d7578cdba104b46e9c388e34", size = 61729426, upload-time = "2026-02-15T13:34:57.147Z" },
@@ -408,7 +408,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -478,7 +478,7 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.13'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
 wheels = [
@@ -746,7 +746,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "antlr4-python3-runtime", specifier = "<4.10" },
-    { name = "b123d-recognisers", specifier = "==0.2.4" },
+    { name = "b123d-recognisers", specifier = "==0.2.6" },
     { name = "build123d", marker = "python_full_version < '3.13'", specifier = ">=0.9.0,<0.11" },
     { name = "build123d", marker = "python_full_version >= '3.13'", specifier = ">=0.11,<0.12" },
     { name = "build123d-drafting-helpers", specifier = ">=0.14.1" },
@@ -783,7 +783,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1029,17 +1029,17 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version < '3.11'" },
-    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
-    { name = "jedi", marker = "python_full_version < '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
-    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
-    { name = "pygments", marker = "python_full_version < '3.11'" },
-    { name = "stack-data", marker = "python_full_version < '3.11'" },
-    { name = "traitlets", marker = "python_full_version < '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "exceptiongroup" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -1055,18 +1055,18 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.13'",
 ]
 dependencies = [
-    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
-    { name = "decorator", marker = "python_full_version >= '3.11'" },
-    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
-    { name = "jedi", marker = "python_full_version >= '3.11'" },
-    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
-    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
-    { name = "psutil", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten'" },
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
-    { name = "stack-data", marker = "python_full_version >= '3.11'" },
-    { name = "traitlets", marker = "python_full_version >= '3.11'" },
-    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil", marker = "sys_platform != 'emscripten'" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e2/23/3a27530575643c8bb7bfc757a28e2e7ef80092afbf59a2bc5716320b6602/ipython-9.14.1.tar.gz", hash = "sha256:f913bf74df06d458e46ced84ca506c23797590d594b236fe60b14df213291e7b", size = 4433457, upload-time = "2026-06-05T08:12:34.921Z" }
 wheels = [
@@ -1078,7 +1078,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "pygments" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -1569,15 +1569,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "cycler", marker = "python_full_version < '3.11'" },
-    { name = "fonttools", marker = "python_full_version < '3.11'" },
-    { name = "kiwisolver", marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "packaging", marker = "python_full_version < '3.11'" },
-    { name = "pillow", marker = "python_full_version < '3.11'" },
-    { name = "pyparsing", marker = "python_full_version < '3.11'" },
-    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
@@ -1645,15 +1645,15 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.13'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "cycler", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "fonttools", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "kiwisolver", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "packaging", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "pillow", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "pyparsing", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
-    { name = "python-dateutil", marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "cycler" },
+    { name = "fonttools" },
+    { name = "kiwisolver" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "packaging" },
+    { name = "pillow" },
+    { name = "pyparsing" },
+    { name = "python-dateutil" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/24/080c99d223d158d3a8902769269ab6da5b50f7a0e6e072513907e02b7a6c/matplotlib-3.11.0.tar.gz", hash = "sha256:68c0c7be01b30dcca3638934f7f591df73401235cbdbf0d1ab1c71e7db7f8b57", size = 33251176, upload-time = "2026-06-12T02:29:15.508Z" }
 wheels = [
@@ -2083,8 +2083,8 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "cadquery-ocp", marker = "python_full_version < '3.13'" },
-    { name = "svgelements", marker = "python_full_version < '3.13'" },
+    { name = "cadquery-ocp" },
+    { name = "svgelements" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/af/e2/3ba2ad53395f91c72070cb3b8b033c5d9f9ba2ae6f61e869ef2a5f7f8ade/ocpsvg-0.5.0.tar.gz", hash = "sha256:5cd8dbec8bf590d373a82aaebeab241838185aab04ee2859f33b9d7956bbfba6", size = 54195, upload-time = "2025-02-21T15:54:12.333Z" }
 wheels = [
@@ -2099,8 +2099,8 @@ resolution-markers = [
     "python_full_version >= '3.13'",
 ]
 dependencies = [
-    { name = "cadquery-ocp-proxy", version = "7.9.3.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "svgelements", marker = "python_full_version >= '3.13'" },
+    { name = "cadquery-ocp-proxy", version = "7.9.3.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "svgelements" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/89/48/f121f459dc6e184ca2ee99b8fba0a2f51b1ef710d829eafb43d9acd1100d/ocpsvg-0.6.0.tar.gz", hash = "sha256:f08da4347cc90ecd3565395e9bda5746d46ab8aafd6a2681bb03a9c321b54039", size = 54342, upload-time = "2026-01-08T12:31:35.206Z" }
 wheels = [
@@ -2567,10 +2567,10 @@ name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "certifi", marker = "python_full_version >= '3.13'" },
-    { name = "charset-normalizer", marker = "python_full_version >= '3.13'" },
-    { name = "idna", marker = "python_full_version >= '3.13'" },
-    { name = "urllib3", marker = "python_full_version >= '3.13'" },
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
@@ -2620,11 +2620,11 @@ name = "scikit-learn"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "joblib", marker = "python_full_version >= '3.13'" },
-    { name = "narwhals", marker = "python_full_version >= '3.13'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
-    { name = "threadpoolctl", marker = "python_full_version >= '3.13'" },
+    { name = "joblib" },
+    { name = "narwhals" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "threadpoolctl" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
 wheels = [
@@ -2668,7 +2668,7 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -2728,7 +2728,7 @@ resolution-markers = [
     "python_full_version >= '3.11' and python_full_version < '3.13'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -3041,7 +3041,7 @@ name = "vtk"
 version = "9.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.13'" },
     { name = "matplotlib", version = "3.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.13'" },
 ]
 wheels = [


### PR DESCRIPTION
Two releases. Every fail-closed guard fired exactly as designed — three new
families cannot arrive unnoticed — and running them down turned up two real
behaviour changes my first assessment had missed.

## The declarations

`angled-steps`, `passages` and `prismatic-pockets` are declared **unsupported**,
each against the issue deciding what it should mean: #1247, #1245, #1246. Three
registers had to learn them, and each is deliberately its own thing rather than a
line added to an existing set:

- `recogniser_contract._UNSUPPORTED` — disposition `unsupported`, every boundary
  with a rationale, completeness `deferred` with the tracking issue.
- `detect._UNCONSUMED_RECORDS` — a fourth registry tier. NOT folded into
  `_ORCHESTRATED_RECORDS`: those are nested sub-records with permanent design
  reasons, these are open questions, and a new test requires each entry to cite
  an issue the capability declaration also tracks, so the tier is a waiting room
  and not a bin.
- `quality._UNDECIDED_INVENTORIES` — held apart from
  `_NON_REQUIREMENT_INVENTORIES` for the same reason, with a test that the two
  never overlap and that each cites a tracked issue. The blind spot is stated
  plainly: a drawing omitting a recognised passage scores complete today.

## Two behaviour changes on real parts

**A regression, filed upstream (pzfreo/b123d-recognisers#140).** A slot with a
coaxial post at its own depth is no longer recognised at all — 0.2.4 reported the
flat span. Scope measured over seven slot shapes: plain, blind, obround, pivot
boss and parallel slots are unaffected; one post or two defeats it. The cost is
a drawing losing `m_slot0_length`, `m_slot0_pos` and `m_slot0_width` silently.
`test_coaxial_posts_at_both_ends_do_not_extend_length` is `xfail(strict=True)`
so it flips the day the fix lands rather than the marker outliving the defect.

**An improvement.** On the vendored GRM-03 thumbwheel, 0.2.6 finds a real
⌀6 × 0.5 step where 0.2.4 reported two adjacent ⌀10 steps. The workflow doc
quoted the old emitted script; updated to what the tool now produces.

## The aggregate reconciles; the direct call does not

Worth recording, because I got it wrong first: `recognise_prismatic_pockets`
and `recognise_pockets` both claim a rectangular recess when called directly,
and I filed that as a collision. Draftwright consumes the AGGREGATE, which
applies `_reconcile.*` and keeps the `Pocket`. So any test treating a direct
call as the oracle for an aggregate field is invalid for a reconciled family —
including `chamfers`, whose direct call now reports a blind step's slant.
`_expected_inventory` asserts subset for those four fields and equality for the
other eighteen, and three new oracle fixtures make the new inventories non-empty
(the angled-step one is the package's own golden construction, which carries a
chamfer AND an angled step so the reconciliation is exercised, not assumed).

## Private API

My first audit under-counted: it read the names in import statements, but two
tests reach attributes dynamically. Four reaches, three broken by a patch bump
with no announced removals — the cost of testing past the published surface.
Production code (`src/`) is clean.

- `_features._edge_face_map` -> the public `FaceEdges` memo.
- `_recess_core._body_signature` -> the ambiguous case is now built on the public
  `Slot`/`Pocket` dataclasses; it cannot be induced through geometry, since a body
  key embeds the bounding box.
- `polygonal_bosses._normal` and `result.analyse_cylinders` -> deleted. Both
  asserted the dependency's internals and nothing about draftwright; the property
  we depend on ("each family runs once per build") is asserted from our side by
  `test_recognition_manifest`.

Also: the capability tests selected families by list POSITION, and `angled-steps`
sorts ahead of `bosses`, so mutations aimed at a supported family began hitting an
unsupported one. They select by disposition or by id now.

The pin, lock, release evidence and changelog were regenerated by
`scripts/update-recogniser-dependency`, which verifies the PyPI hashes and the
capability-manifest digest, rather than by hand.

4393 passed (fast), 45 passed (slow), pr-check --static exit 0, no golden drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTXU3X3YFa1HPRdmUgCw22