### PR TITLE
ADR 0018: make dimension planning view-set aware

### DIFF
--- a/docs/adr/0018-requirement-driven-view-planning-and-editable-sheet-layout.md
+++ b/docs/adr/0018-requirement-driven-view-planning-and-editable-sheet-layout.md
@@ -4,7 +4,9 @@
   (2026-08-21) for the authored surface. Delivery is phased through #1130. What exists:
   `ViewSpec`, `ResolvedViewPlan` and `ViewCoverage` (`view_plan.py`); the layout choice as a
   candidate over scale x sheet x **arrangement**, with §5's first hard gate applied by real
-  compile; and a chosen view set that is buildable, refusable and reclaims the paper it frees.
+  compile; a view-set-aware dimension plan that re-homes eligible requirements or raises
+  `ViewPlanIncomplete` before projection; and a chosen view set that is buildable, refusable
+  and reclaims the paper it frees.
   What does not: `ViewConstraints` and the `Sheet` verbs, automatic view SELECTION (nothing
   drops a view on its own — the case study reaches its A2 target and costs six annotations, so
   a gate weighing it refuses), and any planning of sections or details. `_views` is an engine
@@ -100,10 +102,10 @@ An authored view set can be wrong in a way an authored dimension set cannot: omi
 dimension omits one thing, but omitting a *view* can strand dimensions the compiler assigned
 to it. The surface must therefore say so, at the earliest moment that can.
 
-Today it says so at the worst one. A `Sheet` user whose views cannot carry their dimensions
-gets `ViewNotPlanned` raised from inside `render_centermarks` — an exception naming the view
-but not their line, not the dimension that needed it, and not what to add. That is an internal
-invariant escaping to a user.
+Before the Phase 5.5 planner boundary, it said so at the worst one. A caller whose views could
+not carry their dimensions got `ViewNotPlanned` raised from inside `render_centermarks` — an
+exception naming the view but not their line, not the dimension that needed it, and not what
+to add. That is an internal invariant escaping to a user.
 
 **Three moments, and the rule is to fail at the earliest one that can give a complete answer.**
 
@@ -153,16 +155,18 @@ plausible-looking incomplete drawing is worse than a visible failure, and on §6
 authored constraints are never silently relaxed. A `permissive` opt-in may return the
 incomplete drawing, and must warn.
 
-**Consequence for `ViewNotPlanned`.** Once the pre-projection check exists, that exception is
-unreachable from the public API — it becomes an internal invariant. A user who sees one has
-found a hole in the check, and that is the bug, not the drawing.
+**Consequence for `ViewNotPlanned`.** The pre-projection check now makes that exception
+unreachable for a selected set whose approved dimensional requirements were planned. It is an
+internal invariant: a user who sees one has found a hole in the check, and that is the bug, not
+the drawing. The authored view verbs and their source-line provenance remain #1260; Phase 5.5
+provides the compiler result they consume.
 
-**This is gated on the compiler, not the DSL.** The check asks "which view does this
-dimension need, given this view set", which is `planner._group_view` — still hardwired to the
-fixed topology, so it cannot answer for a set it was not told about. Until it takes the
-planned view set, the earliest a user can find out remains a render pass tripping over a
-missing view. That is the same prerequisite the rest of this amendment has, and it is the
-reason to take it first.
+**This is gated on the compiler, not the DSL.** The check asks "which view does this dimension
+need, given this view set". Phase 5.5 delivered that prerequisite: `planner._group_view` takes
+the planned principal set, the planner retains ADR 0016 identity while collecting uncovered
+requirements, and analysis runs the check before scale selection or projection. The DSL in
+#1260 supplies authored `ViewConstraints` and source-line provenance to this boundary; it does
+not reimplement the feasibility decision.
 
 ### Sections and details are views, and their verbs are reshaped
 

--- a/src/draftwright/__init__.py
+++ b/src/draftwright/__init__.py
@@ -36,6 +36,7 @@ _LAZY = {
     "extract_pmi": "draftwright.pmi",
     "extract_pmi_report": "draftwright.pmi",
     "choose_scale": "draftwright.compose",
+    "ViewPlanIncomplete": "draftwright.view_plan",
     # A warning category users are told to filter must be importable without reaching into a
     # private module (#1043 review) — and without paying for the CAD kernel. It lives in the
     # dependency-free `_warnings` leaf for that second reason: defined in `_core` it cost ~6 s
@@ -91,6 +92,7 @@ if TYPE_CHECKING:  # static analysers / IDEs — no runtime import, no kernel co
         extract_pmi_report,
     )
     from draftwright.sheet import Sheet
+    from draftwright.view_plan import ViewPlanIncomplete
 
 
 def __dir__():
@@ -110,6 +112,7 @@ __all__ = [
     "Sheet",
     "ScaleIncompatibilityError",
     "ScaleCompletenessWarning",
+    "ViewPlanIncomplete",
     "build_drawing",
     "choose_scale",
     "extract_pmi",

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -717,7 +717,10 @@ def _analyse(
             cyls=shared_cyls,
         )
     )
-    sizing_groups = plan_dimensions(sizing_model)
+    # ADR 0018 Phase 5.5: prove the chosen principal set can carry every approved
+    # dimension before scale selection or projection.  A reduced view set is therefore a
+    # re-plan, not the fixed three-view plan rendered into fewer views.
+    sizing_groups = plan_dimensions(sizing_model, planned_views=_views)
     bore_callout_width = _est_planned_bore_callout_width(
         sizing_groups, _draft_est, font_size=_FONT_SIZE, pad_around_text=_pad_around_text
     )

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -634,12 +634,13 @@ def _location_candidate(
     footprint=None,
     location_coverage=(),
     hole_requirements=(),
+    placement_side="above",
 ):
     """A :class:`CorridorCandidate` for a datum-referenced hole/pattern location dim.
     Location dims outrank a coincident slot-position line in dedup (#345) and form the
-    outer, datum-distance-ordered run of the ladder (#346). Force-kept (policy B): a plan-X
-    / side-Y location has no alternate view, so a corridor block keeps it rather than drops
-    it; only a physically full strip drops (``location_ref_dropped`` → hole-table escalate)."""
+    outer, datum-distance-ordered run of the ladder (#346). After view planning has assigned
+    the member to plan/side, it is force-kept within that view (policy B); only a physically
+    full strip drops (``location_ref_dropped`` → hole-table escalate)."""
 
     def _placed(nm):
         # Only loose HoleFeatures have rows in the automatic scattered-hole table.
@@ -653,10 +654,11 @@ def _location_candidate(
 
     def _drop(nm):
         edge = "plan view" if view == "plan" else "side view"
+        where = "beside" if placement_side in {"left", "right"} else placement_side
         ctx.record_issue(
             "warning",
             "location_ref_dropped",
-            f"{nm} not placed (no room above the {edge})",
+            f"{nm} not placed (no room {where} the {edge})",
             measurement=measurement,
             hole_requirements=hole_requirements,
         )
@@ -682,8 +684,9 @@ def _location_candidate(
 def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
     """Baseline X/Y hole-location dims from the compiled plan (#238). The compiler decides
     the content (`plan.locations`: which refs survived, from which datum); this renderer owns
-    the layout (Amendment 4) — X dims tier above the plan view, Y dims above the side
-    view, nearest-datum-first, legibility-gated, allocated from the existing strips;
+    the layout (Amendment 4) — X dims tier above the plan view; Y dims prefer above side
+    and re-home vertically beside plan when side is not selected; both remain
+    nearest-datum-first, legibility-gated, allocated from the existing strips;
     a ref with no room is dropped as `location_ref_dropped`. Replaces the engine's
     `_add_location_dims`. Returns the count placed.
 
@@ -884,9 +887,14 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
             ),
         )
 
-    # --- Y locations: tier above the side view (which maps world-Y horizontally) ---
+    # --- Y locations: above side, or vertically beside plan when side is absent ---
+    #
+    # Both are the same face-on Z-feature location requirement. The fixed topology preferred
+    # side because Y runs horizontally there; ADR 0018 reduced view sets must not retain side
+    # solely for that presentation choice, so plan's vertical Y axis is the fallback.
+    side_planned = "side" in dwg.views
     SX, SZ = a.proj.side_x, a.proj.side_z
-    side_top = SZ(a.bb.max.Z)
+    side_top = SZ(a.bb.max.Z) if side_planned else 0.0
     iso_x0, iso_y0, _, _ = _iso_bbox(dwg)
     y_refs: list = []
     for r in refs:
@@ -925,13 +933,19 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
                 (feature, parameter) for ref in dropped_y for feature, parameter, _point in ref[5]
             ),
         )
-        ctx.escalations.append(Escalation("location", "side", None, "illegible"))
+        ctx.escalations.append(
+            Escalation("location", "side" if side_planned else "plan", None, "illegible")
+        )
     _kept_y_set = set(_kept_y)
     y_refs = [r for r in y_refs if r[1] not in _y_drawable or r[1] in _kept_y_set]
     # Cap the side-above strip below the iso view so Y-location dims never run under it
     # (the carve respects outer_limit); the dim_pitch_side dims are obstacles the carve
     # avoids structurally, retiring the old manual allocate(10.0) reservation + cursor.
-    if y_refs and any(SX(ry) + 10 > iso_x0 - 4 for _, ry, _feat, _pin, _mids, _facts in y_refs):
+    if (
+        side_planned
+        and y_refs
+        and any(SX(ry) + 10 > iso_x0 - 4 for _, ry, _feat, _pin, _mids, _facts in y_refs)
+    ):
         a.sv_zones.above.outer_limit = min(a.sv_zones.above.outer_limit, iso_y0 - 4)
     for i, (rx, ry, feat, pin_ref, mids, location_facts) in enumerate(
         sorted(y_refs, key=lambda r: abs(r[1] - datum_y))
@@ -944,27 +958,47 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
         _yfeat = None if _shared_y else feat
         # Every collapsed feature-level location; the structured facts carry Y (see X above).
         _ymid = tuple(mids)
+        if side_planned:
+            view, direction, strip, stack = "side", "above", a.sv_zones.above, "y"
+            edge = side_top
+            pa = (SX(datum_y), edge, 0)
+            pb = (SX(ry), edge, 0)
+            span_key = (round(pa[0], 1), round(pb[0], 1))
+        else:
+            view, stack = "plan", "x"
+            if a.pv_zones.right is not None:
+                direction, strip = "right", a.pv_zones.right
+                edge = PX(a.bb.max.X)
+            else:
+                direction, strip = "left", a.pv_zones.left
+                edge = PX(a.bb.min.X)
+            pa = (edge, PY(datum_y), 0)
+            pb = (edge, PY(ry), 0)
+            span_key = (round(pa[1], 1), round(pb[1], 1))
+        label = _fmt(ry - datum_y)
         register_corridor(
             ctx,
-            ("side", "above"),
-            a.sv_zones.above,
-            "side",
-            "y",
+            (view, direction),
+            strip,
+            view,
+            stack,
             tier,
             _location_candidate(
                 dwg,
                 ctx,
                 _loc_name("m_locy", i),
-                view="side",
-                span_key=(round(SX(datum_y), 1), round(SX(ry), 1)),
+                view=view,
+                span_key=span_key,
                 distance=abs(ry - datum_y),
-                build=lambda pos, _ry=ry: _dim(
-                    (SX(datum_y), SZ(a.bb.max.Z), 0),
-                    (SX(_ry), SZ(a.bb.max.Z), 0),
-                    "above",
-                    pos - side_top,
-                    draft,
-                    label=_fmt(_ry - datum_y),
+                build=lambda pos, _pa=pa, _pb=pb, _direction=direction, _edge=edge, _label=label: (
+                    _dim(
+                        _pa,
+                        _pb,
+                        _direction,
+                        abs(pos - _edge),
+                        draft,
+                        label=_label,
+                    )
                 ),
                 feature=_yfeat,
                 measurement=_ymid,
@@ -972,14 +1006,17 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
                 hole_requirements=tuple(
                     (feature, parameter) for feature, parameter, _point in location_facts
                 ),
+                placement_side=direction,
                 pinned=pin_ref,
-                footprint=lambda pos, _ry=ry: dim_footprint(
-                    (SX(datum_y), SZ(a.bb.max.Z), 0),
-                    (SX(_ry), SZ(a.bb.max.Z), 0),
-                    "above",
-                    pos - side_top,
-                    draft,
-                    _fmt(_ry - datum_y),
+                footprint=lambda pos, _pa=pa, _pb=pb, _direction=direction, _edge=edge, _label=label: (
+                    dim_footprint(
+                        _pa,
+                        _pb,
+                        _direction,
+                        abs(pos - _edge),
+                        draft,
+                        _label,
+                    )
                 ),
             ),
         )

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -387,7 +387,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     ctx.model_declared = dwg.model_declared
     # Plan the dimensions ONCE and thread the groups to every renderer that reads them
     # (was recomputed per renderer, #275). One rule set over DimParameters, literally.
-    _groups = plan_dimensions(_model)
+    _groups = plan_dimensions(_model, planned_views=a.planned_views)
     # ONE compiled plan, shared by every migrated consumer (#923 review round 4).
     # Compiling per stage ran the compiler three times and, worse, let the direct
     # ladder, the shoulders and the detail escalation each hold a separately

--- a/src/draftwright/model/__init__.py
+++ b/src/draftwright/model/__init__.py
@@ -98,6 +98,7 @@ from draftwright.model.planner import (
     plan_dimensions,
     plan_sections,
 )
+from draftwright.view_plan import UncoveredViewRequirement, ViewPlanIncomplete
 
 __all__ = [
     "AuthoredDimension",
@@ -117,6 +118,8 @@ __all__ = [
     "AddressableDimension",
     "DimensionGroup",
     "DimensionId",
+    "UncoveredViewRequirement",
+    "ViewPlanIncomplete",
     "Feature",
     "Frame",
     "HoleFeature",

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -1344,7 +1344,7 @@ def _compile_groups(planned) -> tuple[list[ApprovedGroup], list[Omission]]:
 
 
 def compile_dimensions(
-    model: PartModel, *, include_overall: bool = True, groups=None
+    model: PartModel, *, include_overall: bool = True, groups=None, planned_views=None
 ) -> RenderableDimensionPlan:
     """Compile *model* into the dimensions that will be drawn, and the ones that will not.
 
@@ -1354,8 +1354,16 @@ def compile_dimensions(
     *groups* accepts a `plan_dimensions` result the caller already has, so the engine's
     plan-once invariant holds through the migration instead of the compiler quietly
     re-planning behind it (#923 review).
+
+    *planned_views* is the ADR 0018 pre-projection constraint used only when the compiler
+    must plan for itself.  Callers supplying *groups* have already resolved that constraint;
+    the exact model/groups identity check below prevents substituting another plan.
     """
-    planned = tuple(groups) if groups is not None else tuple(plan_dimensions(model))
+    planned = (
+        tuple(groups)
+        if groups is not None
+        else tuple(plan_dimensions(model, planned_views=planned_views))
+    )
     if groups is not None:
         model_feature_ids = {id(feature) for feature in model.features}
         foreign = [g.feature for g in planned if id(g.feature) not in model_feature_ids]

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -46,6 +46,12 @@ from draftwright.model.ir import (
     Point,
     SlotFeature,
     SlotPatternFeature,
+    StepLevelFeature,
+)
+from draftwright.view_plan import (
+    UncoveredViewRequirement,
+    ViewPlanIncomplete,
+    views_showing,
 )
 
 #: The `reason` marking a measurement the AUTHORED set left out — the author's own
@@ -285,11 +291,27 @@ class DimensionGroup:
 _PROFILE = _EDGE_ON
 
 
-def _group_view(feature: Feature) -> str:
-    """The single view a feature's callout lands on — derived from the feature's
-    axis, never hardcoded, so X and Z are handled by the same rule (parity). A
-    diameter callout (hole / boss) reads on the view where the cylinder is end-on
-    (z→plan, x→side, y→front). A turned step is the opposite case (#731): its
+def _plane_normal(feature) -> str:
+    """Principal axis normal to a feature's width/length presentation plane."""
+    return next(axis for axis in "xyz" if axis not in (feature.width_axis, feature.long_axis))
+
+
+def _preferred_group_view(feature: Feature) -> str:
+    """The single view a feature's compound dimensional group lands on.
+
+    Derived from feature semantics rather than a renderer literal, so X/Y/Z variants are
+    handled by one rule.  A diameter callout (hole / boss) reads face-on; a turned step,
+    groove, rotational body or plate thickness reads in profile; planar slot/pocket groups
+    read normal to their defining plane.
+
+    Historically this only distinguished flats and steps and otherwise used ``frame.axis``:
+    that made the planner claim a slot belonged to the view down its *long* axis and a pocket
+    belonged to the view down its *length*, while their renderers quietly used the opening
+    normal.  A fixed-topology sheet hid the disagreement; a reduced set cannot.
+
+    The turned-step detail remains worth stating. A diameter callout (hole / boss)
+    reads on the view where the cylinder is end-on (z→plan, x→side, y→front). A
+    turned step is the opposite case (#731): its
     length + OD read where the turning axis lies IN-PLANE — `_PROFILE`, not
     `_END_ON` — which derives to "front" for both X- and Z-turned steps because
     the front view is the x–z plane. That matches the renderers per axis:
@@ -297,12 +319,37 @@ def _group_view(feature: Feature) -> str:
     above, Z → vertical right) and `render_diameters` hangs its ø row/column off
     the front view (X → row below, Z → column left). A Y-axis step derives to
     its geometric profile ("side"); no step render pipeline consumes Y today
-    (`render_diameters` buckets x/z only)."""
+    (`render_diameters` buckets x/z only).
+    """
     if isinstance(feature, FlatFeature):
         return _END_ON.get(feature.presentation_axis, "plan")
-    if feature.kind == "step":
+    if isinstance(feature, StepLevelFeature):
+        return "front"
+    if feature.kind in {"step", "groove", "rotational", "plate"}:
         return _PROFILE.get(feature.frame.axis, "front")
+    if isinstance(feature, SlotFeature | PadFeature):
+        return _END_ON[_plane_normal(feature)]
+    if isinstance(feature, PocketFeature):
+        return _END_ON[feature.depth_axis]
+    if isinstance(feature, ChannelFeature):
+        return _END_ON[feature.long_axis]
     return _END_ON.get(feature.frame.axis, "plan")
+
+
+def _group_view(feature: Feature, planned_views=None) -> str | None:
+    """Resolve a feature group's semantic home against *planned_views*.
+
+    ``None`` is an uncovered planning result, never permission to drop the group.  The
+    envelope is the first genuinely re-homeable group: its width can move from plan to
+    front.  Feature callouts that require a face-on/profile presentation remain single-view
+    until their alternate renderers land in #1261.
+    """
+    preferred = _preferred_group_view(feature)
+    if planned_views is None or preferred in set(planned_views):
+        return preferred
+    if feature.kind == "envelope":
+        return views_showing("x", planned_views, horizontal=True)
+    return None
 
 
 _PLANE_TOL = 1e-6
@@ -966,7 +1013,204 @@ def _check_authored_targets(model: PartModel) -> None:
             )
 
 
-def plan_dimensions(model: PartModel) -> list[DimensionGroup]:
+def _feature_labels(model: PartModel) -> dict[int, str]:
+    """Human labels for diagnostics; semantic correspondence still uses ``DimensionId``."""
+    totals: dict[str, int] = {}
+    for feature in model.features:
+        totals[feature.kind] = totals.get(feature.kind, 0) + 1
+    seen: dict[str, int] = {}
+    labels = {}
+    for feature in model.features:
+        seen[feature.kind] = seen.get(feature.kind, 0) + 1
+        labels[id(feature)] = (
+            feature.kind
+            if totals[feature.kind] == 1 and feature.kind == "envelope"
+            else f"{feature.kind}_{seen[feature.kind]}"
+        )
+    return labels
+
+
+def _parameter_view_preferences(feature: Feature, pd: PlannedDimension) -> tuple[str, ...]:
+    """Preference-ordered principal views that can carry one planned parameter.
+
+    This is intentionally conservative: it lists views for which a renderer exists today.
+    #1261 widens these sets as displaced callouts gain alternate renderers.  Claiming a
+    merely geometric view before the compiler can render the requirement there would turn
+    an early proof into a late ``ViewNotPlanned`` or, worse, a silent omission.
+    """
+    role = pd.param.role
+    kind = feature.kind
+    axis = feature.frame.axis
+    if kind == "envelope":
+        if role == "width":
+            return ("plan", "front")
+        if role == "depth":
+            return ("side",)
+        if role == "height":
+            return ("front",)
+    if role in {"boss_height", "stock_length"}:
+        return (_PROFILE.get(axis, "front"),)
+    if kind == "step_level" and role == "step_height":
+        return ("front",)
+    if kind in {"step", "groove", "rotational", "plate"}:
+        return (_PROFILE.get(axis, "front"),)
+    if isinstance(feature, SlotFeature | PadFeature):
+        return (_END_ON[_plane_normal(feature)],)
+    if isinstance(feature, PocketFeature):
+        return (_END_ON[feature.depth_axis],)
+    if kind in {"pocket_pattern", "slot_pattern"}:
+        return (_END_ON[axis],)
+    if isinstance(feature, ChannelFeature):
+        return (_END_ON[feature.long_axis],)
+    return (_preferred_group_view(feature),)
+
+
+def _view_reason(preferences: tuple[str, ...]) -> str:
+    if len(preferences) == 1:
+        return f"reads only in `{preferences[0]}`"
+    return "reads in " + " or ".join(f"`{view}`" for view in preferences)
+
+
+def _uncovered_group_requirements(
+    model: PartModel, groups: list[DimensionGroup], planned_views
+) -> list[UncoveredViewRequirement]:
+    """Approved group dimensions with no renderer in the selected principal set."""
+    planned = set(planned_views)
+    labels = _feature_labels(model)
+    uncovered: list[UncoveredViewRequirement] = []
+    for group in groups:
+        for unit in group.units:
+            approved = [pd for pd in unit.members if not pd.suppressed]
+            if not approved:
+                continue
+            if isinstance(group.feature, StepLevelFeature) and unit.id == "step_position.length":
+                # One correlated ADR 0016 unit, but its X and Y shoulder members route to
+                # plan and side respectively.  Their axis is structural feature evidence;
+                # DimParameter deliberately has no discriminator because the whole ladder
+                # is addressed as one unit.
+                for axis, view in (("x", "plan"), ("y", "side")):
+                    if view in planned or not any(
+                        shoulder_axis == axis for shoulder_axis, _ in group.feature.shoulders
+                    ):
+                        continue
+                    identity = DimensionId(group.feature, unit.id)
+                    uncovered.append(
+                        UncoveredViewRequirement(
+                            identity=identity,
+                            label=f"{labels[id(group.feature)]}.{unit.id}.{axis}",
+                            preferred_view=view,
+                            eligible_views=(view,),
+                            reason=f"reads only in `{view}`",
+                        )
+                    )
+                continue
+            # A correlated unit is one ADR 0016 identity.  Every member must be renderable;
+            # report the unit once at the first unmet member rather than inflate the count.
+            for pd in approved:
+                preferences = _parameter_view_preferences(group.feature, pd)
+                if planned.intersection(preferences):
+                    continue
+                identity = DimensionId(group.feature, unit.id)
+                uncovered.append(
+                    UncoveredViewRequirement(
+                        identity=identity,
+                        label=f"{labels[id(group.feature)]}.{unit.id}",
+                        preferred_view=preferences[0],
+                        eligible_views=preferences,
+                        reason=_view_reason(preferences),
+                    )
+                )
+                break
+    return uncovered
+
+
+def _uncovered_location_requirements(
+    model: PartModel, planned_views
+) -> list[UncoveredViewRequirement]:
+    """Approved datum locations whose current semantic renderer has no selected view.
+
+    Location identity is feature-level today (ADR 0016 / #883), while X and Y are distinct
+    observable members.  The two records therefore retain the same ``DimensionId`` and use
+    an ``.x``/``.y`` diagnostic suffix; correspondence never depends on that suffix.
+    """
+    planned = set(planned_views)
+    labels = _feature_labels(model)
+    uncovered: list[UncoveredViewRequirement] = []
+    seen: set[tuple[int, str, str]] = set()
+    for pd in plan_locations(model):
+        feature = pd.feature
+        if pd.suppressed or feature is None or pd.param.span is None:
+            continue
+        start, end = pd.param.span
+        requirements: list[tuple[str, str]] = []
+        if isinstance(feature, PocketFeature) and feature.frame.axis != "z":
+            requirements.append(("position", _END_ON[feature.depth_axis]))
+        elif feature.frame.axis == "z":
+            # Both in-plane ordinates read in the feature's face-on plan view.  With the
+            # fixed topology the Y member preferred side because it could use a horizontal
+            # above-strip; when side is absent the renderer re-homes that member vertically
+            # beside plan.  One semantic identity therefore requires one view, as ADR 0018's
+            # executable diagnostic specifies.
+            if any(abs(end[index] - start[index]) > _PLANE_TOL for index in (0, 1)):
+                requirements.append(("position", "plan"))
+        else:
+            requirements.append(("position", _END_ON[feature.frame.axis]))
+        identity = DimensionId(feature, pd.param.parameter_id)
+        for component, view in requirements:
+            key = (id(feature), component, view)
+            if view in planned or key in seen:
+                continue
+            seen.add(key)
+            suffix = "" if component == "position" else f".{component}"
+            parameter_label = (
+                LOCATION_ROLE if pd.param.kind == "location" else pd.param.parameter_id
+            )
+            uncovered.append(
+                UncoveredViewRequirement(
+                    identity=identity,
+                    label=f"{labels[id(feature)]}.{parameter_label}{suffix}",
+                    preferred_view=view,
+                    eligible_views=(view,),
+                    reason=f"reads only in `{view}`",
+                )
+            )
+
+    # Bounding-box locations are compiled outside `plan_locations`, but they are still
+    # dimensions and obey the same authored `location` intent.  Side-drilled holes place
+    # both in-plane offsets in their end-on circle view; a slot places its near-end offset
+    # in the view normal to its width/length plane.
+    for feature in model.features:
+        if location_datum(feature) != "bbox" or authored_location_omitted(model, feature):
+            continue
+        parameters: tuple[str, ...]
+        if isinstance(feature, HoleFeature):
+            view = _END_ON[feature.frame.axis]
+            measured = "y" if feature.frame.axis == "x" else "x"
+            parameters = (
+                f"{feature.LOCATION_OFF_AXIS_STEM}.{measured}",
+                f"{feature.LOCATION_OFF_AXIS_STEM}.z",
+            )
+        elif isinstance(feature, SlotFeature):
+            view = _END_ON[_plane_normal(feature)]
+            parameters = (f"{feature.LOCATION_STEM}.length",)
+        else:
+            continue
+        if view in planned:
+            continue
+        for parameter in parameters:
+            uncovered.append(
+                UncoveredViewRequirement(
+                    identity=DimensionId(feature, parameter),
+                    label=f"{labels[id(feature)]}.{parameter}",
+                    preferred_view=view,
+                    eligible_views=(view,),
+                    reason=f"reads only in `{view}`",
+                )
+            )
+    return uncovered
+
+
+def plan_dimensions(model: PartModel, *, planned_views=None) -> list[DimensionGroup]:
     """Plan each feature's parameters into one `DimensionGroup` (anchor + single
     view + planned dims, each carrying its render intent — convention, model-level
     suppression, datum). No cross- or within-feature value de-duplication."""
@@ -1023,13 +1267,22 @@ def plan_dimensions(model: PartModel) -> list[DimensionGroup]:
                 )
             )
         if dims:
+            selected_view = _group_view(feature, planned_views)
             groups.append(
                 DimensionGroup(
                     feature=feature,
-                    view=_group_view(feature),
+                    # Preserve a total internal record while collecting every uncovered
+                    # identity below.  The exception prevents this preferred fallback from
+                    # crossing the planner boundary when it is not actually selected.
+                    view=selected_view or _preferred_group_view(feature),
                     units=_addressable(feature, dims),
                 )
             )
+    if planned_views is not None:
+        uncovered = _uncovered_group_requirements(model, groups, planned_views)
+        uncovered.extend(_uncovered_location_requirements(model, planned_views))
+        if uncovered:
+            raise ViewPlanIncomplete(planned_views, uncovered)
     return groups
 
 

--- a/src/draftwright/view_plan.py
+++ b/src/draftwright/view_plan.py
@@ -33,6 +33,52 @@ from dataclasses import dataclass
 from types import MappingProxyType
 from typing import Any
 
+
+@dataclass(frozen=True)
+class UncoveredViewRequirement:
+    """One semantic requirement no selected principal view can carry.
+
+    ``identity`` is deliberately opaque here.  The view-planning leaf must not import the
+    model waist, while the planner supplies an ADR 0016 ``DimensionId`` at the boundary.
+    ``label`` is only the human-readable rendering of that identity; callers must use
+    ``identity`` for correspondence and never parse the label.
+    """
+
+    identity: Any
+    label: str
+    preferred_view: str
+    eligible_views: tuple[str, ...]
+    reason: str
+
+
+class ViewPlanIncomplete(ValueError):
+    """The selected principal views cannot carry every approved requirement.
+
+    Raised by the dimension planner before projection.  This is a user/actionable planning
+    result, unlike ``Drawing.ViewNotPlanned``: the latter remains the internal invariant for
+    code that tries to project into a view after this check has succeeded.
+    """
+
+    def __init__(self, planned, uncovered, *, source: str = "selected") -> None:
+        self.planned = tuple(planned)
+        self.uncovered = tuple(uncovered)
+        self.source = source
+        noun = "dimension" if len(self.uncovered) == 1 else "dimensions"
+        lines = [
+            f"{len(self.uncovered)} approved {noun} cannot be shown by the {source} "
+            f"view set {self.planned!r}:"
+        ]
+        for requirement in self.uncovered:
+            eligible = ", ".join(f"`{view}`" for view in requirement.eligible_views)
+            add = (
+                f"add {eligible}"
+                if len(requirement.eligible_views) == 1
+                else f"add one of {eligible}"
+            )
+            lines.append(f"  {requirement.label}  {requirement.reason} — {add}")
+        super().__init__("\n".join(lines))
+
+
 #: The model axes a principal view projects onto the page, as ``(page_x, page_y)``.
 #: Third-angle front shows model x across and z up; the plan shows x across and y up; the side
 #: shows y across and z up. Held here rather than inferred from the camera because

--- a/tests/test_adr0018_view_selection.py
+++ b/tests/test_adr0018_view_selection.py
@@ -23,9 +23,8 @@ import math
 import pytest
 from build123d import Box, Cylinder, Pos, Rot
 
-from draftwright import build_drawing
+from draftwright import ViewPlanIncomplete, build_drawing
 from draftwright.compose import _layout_geometry
-from draftwright.drawing import ViewNotPlanned
 from draftwright.view_plan import VIEW_AXES, VIEWS_SHOWING, views_showing
 
 ALL_THREE = ("front", "plan", "side")
@@ -168,9 +167,71 @@ class TestTheAsymmetricCounterexample:
     """Same box, same single hole, different axis — opposite verdicts."""
 
     def test_a_view_the_features_need_is_refused(self):
-        with pytest.raises(ViewNotPlanned) as caught:
+        with pytest.raises(ViewPlanIncomplete) as caught:
             build_drawing(_z_hole(), _views=("front", "side"))
-        assert caught.value.view == "plan"
+        assert caught.value.planned == ("front", "side")
+        assert {item.identity.parameter for item in caught.value.uncovered} == {
+            "bore.diameter",
+            "location.location",
+        }
+        assert all(item.preferred_view == "plan" for item in caught.value.uncovered)
+        assert "hole_1.bore.diameter" in str(caught.value)
+        assert "add `plan`" in str(caught.value)
+
+    def test_an_authored_location_names_its_constraint_before_projection(self):
+        from draftwright.model import Datum, Frame, HoleFeature, PartModel
+        from draftwright.model.ir import RequestedDimension
+
+        part = _z_hole()
+        bbox = part.bounding_box()
+        hole = HoleFeature(Frame((20.0, 15.0, 12.5), "z"), 8.0, depth=None, through=True)
+        model = PartModel(
+            bbox=bbox,
+            orientation="prismatic",
+            features=[hole],
+            datums=[Datum("datum_xy", "point", (bbox.min.X, bbox.min.Y, bbox.min.Z))],
+            authored_dimensions=(RequestedDimension(hole, "location"),),
+        )
+
+        with pytest.raises(ViewPlanIncomplete) as caught:
+            build_drawing(part, model=model, _views=("front", "side"))
+
+        assert [item.identity.parameter for item in caught.value.uncovered] == [
+            "location.location"
+        ]
+        assert "hole_1.location" in str(caught.value)
+        assert "bore.diameter" not in str(caught.value), "the authored omission stays omitted"
+
+        drawing = build_drawing(part, model=model, _views=("front", "plan"))
+        y_names = [name for name in drawing.annotations() if name.startswith("m_locy")]
+        assert y_names, "the approved Y member must re-home rather than disappear"
+        assert {drawing.view_of(name) for name in y_names} == {"plan"}
+
+    def test_the_adrs_two_requirement_diagnostic_is_executable(self):
+        from dataclasses import replace
+
+        from draftwright.model.ir import RequestedDimension
+
+        part = _z_hole()
+        detected = build_drawing(part).model()
+        assert detected is not None
+        envelope = next(feature for feature in detected.features if feature.kind == "envelope")
+        hole = next(feature for feature in detected.features if feature.kind == "hole")
+        model = replace(
+            detected,
+            authored_dimensions=(
+                RequestedDimension(envelope, "depth.length"),
+                RequestedDimension(hole, "location"),
+            ),
+        )
+
+        with pytest.raises(ViewPlanIncomplete) as caught:
+            build_drawing(part, model=model, _views=("front",))
+
+        assert [(item.label, item.preferred_view) for item in caught.value.uncovered] == [
+            ("envelope.depth.length", "side"),
+            ("hole_1.location", "plan"),
+        ]
 
     def test_the_same_view_is_droppable_when_the_feature_turns(self):
         # The asymmetry: identical geometry apart from the hole's axis. Dropping plan is
@@ -183,9 +244,37 @@ class TestTheAsymmetricCounterexample:
     def test_dropping_the_view_the_x_hole_needs_is_refused_in_turn(self):
         # The other half of the asymmetry, so neither result is an accident of which view
         # happens to be named: for this part SIDE is the necessary one.
-        with pytest.raises(ViewNotPlanned) as caught:
+        with pytest.raises(ViewPlanIncomplete) as caught:
             build_drawing(_x_hole(), _views=("front", "plan"))
-        assert caught.value.view == "side"
+        assert caught.value.planned == ("front", "plan")
+        # Collected, not first-failure-only: the same missing side view strands both the
+        # asymmetric bore and the mandatory overall depth, and neither may be discarded.
+        assert {item.identity.parameter for item in caught.value.uncovered} == {
+            "bore.diameter",
+            "depth.length",
+            "location_off_axis.y",
+            "location_off_axis.z",
+        }
+        assert all(item.preferred_view == "side" for item in caught.value.uncovered)
+
+    def test_an_authored_off_axis_location_is_checked_at_the_same_boundary(self):
+        from draftwright.model import Frame, HoleFeature, PartModel
+        from draftwright.model.ir import RequestedDimension
+
+        part = _x_hole()
+        hole = HoleFeature(Frame((45.0, 30.0, 12.5), "x"), 10.0, depth=None, through=True)
+        model = PartModel(
+            bbox=part.bounding_box(),
+            orientation="prismatic",
+            features=[hole],
+            authored_dimensions=(RequestedDimension(hole, "location"),),
+        )
+        with pytest.raises(ViewPlanIncomplete) as caught:
+            build_drawing(part, model=model, _views=("front", "plan"))
+        assert {item.identity.parameter for item in caught.value.uncovered} == {
+            "location_off_axis.y",
+            "location_off_axis.z",
+        }
 
 
 class TestAnExtentMovesOrIsReported:
@@ -195,14 +284,110 @@ class TestAnExtentMovesOrIsReported:
         assert "m_env_width" in drawing.annotations()
         assert "m_env_depth" in drawing.annotations()
 
-    def test_an_extent_no_planned_view_can_show_is_reported_not_dropped(self):
+    def test_the_planner_record_itself_re_homes_instead_of_only_the_renderer(self):
+        from draftwright.model.planner import plan_dimensions
+
+        model = build_drawing(Box(90, 60, 25)).model()
+        assert model is not None
+        envelope = next(
+            group
+            for group in plan_dimensions(model, planned_views=("front", "side"))
+            if group.feature.kind == "envelope"
+        )
+        assert envelope.view == "front"
+
+    def test_the_compiler_cannot_silently_replan_against_the_fixed_topology(self):
+        from draftwright.model.compiled import compile_dimensions
+
+        model = build_drawing(_z_hole()).model()
+        assert model is not None
+        with pytest.raises(ViewPlanIncomplete) as caught:
+            compile_dimensions(model, planned_views=("front", "side"))
+        assert {item.identity.parameter for item in caught.value.uncovered} >= {
+            "bore.diameter",
+            "location.location",
+        }
+
+    @pytest.mark.parametrize(
+        ("shoulder", "views", "missing"),
+        [(("x", 30.0), ("front", "side"), "plan"), (("y", 20.0), ("front", "plan"), "side")],
+    )
+    def test_a_correlated_step_position_keeps_each_directional_member(
+        self, shoulder, views, missing
+    ):
+        from draftwright.model import Frame, PartModel, StepLevelFeature
+        from draftwright.model.planner import plan_dimensions
+
+        model = PartModel(
+            bbox=Box(90, 60, 25).bounding_box(),
+            orientation="prismatic",
+            features=[
+                StepLevelFeature(
+                    Frame((0.0, 0.0, 0.0), "z"),
+                    base=0.0,
+                    levels=(10.0,),
+                    shoulders=(shoulder,),
+                )
+            ],
+        )
+        with pytest.raises(ViewPlanIncomplete) as caught:
+            plan_dimensions(model, planned_views=views)
+        position = next(
+            item
+            for item in caught.value.uncovered
+            if item.identity.parameter == "step_position.length"
+        )
+        assert position.preferred_view == missing
+
+    def test_an_extent_no_planned_view_can_show_is_rejected_before_projection(self):
         # Depth reads horizontally ONLY in side. Without it the extent cannot be drawn, and
         # ADR 0016 Amdt 6 says it must be reported against its measurement rather than
-        # disappear — which is also the signal a requirement gate weighs.
-        drawing = build_drawing(Box(90, 60, 25), _views=("front", "plan"))
-        assert "m_env_depth" not in drawing.annotations()
-        assert "overall_dim_withheld" in _lint(drawing)
-        assert "m_env_width" in drawing.annotations(), "the width must still be drawn"
+        # disappear. Phase 5.5 moves that feasibility decision above projection, so a
+        # plausible-looking incomplete drawing is no longer returned.
+        with pytest.raises(ViewPlanIncomplete) as caught:
+            build_drawing(Box(90, 60, 25), _views=("front", "plan"))
+        assert [item.identity.parameter for item in caught.value.uncovered] == ["depth.length"]
+        assert "envelope.depth.length" in str(caught.value)
+
+    def test_a_width_diagnostic_lists_both_semantically_eligible_views(self):
+        from draftwright.model.planner import plan_dimensions
+
+        model = build_drawing(Box(90, 60, 25)).model()
+        assert model is not None
+        with pytest.raises(ViewPlanIncomplete) as caught:
+            plan_dimensions(model, planned_views=("side",))
+        width = next(
+            item for item in caught.value.uncovered if item.identity.parameter == "width.length"
+        )
+        assert width.eligible_views == ("plan", "front")
+        assert "add one of `plan`, `front`" in str(caught.value)
+
+    def test_an_authored_slot_position_uses_the_slot_plane_not_its_long_axis(self):
+        from draftwright.model import Frame, PartModel, SlotFeature
+        from draftwright.model.ir import RequestedDimension
+        from draftwright.model.planner import plan_dimensions
+
+        slot = SlotFeature(
+            Frame((30.0, 20.0, 10.0), "x"),
+            width_axis="y",
+            long_axis="x",
+            width=8.0,
+            length=30.0,
+            w_center=20.0,
+            lo=15.0,
+            hi=45.0,
+        )
+        model = PartModel(
+            bbox=Box(60, 40, 20).bounding_box(),
+            orientation="prismatic",
+            features=[slot],
+            authored_dimensions=(RequestedDimension(slot, "location"),),
+        )
+        with pytest.raises(ViewPlanIncomplete) as caught:
+            plan_dimensions(model, planned_views=("front", "side"))
+        assert [
+            (item.identity.parameter, item.preferred_view) for item in caught.value.uncovered
+        ] == [("location_slot.length", "plan")]
 
 
 class TestTheDecisionSurvivesEveryRebuild:
@@ -272,8 +457,10 @@ class TestTheCaseStudy:
         # This part is the cheapest thing that reaches that code with the front view gone:
         # it needs enough diameters for the row to be attempted at all, and the parts small
         # enough to be fast return early on an empty item list. The distinction the
-        # assertion draws is TypeError (crashed inside a pass) vs ViewNotPlanned (refused,
-        # naming the view) — a view set must be REFUSABLE for a gate to weigh it.
-        with pytest.raises(ViewNotPlanned) as caught:
+        # assertion draws is TypeError (crashed inside a pass) vs a pre-projection planning
+        # refusal naming the semantic requirements — a view set must be refusable for a gate
+        # to weigh it.
+        with pytest.raises(ViewPlanIncomplete) as caught:
             build_drawing(self._plate(), _views=("plan", "side"))
-        assert caught.value.view == "front"
+        assert caught.value.uncovered
+        assert all(item.preferred_view == "front" for item in caught.value.uncovered)

--- a/tests/test_adr0018_view_selection.py
+++ b/tests/test_adr0018_view_selection.py
@@ -389,6 +389,106 @@ class TestAnExtentMovesOrIsReported:
             (item.identity.parameter, item.preferred_view) for item in caught.value.uncovered
         ] == [("location_slot.length", "plan")]
 
+    def test_every_renderer_supported_feature_family_has_semantic_view_ownership(self):
+        """Mutation guard for the conservative ownership table, including uncommon IR arms."""
+        from types import SimpleNamespace
+
+        from draftwright.model import ChannelFeature, Frame, PadFeature, PocketFeature, SlotFeature
+        from draftwright.model.ir import DimParameter
+        from draftwright.model.planner import PlannedDimension, _parameter_view_preferences
+
+        def preferences(feature, role):
+            planned = PlannedDimension(DimParameter("length", role, 1.0), "linear")
+            return _parameter_view_preferences(feature, planned)
+
+        planar = dict(
+            frame=Frame((0.0, 0.0, 0.0), "z"),
+            width_axis="y",
+            long_axis="x",
+            width=8.0,
+            length=30.0,
+            w_center=20.0,
+            lo=15.0,
+            hi=45.0,
+        )
+        cases = [
+            (
+                SimpleNamespace(kind="boss", frame=Frame((0.0, 0.0, 0.0), "x")),
+                "boss_height",
+                ("front",),
+            ),
+            (SimpleNamespace(kind="step", frame=Frame((0.0, 0.0, 0.0), "y")), "step", ("side",)),
+            (SlotFeature(**planar), "slot_width", ("plan",)),
+            (PadFeature(**planar, z0=0.0, z1=5.0), "pad_width", ("plan",)),
+            (
+                PocketFeature(
+                    Frame((0.0, 0.0, 0.0), "x"),
+                    width_axis="y",
+                    long_axis="z",
+                    width=8.0,
+                    length=30.0,
+                    depth=5.0,
+                    w_center=20.0,
+                    lo=15.0,
+                    hi=45.0,
+                ),
+                "pocket_depth",
+                ("side",),
+            ),
+            (
+                SimpleNamespace(kind="pocket_pattern", frame=Frame((0.0, 0.0, 0.0), "z")),
+                "pitch",
+                ("plan",),
+            ),
+            (
+                ChannelFeature(
+                    Frame((0.0, 0.0, 0.0), "z"),
+                    width_axis="x",
+                    long_axis="y",
+                    width=8.0,
+                    w_center=20.0,
+                    lo=0.0,
+                    hi=30.0,
+                    d_lo=0.0,
+                    d_hi=5.0,
+                ),
+                "channel_width",
+                ("front",),
+            ),
+        ]
+        assert [preferences(feature, role) for feature, role, _expected in cases] == [
+            expected for _feature, _role, expected in cases
+        ]
+
+    def test_an_off_axis_pocket_location_uses_its_opening_normal(self):
+        from draftwright.model import Datum, Frame, PartModel, PocketFeature
+        from draftwright.model.ir import RequestedDimension
+        from draftwright.model.planner import plan_dimensions
+
+        pocket = PocketFeature(
+            Frame((30.0, 20.0, 10.0), "x"),
+            width_axis="y",
+            long_axis="z",
+            width=8.0,
+            length=20.0,
+            depth=5.0,
+            w_center=20.0,
+            lo=0.0,
+            hi=20.0,
+        )
+        model = PartModel(
+            bbox=Box(60, 40, 20).bounding_box(),
+            orientation="prismatic",
+            features=[pocket],
+            datums=[Datum("datum_xy", "point", (0.0, 0.0, 0.0))],
+            authored_dimensions=(RequestedDimension(pocket, "location"),),
+        )
+        with pytest.raises(ViewPlanIncomplete) as caught:
+            plan_dimensions(model, planned_views=("front", "plan"))
+        assert [
+            (item.identity.parameter, item.preferred_view) for item in caught.value.uncovered
+        ] == [("location_pocket.location", "side")]
+
 
 class TestTheDecisionSurvivesEveryRebuild:
     def test_a_rebuild_does_not_revert_the_view_set(self):

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -426,7 +426,17 @@ def test_classifier_is_binding_aware_and_context_correct(tmp_path):
 
 # ── model/ IR-waist guards (original #584 WP2 — kept; add the relative-import rejection) ──
 
-_MODEL_MAY_IMPORT = {"_geometry", "fits", "fonts", "layout", "model", "recognition"}
+_MODEL_MAY_IMPORT = {
+    "_geometry",
+    "fits",
+    "fonts",
+    "layout",
+    "model",
+    "recognition",
+    # ADR 0018: the dimension planner resolves requirement ownership against the selected
+    # semantic view set.  `view_plan` is a rank-0, drawing-independent leaf.
+    "view_plan",
+}
 
 
 def _draftwright_imports(path: Path) -> tuple[set[str], list[str]]:

--- a/tests/test_label_provenance.py
+++ b/tests/test_label_provenance.py
@@ -51,7 +51,7 @@ _FMT_BUDGET: dict[str, tuple[int, str]] = {
     # which dims exist, so an entry per axis would approve a mark whose existence the
     # renderer decides. Splitting it means moving that grouping into the compiler. Every
     # other family (off-axis holes, non-Z pockets, slots) is already per-axis.
-    "from_model.render_locations": (4, "Z ladder groups across features before deduping"),
+    "from_model.render_locations": (3, "Z ladder groups across features before deduping"),
     "holes.add_feature_location": (2, "the live verb onto that same Z ladder"),
     # --- The turned step chain composes its labels while collapsing repeat runs, so the
     # text is decided by the collapse rather than per approved entry.


### PR DESCRIPTION
## Symptom and evidence

- User-visible problem: reduced or authored view sets reused the fixed three-view dimension plan, so requirements could fail late with `ViewNotPlanned` or disappear from a plausible-looking drawing.
- Fixture/reproducer: the ADR 0018 asymmetric Z-hole/X-hole counterexample plus authored extent, location, slot, and correlated-step cases.
- Before/after result: the planner now re-homes renderer-supported requirements and otherwise raises one `ViewPlanIncomplete` before scale selection or projection, retaining ADR 0016 identities and naming every unmet requirement.
- Mutation that makes the guard fail: restoring fixed-topology `_group_view` routing, skipping either directional member of a step-position unit, or omitting the plan-view Y-location fallback fails the focused tests.

## Contract and scope

- Smallest contract this change tests: for a selected principal view set, every approved dimensional requirement has a renderer-supported owner before projection or appears in the aggregated refusal.
- Relevant ADRs: ADR 0016 identity and authored completeness, ADR 0017 requirement outcomes, ADR 0018 §5 and Phase 5.5.
- Explicitly deferred: public `Sheet` view verbs and source-line provenance (#1260), displaced-callout renderer expansion (#1261), automatic semantic view selection (#1262), and annotation coordinate control.

Closes #1259

## Validation

- [x] `scripts/pr-check --quick`
- [x] `scripts/pr-check` before final review (`4492 passed, 5 skipped, 3 xfailed`; 94.67% total coverage)
- [x] Cross-repository recogniser changes: N/A; no recogniser repository or detection contract changed.
- [x] The named mutation was observed failing before the implementation passed it.
- [x] Automatic, declared, and generated-script paths were checked where affected; automatic and supplied-model paths are covered, while public authored-view verbs remain #1260.
- [x] Recognition and repeated-lint call counts: N/A; no recognition or lint scheduling changed.
- [x] Applicable slow checks: `2 passed, 44 deselected`.
- [x] Changed-line coverage: 93% against `origin/main` (threshold 93%).
- [x] `scripts/project-audit 3 pzfreo draftwright`.

## Stop check

- [x] No two consecutive review rounds invalidated the same core association strategy.
- [x] New prerequisites were split or explicitly deferred to #1260–#1262.