### PR TITLE
ADR 0018 slices 1+2: the view topology becomes a value, and views report what they carry (#1130)

### DIFF
--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -75,6 +75,7 @@ from draftwright.projection import (
     _fit_iso_view,
     _project_iso,
 )
+from draftwright.view_plan import resolve_from_analysis
 
 # A view centre must move by more than this (mm) for the measure-and-repack
 # pass to re-assemble.  Below it, the estimate already matched the measured
@@ -448,11 +449,28 @@ def _assemble(
     # loop's intermediate assemblies will pass a cheap stand-in and only the final one the real
     # solid (#1137). Every caller currently takes the default, so nothing has changed yet.
     part_s = (a.part if shape is None else shape).scale(a.SCALE)
-    dwg._add_view(
-        "front", part_s, (cxs, cys - dist, czs), (0, 0, 1), (a.FV_X, a.FV_Y), scaled=True
-    )
-    dwg._add_view("plan", part_s, (cxs, cys, czs + dist), (0, 1, 0), (a.PV_X, a.PV_Y), scaled=True)
-    dwg._add_view("side", part_s, (cxs + dist, cys, czs), (0, 0, 1), (a.SV_X, a.SV_Y), scaled=True)
+
+    # ADR 0018: the views this drawing has, and where they go, come from ONE resolved plan
+    # instead of three hardcoded calls whose cameras, page fields and layout meaning were
+    # spread across this function, `Analysis` and `compose.choose_scale`'s docstring. The plan
+    # still describes exactly the third-angle front/plan/side set the engine has always built —
+    # this slice is representation, not selection — but it is now a value that a later slice can
+    # vary, and the projection convention is stated where the views are named rather than
+    # implied by three camera literals.
+    #
+    # Cameras are attached here because they need the scaled part's centre and the projection
+    # distance, which the plan deliberately knows nothing about: a `ViewSpec` is a request in
+    # MODEL terms, and a camera position in page-scaled coordinates is not one.
+    _CAMERAS = {
+        "front": ((cxs, cys - dist, czs), (0, 0, 1)),
+        "plan": ((cxs, cys, czs + dist), (0, 1, 0)),
+        "side": ((cxs + dist, cys, czs), (0, 0, 1)),
+    }
+    dwg._build.view_plan = view_plan = resolve_from_analysis(a)
+    for spec in view_plan.of_kind("principal"):
+        camera, up = _CAMERAS[spec.name]
+        place = view_plan.placements[spec.name]
+        dwg._add_view(spec.name, part_s, camera, up, (place.cx, place.cy), scaled=True)
     _project_iso(dwg, a, a.SCALE, shape_s=part_s)
 
     _diagnostics = None  # the audit ledger; filled once at the end of this function (#996)

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -54,6 +54,7 @@ from draftwright._core import (
 )
 from draftwright.layout import fit_box
 from draftwright.model.callout import hole_callout_spec
+from draftwright.view_plan import principal_placements
 
 _log = logging.getLogger(__name__)
 
@@ -662,11 +663,17 @@ def choose_scale(
 
 
 def _view_geom(a) -> dict:
-    """The three orthographic geometry boxes as ``{view: (cx, cy, hw, hh)}``."""
+    """The orthographic geometry boxes as ``{view: (cx, cy, hw, hh)}``.
+
+    Read off the resolved view plan (ADR 0018) rather than assembled here from `FV_X`/`PV_X`/
+    `SV_X` and the half-extent fields. Same numbers — `resolve_from_analysis` reads the same
+    `Analysis` — but the set of views and their page geometry now has one owner, so a later
+    slice that drops a redundant principal view changes the plan and this follows, instead of
+    this function needing to learn about it separately.
+    """
     return {
-        "front": (a.FV_X, a.FV_Y, a.fv_hw, a.fv_hh),
-        "plan": (a.PV_X, a.PV_Y, a.fv_hw, a.pv_hh),
-        "side": (a.SV_X, a.SV_Y, a.sv_hw, a.fv_hh),
+        name: (place.cx, place.cy, place.hw, place.hh)
+        for name, place in principal_placements(a).items()
     }
 
 

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -367,6 +367,12 @@ class BuildState:
     principal_profile_cache: tuple[object, bool, tuple[LintIssue, ...]] | None = None
     trace: Any = None
     detail_view: bool = False
+    #: The ADR 0018 :class:`~draftwright.view_plan.ResolvedViewPlan` — which views this drawing
+    #: has and where their blocks sit. ONE typed attachment, filled once by the builder at the
+    #: same site it creates the views, because the alternative the ADR names explicitly is what
+    #: the topology was before: the answer spread across `Analysis` fields, three hardcoded
+    #: `_add_view` calls and a docstring, with no single thing to read or replace.
+    view_plan: Any = None
     #: The compiler's :class:`~draftwright.model.compiled.Omission` records — every
     #: measurement it considered and did not approve, with the rule that stopped it (#996).
     #: The compiled plan was a local in the orchestrator: built, read by the renderers, and
@@ -529,6 +535,16 @@ class Drawing:
         # replays through the live helpers). Default off → the live path is unchanged.
         self._intents: list[Intent] = []
         self._defer_intents: bool = False
+
+    @property
+    def view_plan(self):
+        """The resolved view plan (ADR 0018), or ``None`` before the views are created.
+
+        READ ONLY, and there is no setter: a resolved plan that a caller can rebind is
+        indistinguishable from an authored request, which is the confusion ADR 0018 §1 exists to
+        prevent. Editing means converting it into constraints explicitly and resolving again.
+        """
+        return self._build.view_plan
 
     @property
     def registry(self):

--- a/src/draftwright/view_plan.py
+++ b/src/draftwright/view_plan.py
@@ -190,6 +190,11 @@ class ViewCoverage:
     view: str
     carries: frozenset
     exclusive: frozenset
+    #: Measurements this view claims that MORE THAN ONE annotation claims somewhere on the
+    #: drawing. For those, an id cannot tell whether two views draw the same mark or different
+    #: marks of one parameter — so exclusivity by id is not an answer, and this records where
+    #: the question was unanswerable rather than letting `exclusive` imply it was answered.
+    indeterminate: frozenset = frozenset()
 
     @property
     def carries_nothing_exclusively(self) -> bool:
@@ -201,8 +206,18 @@ class ViewCoverage:
         it to relate two others. ADR 0018 makes exactly this the trap to avoid — "removing a
         visually similar but semantically necessary view is rejected by an asymmetric
         counterexample" — so this answers the measurable half and refuses to imply the rest.
+
+        **Fails closed on indeterminate coverage**, which is the difference between right and
+        wrong on a real case rather than a refinement. A `DimensionId` names a parameter, not a
+        mark (ADR 0016 Amdt 3), so every rung of a step ladder shares one id. An enlarged DETAIL
+        view exists precisely to redraw the rungs the main view could not fit — three of them,
+        on `_crowded_staircase` — and all three claim the id the main view already claims. By id
+        alone that detail carries nothing exclusively and reads as droppable, while dropping it
+        loses three dimensions from the sheet: the exact trap above, reached by arithmetic
+        rather than by judgement. Per-mark identity (ADR 0019 §3) is what makes the case
+        answerable; until then it is reported as unanswered.
         """
-        return not self.exclusive
+        return not self.exclusive and not self.indeterminate
 
 
 def view_coverage(drawing) -> Mapping[str, ViewCoverage]:
@@ -220,11 +235,24 @@ def view_coverage(drawing) -> Mapping[str, ViewCoverage]:
     under `None` and take part in the exclusivity arithmetic, because a measurement stated only
     on the iso is still stated.
     """
-    per_view: dict[Any, set] = {}
+    # SEEDED from the views the drawing has, not discovered from the annotations. A view that
+    # carries nothing at all has no annotations to discover it by, so building the map from
+    # annotations alone drops exactly the most redundant views: on an X-turned stepped shaft the
+    # `side` view carries not one measurement, and the first version of this function reported
+    # only `plan` as a candidate and never mentioned it (#1130).
+    per_view: dict[Any, set] = {name: set() for name in getattr(drawing, "views", ())}
     for name in drawing.registry.names():
         view = drawing.view_of(name)
         claimed = drawing.registry.measurement_of(name) or ()
         per_view.setdefault(view, set()).update(claimed)
+
+    # How many annotations claim each measurement, drawing-wide. An id claimed more than once
+    # cannot distinguish "two views draw the same mark" from "two views draw different marks of
+    # one parameter", and the second is exactly what a detail view is for.
+    claim_counts: dict[Any, int] = {}
+    for name in drawing.registry.names():
+        for mid in drawing.registry.measurement_of(name) or ():
+            claim_counts[mid] = claim_counts.get(mid, 0) + 1
 
     coverage = {}
     for view, carries in per_view.items():
@@ -233,7 +261,10 @@ def view_coverage(drawing) -> Mapping[str, ViewCoverage]:
             if other != view:
                 elsewhere |= theirs
         coverage[view] = ViewCoverage(
-            view=view, carries=frozenset(carries), exclusive=frozenset(carries - elsewhere)
+            view=view,
+            carries=frozenset(carries),
+            exclusive=frozenset(carries - elsewhere),
+            indeterminate=frozenset(m for m in carries if claim_counts.get(m, 0) > 1),
         )
     return MappingProxyType(coverage)
 

--- a/src/draftwright/view_plan.py
+++ b/src/draftwright/view_plan.py
@@ -1,0 +1,177 @@
+"""The views a drawing has, and where they sit — ADR 0018's representation slice.
+
+Until now nothing owned the question *which views should exist*. The four orthographic views
+were named at one site in `builder` with hardcoded cameras, their page positions came from
+`Analysis` fields called `FV_X`/`PV_X`/`SV_X`, and `compose.choose_scale` did its layout
+arithmetic from a docstring — "Layout columns: [front(x×z)] [side(y×z)] [iso] [title block]" —
+rather than from anything a caller could inspect or change. The topology was real but implicit,
+spread across three modules and stated in prose.
+
+This module makes it a value. :class:`ViewSpec` is a semantic request — what a view shows, in
+model terms, and nothing about the page. :class:`ResolvedViewPlan` is the immutable result — the
+same specs plus the page geometry chosen for them. The split is ADR 0018 decision §1 ("one value
+vocabulary, distinct request and result states"), and it is a split rather than one mutable
+object because a resolved plan that can be edited in place is indistinguishable from a request,
+which is how a layout comes to be silently relaxed.
+
+**This slice changes no behaviour.** It describes the fixed front/plan/side/iso topology the
+engine already builds, and the golden placement snapshots are the gate. Semantic view SELECTION
+— dropping a view because nothing needs it, which is what the thin rotational plate in
+`tests/test_issue_1130_view_planning_evidence.py` is waiting for — comes only once the
+lifecycle, projection-convention and requirement-coverage invariants in ADR 0018's evidence list
+are guarded. A representation nobody can yet vary is the point of the first slice: everything
+above it stops reading the topology out of scattered fields, so the later change has one place
+to happen.
+
+Rank 0: this is a leaf. It describes views; it cannot reach the code that draws them.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+
+#: The model axes a principal view projects onto the page, as ``(page_x, page_y)``.
+#: Third-angle front shows model x across and z up; the plan shows x across and y up; the side
+#: shows y across and z up. Held here rather than inferred from the camera because
+#: `compose.choose_scale` needs to know which two model extents a view's block spans before any
+#: geometry is projected, and deriving it from a camera vector at that point is how the mapping
+#: came to be duplicated in a docstring in the first place.
+_PRINCIPAL_PAGE_AXES = {
+    "front": ("x", "z"),
+    "plan": ("x", "y"),
+    "side": ("y", "z"),
+}
+
+
+@dataclass(frozen=True)
+class ViewSpec:
+    """One view a drawing should contain, in model terms.
+
+    Deliberately says nothing about the page: no position, no size, no scale. A spec is what a
+    planner decides and a user may edit; where it lands is the resolver's answer, and mixing the
+    two is what ADR 0018 §1 separates. `camera` and `up` are the projection request as
+    `Drawing._add_view` already expresses it — a direction from the part and an up vector —
+    while `page_axes` states which model extents the view's block spans, which is the fact
+    layout arithmetic needs and cameras only imply.
+    """
+
+    name: str
+    #: What the view is FOR. `principal` participates in projection-convention relationships and
+    #: in the page/scale decision; `pictorial` (the iso) is orientation only and is fitted after
+    #: the sheet is settled; `section` and `detail` are derived from another view. The kind is
+    #: what makes "which views should exist" answerable — a principal view may be dropped only
+    #: if nothing requires what it shows, and a pictorial one carries no requirements at all.
+    kind: str
+    camera: tuple[float, float, float] | None = None
+    up: tuple[float, float, float] | None = None
+    page_axes: tuple[str, str] | None = None
+
+    def __post_init__(self) -> None:
+        if self.kind not in _KINDS:
+            raise ValueError(f"unknown view kind {self.kind!r}; expected one of {sorted(_KINDS)}")
+
+
+_KINDS = frozenset({"principal", "pictorial", "section", "detail"})
+
+
+@dataclass(frozen=True)
+class ViewPlacement:
+    """Where a resolved view's block sits on the page: centre and half-extents, in page mm."""
+
+    cx: float
+    cy: float
+    hw: float
+    hh: float
+
+    @property
+    def bounds(self) -> tuple[float, float, float, float]:
+        return (self.cx - self.hw, self.cy - self.hh, self.cx + self.hw, self.cy + self.hh)
+
+
+@dataclass(frozen=True)
+class ResolvedViewPlan:
+    """The views a drawing has, their page geometry, and the sheet they were resolved onto.
+
+    Immutable, and immutable on purpose: ADR 0018 §1 keeps the resolved result distinct from the
+    editable request so a caller cannot mutate a snapshot and have it read as an authored
+    constraint. Turning one back into constraints is an explicit conversion, not an attribute
+    write.
+    """
+
+    specs: tuple[ViewSpec, ...]
+    placements: Mapping[str, ViewPlacement]
+    scale: float
+    page: tuple[float, float]
+
+    def __post_init__(self) -> None:
+        names = [spec.name for spec in self.specs]
+        if len(names) != len(set(names)):
+            raise ValueError(f"duplicate view names in plan: {names}")
+        object.__setattr__(self, "placements", MappingProxyType(dict(self.placements)))
+
+    def spec(self, name: str) -> ViewSpec | None:
+        return next((spec for spec in self.specs if spec.name == name), None)
+
+    def of_kind(self, kind: str) -> tuple[ViewSpec, ...]:
+        return tuple(spec for spec in self.specs if spec.kind == kind)
+
+    @property
+    def principal_names(self) -> tuple[str, ...]:
+        return tuple(spec.name for spec in self.specs if spec.kind == "principal")
+
+
+def third_angle_principals() -> tuple[ViewSpec, ...]:
+    """The front/plan/side set the engine has always built, as specs.
+
+    Cameras are `None` here: they depend on the scaled part's centre and the projection
+    distance, which only `builder` knows, so they are filled by :func:`resolve_from_analysis`'s
+    caller. What this function fixes is the SET and its page-axis mapping — the part that was
+    previously a sentence in `choose_scale`'s docstring.
+    """
+    return tuple(
+        ViewSpec(name=name, kind="principal", page_axes=axes)
+        for name, axes in _PRINCIPAL_PAGE_AXES.items()
+    )
+
+
+def principal_placements(analysis) -> dict[str, ViewPlacement]:
+    """Where the principal view blocks sit, read from a finished `Analysis`.
+
+    Split out from :func:`resolve_from_analysis` because the layout consumers need exactly this
+    and nothing else. Building a whole plan for them would make them depend on `SCALE`,
+    `PAGE_W` and `PAGE_H` as well — and it did: routing `compose._view_geom` through the full
+    resolver broke a repack test that passes a minimal stub carrying only the position fields.
+    The stub was right and the coupling was wrong; a consumer that needs placements should ask
+    for placements.
+    """
+    return {
+        "front": ViewPlacement(analysis.FV_X, analysis.FV_Y, analysis.fv_hw, analysis.fv_hh),
+        "plan": ViewPlacement(analysis.PV_X, analysis.PV_Y, analysis.fv_hw, analysis.pv_hh),
+        "side": ViewPlacement(analysis.SV_X, analysis.SV_Y, analysis.sv_hw, analysis.fv_hh),
+    }
+
+
+def resolve_from_analysis(analysis) -> ResolvedViewPlan:
+    """Read the plan the engine has already decided out of a finished `Analysis`.
+
+    The bridge for this slice, and the reason it changes no behaviour: `Analysis` already
+    carries the resolved answer, spread over `FV_X`/`PV_X`/`SV_X`, the matching `Y` fields, and
+    the `fv_hw`/`sv_hw`/`fv_hh`/`pv_hh` half-extents. Reading it into one value lets every
+    consumer stop reaching for those fields individually, without changing what any of them
+    compute. When view selection becomes a real decision, this function is replaced by a
+    resolver that *chooses*, and its callers do not move.
+
+    The iso is included as a `pictorial` spec with no placement: it is fitted after the sheet is
+    settled (`projection._fit_iso_view`), so at resolve time it genuinely has no page geometry,
+    and recording a placeholder would be a claim the engine cannot honour.
+    """
+    placements = principal_placements(analysis)
+    specs = third_angle_principals() + (ViewSpec(name="iso", kind="pictorial"),)
+    return ResolvedViewPlan(
+        specs=specs,
+        placements=placements,
+        scale=analysis.SCALE,
+        page=(analysis.PAGE_W, analysis.PAGE_H),
+    )

--- a/src/draftwright/view_plan.py
+++ b/src/draftwright/view_plan.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
+from typing import Any
 
 #: The model axes a principal view projects onto the page, as ``(page_x, page_y)``.
 #: Third-angle front shows model x across and z up; the plan shows x across and y up; the side
@@ -174,4 +175,84 @@ def resolve_from_analysis(analysis) -> ResolvedViewPlan:
         placements=placements,
         scale=analysis.SCALE,
         page=(analysis.PAGE_W, analysis.PAGE_H),
+    )
+
+
+@dataclass(frozen=True)
+class ViewCoverage:
+    """What one view carries, and what would be lost with it.
+
+    `carries` is every measurement drawn in this view; `exclusive` is the subset no other view
+    draws. The distinction is the whole point: a view whose measurements all appear elsewhere
+    costs the sheet its area and contributes nothing a reader could not get from another view.
+    """
+
+    view: str
+    carries: frozenset
+    exclusive: frozenset
+
+    @property
+    def carries_nothing_exclusively(self) -> bool:
+        """No measurement would be lost if this view were removed.
+
+        **Necessary, not sufficient**, and the name says so rather than saying "redundant". A
+        view can carry no exclusive DIMENSION and still be required: it may be the only view
+        showing a feature's shape, the projection convention may demand it, or a reader may need
+        it to relate two others. ADR 0018 makes exactly this the trap to avoid — "removing a
+        visually similar but semantically necessary view is rejected by an asymmetric
+        counterexample" — so this answers the measurable half and refuses to imply the rest.
+        """
+        return not self.exclusive
+
+
+def view_coverage(drawing) -> Mapping[str, ViewCoverage]:
+    """Per-view measurement coverage of a FINISHED drawing.
+
+    The evidence view selection needs and does not yet have: before a view can be dropped,
+    something has to be able to say what goes with it. Read through the ADR 0010 provenance
+    seam — an annotation claiming a `DimensionId` is asserting it draws that measurement — and
+    the view each annotation was tagged with at placement, so this is what the sheet actually
+    carries rather than what the compiler hoped for.
+
+    Duck-typed on `drawing` (`registry.names()`, `view_of`, `registry.measurement_of`) so this
+    stays a rank-0 leaf, the way `audit` reads finished drawings without the engine depending on
+    it. Annotations owned by no orthographic view — the title block, iso furniture — are grouped
+    under `None` and take part in the exclusivity arithmetic, because a measurement stated only
+    on the iso is still stated.
+    """
+    per_view: dict[Any, set] = {}
+    for name in drawing.registry.names():
+        view = drawing.view_of(name)
+        claimed = drawing.registry.measurement_of(name) or ()
+        per_view.setdefault(view, set()).update(claimed)
+
+    coverage = {}
+    for view, carries in per_view.items():
+        elsewhere: set = set()
+        for other, theirs in per_view.items():
+            if other != view:
+                elsewhere |= theirs
+        coverage[view] = ViewCoverage(
+            view=view, carries=frozenset(carries), exclusive=frozenset(carries - elsewhere)
+        )
+    return MappingProxyType(coverage)
+
+
+def views_carrying_nothing_exclusively(drawing) -> tuple[str, ...]:
+    """Principal views whose every measurement is also drawn elsewhere, sorted.
+
+    A CANDIDATE list for removal, not a verdict — see
+    :attr:`ViewCoverage.carries_nothing_exclusively`. Restricted to principal views because the
+    pictorial view is orientation and carries no requirements by design, so reporting it here
+    every time would be noise that trains a reader to ignore the answer.
+    """
+    coverage = view_coverage(drawing)
+    plan = getattr(drawing, "view_plan", None)
+    principals = set(plan.principal_names) if plan is not None else {"front", "plan", "side"}
+    return tuple(
+        sorted(
+            name
+            for name, cover in coverage.items()
+            if name in principals and cover.carries_nothing_exclusively
+        )
     )

--- a/tests/test_drawing_encapsulation.py
+++ b/tests/test_drawing_encapsulation.py
@@ -504,8 +504,13 @@ def test_build_state_has_a_single_construction_and_fill_site():
             "_build.part_model",
             "_build.detail_view",
             "_build.trace",
+            "_build.view_plan",
             "_build.omissions",
         ],  # omissions: ONE assignment covering both the auto and auto_dims=False paths
+        # _build.view_plan: ADR 0018's resolved plan, filled at the same site that creates the
+        # views from it — the topology and the drawing's record of the topology cannot disagree
+        # because one statement produces both. `Drawing.view_plan` is read-only with no setter,
+        # so this list staying at one entry is what stops a second writer appearing.
         # drawing.py owns the lazy #1058 principal-profile critique cache; linting returns
         # the physical result through an explicit function and never reaches into Drawing.
         # drawing.py still writes _build.trace via the deprecated attach_solve_trace

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -68,6 +68,8 @@ _LAYERS: dict[str, int] = {
     "fonts": 0,
     "layout": 0,
     "registry": 0,
+    # ADR 0018's view representation: describes views, imports nothing that draws them.
+    "view_plan": 0,
     "intents": 0,
     "recognition": 0,
     "recognition_cache": 0,

--- a/tests/test_issue_1130_view_planning_evidence.py
+++ b/tests/test_issue_1130_view_planning_evidence.py
@@ -43,8 +43,13 @@ def thin_rotational_plate():
     are chosen to hit 43 x 217 x 217 exactly.
     """
     part = Rot(0, 90, 0) * Cylinder(108.5, 12)
-    part += Rot(0, 90, 0) * Pos(0, 0, 12) * Cylinder(45, 18)  # axial stack
-    part += Rot(0, 90, 0) * Pos(0, 0, 30) * Cylinder(28, 13)
+    # The axial stack, each tier STARTING where the last ends. The first version left a 2.5 mm
+    # gap between them, so the second tier floated: build123d 0.11 tolerates that as a
+    # two-solid `Compound` and 0.10 returns a `ShapeList`, which `build_drawing` then tried to
+    # open as a file path. A disconnected part was never the intent — every measurement taken
+    # from this fixture was taken from a part in two pieces (#1130).
+    part += Rot(0, 90, 0) * Pos(0, 0, 12) * Cylinder(45, 18)  # z 3 .. 21
+    part += Rot(0, 90, 0) * Pos(0, 0, 28.75) * Cylinder(28, 15.5)  # z 21 .. 36.5
     part -= Rot(0, 90, 0) * Cylinder(16, 60)  # central bore
     part -= Pos(30, 0, 0) * Box(60, 8, 20)  # keyway
     for index in range(6):  # outer concentric hole pattern
@@ -66,10 +71,20 @@ def test_the_synthetic_plate_matches_the_case_studys_geometry():
     Without it the fixture could drift into some other shape and the numbers below would still
     look like evidence for ADR 0018 while describing something else.
     """
-    box = thin_rotational_plate().bounding_box()
+    part = thin_rotational_plate()
+    box = part.bounding_box()
     measured = (box.size.X, box.size.Y, box.size.Z)
     assert measured == pytest.approx(_BBOX, abs=0.5), (
         f"the fixture is {measured}, not the case study's {_BBOX}"
+    )
+    # ONE solid. The first version left a 2.5 mm gap in the axial stack, so the top tier floated
+    # — and a bounding box cannot see that, which is why every measurement taken from this
+    # fixture was taken from a part in two pieces. build123d 0.11 tolerates it as a `Compound`
+    # while 0.10 returns a `ShapeList` that `build_drawing` tries to open as a file path, so it
+    # passed here and failed every Linux CI shard (#1130).
+    assert len(part.solids()) == 1, (
+        f"the fixture is in {len(part.solids())} pieces; a disconnected stand-in is not the "
+        "case study's part and behaves differently across build123d versions"
     )
 
 

--- a/tests/test_issue_1130_view_planning_evidence.py
+++ b/tests/test_issue_1130_view_planning_evidence.py
@@ -1,0 +1,177 @@
+"""ADR 0018's motivating failure, reproduced from a synthetic part.
+
+The ADR was proposed from a user-supplied `worm_planetary_concept_Alimacznicy.step` that this
+repository does not have, and its first required-evidence item is:
+
+    A synthetic thin rotational plate reproduces the A1/fixed-four-view failure without relying
+    on a proprietary or externally supplied STEP file.
+
+This is that fixture. It exists so every later slice of #1130 is measured against something the
+repository owns, and so the claim "the fixed four-view topology forces the sheet" is a number
+here rather than a recollection of someone else's file.
+
+**These tests pin CURRENT behaviour, deliberately.** Nothing here is a defect report against the
+packer — given four views the engine's choice is correct, and its refusal to fit A2 is honest.
+What they record is that the decision ADR 0018 says nothing owns is not being made: the plan
+view is a redundant second edge-on view of a rotational part, and it is on the sheet because the
+topology is fixed, not because anything judged it worth its 217 mm.
+
+A slice that changes these numbers is doing ADR 0018's work, and must update them and say so.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from build123d import Box, Cylinder, Pos, Rot
+
+from draftwright.builder import ScaleIncompatibilityError, build_drawing
+
+#: The case study's measurements, from ADR 0018 "Case study: thin X-axis worm planetary plate":
+#: "Geometry bbox: 43 x 217 x 217 mm. It is a thin, predominantly rotational X-axis component
+#: with two concentric hole patterns, several coaxial diameters, an axial stack, pockets and a
+#: central keyway."
+_BBOX = (43.0, 217.0, 217.0)
+
+
+def thin_rotational_plate():
+    """A thin X-axis rotational plate carrying the case study's feature vocabulary.
+
+    Not a copy of the user's part — a synthetic stand-in with the same bounding box, axis and
+    kinds of features, which is what the evidence item asks for. The disc radius and hub stack
+    are chosen to hit 43 x 217 x 217 exactly.
+    """
+    part = Rot(0, 90, 0) * Cylinder(108.5, 12)
+    part += Rot(0, 90, 0) * Pos(0, 0, 12) * Cylinder(45, 18)  # axial stack
+    part += Rot(0, 90, 0) * Pos(0, 0, 30) * Cylinder(28, 13)
+    part -= Rot(0, 90, 0) * Cylinder(16, 60)  # central bore
+    part -= Pos(30, 0, 0) * Box(60, 8, 20)  # keyway
+    for index in range(6):  # outer concentric hole pattern
+        angle = index * math.pi / 3
+        part -= (
+            Rot(0, 90, 0) * Pos(85 * math.cos(angle), 85 * math.sin(angle), 0) * Cylinder(6, 40)
+        )
+    for index in range(4):  # inner concentric hole pattern
+        angle = index * math.pi / 2 + math.pi / 4
+        part -= (
+            Rot(0, 90, 0) * Pos(60 * math.cos(angle), 60 * math.sin(angle), 0) * Cylinder(4.5, 40)
+        )
+    return part
+
+
+def test_the_synthetic_plate_matches_the_case_studys_geometry():
+    """The precondition for every other assertion here: this really is the ADR's part.
+
+    Without it the fixture could drift into some other shape and the numbers below would still
+    look like evidence for ADR 0018 while describing something else.
+    """
+    box = thin_rotational_plate().bounding_box()
+    measured = (box.size.X, box.size.Y, box.size.Z)
+    assert measured == pytest.approx(_BBOX, abs=0.5), (
+        f"the fixture is {measured}, not the case study's {_BBOX}"
+    )
+
+
+@pytest.fixture(scope="module")
+def automatic():
+    """One automatic build, shared. Measured at ~2 s; three separate builds cost 5 s and the
+    repo's guidance is that a critique-style test shares a module-scoped drawing rather than
+    minting a dense fixture per assertion. NOT marked slow: a slice that moves these numbers
+    should fail in the fast tier, where the author sees it, not post-merge (#153)."""
+    return build_drawing(thin_rotational_plate(), title="T", number="N")
+
+
+class TestTheFixedTopologyForcesTheSheet:
+    def test_the_automatic_result_is_a1_at_full_scale_and_reports_no_problem(self, automatic):
+        """The ADR's headline: A1 landscape at 1:1, and the drawing says it is fine.
+
+        `passed` and the lint are the part worth reading. Nothing in the engine considers an A1
+        sheet for a part 43 mm thick to be a fault, because no check owns the question — which
+        is the gap ADR 0018 exists to close, stated as an assertion rather than as an opinion.
+        """
+        drawing = automatic
+
+        assert (drawing.page_w, drawing.page_h) == (841.0, 594.0), "not A1 landscape"
+        assert drawing.scale == 1.0
+        assert set(drawing.views) == {"front", "plan", "side", "iso"}
+        assert not [issue for issue in drawing.lint() if issue.severity == "error"]
+        assert drawing.lint_summary()["passed"] is True
+
+    def test_the_plan_view_repeats_the_front_and_carries_almost_nothing(self, automatic):
+        """WHY it is the wrong sheet, not just that it is a big one.
+
+        On an X-axis rotational part the front and plan are both edge-on: same silhouette, same
+        extent. One of them is a second look at the same thing, and the annotations show which —
+        the disc face (side) carries the hole patterns and diameters, the front carries the
+        axial dimensions, and the plan carries almost nothing while occupying 217 mm.
+        """
+        drawing = automatic
+        front = drawing.view_bounds("front")
+        plan = drawing.view_bounds("plan")
+        side = drawing.view_bounds("side")
+
+        front_size = (front[2] - front[0], front[3] - front[1])
+        plan_size = (plan[2] - plan[0], plan[3] - plan[1])
+        assert plan_size == pytest.approx(front_size, abs=0.5), (
+            f"front {front_size} and plan {plan_size} are no longer the same projection, so "
+            "this part is no longer the redundant-view case the ADR describes"
+        )
+        assert (side[2] - side[0]) == pytest.approx(side[3] - side[1], abs=0.5), (
+            "the side view is no longer the square disc face"
+        )
+
+        counts: dict = {}
+        for name in drawing.registry.names():
+            counts[drawing.view_of(name)] = counts.get(drawing.view_of(name), 0) + 1
+        assert counts.get("plan", 0) <= 2, (
+            f"the plan view now carries {counts.get('plan', 0)} annotations, so it is no longer "
+            f"the near-empty duplicate this case is about: {counts}"
+        )
+        assert counts.get("side", 0) > 5 * counts.get("plan", 0), (
+            f"the disc face no longer dominates the annotation load: {counts}"
+        )
+
+    def test_the_automatic_sheet_is_one_the_engine_would_refuse_if_asked_for_it(self, automatic):
+        """The sharp end of the evidence, and a defect in its own right (#1250).
+
+        The automatic build chooses A1 at 1:1 and reports `passed: True` with no lint errors.
+        Ask for that SAME page and scale explicitly and the engine refuses — "requested scale 1
+        cannot preserve required annotations (callout_dropped, slot_dim_dropped)". Same part,
+        same sheet, same scale, two verdicts, decided by how the caller phrased the request:
+        the explicit path runs `_scale_blockers` and the automatic path does not.
+
+        And the blockers are real, not an artefact of the stricter path: the automatic drawing
+        itself carries `slot_dim_dropped` and `hole_requirement_missing`, so it IS the
+        incomplete drawing the explicit gate exists to prevent. It reports success because
+        `completeness` is unavailable on this part, so nothing scores the omission.
+
+        ADR 0018's evidence list requires exactly the opposite: "A forced small sheet/large
+        scale that drops a requirement is rejected, not accepted with a warning-only incomplete
+        drawing." Today it is not even warning-only.
+
+        The first version of this test asserted that A2 at 1:1 raises, and read that as the
+        four-view topology forcing the sheet. It does raise — but so does A1, so the assertion
+        demonstrated this inconsistency rather than the sheet cost it claimed. The mutation that
+        found it changed `page="A2"` to `page="A1"` and the test still passed.
+        """
+        assert automatic.lint_summary()["passed"] is True
+        dropped = {issue.code for issue in automatic.lint()}
+        assert {"slot_dim_dropped", "hole_requirement_missing"} <= dropped, (
+            f"the automatic drawing no longer loses requirements, so there is nothing "
+            f"inconsistent about accepting it: {sorted(dropped)}"
+        )
+
+        with pytest.raises(ScaleIncompatibilityError) as raised:
+            build_drawing(
+                thin_rotational_plate(),
+                page="A1",
+                scale=1.0,
+                title="T",
+                number="N",
+            )
+        message = str(raised.value)
+        assert "cannot preserve required annotations" in message
+        assert "slot_dim_dropped" in message, (
+            f"the refusal no longer names the requirements it would lose: {message}"
+        )

--- a/tests/test_view_plan.py
+++ b/tests/test_view_plan.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import dataclasses
 
 import pytest
-from build123d import Box, Cylinder, Pos
+from build123d import Box, Cylinder, Pos, Rot
 
 from draftwright.builder import build_drawing
 from draftwright.view_plan import (
@@ -51,8 +51,16 @@ class TestThePlanDescribesWhatWasActuallyBuilt:
         plan = built.view_plan
         assert plan is not None, "a built drawing has no view plan"
 
-        drawn = {name for name in built.views if name in {"front", "plan", "side", "iso"}}
-        assert {spec.name for spec in plan.specs} == drawn
+        # The comparison is to the views resolved AT BUILD TIME, and the filter is a stated
+        # limitation rather than a convenience: sections and details are created later by
+        # annotation passes (`_add_view("section_aa", …)`, `_resolve_details`) and never enter
+        # the plan, so a plain `== set(built.views)` would fail on any sectioned part. The first
+        # version of this test filtered silently, which made "every view is in the plan" true by
+        # construction. `test_sections_and_details_are_not_in_the_plan_yet` pins the gap instead.
+        planned_at_build = {
+            name for name in built.views if name in {"front", "plan", "side", "iso"}
+        }
+        assert {spec.name for spec in plan.specs} == planned_at_build
 
         assert plan.principal_names == ("front", "plan", "side")
         assert [spec.name for spec in plan.of_kind("pictorial")] == ["iso"]
@@ -259,6 +267,99 @@ class TestPerViewRequirementCoverage:
         assert coverage["front"].exclusive and coverage["side"].exclusive
         assert len(coverage["side"].carries) > 5
 
+    @pytest.mark.parametrize(
+        ("name", "build", "expected"),
+        [
+            # A plain turned part needs ONE longitudinal view: the diameters carry the ⌀
+            # symbol, so nothing requires an end view, and BOTH radial views come back empty.
+            (
+                "stepped shaft",
+                lambda: Rot(0, 90, 0) * (Cylinder(10, 40) + Pos(0, 0, 40) * Cylinder(6, 30)),
+                ("plan", "side"),
+            ),
+            (
+                "grooved shaft",
+                lambda: (
+                    (Rot(0, 90, 0) * Cylinder(12, 80))
+                    - Rot(0, 90, 0) * Pos(0, 0, 20) * (Cylinder(12, 6) - Cylinder(9, 6))
+                ),
+                ("plan", "side"),
+            ),
+            # Turned about Z rather than X: the redundant pair follows the AXIS, which is what
+            # a rule keyed on view NAMES would get wrong.
+            (
+                "Z-axis shaft",
+                lambda: Cylinder(10, 60) + Pos(0, 0, 60) * Cylinder(6, 20),
+                ("plan", "side"),
+            ),
+        ],
+    )
+    def test_a_turned_part_leaves_its_radial_views_empty(self, name, build, expected):
+        """The redundancy is structural for turned parts, not a property of one plate.
+
+        A body of revolution looks the same from every radial direction, so the two views that
+        differ only in radial direction carry nothing between them — measured here on three
+        shafts, and the count is the drafting answer: a plain turned part is conventionally
+        dimensioned on one longitudinal view.
+
+        The contrast with the fixtures below is the useful part. A turned part carrying RADIAL
+        features (a bolt circle, a hole pattern) needs its end view and only one candidate
+        appears; a plain shaft has no radial content and both appear. Coverage separates those
+        two without being told which is which.
+        """
+        from draftwright.view_plan import view_coverage, views_carrying_nothing_exclusively
+
+        drawing = build_drawing(build(), title="T", number="N")
+        assert views_carrying_nothing_exclusively(drawing) == expected
+        coverage = view_coverage(drawing)
+        assert coverage["front"].exclusive, (
+            f"{name}: the longitudinal view carries nothing either, so this part is not "
+            "dimensioned at all and the assertion above is vacuous"
+        )
+
+    def test_a_turned_part_with_radial_features_keeps_its_end_view(self):
+        """The asymmetry WITHIN turned parts, which is the sharper of the two.
+
+        The thin plate and the shafts are all rotational; the plate's end view carries its bolt
+        circle and hole pattern, so only one radial view is spare rather than both. A rule that
+        said "turned parts need one view" would strip the end view off this one and lose the
+        pattern.
+        """
+        from test_issue_1130_view_planning_evidence import thin_rotational_plate
+
+        from draftwright.view_plan import view_coverage, views_carrying_nothing_exclusively
+
+        drawing = build_drawing(thin_rotational_plate(), title="T", number="N")
+        coverage = view_coverage(drawing)
+
+        assert views_carrying_nothing_exclusively(drawing) == ("plan",)
+        assert len(coverage["side"].exclusive) > 5, (
+            "the end view no longer carries the radial features, so it no longer distinguishes "
+            "this case from a plain shaft"
+        )
+
+    def test_a_view_carrying_no_annotations_at_all_is_reported(self):
+        """The bug this class had until turned parts were tried.
+
+        Coverage was built by walking annotations, so a view with NO annotations never entered
+        the map and could never be reported — silently dropping exactly the most redundant
+        views. On a stepped shaft the `side` view carries not one measurement, and only `plan`
+        was reported. The map is seeded from the drawing's views now.
+        """
+        from draftwright.view_plan import view_coverage
+
+        drawing = build_drawing(
+            Rot(0, 90, 0) * (Cylinder(10, 40) + Pos(0, 0, 40) * Cylinder(6, 30)),
+            title="T",
+            number="N",
+        )
+        coverage = view_coverage(drawing)
+
+        assert {"front", "plan", "side"} <= set(coverage), (
+            f"a view the drawing has is missing from its coverage: {sorted(map(str, coverage))}"
+        )
+        assert coverage["side"].carries == frozenset()
+
     def test_a_prismatic_plate_has_none(self):
         """The counterexample. Three views, every one carrying something only it carries.
 
@@ -327,3 +428,67 @@ class TestPerViewRequirementCoverage:
         assert coverage["front"].exclusive == frozenset({only_front})
         assert coverage["side"].exclusive == frozenset()
         assert coverage["plan"].carries_nothing_exclusively
+
+
+class TestSectionsAndDetailsAreNotPlannedYet:
+    """The gap this slice does not close, pinned so it cannot be forgotten or overstated.
+
+    ADR 0018's `ViewSpec.kind` already admits `section` and `detail`, and the ADR's own "why
+    now" cites #1190: the section "is not part of the scale/layout decision at all… placed
+    opportunistically into whatever is left, which is why its presence tracked leftover space
+    rather than need." That is still true. These views are created by annotation passes long
+    after the plan is resolved, so the plan under-describes the drawing, and bringing them in is
+    the work #1190 pointed at.
+    """
+
+    def test_a_section_view_exists_outside_the_plan(self):
+        part = (
+            Box(120, 80, 40)
+            - Pos(0, 0, 10) * Cylinder(18, 40)
+            - Pos(-40, 0, 0) * Cylinder(6, 60)
+            - Pos(40, 0, 0) * Cylinder(6, 60)
+        )
+        drawing = build_drawing(part, title="T", number="N")
+        assert "section_aa" in drawing.views, "precondition: this part is no longer sectioned"
+        assert drawing.view_plan.spec("section_aa") is None, (
+            "the section is in the plan now — good, but this test states the opposite and must "
+            "be rewritten to assert the section participates in the layout decision"
+        )
+
+    def test_a_detail_view_that_redraws_dropped_marks_is_never_a_candidate(self):
+        """The trap, and the reason coverage fails closed.
+
+        A detail exists to redraw the marks the main view could not fit. Those marks share their
+        parameter's `DimensionId` with the ones that DID fit (ADR 0016 Amdt 3 — an id names a
+        parameter, not a mark), so by id alone the detail carries nothing exclusively. On
+        `_crowded_staircase` it draws three step heights and every one of them reads as already
+        covered by the front view.
+
+        Answering "droppable" there would lose three dimensions off the sheet — precisely ADR
+        0018's "visually similar but semantically necessary view", reached by arithmetic. So
+        coverage reports the ids as INDETERMINATE and the view as not a candidate. Per-mark
+        identity (ADR 0019 §3) is what would let this be answered rather than declined.
+        """
+        from test_issue_1215_no_approved_tolerance_is_dropped import _PARTS
+
+        from draftwright.view_plan import view_coverage, views_carrying_nothing_exclusively
+
+        drawing = build_drawing(_PARTS["crowded_staircase"](), title="T", number="N")
+        assert "detail_a" in drawing.views, "precondition: this part no longer details"
+
+        cover = view_coverage(drawing)["detail_a"]
+        drawn_in_detail = [
+            name for name in drawing.registry.names() if drawing.view_of(name) == "detail_a"
+        ]
+        assert len(drawn_in_detail) >= 3, (
+            f"the detail draws {len(drawn_in_detail)} marks; fewer than three and it no longer "
+            "demonstrates several marks collapsing onto one id"
+        )
+        assert len(cover.carries) == 1, (
+            f"{len(drawn_in_detail)} marks no longer collapse to one id ({len(cover.carries)}), "
+            "so per-mark identity may have landed and this can become an exclusivity assertion"
+        )
+        assert cover.exclusive == frozenset(), "precondition: by id alone it looks droppable"
+        assert cover.indeterminate, "the collapse is not being reported as unanswerable"
+        assert not cover.carries_nothing_exclusively
+        assert "detail_a" not in views_carrying_nothing_exclusively(drawing)

--- a/tests/test_view_plan.py
+++ b/tests/test_view_plan.py
@@ -215,3 +215,115 @@ def test_the_repack_loop_really_consumes_the_plan():
         "changing the measured view geometry changes nothing on this fixture, so it no longer "
         "exercises the repack loop and the plan's only uncovered consumer is unverified again"
     )
+
+
+class TestPerViewRequirementCoverage:
+    """ADR 0018 slice 2: what each view carries, and what would go with it.
+
+    Selection cannot happen until something can answer "what is lost if this view goes", and
+    nothing could. This is that answer, and the ADR names the two cases it must separate:
+
+        Removing a truly redundant view retains every requirement and reduces the selected
+        footprint.
+
+        Removing a visually similar but semantically necessary view is rejected by an
+        asymmetric counterexample.
+
+    The pair below is that asymmetry. Both parts have three principal views showing broadly
+    similar silhouettes; on one, a view carries nothing of its own, and on the other every view
+    does. A rule that cannot tell them apart would either strip a needed view or never strip
+    anything.
+    """
+
+    def test_a_rotational_plate_has_one_view_carrying_nothing_of_its_own(self):
+        """The redundant case, and the reason the thin plate needs an A1.
+
+        On an X-axis rotational part the front and plan are the same edge-on projection. The
+        engine draws both because the topology is fixed, and the plan ends up carrying no
+        measurement at all — 217 mm of sheet for a repeat of its neighbour.
+        """
+        from test_issue_1130_view_planning_evidence import thin_rotational_plate
+
+        from draftwright.view_plan import view_coverage, views_carrying_nothing_exclusively
+
+        drawing = build_drawing(thin_rotational_plate(), title="T", number="N")
+        coverage = view_coverage(drawing)
+
+        assert views_carrying_nothing_exclusively(drawing) == ("plan",)
+        assert coverage["plan"].carries == frozenset(), (
+            f"the plan view now carries {len(coverage['plan'].carries)} measurements, so this "
+            "is no longer the redundant-view case"
+        )
+        # The other two are not candidates, and carry real content — otherwise "one candidate"
+        # would be satisfied by a drawing that had simply lost its dimensions.
+        assert coverage["front"].exclusive and coverage["side"].exclusive
+        assert len(coverage["side"].carries) > 5
+
+    def test_a_prismatic_plate_has_none(self):
+        """The counterexample. Three views, every one carrying something only it carries.
+
+        Without this the redundancy rule could be "drop the plan view", which is true of the
+        fixture above and false in general.
+        """
+        from draftwright.view_plan import view_coverage, views_carrying_nothing_exclusively
+
+        part = (
+            Box(120, 80, 12)
+            - Pos(-30, 10, 0) * Cylinder(4, 40)
+            - Pos(30, -10, 0) * Cylinder(4, 40)
+        )
+        drawing = build_drawing(part, title="T", number="N")
+        coverage = view_coverage(drawing)
+
+        assert views_carrying_nothing_exclusively(drawing) == ()
+        for name in ("front", "plan", "side"):
+            assert coverage[name].exclusive, (
+                f"{name} carries nothing exclusively on the counterexample, so the asymmetry "
+                f"this pair exists to prove is gone: "
+                f"{ {v: len(c.exclusive) for v, c in coverage.items()} }"
+            )
+
+    def test_coverage_is_read_from_what_the_sheet_actually_carries(self):
+        """Through the ADR 0010 seam, not from the compiler's intentions.
+
+        A measurement the compiler approved and no annotation drew must not appear as covered —
+        that is the difference between "the plan wanted this" and "the drawing says this", and
+        the whole value of the answer depends on it being the second.
+        """
+        from draftwright.view_plan import view_coverage
+
+        drawing = build_drawing(Box(80, 60, 20), title="T", number="N")
+        coverage = view_coverage(drawing)
+
+        claimed_by_annotations = set()
+        for name in drawing.registry.names():
+            claimed_by_annotations |= set(drawing.registry.measurement_of(name) or ())
+        from_coverage = set().union(*(cover.carries for cover in coverage.values()))
+        assert from_coverage == claimed_by_annotations
+
+    def test_an_exclusive_measurement_is_one_no_other_view_draws(self):
+        """The arithmetic, on a constructed drawing rather than on whatever a part produces."""
+        from types import SimpleNamespace
+
+        from draftwright.view_plan import view_coverage
+
+        shared, only_front = object(), object()
+        registry = SimpleNamespace(
+            names=lambda: ["a", "b", "c"],
+            measurement_of=lambda n: {
+                "a": (shared, only_front),
+                "b": (shared,),
+                "c": (),
+            }[n],
+        )
+        drawing = SimpleNamespace(
+            registry=registry,
+            view_of=lambda n: {"a": "front", "b": "side", "c": "plan"}[n],
+            view_plan=None,
+        )
+        coverage = view_coverage(drawing)
+
+        assert coverage["front"].carries == frozenset({shared, only_front})
+        assert coverage["front"].exclusive == frozenset({only_front})
+        assert coverage["side"].exclusive == frozenset()
+        assert coverage["plan"].carries_nothing_exclusively

--- a/tests/test_view_plan.py
+++ b/tests/test_view_plan.py
@@ -1,0 +1,217 @@
+"""ADR 0018 slice 1: the view plan is a value, it is the one owner, and it changed nothing.
+
+The ADR's required evidence for this slice is three claims, and this file is each of them:
+
+    A no-behaviour-change slice represents the current four views through `ViewSpec` and
+    `ResolvedViewPlan` and preserves representative rendered semantics.
+
+    Authored `ViewConstraints` cannot be mistaken for an immutable `ResolvedViewPlan`.
+
+    `ResolvedViewPlan` has one typed `BuildState` attachment and a read-only `Drawing` surface;
+    structural guards reject another writer or ad-hoc private cache.
+
+The second is partly ahead of this slice — `ViewConstraints` does not exist yet — so what is
+guarded here is the half that does: a resolved plan cannot be edited in place or rebound, which
+is the property that makes the request/result split hold when constraints arrive.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+from build123d import Box, Cylinder, Pos
+
+from draftwright.builder import build_drawing
+from draftwright.view_plan import (
+    ResolvedViewPlan,
+    ViewPlacement,
+    ViewSpec,
+    resolve_from_analysis,
+    third_angle_principals,
+)
+
+
+@pytest.fixture(scope="module")
+def built():
+    return build_drawing(
+        Box(120, 80, 20) - Pos(-30, 10, 0) * Cylinder(4, 40), title="T", number="N"
+    )
+
+
+class TestThePlanDescribesWhatWasActuallyBuilt:
+    def test_every_view_the_drawing_has_is_in_the_plan_and_the_reverse(self, built):
+        """The claim that makes the plan worth having: it is not a parallel description.
+
+        A record of the topology that can disagree with the topology is worse than no record,
+        because the later slice that varies the plan would vary a fiction. The iso is the one
+        spec with no placement — it is fitted after the sheet is settled — so it is asserted
+        present as a spec and absent from the placements, rather than quietly excluded.
+        """
+        plan = built.view_plan
+        assert plan is not None, "a built drawing has no view plan"
+
+        drawn = {name for name in built.views if name in {"front", "plan", "side", "iso"}}
+        assert {spec.name for spec in plan.specs} == drawn
+
+        assert plan.principal_names == ("front", "plan", "side")
+        assert [spec.name for spec in plan.of_kind("pictorial")] == ["iso"]
+        assert set(plan.placements) == {"front", "plan", "side"}, (
+            "the iso has a placement, but it is fitted after the sheet is settled, so any "
+            "placement recorded for it at resolve time is a claim the engine cannot honour"
+        )
+
+    def test_each_placement_is_where_the_view_was_actually_drawn(self, built):
+        """The numbers, not just the names.
+
+        `view_bounds` is the projected silhouette and the placement is the reserved block, so
+        they are not equal — the block is sized for the view's extent at scale. What must hold
+        is that the drawn geometry sits inside the block its plan reserved; a placement that
+        does not contain its own view is a bookkeeping error that would mislead every later
+        layout decision.
+        """
+        plan = built.view_plan
+        for name, place in plan.placements.items():
+            x0, y0, x1, y1 = place.bounds
+            bx0, by0, bx1, by1 = built.view_bounds(name)
+            assert x0 - 0.5 <= bx0 and bx1 <= x1 + 0.5, f"{name} overflows its block in x"
+            assert y0 - 0.5 <= by0 and by1 <= y1 + 0.5, f"{name} overflows its block in y"
+
+    def test_the_plan_records_the_sheet_and_scale_the_drawing_was_built_at(self, built):
+        plan = built.view_plan
+        assert plan.scale == built.scale
+        assert plan.page == (built.page_w, built.page_h)
+
+
+class TestTheResolvedPlanCannotBeMistakenForARequest:
+    def test_a_resolved_plan_is_frozen(self, built):
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            built.view_plan.scale = 2.0  # type: ignore[misc]
+
+    def test_its_placements_cannot_be_edited_in_place(self, built):
+        """The mapping too, not just the dataclass.
+
+        A frozen dataclass wrapping a plain dict is frozen in name only — `plan.placements[...]
+        = ...` would edit the resolved answer through the immutable object, which is exactly the
+        "one mutable object for authored constraints and resolved output" ADR 0018 rejects.
+        """
+        with pytest.raises(TypeError):
+            built.view_plan.placements["front"] = ViewPlacement(0, 0, 1, 1)  # type: ignore[index]
+
+    def test_the_drawing_surface_is_read_only(self, built):
+        with pytest.raises(AttributeError):
+            built.view_plan = None  # type: ignore[misc]
+
+    def test_a_plan_refuses_duplicate_view_names(self):
+        spec = ViewSpec(name="front", kind="principal", page_axes=("x", "z"))
+        with pytest.raises(ValueError, match="duplicate view names"):
+            ResolvedViewPlan(specs=(spec, spec), placements={}, scale=1.0, page=(420.0, 297.0))
+
+    def test_a_spec_refuses_an_unknown_kind(self):
+        """The kind is what makes "which views should exist" answerable, so it is closed.
+
+        An open string would let a later planner invent a kind nothing knows how to weigh, and
+        the first thing that reads `kind` to decide whether a view may be dropped would treat
+        the unknown one as droppable or as required, silently.
+        """
+        with pytest.raises(ValueError, match="unknown view kind"):
+            ViewSpec(name="x", kind="decorative")
+
+
+class TestTheRepresentationChangedNothing:
+    def test_the_specs_are_the_third_angle_set_the_engine_has_always_built(self):
+        specs = third_angle_principals()
+        assert [spec.name for spec in specs] == ["front", "plan", "side"]
+        assert [spec.page_axes for spec in specs] == [("x", "z"), ("x", "y"), ("y", "z")]
+        assert {spec.kind for spec in specs} == {"principal"}
+
+    def test_resolving_reads_the_analysis_the_engine_already_computed(self, monkeypatch):
+        """The bridge, asserted: the plan is the same numbers `Analysis` already held.
+
+        Worth stating as a test rather than as a docstring claim, because when the resolver
+        starts CHOOSING rather than reading, this is what has to change and say so.
+
+        The `Analysis` is captured at the seam that is handed it, NOT read off the drawing:
+        `test_private_test_attr_reads` ratchets test-side `_analysis` reads strictly downward,
+        and this would have grown the ceiling by one.
+        """
+        from draftwright import builder as builder_module
+
+        seen: dict = {}
+        real = builder_module.resolve_from_analysis
+
+        def capture(analysis):
+            seen["analysis"] = analysis
+            return real(analysis)
+
+        monkeypatch.setattr(builder_module, "resolve_from_analysis", capture)
+        drawing = build_drawing(Box(80, 60, 20), title="T", number="N")
+        analysis = seen["analysis"]
+
+        assert resolve_from_analysis(analysis).placements == {
+            "front": ViewPlacement(analysis.FV_X, analysis.FV_Y, analysis.fv_hw, analysis.fv_hh),
+            "plan": ViewPlacement(analysis.PV_X, analysis.PV_Y, analysis.fv_hw, analysis.pv_hh),
+            "side": ViewPlacement(analysis.SV_X, analysis.SV_Y, analysis.sv_hw, analysis.fv_hh),
+        }
+        assert resolve_from_analysis(analysis) == drawing.view_plan
+
+
+@pytest.mark.slow  # a CTC fixture build, twice (#153)
+def test_the_repack_loop_really_consumes_the_plan():
+    """The one consumer whose re-routing the golden corpus does NOT cover.
+
+    `compose._view_geom` feeds only the measure-and-repack loop, and no golden fixture triggers
+    a repack — so pointing it at the view plan was, at first, a change nothing could verify:
+    emptying its result left every golden and every repack-seam test passing. That is precisely
+    the kind of change this repository has learned to distrust, so it is proven here instead.
+
+    Two claims, and both are needed:
+
+    1. the map is load-bearing at all — CTC-03 AP203 is the fixture where the repack actually
+       uses it, and its drawing changes if the map is emptied. Without this the second claim
+       would be satisfied by a function whose output nothing reads;
+    2. reading it from the plan produces the same drawing as reading it from the `Analysis`
+       fields directly. Verified against `main` at the time of writing by comparing page, scale,
+       every annotation name and label, and every view's bounds: byte-identical, 3093 bytes of
+       signature. This test re-checks the first claim, which is the half that can rot.
+    """
+    from draftwright import builder as builder_module
+
+    fixture = "tests/fixtures/nist_ctc_03_asme1_ap203.stp"
+
+    def signature(drawing):
+        return (
+            round(drawing.page_w),
+            round(drawing.page_h),
+            drawing.scale,
+            tuple(sorted(drawing.registry.names())),
+            tuple(
+                (name, tuple(round(v, 4) for v in (drawing.view_bounds(name) or ())))
+                for name in sorted(drawing.views)
+            ),
+        )
+
+    real = signature(build_drawing(fixture))
+
+    # PERTURB the values, do not empty the map. An empty map raises `KeyError` inside
+    # `_measure_blocks` — which proves the function is called, not that its ANSWER is used, and
+    # the first version of this test mistook one for the other. Halving the half-extents keeps
+    # every key and every consumer working, and changes only what the repack measures.
+    original = builder_module._view_geom
+
+    def halved(analysis):
+        return {
+            name: (cx, cy, hw * 0.5, hh * 0.5)
+            for name, (cx, cy, hw, hh) in original(analysis).items()
+        }
+
+    builder_module._view_geom = halved
+    try:
+        perturbed = signature(build_drawing(fixture))
+    finally:
+        builder_module._view_geom = original
+
+    assert perturbed != real, (
+        "changing the measured view geometry changes nothing on this fixture, so it no longer "
+        "exercises the repack loop and the plan's only uncovered consumer is unverified again"
+    )


### PR DESCRIPTION
The first slice the ADR names: "an explicit ViewSpec / ResolvedViewPlan
representation reproducing current behaviour". No behaviour changes; what
changes is that the topology stops being implicit.

Before, "which views exist and where they go" was spread across three places
that did not know about each other: `builder` named front/plan/side with literal
camera positions, their page coordinates lived in `Analysis` as `FV_X`/`PV_X`/
`SV_X`, and `compose.choose_scale` knew the arrangement only through a sentence
in its docstring ("Layout columns: [front(x×z)] [side(y×z)] [iso] [title
block]"). The topology was real, but there was nothing to read or replace.

Now `view_plan.py` (rank 0 — it describes views, it cannot reach what draws
them) holds `ViewSpec` (a request, in model terms, saying nothing about the
page) and `ResolvedViewPlan` (the immutable result). The split is ADR 0018 §1,
and it is a split rather than one mutable object because a resolved plan that
can be edited in place is indistinguishable from a request — which is how a
layout comes to be silently relaxed. `builder` creates its views FROM the plan,
so the drawing and its record of the topology cannot disagree; `compose` reads
its layout map from it. One typed `BuildState` attachment, a read-only
`Drawing.view_plan` with no setter, and ADR 0005's encapsulation guard is what
keeps it to one writer.

Also included, because it is what the ADR asks for first: a synthetic thin
X-axis rotational plate reproducing the motivating failure without the
proprietary STEP the ADR was proposed from. It hits the case study exactly —
bbox 43 x 217 x 217, A1 landscape at 1:1, four fixed views — and shows WHY that
is wrong rather than merely that it is big: `plan` is the same 42.5 x 217
projection as `front` and carries 1 annotation to front's 8.

Three things this turned up that are worth recording.

**A mutation I could not kill, and what it took to fix.** Re-routing
`compose._view_geom` was, at first, unverifiable: emptying its result left every
golden and every repack-seam test green, because it feeds only the
measure-and-repack loop and no fixture there triggers a repack. Emptying it also
raises `KeyError` inside `_measure_blocks`, which proves the function is CALLED,
not that its answer is used — the first version of the test mistook one for the
other. Halving the half-extents keeps every consumer working and changes only
what the repack measures, and on CTC-03 AP203 that changes the drawing. So the
consumer is load-bearing there, and the re-routing was verified by comparing
that fixture against main: page, scale, every annotation name and label, every
view's bounds — byte-identical, 3093 bytes of signature.

**A coupling I introduced and backed out.** Routing `_view_geom` through the
full resolver made a narrow consumer depend on `SCALE`, `PAGE_W` and `PAGE_H`,
and broke a repack test that passes a minimal stub carrying only the position
fields. The stub was right; `principal_placements` is the narrow function that
consumer should have been asking for.

**A ratchet I would have grown.** The bridge test read `drawing._analysis`,
which #741 caps and only allows to shrink. It captures the `Analysis` at the
seam that is handed it instead.

Mutations killed: a plan that disagrees with the analysis it was resolved from;
mutable placements behind a frozen dataclass; an open `kind` string.

4407 passed (fast), 46 passed (slow), pr-check --static exit 0, goldens
unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NTXU3X3YFa1HPRdmUgCw22