### PR TITLE
Stabilize the slow repack seam test

### DIFF
--- a/tests/test_view_plan.py
+++ b/tests/test_view_plan.py
@@ -165,6 +165,7 @@ class TestTheRepresentationChangedNothing:
 
 
 @pytest.mark.slow  # a CTC fixture build, twice (#153)
+@pytest.mark.timeout(600)  # Two OCC builds exceed the global 300 s cap under xdist load (#1266).
 def test_the_repack_loop_really_consumes_the_plan():
     """The one consumer whose re-routing the golden corpus does NOT cover.
 


### PR DESCRIPTION
## Outcome

The intentionally heavy repack seam test now has a 600-second per-test timeout, matching the execution envelope already used by other full CTC builds. It still performs both real builds and keeps the load-bearing perturbation assertion intact.

This fixes a repeated post-merge CI failure: the test exceeded the global 300-second cap on 3 of 4 recent `main` runs while contending with the other xdist worker, despite passing in isolation.

## ADR assessment

No compiler, placement, view-plan, or public-surface behavior changes. ADR 0018's seam evidence is preserved exactly; this change only makes the test's declared resource budget honest under the slow-tier execution model.

## Verification

- `scripts/pr-check --static`
- `uv run pytest tests/test_view_plan.py::test_the_repack_loop_really_consumes_the_plan -m slow -q` (1 passed in 71.61 s)

Fixes #1266
