### PR TITLE
Omit datum-coincident step shoulders

### DIFF
--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -66,14 +66,13 @@ PartModel
   → compile_dimensions()            # one place: rules, requests, authored sets
       → RenderableDimensionPlan     # APPROVED entries only
       → diagnostics                 # what was omitted, and why
-  → renderers consume approved entries (diagnostics: see below — no consumer yet)
+  → renderers consume approved entries; audit/lint consume diagnostics
 ```
 
 - `ApprovedDimension` has **no `suppressed` field**. There is nothing to forget.
-- Withheld measurements leave through `diagnostics`. **Nothing consumes them yet** — the
-  consumer is `linting/coverage.py` and it arrives with #921, whose authored sets are the
-  first omissions coverage must tell apart from a measurement simply missed. Until then
-  every omission is a planner rule the lint layer already knows by other means.
+- Withheld measurements leave through `diagnostics`. The builder retains them as
+  `Drawing.suppressions()`, coverage consumes their family outcomes, and selected validation
+  omissions additionally surface through lint. They never enter a renderer.
 - The feature a dimension came from travels as an **opaque `FeatureRef`**: identity and
   category, no measurement. Carrying the `Feature` itself would have left the bypass one
   attribute access away — `.feature.levels` rebuilds exactly what the compiler withheld.
@@ -83,6 +82,11 @@ PartModel
 - Correlated sets (a step-height ladder, a shoulder chain) arrive as explicit
   `ApprovedLadder` groups, so a renderer never rebuilds one from a feature. This preserves
   the tier-3 identity rule — the set is approved or omitted whole, never half a staircase.
+  A datum-coincident shoulder is the validation exception, not a partial authored decision:
+  it measures no distance and cannot form border geometry, so the compiler removes that
+  non-measurement before the correlated set forms, retains every non-degenerate sibling under
+  the same tier-3 identity, and emits `step_position_coincident_with_datum` through both the
+  omission ledger and lint. A renderer never receives identical endpoints.
 - Spans travel in **part space**; the renderer projects them. That is the split in one line:
   the compiler says "this measurement, this value, between these two points"; the renderer
   says which view, which strip, which side, and what happens when it does not fit.

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -91,6 +91,7 @@ from draftwright.annotations.sections import (
     feature_hole_keys,
 )
 from draftwright.model import (
+    DimensionId,
     Frame,
     HoleFeature,
     PatternFeature,
@@ -393,6 +394,21 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # ladder, the shoulders and the detail escalation each hold a separately
     # derived decision — three chances to disagree about one drawing.
     _compiled = compile_dimensions(_model, groups=_groups)
+    for omission in _compiled.diagnostics:
+        if omission.code != "step_position_coincident_with_datum":
+            continue
+        measurement = (
+            DimensionId(omission.feature, omission.parameter_id)
+            if omission.feature is not None
+            else None
+        )
+        ctx.record_issue(
+            "info",
+            "step_position_coincident_with_datum",
+            omission.reason,
+            measurement=measurement,
+            outcome_stage="validation",
+        )
     # Placement may release compiler-approved alternatives. Keep that runtime selection
     # separate from the immutable base plan consumed by every ordinary stage.
     _runtime_plan = _compiled

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -271,6 +271,7 @@ _UNSCORED_CODES = frozenset(
         "step_dim_withheld",
         "pattern_pitch_tolerance_withheld",
         "pocket_not_located",
+        "step_position_coincident_with_datum",
         # Neither confirmed nor refuted: the annotation renders no readable text, or the
         # compiler approved the measurement with no displayable value. Reported so an
         # unverifiable claim is visible rather than counted as a pass — but it is evidence

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -70,6 +70,7 @@ from draftwright.model.planner import (
     _AUTHORED_OMISSION,
     DimensionId,
     _decorated,
+    _is_zero_step_position,
     authored_location_omitted,
     location_datum,
     plan_dimensions,
@@ -170,8 +171,8 @@ class ApprovedDimension:
     discriminator: str | None = None
     tolerance: object | None = None
     #: Structural direction needed when a span cannot encode it. In particular, a
-    #: shoulder coincident with its datum has a zero-length span in every coordinate;
-    #: deriving X/Y from "the varying coordinate" is then impossible.
+    #: shoulder rung retains X/Y explicitly rather than asking a renderer to infer semantic
+    #: direction from projected coordinates.
     axis: str | None = None
     #: A complete compiler-owned label for correlated marks whose wording is itself a
     #: content decision (for example ``"4× 10"``). Ordinary group dimensions leave this
@@ -432,6 +433,11 @@ class Omission:
     #: Completeness lint requires this owner to have actually landed; a consolidation
     #: onto a dimension the placer then drops is a missing measurement, not a covered one.
     conveyed_by: DimensionId | None = None
+    #: Stable lint code when this compiler decision should also be visible through
+    #: ``Drawing.lint()``. Most ordinary suppression rules remain audit-only and leave this
+    #: unset; a datum-coincident shoulder sets it because otherwise the validation decision
+    #: that prevented invalid border geometry would be invisible to the drawing caller.
+    code: str | None = None
 
     @property
     def authored(self) -> bool:
@@ -526,8 +532,9 @@ class RenderableDimensionPlan:
     chain (the first migrated slice). Renderers not yet migrated keep consuming
     `plan_dimensions` directly, and the migration is finished when none do.
 
-    :attr:`diagnostics` is produced but not yet consumed — see the module docstring. It is
-    an output with a named owner and a date, not a claim about today's behaviour.
+    :attr:`diagnostics` is retained by the builder as the drawing's suppression ledger;
+    coverage consumes its family outcomes, and selected validation omissions also surface
+    through lint. It stays separate from approved content so no renderer can see it.
     """
 
     groups: tuple[ApprovedGroup, ...] = ()
@@ -807,9 +814,8 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
 
         Carried rather than left ``None`` so consumers never go back to the feature for the
         station: the detail crop needs the X positions to frame the crowded band, and
-        `render_step_positions` will need both ends when it migrates. The varying
-        coordinate usually shows which axis it runs along. It cannot do so for a shoulder
-        coincident with its datum, so the approved entry also carries the explicit axis."""
+        `render_step_positions` needs both ends. The approved entry also carries the explicit
+        axis because direction is semantic content, not something projection should infer."""
         lo = list(step.datum)
         hi = list(step.datum)
         hi[_di[axis]] = pos
@@ -824,19 +830,35 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
     shoulder_tol = (
         _decorated(model, step, shoulder_param).tolerance if shoulder_param is not None else None
     )
-    shoulders = [
-        ApprovedDimension(
-            id=_dim_id(step, "step_position.length"),
-            value_text=_fmt(abs(pos - step.datum[_di[axis]])),
-            value=abs(pos - step.datum[_di[axis]]),
-            span=_shoulder_span(axis, pos),
-            ref=step_ref,
-            axis=axis,
-            tolerance=shoulder_tol,
-            rendered_label=_fmt(abs(pos - step.datum[_di[axis]])),
+    shoulders: list[ApprovedDimension] = []
+    degenerate_shoulders: list[Omission] = []
+    for axis, pos in sorted(step.shoulders):
+        datum = step.datum[_di[axis]]
+        value = abs(pos - datum)
+        if _is_zero_step_position(value):
+            degenerate_shoulders.append(
+                Omission(
+                    step,
+                    "step_position.length",
+                    0.0,
+                    f"{axis.upper()} shoulder at {_fmt(pos)} is coincident with its datum "
+                    f"{_fmt(datum)}; zero-length step positions are omitted before rendering",
+                    code="step_position_coincident_with_datum",
+                )
+            )
+            continue
+        shoulders.append(
+            ApprovedDimension(
+                id=_dim_id(step, "step_position.length"),
+                value_text=_fmt(value),
+                value=value,
+                span=_shoulder_span(axis, pos),
+                ref=step_ref,
+                axis=axis,
+                tolerance=shoulder_tol,
+                rendered_label=_fmt(value),
+            )
         )
-        for axis, pos in sorted(step.shoulders)
-    ]
     pos_marks = [
         (pid, v, why)
         for (fid, pid), (v, why) in marked.items()
@@ -846,6 +868,8 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
         approved.append(ApprovedLadder("step_position", tuple(shoulders), ref=step_ref))
     else:
         omissions += [Omission(step, pid, v, why) for pid, v, why in pos_marks]
+    if not pos_marks:
+        omissions += degenerate_shoulders
     return approved, omissions
 
 
@@ -1329,6 +1353,15 @@ def _compile_groups(planned) -> tuple[list[ApprovedGroup], list[Omission]]:
             )
             for pd in g.dims
             if not pd.suppressed
+            # A datum-coincident shoulder is not a zero-valued dimension the general group
+            # may keep after the dedicated ladder rejected its identical endpoints. It is
+            # validation-pruned before either compiled representation forms; the ladder
+            # compiler owns the axis-specific omission diagnostic.
+            and not (
+                isinstance(g.feature, StepLevelFeature)
+                and pd.param.role == "step_position"
+                and _is_zero_step_position(pd.param.value)
+            )
         )
         out.append(
             ApprovedGroup(

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -59,6 +59,16 @@ from draftwright.view_plan import (
 #: sets it, and re-exported by `model/compiled.py` so the two cannot drift.
 _AUTHORED_OMISSION = "not in the authored dimension set"
 
+
+def _is_zero_step_position(value: float) -> bool:
+    """Whether a shoulder measures no distance from its datum.
+
+    This validation is exact: every nonzero declared measurement remains approved and keeps
+    its directional-view requirement, however small its value.
+    """
+    return float(value) == 0.0
+
+
 # How each (role, kind) is drawn. Defaults keep the table small.
 _CONVENTION = {
     ("step", "length"): "chain",
@@ -1090,7 +1100,11 @@ def _uncovered_group_requirements(
                 # is addressed as one unit.
                 for axis, view in (("x", "plan"), ("y", "side")):
                     if view in planned or not any(
-                        shoulder_axis == axis for shoulder_axis, _ in group.feature.shoulders
+                        shoulder_axis == axis
+                        and not _is_zero_step_position(
+                            position - group.feature.datum["xyz".index(shoulder_axis)]
+                        )
+                        for shoulder_axis, position in group.feature.shoulders
                     ):
                         continue
                     identity = DimensionId(group.feature, unit.id)

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -285,8 +285,8 @@ class TestTheRendererCannotSeeContent:
             for rung in ladder.rungs:
                 assert rung.id is not None, f"{ladder.kind} rung lost its DimensionId"
 
-    def test_zero_length_shoulder_keeps_its_explicit_axis(self):
-        """A degenerate datum→shoulder span cannot reveal whether it is X or Y."""
+    def test_zero_length_shoulder_is_an_explicit_compiler_omission(self):
+        """A datum-coincident shoulder never becomes invalid renderer geometry (#924)."""
         from draftwright.model.ir import Frame, PartModel, StepLevelFeature
 
         part = Box(90, 60, 30)
@@ -302,11 +302,11 @@ class TestTheRendererCannotSeeContent:
             orientation=None,
             features=[step],
         )
-        ladder = compile_dimensions(model).ladder("step_position")
-        assert ladder is not None
-        assert len(ladder.rungs) == 1
-        assert ladder.rungs[0].span[0] == ladder.rungs[0].span[1]
-        assert ladder.rungs[0].axis == "x"
+        plan = compile_dimensions(model)
+        assert plan.ladder("step_position") is None
+        omitted = [o for o in plan.diagnostics if o.parameter_id == "step_position.length"]
+        assert len(omitted) == 1
+        assert omitted[0].code == "step_position_coincident_with_datum"
 
     def test_the_layout_frame_carries_no_part_geometry(self):
         from draftwright._core import LayoutFrame

--- a/tests/test_issue_924_zero_length_shoulders.py
+++ b/tests/test_issue_924_zero_length_shoulders.py
@@ -57,9 +57,10 @@ def test_the_compiler_omits_a_shoulder_coincident_with_its_datum(axis):
 
 @pytest.mark.parametrize("axis", ["x", "y"])
 def test_the_real_build_reports_the_omission_without_constructing_a_border(axis):
-    part, _step, model = _declared_step(axis)
+    part, step, _model = _declared_step(axis)
 
-    drawing = build_drawing(part, model=model)
+    # Exercise the issue's exact public reproducer shape, not only a prebuilt PartModel.
+    drawing = build_drawing(part, model=[step])
 
     assert not [name for name in drawing.annotations() if name.startswith("dim_shoulder")]
     suppression = next(

--- a/tests/test_issue_924_zero_length_shoulders.py
+++ b/tests/test_issue_924_zero_length_shoulders.py
@@ -1,0 +1,117 @@
+"""#924: datum-coincident shoulders are compiler omissions, never render geometry."""
+
+from __future__ import annotations
+
+import pytest
+from build123d import Box, Pos
+
+from draftwright import build_drawing
+from draftwright.builder import detect_part_model
+from draftwright.model.compiled import FeatureRef, compile_dimensions
+from draftwright.model.ir import Frame, PartModel, StepLevelFeature
+from draftwright.model.planner import plan_dimensions
+
+
+def _declared_step(axis: str, *, with_nonzero_sibling: bool = False):
+    part = Box(90, 60, 30)
+    datum = (-45.0, -30.0, 0.0)
+    coincident = datum["xyz".index(axis)]
+    shoulders = [(axis, coincident)]
+    if with_nonzero_sibling:
+        shoulders.append((axis, coincident + 20.0))
+    step = StepLevelFeature(
+        Frame((0.0, 0.0, 0.0), "z"),
+        base=0.0,
+        levels=(10.0,),
+        shoulders=tuple(shoulders),
+        datum=datum,
+    )
+    model = PartModel(
+        bbox=part.bounding_box(),
+        orientation="prismatic",
+        features=[step],
+    )
+    return part, step, model
+
+
+@pytest.mark.parametrize("axis", ["x", "y"])
+def test_the_compiler_omits_a_shoulder_coincident_with_its_datum(axis):
+    _part, step, model = _declared_step(axis)
+
+    plan = compile_dimensions(model)
+
+    assert plan.ladder("step_position") is None
+    omissions = [
+        omission
+        for omission in plan.diagnostics
+        if omission.feature is step and omission.parameter_id == "step_position.length"
+    ]
+    assert len(omissions) == 1
+    assert omissions[0].value == 0.0
+    assert omissions[0].code == "step_position_coincident_with_datum"
+    assert f"{axis.upper()} shoulder" in omissions[0].reason
+    assert "coincident with its datum" in omissions[0].reason
+    step_group = next(group for group in plan.groups if group.ref == FeatureRef(step))
+    assert step_group.dim(role="step_position") is None
+
+
+@pytest.mark.parametrize("axis", ["x", "y"])
+def test_the_real_build_reports_the_omission_without_constructing_a_border(axis):
+    part, _step, model = _declared_step(axis)
+
+    drawing = build_drawing(part, model=model)
+
+    assert not [name for name in drawing.annotations() if name.startswith("dim_shoulder")]
+    suppression = next(
+        row for row in drawing.suppressions() if row["parameter_id"] == "step_position.length"
+    )
+    assert suppression["value"] == 0.0
+    assert suppression["authored"] is False
+    assert "coincident with its datum" in suppression["reason"]
+    issue = next(
+        issue for issue in drawing.lint() if issue.code == "step_position_coincident_with_datum"
+    )
+    assert issue.severity == "info"
+    assert f"{axis.upper()} shoulder" in issue.message
+
+
+@pytest.mark.parametrize("axis", ["x", "y"])
+def test_only_the_degenerate_member_is_removed_from_a_mixed_shoulder_chain(axis):
+    _part, step, model = _declared_step(axis, with_nonzero_sibling=True)
+
+    plan = compile_dimensions(model)
+
+    ladder = plan.ladder("step_position")
+    assert ladder is not None
+    assert [(rung.axis, rung.value) for rung in ladder.rungs] == [(axis, 20.0)]
+    assert ladder.rungs[0].id is not None
+    assert ladder.rungs[0].id.feature == step
+    assert ladder.rungs[0].id.parameter == "step_position.length"
+    assert [omission.value for omission in plan.diagnostics if omission.feature is step] == [0.0]
+    step_group = next(group for group in plan.groups if group.ref == FeatureRef(step))
+    assert [dim.value for dim in step_group.dims if dim.role == "step_position"] == [20.0]
+
+
+@pytest.mark.parametrize(
+    ("axis", "planned_views"),
+    [("x", ("front", "side")), ("y", ("front", "plan"))],
+)
+def test_an_omitted_shoulder_does_not_require_its_directional_view(axis, planned_views):
+    _part, _step, model = _declared_step(axis)
+
+    groups = plan_dimensions(model, planned_views=planned_views)
+
+    assert groups
+
+
+def test_a_detected_non_degenerate_step_chain_is_unchanged():
+    part = Box(90, 60, 10) + Pos(0, 0, 10) * Box(45, 60, 10)
+    model = detect_part_model(part)
+    assert any(isinstance(feature, StepLevelFeature) for feature in model.features)
+
+    ladder = compile_dimensions(model).ladder("step_position")
+
+    assert ladder is not None
+    assert [(rung.axis, rung.value) for rung in ladder.rungs] == [("x", 22.5), ("x", 67.5)]
+    drawing = build_drawing(part)
+    assert len([name for name in drawing.annotations() if name.startswith("dim_shoulder")]) == 2


### PR DESCRIPTION
## Symptom and evidence\n\n- User-visible problem: a declared StepLevelFeature shoulder whose station equals its datum reaches the border helper with identical endpoints and raises ValueError instead of producing a drawing.\n- Fixture/reproducer: tests/test_issue_924_zero_length_shoulders.py builds declared X and Y shoulders at their datum through the real build path.\n- Before/after result: before, both real builds crashed; after, the compiler omits only the zero-length member, preserves valid siblings, records the omission in Drawing.suppressions(), and reports info lint code step_position_coincident_with_datum.\n- Mutation that makes the guard fail: removing the compiler validation restores six observed failures, including both identical-endpoint crashes and zero rungs leaking into compiled groups.\n\n## Contract and scope\n\n- Smallest contract this change tests: a datum-coincident step position is validation-pruned before its correlated ladder and general compiled group form; no renderer receives identical endpoints.\n- Relevant ADRs: ADR 0016 (compiled-plan boundary, correlated-set identity, omission diagnostics); ADR 0018 (view feasibility uses only renderable nonzero shoulders).\n- Explicitly deferred: no recognition policy or numeric near-coincidence tolerance changes; every nonzero shoulder retains existing behavior and view requirements.\n\n## Validation\n\n- [x] scripts/pr-check --quick\n- [x] scripts/pr-check --full before final review (4,505 passed; 5 skipped; 3 expected xfails; 94.76% total and 100% diff coverage)\n- [x] Cross-repository recogniser changes: N/A — no recogniser or cross-repository change.\n- [x] The named mutation was observed failing before the implementation passed it.\n- [x] Automatic and declared paths were checked; generated-script path is N/A because no emitter surface changes, and the full emitter suite passed.\n- [x] Recognition and repeated-lint call counts: recognition behavior is covered unchanged; lint code classification and repeated full-suite lint paths pass.\n\n## Stop check\n\n- [x] No two consecutive review rounds invalidated the same core association strategy.\n- [x] New prerequisites were split or the work was explicitly reclassified as discovery: N/A — no new prerequisite or discovery reclassification.\n\nCloses #924