### PR TITLE
Lower AP242 hole tolerances onto Sheet features

### DIFF
--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -838,7 +838,8 @@ constraining planner internals that are still moving. The gaps are known and fin
 | Correlated sets, per member | `step_height` / `step_position` ladders and rotational bores are one `AddressableDimension` holding N members | **One** line per set; suppress the set, not a member |
 | Location dimensions, per member | Addressable per FEATURE since #925 (`dimension(hole, "location")`); whether a patterned hole's position splits per member is **#883** | **One** line per feature |
 | Inter-feature spans and angles | No `(feature, role)` form — needs `RelationDimensionId`, whose selector spelling is still open | Comment floor until the relation selector lands |
-| Imported AP242 PMI | Materialized: carries `ref_pts` / `ref_bbox` / `at`, so there is nothing to reference | `sheet.measured_dimension(...)` — still one editable line |
+| Supported AP242 feature enrichment with no proven canonical owner | Materialized: its source geometry cannot safely identify a feature parameter | `sheet.measured_dimension(...)`, carrying a structured lowering blocker |
+| Supported AP242 feature enrichment that proves a canonical parameter | Referential enrichment: the source geometry uniquely identifies the feature/member and parameter | The feature line's aspect, e.g. `hole.tolerance(..., source="ap242_pmi", source_ids=...)` |
 | Low-level furniture | Centre marks, section arrows, hatching, the NTS caption carry no editable intent | Engine-automatic, by decision |
 | Anything the emitter cannot re-solve | The fidelity floor `emit_sheet_script` already holds for features | Self-describing comment |
 
@@ -1094,10 +1095,18 @@ second with the single-source-of-truth of the first — over the identified set,
   the drawing's placed annotations, so a solver-dropped dimension keeps its line. What it
   promises is a mirror of round-trippable, semantically identified planner intent, not of
   every mark — the gaps are tabulated in "What the mirror does and does not cover".
-- **Imported AP242 PMI stays materialized.** It carries `ref_pts` / `ref_bbox` / `at` and
-  has no referential form, so it emits as `sheet.measured_dimension(...)` — still one
-  editable line, so the intent-mirror property holds; the two verbs stay distinct precisely
-  because one references and the other restates.
+- **Imported AP242 PMI is materialized only when it has no proven canonical owner**
+  *(Amendment 4, #1116, 2026-08-22).* A supported source requirement whose nominal,
+  orientation and reference geometry identify exactly one canonical feature parameter is
+  consumed once as that parameter's authored aspect — for example
+  `hole.tolerance(..., source="ap242_pmi", source_ids=(...))`. Count-groups split only where
+  member requirements differ; a recognised pattern accepts only pattern-wide enrichment, so
+  its membership is not destroyed to force a match. Unmatched, ambiguous, conflicting and
+  unsupported correlations remain `sheet.measured_dimension(...)` and carry a structured
+  reason. This narrows the former blanket materialization rule: `ref_pts` / `ref_bbox` are
+  correlation evidence when sufficient, not proof that the source must own a second drafting
+  dimension. The planner still owns the one rendered parameter and the placement solve still
+  owns its coordinates.
 - **A duplicate/redundancy lint code joins `linting/structural.py`** — the third protection
   layer; nothing reports redundant dimensioning today.
 - **`--style imperative` retires once the declarative mirror reaches its coverage**, leaving

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -714,6 +714,7 @@ def _analyse(
             face_levels=list(recognition.step_levels) if recognition else None,
             rotational=(od_diam, _bores, od_axis) if is_rotational else None,
             pmi=pmi_records,
+            lower_pmi=pmi_mode == "annotate",
             cyls=shared_cyls,
         )
     )

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -423,14 +423,23 @@ def _assemble(
         # annotations detection would (render_pmi reads them off the model, gated on a.pmi_mode)
         # so a re-run reproduces the PMI dims (#472). Gated on the caller not having declared
         # imported authored annotations, so an explicit set wins.
-        if a.pmi_mode == "annotate" and not any(
-            f.kind in ("authored_dimension", "pmi")
-            or (f.kind == "control_frame" and bool(getattr(f, "source_id", "")))
-            for f in pm.features
+        if (
+            a.pmi_mode == "annotate"
+            and not any(
+                f.kind in ("authored_dimension", "pmi")
+                or (f.kind == "control_frame" and bool(getattr(f, "source_id", "")))
+                for f in pm.features
+            )
+            and not any(
+                getattr(value, "source", "") == "ap242_pmi" and getattr(value, "source_ids", ())
+                for value in pm.decorations.values()
+            )
         ):
             pmi_feats = build_pmi_features(a.pmi, a.part.bounding_box())
             if pmi_feats:
-                pm = replace(pm, features=[*pm.features, *pmi_feats])
+                from draftwright.model.pmi_lowering import lower_ap242_hole_tolerances
+
+                pm = lower_ap242_hole_tolerances(replace(pm, features=[*pm.features, *pmi_feats]))
     # ADR 0005 §2 (#639): the ONE build-context attachment — analysis + finished model
     # in a single typed BuildState; the compat properties on Drawing read through it.
     dwg._build.analysis = a

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -3410,11 +3410,13 @@ class Drawing:
                 self._analysis.pmi_report,
                 getattr(self._part_model, "features", ()),
                 self._analysis.pmi_mode,
+                decorations=getattr(self._part_model, "decorations", {}),
             )
             issues += lint_pmi_rendering(
                 getattr(self._part_model, "features", ()),
                 self._registry,
                 self._analysis.pmi_mode,
+                decorations=getattr(self._part_model, "decorations", {}),
             )
         issues += list(self._registry.issues)
         # Attach a ready-to-paste fix snippet where one is computable (#29).
@@ -3465,6 +3467,7 @@ class Drawing:
                 getattr(self._part_model, "features", ()),
                 self._registry,
                 self._analysis.pmi_mode,
+                decorations=getattr(self._part_model, "decorations", {}),
             )
             if self._analysis is not None
             else None

--- a/src/draftwright/linting/pmi_coverage.py
+++ b/src/draftwright/linting/pmi_coverage.py
@@ -25,6 +25,18 @@ def _source_category_counts(report: PmiExtractionReport) -> dict[str, int]:
     return dict(sorted(Counter(source.category for source in report.sources).items()))
 
 
+def _decorated_source_features(decorations) -> list[tuple[object, tuple[str, ...]]]:
+    """Imported requirement provenance carried by canonical feature decorations (#1116)."""
+    out = []
+    for key, value in (decorations or {}).items():
+        if not isinstance(key, tuple) or not key:
+            continue
+        source_ids = _source_ids(value)
+        if source_ids:
+            out.append((key[0], source_ids))
+    return out
+
+
 def lint_pmi_ignored(
     report: PmiExtractionReport | None, mode: str, *, defaulted: bool
 ) -> list[LintIssue]:
@@ -56,7 +68,12 @@ def lint_pmi_ignored(
 
 
 def pmi_stage_summary(
-    report: PmiExtractionReport | None, features, registry, mode: str
+    report: PmiExtractionReport | None,
+    features,
+    registry,
+    mode: str,
+    *,
+    decorations=None,
 ) -> dict[str, object] | None:
     """Derive source-to-render stage counts from the canonical report, IR, and registry.
 
@@ -73,13 +90,30 @@ def pmi_stage_summary(
         for feature in features
         if set(_source_ids(feature)) & extracted and getattr(feature, "kind", None) != "pmi"
     ]
+    decorated = _decorated_source_features(decorations)
+    lowered_features.extend(
+        feature for feature, source_ids in decorated if set(source_ids) & extracted
+    )
     lowered = {source_id for feature in lowered_features for source_id in _source_ids(feature)}
+    lowered.update(
+        source_id
+        for _feature, source_ids in decorated
+        for source_id in source_ids
+        if source_id in extracted
+    )
     rendered = {
         source_id
         for feature in lowered_features
         for source_id in _source_ids(feature)
         if registry.names_for_feature(_registry_subject(feature))
     }
+    rendered.update(
+        source_id
+        for feature, source_ids in decorated
+        if registry.names_for_feature(_registry_subject(feature))
+        for source_id in source_ids
+        if source_id in extracted
+    )
     dropped = {
         source_id
         for issue in registry.issues
@@ -134,7 +168,9 @@ def lint_pmi_extraction(report: PmiExtractionReport | None, mode: str) -> list[L
     return issues
 
 
-def lint_pmi_lowering(report: PmiExtractionReport | None, features, mode: str) -> list[LintIssue]:
+def lint_pmi_lowering(
+    report: PmiExtractionReport | None, features, mode: str, *, decorations=None
+) -> list[LintIssue]:
     """Report extracted AP242 requirements that did not reach concept-shaped IR."""
     if report is None or mode == "off":
         return []
@@ -143,6 +179,9 @@ def lint_pmi_lowering(report: PmiExtractionReport | None, features, mode: str) -
     by_source: dict[str, list[object]] = {}
     for feature in features:
         for source_id in _source_ids(feature):
+            by_source.setdefault(source_id, []).append(feature)
+    for feature, source_ids in _decorated_source_features(decorations):
+        for source_id in source_ids:
             by_source.setdefault(source_id, []).append(feature)
 
     issues = []
@@ -184,7 +223,7 @@ _EXPLAINED_OMISSION_CODES = frozenset(
 )
 
 
-def lint_pmi_rendering(features, registry, mode: str) -> list[LintIssue]:
+def lint_pmi_rendering(features, registry, mode: str, *, decorations=None) -> list[LintIssue]:
     """Report source-bearing typed PMI that produced no annotation or placement drop.
 
     ADR 0010's registry is the existing annotation-to-feature provenance owner. A placement
@@ -199,6 +238,9 @@ def lint_pmi_rendering(features, registry, mode: str) -> list[LintIssue]:
         if getattr(feature, "kind", None) != "pmi":
             for source_id in _source_ids(feature):
                 by_source.setdefault(source_id, []).append(feature)
+    for feature, source_ids in _decorated_source_features(decorations):
+        for source_id in source_ids:
+            by_source.setdefault(source_id, []).append(feature)
 
     dropped = {
         source_id

--- a/src/draftwright/model/__init__.py
+++ b/src/draftwright/model/__init__.py
@@ -87,6 +87,7 @@ from draftwright.model.ir import (
     SlotPatternFeature,
     StepFeature,
     StepLevelFeature,
+    ToleranceDecoration,
     display,
 )
 from draftwright.model.planner import (
@@ -141,6 +142,7 @@ __all__ = [
     "PolygonalBossFeature",
     "PolygonalStockFeature",
     "StepLevelFeature",
+    "ToleranceDecoration",
     "measured_dimension",
     "build_part_model",
     "build_pmi_features",

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -1975,6 +1975,7 @@ def measured_dimension(
     source: str = "sheet",
     source_kind: str | None = None,
     source_id: str = "",
+    lowering_blockers: tuple[str, ...] = (),
 ) -> AuthoredDimension:
     """A pre-authored drafting dimension from explicit measured values — the IR constructor
     behind :meth:`Sheet.measured_dimension` (#704: extracted so ``build_drawing(model=…)``
@@ -1983,7 +1984,8 @@ def measured_dimension(
     ``at`` (the ``ref_bbox`` centre, else the ``ref_pts`` centroid) when not given.
     ``lower_bound`` and ``upper_bound`` carry a limit range and must be supplied together; they
     are mutually exclusive with deviation tolerances. ``source_id`` preserves an external
-    record identity; ordinary Sheet declarations leave it blank."""
+    record identity; ordinary Sheet declarations leave it blank. ``lowering_blockers`` retains
+    why an imported requirement could not safely enrich a canonical feature parameter."""
     _require_positive(value=value)
     dim_kind = str(kind).lower()
     if dim_kind not in AUTHORED_DIMENSION_KINDS:
@@ -2036,4 +2038,5 @@ def measured_dimension(
         source=source,
         source_kind=source_kind or dim_kind,
         source_id=str(source_id),
+        lowering_blockers=tuple(str(reason) for reason in lowering_blockers),
     )

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -249,6 +249,7 @@ def build_pmi_features(
                     ref_pts=tuple(r.ref_pts),
                     source_kind=r.kind,
                     source_id=r.source_id,
+                    lowering_blockers=r.lowering_blockers,
                 )
             )
             continue
@@ -759,6 +760,7 @@ def build_part_model(
     face_levels=None,
     rotational=None,
     pmi=None,
+    lower_pmi: bool = True,
     cyls=None,
 ) -> PartModel:
     """Run the detectors and assemble the :class:`PartModel` IR for *part*.
@@ -777,7 +779,9 @@ def build_part_model(
     ``cyls`` is a precomputed ``analyse_cylinders(part)`` result threaded into every
     cylinder-substrate recogniser called here (holes/bosses/turned/grooves/flats), so
     the solid is scanned once per build (#703); omitted, each recogniser scans for
-    itself."""
+    itself. ``lower_pmi=False`` retains extracted PMI as materialised/report-only IR;
+    annotate mode uses the default and correlates supported requirements onto canonical
+    feature parameters (#1116)."""
     bbox = part.bounding_box()
     features: list[Feature] = []
 
@@ -1084,7 +1088,13 @@ def build_part_model(
     # in the plan view), per inspection practice. Hole location dims measure from
     # it (#238); a human/LLM pass can re-anchor.
     datums = [Datum(id="datum_xy", kind="point", at=(bbox.min.X, bbox.min.Y, bbox.min.Z))]
-    return PartModel(bbox=bbox, orientation=orientation, features=features, datums=datums)
+    model = PartModel(bbox=bbox, orientation=orientation, features=features, datums=datums)
+    # Correlation runs after the complete geometry + PMI inventories exist, at the shared IR
+    # waist.  Direct drawings and emitted scripts therefore consume the same lowered model
+    # instead of the emitter inventing a second ownership decision (#1116).
+    from draftwright.model.pmi_lowering import lower_ap242_hole_tolerances
+
+    return lower_ap242_hole_tolerances(model) if lower_pmi else model
 
 
 def _is_round(bbox, bosses, tol: float = 0.5) -> bool:

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -188,6 +188,20 @@ class DimParameter:
         return f"{base}.{self.discriminator}" if self.discriminator else base
 
 
+@dataclass(frozen=True)
+class ToleranceDecoration:
+    """A tolerance aspect plus the external requirement it came from.
+
+    Ordinary declared tolerances remain plain numbers/tuples.  Imported requirements use
+    this wrapper so AP242 provenance survives the concept-lowering and generated-Sheet seams
+    without changing the renderer-facing :attr:`DimParameter.tolerance` value type.
+    """
+
+    value: float | tuple[float, float] | FitClass
+    source: str
+    source_ids: tuple[str, ...] = ()
+
+
 def display(p: DimParameter) -> str:
     """A font-safe text form of a parameter (uses only glyphs the pinned font has;
     GD&T symbols are the renderer's job). For debug and tests, not output."""
@@ -1330,6 +1344,10 @@ class AuthoredDimension:
     # Appended to preserve positional construction of the original IR record.
     lower_bound: float | None = None
     upper_bound: float | None = None
+    # A supported source dimension remains materialised only when it cannot safely enrich a
+    # canonical geometry feature.  The reason is structured and round-trips, rather than
+    # disappearing into a log line or an emitter-only comment (#1116).
+    lowering_blockers: tuple[str, ...] = ()
     kind: ClassVar[str] = "authored_dimension"
 
     @property
@@ -1523,8 +1541,10 @@ class PartModel:
     features: list[Feature] = field(default_factory=list)
     datums: list[Datum] = field(default_factory=list)
     # Authored aspects the frozen features can't carry (ADR 0011 §4). P2a uses it for
-    # per-dimension tolerances: ``{(feature, ParamKind) -> float | (lo, hi)}``. The
-    # planner consults it to set ``DimParameter.tolerance``; empty on a detected model.
+    # per-dimension tolerances: ``{(feature, ParamKind) -> float | (lo, hi)}``. Imported
+    # requirements wrap that value in :class:`ToleranceDecoration` so source identities
+    # survive without widening renderer tolerance types (#1116). The planner consults this
+    # map to set ``DimParameter.tolerance``; otherwise empty on a detected model.
     decorations: dict = field(default_factory=dict)
     # Caller-requested augmenting measurements (ADR 0016 / #872) — the planner's
     # *intent input*. Kept distinct from `decorations` on purpose: a decoration enriches

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -479,6 +479,13 @@ def _decorated(model: PartModel, feature: Feature, param: DimParameter) -> DimPa
     tol = model.decorations.get((feature, param.kind, param.role))
     if tol is None:
         tol = model.decorations.get((feature, param.kind))
+    # Imported AP242 provenance belongs to the authored aspect, not to geometry and not to
+    # the renderer's tolerance algebra.  Unwrap it at the planner waist so every downstream
+    # label/render path continues to see the established float/tuple/FitClass contract.
+    from draftwright.model.ir import ToleranceDecoration
+
+    if isinstance(tol, ToleranceDecoration):
+        tol = tol.value
     return param if tol is None else replace(param, tolerance=tol)
 
 

--- a/src/draftwright/model/pmi_lowering.py
+++ b/src/draftwright/model/pmi_lowering.py
@@ -1,0 +1,276 @@
+"""Geometry-correlated AP242 dimensional PMI lowering (#1116).
+
+The extractor reports source semantics and recognition reports geometry.  This module is the
+single correlation seam between them: a supported diameter tolerance enriches the canonical
+hole/pattern dimension, while an unproven match remains a materialised authored dimension with
+an explicit reason.  It deliberately knows nothing about annotation coordinates or rendering.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import replace
+from decimal import Decimal
+
+from draftwright.model.ir import (
+    AuthoredDimension,
+    Feature,
+    HoleFeature,
+    PartModel,
+    PatternFeature,
+    ToleranceDecoration,
+)
+
+ToleranceValue = float | tuple[float, float]
+
+
+def _members(feature: HoleFeature | PatternFeature):
+    if isinstance(feature, PatternFeature):
+        return tuple(feature.members) or (feature.member.frame.origin,)
+    return tuple(feature.members) or (feature.frame.origin,)
+
+
+def _diameter(feature: HoleFeature | PatternFeature) -> float:
+    return float(
+        feature.member.diameter if isinstance(feature, PatternFeature) else feature.diameter
+    )
+
+
+def _requirement(dim: AuthoredDimension):
+    """Return the renderer-facing lower/upper magnitudes, or ``None`` when not toleranced."""
+    if (dim.lower_bound is None) != (dim.upper_bound is None):
+        raise ValueError("a limit requirement needs both lower and upper bounds")
+    if dim.lower_bound is not None and dim.upper_bound is not None:
+        nominal = Decimal(str(dim.value))
+        lower = float(nominal - Decimal(str(dim.lower_bound)))
+        upper = float(Decimal(str(dim.upper_bound)) - nominal)
+    elif dim.lower_tol is not None or dim.upper_tol is not None:
+        lower = float(dim.lower_tol or 0.0)
+        upper = float(dim.upper_tol or 0.0)
+    else:
+        return None
+    if lower < 0 or upper < 0:
+        raise ValueError("negative deviation magnitude")
+    return lower if lower == upper else (lower, upper)
+
+
+def _inside(point, bbox, *, pad=1e-6) -> bool:
+    return all(bbox[i] - pad <= point[i] <= bbox[i + 3] + pad for i in range(3))
+
+
+def _block(dim: AuthoredDimension, reason: str) -> AuthoredDimension:
+    return replace(dim, lowering_blockers=tuple(dict.fromkeys((*dim.lowering_blockers, reason))))
+
+
+def _source_ids(dim: AuthoredDimension) -> tuple[str, ...]:
+    return (dim.source_id,) if dim.source_id else ()
+
+
+def lower_ap242_hole_tolerances(model: PartModel) -> PartModel:
+    """Consume confidently correlated AP242 hole-tolerance dimensions exactly once.
+
+    A count-group is split only where member requirements differ.  A real pattern stays a
+    pattern and therefore accepts only a requirement whose referenced geometry covers every
+    member.  Those rules preserve machining-spec identity instead of applying one member's
+    tolerance to its untoleranced siblings or destroying pattern membership to make a match.
+    """
+    targets: list[tuple[int, HoleFeature | PatternFeature]] = [
+        (index, feature)
+        for index, feature in enumerate(model.features)
+        if isinstance(feature, (HoleFeature, PatternFeature))
+    ]
+    target_by_index = dict(targets)
+    dimensions = {
+        index: feature
+        for index, feature in enumerate(model.features)
+        if isinstance(feature, AuthoredDimension)
+        and feature.dimension_kind == "diameter"
+        and feature.source == "ap242_pmi"
+        and any(
+            value is not None
+            for value in (
+                feature.lower_tol,
+                feature.upper_tol,
+                feature.lower_bound,
+                feature.upper_bound,
+            )
+        )
+    }
+    if not dimensions:
+        return model
+
+    # dim index -> (owner index, selected member indices, tolerance value)
+    proposals: dict[int, tuple[int, tuple[int, ...], ToleranceValue]] = {}
+    blocked: dict[int, str] = {}
+    for dim_index, dim in dimensions.items():
+        if dim.lowering_blockers:
+            blocked[dim_index] = ""
+            continue
+        if dim.ref_bbox is None:
+            blocked[dim_index] = (
+                "unmatched hole correlation: source diameter has no referenced geometry"
+            )
+            continue
+        if dim.dominant_axis not in ("X", "Y", "Z"):
+            blocked[dim_index] = (
+                "unsupported hole correlation: source diameter has no principal bore axis"
+            )
+            continue
+        matches: list[tuple[int, tuple[int, ...]]] = []
+        for owner_index, owner in targets:
+            if owner.frame.axis != dim.dominant_axis.lower():
+                continue
+            if abs(_diameter(owner) - float(dim.value)) > max(1e-6, abs(float(dim.value)) * 1e-6):
+                continue
+            member_indices = tuple(
+                member_index
+                for member_index, point in enumerate(_members(owner))
+                if _inside(point, dim.ref_bbox)
+            )
+            if member_indices:
+                matches.append((owner_index, member_indices))
+        if not matches:
+            blocked[dim_index] = (
+                f"unmatched hole correlation: no {_diameter_text(dim.value)} "
+                f"{dim.dominant_axis}-axis hole member lies in the source reference bounds"
+            )
+            continue
+        if len(matches) != 1:
+            blocked[dim_index] = (
+                f"ambiguous hole correlation: source reference bounds match {len(matches)} "
+                "canonical hole/pattern features"
+            )
+            continue
+        owner_index, member_indices = matches[0]
+        owner = target_by_index[owner_index]
+        if isinstance(owner, PatternFeature) and len(member_indices) != len(_members(owner)):
+            blocked[dim_index] = (
+                "unsupported hole correlation: AP242 requirement covers only part of a "
+                "canonical hole pattern"
+            )
+            continue
+        try:
+            value = _requirement(dim)
+        except ValueError as exc:
+            blocked[dim_index] = f"unsupported hole tolerance: {exc}"
+            continue
+        assert value is not None
+        proposals[dim_index] = (owner_index, member_indices, value)
+
+    # Existing authored ownership wins.  Silently replacing it with imported PMI would make
+    # the same parameter have two sources and violate ADR 0011's single-owner decoration map.
+    for dim_index, (owner_index, _member_indices, _value) in tuple(proposals.items()):
+        owner = target_by_index[owner_index]
+        if (owner, "diameter", "bore") in model.decorations or (
+            owner,
+            "diameter",
+        ) in model.decorations:
+            blocked[dim_index] = "ambiguous hole tolerance ownership: bore already has a tolerance"
+            del proposals[dim_index]
+
+    # A member cannot carry two different imported requirements.  Equal repeats are one
+    # requirement with multiple source identities; conflicting ones remain explicit.
+    by_member: dict[tuple[int, int], list[int]] = defaultdict(list)
+    for dim_index, (owner_index, member_indices, _value) in proposals.items():
+        for member_index in member_indices:
+            by_member[(owner_index, member_index)].append(dim_index)
+    for dim_indices in by_member.values():
+        active = [index for index in dim_indices if index in proposals]
+        values = {proposals[index][2] for index in active}
+        if len(values) > 1:
+            for dim_index in active:
+                blocked[dim_index] = (
+                    "ambiguous hole tolerance ownership: one member has conflicting AP242 requirements"
+                )
+                proposals.pop(dim_index, None)
+
+    lowered = set(proposals)
+    incoming: dict[int, dict[int, list[int]]] = defaultdict(lambda: defaultdict(list))
+    for dim_index, (owner_index, member_indices, _value) in proposals.items():
+        for member_index in member_indices:
+            incoming[owner_index][member_index].append(dim_index)
+
+    decorations = dict(model.decorations)
+    rebuilt: list[Feature] = []
+    for feature_index, feature in enumerate(model.features):
+        if feature_index in dimensions:
+            if feature_index in lowered:
+                continue
+            dimension = dimensions[feature_index]
+            rebuilt.append(
+                _block(dimension, blocked[feature_index])
+                if blocked.get(feature_index)
+                else dimension
+            )
+            continue
+        member_requirements = incoming.get(feature_index)
+        if not member_requirements:
+            rebuilt.append(feature)
+            continue
+
+        if isinstance(feature, PatternFeature):
+            dim_indices = sorted({i for indices in member_requirements.values() for i in indices})
+            value = proposals[dim_indices[0]][2]
+            ids = tuple(
+                dict.fromkeys(
+                    source_id
+                    for dim_index in dim_indices
+                    for source_id in _source_ids(dimensions[dim_index])
+                )
+            )
+            rebuilt.append(feature)
+            decorations[(feature, "diameter", "bore")] = ToleranceDecoration(
+                value=value, source="ap242_pmi", source_ids=ids
+            )
+            continue
+
+        assert isinstance(feature, HoleFeature)
+        points = _members(feature)
+        inherited = [
+            (key[1:], value)
+            for key, value in tuple(decorations.items())
+            if isinstance(key, tuple) and key and key[0] == feature
+        ]
+        for key in [
+            key
+            for key in tuple(decorations)
+            if isinstance(key, tuple) and key and key[0] == feature
+        ]:
+            del decorations[key]
+        # Group members by effective tolerance, retaining first-member order.  ``None`` is
+        # the untoleranced remainder; equal member requirements keep their count× callout.
+        groups: dict[ToleranceValue | None, list[int]] = {}
+        group_sources: dict[ToleranceValue | None, list[int]] = {}
+        for member_index in range(len(points)):
+            dim_indices = member_requirements.get(member_index, [])
+            value = proposals[dim_indices[0]][2] if dim_indices else None
+            groups.setdefault(value, []).append(member_index)
+            group_sources.setdefault(value, []).extend(dim_indices)
+        for value, group_member_indices in groups.items():
+            members = tuple(points[index] for index in group_member_indices)
+            split = replace(
+                feature,
+                frame=replace(feature.frame, origin=members[0]),
+                count=len(members),
+                members=members,
+            )
+            rebuilt.append(split)
+            for tail, inherited_value in inherited:
+                decorations[(split, *tail)] = inherited_value
+            if value is not None:
+                ids = tuple(
+                    dict.fromkeys(
+                        source_id
+                        for dim_index in group_sources[value]
+                        for source_id in _source_ids(dimensions[dim_index])
+                    )
+                )
+                decorations[(split, "diameter")] = ToleranceDecoration(
+                    value=value, source="ap242_pmi", source_ids=ids
+                )
+
+    return replace(model, features=rebuilt, decorations=decorations)
+
+
+def _diameter_text(value: float) -> str:
+    return f"diameter {value:g}"

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -98,7 +98,7 @@ from draftwright.model.declare import (
 )
 from draftwright.model.declare import read_bore_step as _read_bore_step
 from draftwright.model.declare import read_countersink as _read_countersink
-from draftwright.model.ir import RequestedDimension
+from draftwright.model.ir import RequestedDimension, ToleranceDecoration
 from draftwright.model.planner import LOCATION_ROLE as _LOCATION_ROLE
 from draftwright.model.planner import location_role as _location_role
 
@@ -142,6 +142,20 @@ def _tol_value(lo, hi):
     an ``(lower, upper)`` limit pair. The pair renders ``+upper -lower`` (helpers'
     convention), so ``.tolerance(0.0, 0.1)`` → ``+0.1 -0.0`` — both magnitudes positive."""
     return lo if hi is None else (lo, hi)
+
+
+def _tolerance_decoration(lo, hi, *, source, source_ids):
+    """Keep ordinary Sheet tolerances source-free; preserve imported provenance explicitly."""
+    value = _tol_value(lo, hi)
+    ids = tuple(dict.fromkeys(str(source_id) for source_id in source_ids if source_id))
+    if source is None:
+        if ids:
+            raise ValueError("tolerance() source_ids require source=")
+        return value
+    source = str(source).strip()
+    if not source:
+        raise ValueError("tolerance() source must be a non-empty string")
+    return ToleranceDecoration(value=value, source=source, source_ids=ids)
 
 
 class _FeatureView(MutableSequence):
@@ -315,10 +329,20 @@ class _Hole(_Nameable):
         """A blind hole *d* mm deep — adds a depth callout."""
         return self._set(through=False, depth=d)
 
-    def tolerance(self, lo: float, hi: float | None = None) -> _Hole:
+    def tolerance(
+        self,
+        lo: float,
+        hi: float | None = None,
+        *,
+        source: str | None = None,
+        source_ids: tuple[str, ...] = (),
+    ) -> _Hole:
         """A ± tolerance on the bore ⌀: symmetric ``.tolerance(0.05)`` (→ ``±0.05``) or a
-        limit pair ``.tolerance(0.0, 0.1)`` (→ ``+0.1 -0.0``)."""
-        self._sheet._tolerances[(self._token, "diameter")] = _tol_value(lo, hi)
+        limit pair ``.tolerance(0.0, 0.1)`` (→ ``+0.1 -0.0``). Generated import scripts use
+        ``source`` / ``source_ids`` to retain external requirement provenance."""
+        self._sheet._tolerances[(self._token, "diameter")] = _tolerance_decoration(
+            lo, hi, source=source, source_ids=source_ids
+        )
         return self
 
     def fit(self, code: str, *, show: str = "class") -> _Hole:
@@ -416,11 +440,22 @@ class _Dim(_Nameable):
         """See :attr:`_Hole._i` — token-resolved, not stored (#908)."""
         return self._sheet._index_of_token(self._token)
 
-    def tolerance(self, lo: float, hi: float | None = None, *, on: str | None = None) -> _Dim:
+    def tolerance(
+        self,
+        lo: float,
+        hi: float | None = None,
+        *,
+        on: str | None = None,
+        source: str | None = None,
+        source_ids: tuple[str, ...] = (),
+    ) -> _Dim:
         """A ± tolerance on this dimension: symmetric ``.tolerance(0.05)`` (→ ``±0.05``) or a
         limit pair ``.tolerance(0.0, 0.1)`` (→ ``+0.1 -0.0``). ``on`` picks the parameter for
-        a multi-dim feature — a step's ``"length"`` (default) vs its ``"diameter"`` (OD)."""
-        self._sheet._tolerances[(self._token, on or self._kind)] = _tol_value(lo, hi)
+        a multi-dim feature — a step's ``"length"`` (default) vs its ``"diameter"`` (OD).
+        ``source`` / ``source_ids`` retain provenance on generated imported requirements."""
+        self._sheet._tolerances[(self._token, on or self._kind)] = _tolerance_decoration(
+            lo, hi, source=source, source_ids=source_ids
+        )
         return self
 
     def fit(self, code: str, *, show: str = "class") -> _Dim:
@@ -537,12 +572,21 @@ class _Params(_Nameable):
             if p.kind != "location"
         }
 
-    def tolerance(self, lo: float, hi: float | None = None, *, on: str | None = None) -> _Params:
+    def tolerance(
+        self,
+        lo: float,
+        hi: float | None = None,
+        *,
+        on: str | None = None,
+        source: str | None = None,
+        source_ids: tuple[str, ...] = (),
+    ) -> _Params:
         """A ± tolerance: symmetric ``.tolerance(0.05)`` (→ ``±0.05``) or a limit pair
         ``.tolerance(0.0, 0.1)`` (→ ``+0.1 -0.0``). ``on`` targets ONE parameter by role
         (``on="depth"`` on a pocket → a role-keyed decoration); omit ``on`` to tolerance
-        every parameter of the feature alike (the kind-keyed form)."""
-        val = _tol_value(lo, hi)
+        every parameter of the feature alike (the kind-keyed form). ``source`` /
+        ``source_ids`` retain provenance on generated imported requirements."""
+        val = _tolerance_decoration(lo, hi, source=source, source_ids=source_ids)
         roles = self._roles()
         if not roles:
             # A feature with no dimensioned parameters has nothing to tolerance, and
@@ -949,6 +993,7 @@ class Sheet:
         source: str = "sheet",
         source_kind: str | None = None,
         source_id: str = "",
+        lowering_blockers: tuple[str, ...] = (),
     ) -> _Params:
         """Declare a drafting dimension from explicit **measured** values.
 
@@ -965,7 +1010,8 @@ class Sheet:
         ``lower_bound`` and ``upper_bound`` are the mutually exclusive alternative to
         ``upper_tol``/``lower_tol`` for a limit range. ``source_id`` is the external record
         identity retained by generated imported-PMI scripts; hand-authored dimensions normally
-        leave it blank.
+        leave it blank. ``lowering_blockers`` carries the explicit reason a supported imported
+        requirement could not safely enrich a canonical feature parameter.
         Delegates to :func:`draftwright.model.declare.measured_dimension` (#704), so
         ``build_drawing(model=…)`` callers can author the same feature without the façade.
         """
@@ -986,6 +1032,7 @@ class Sheet:
                 source=source,
                 source_kind=source_kind,
                 source_id=source_id,
+                lowering_blockers=lowering_blockers,
             )
         )
         # A handle like every other declaration verb (#922). A measured dimension carries its

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -37,6 +37,7 @@ from pathlib import Path
 from build123d import Shape
 
 from draftwright.builder import detect_part_model
+from draftwright.model.ir import ToleranceDecoration
 
 
 @dataclass(frozen=True)
@@ -365,6 +366,8 @@ def _measured_dimension_line(f) -> str:
         kw.append(f"source_kind={f.source_kind!r}")
     if f.source_id:
         kw.append(f"source_id={f.source_id!r}")
+    if getattr(f, "lowering_blockers", ()):
+        kw.append(f"lowering_blockers={f.lowering_blockers!r}")
     # `measured_dimension` since #873 — a generated script must not emit the transitional
     # overload, or every regenerated AP242 script would arrive pre-deprecated.
     return "sheet.measured_dimension(" + ", ".join(kw) + ")"
@@ -1217,7 +1220,10 @@ def _dimension_block(model, names: dict[int, str], synthesised_envelope=None) ->
 
 
 def _feature_block(
-    features, part_envelope=None, object_refs: Mapping[int, str] | None = None
+    features,
+    part_envelope=None,
+    object_refs: Mapping[int, str] | None = None,
+    decorations: Mapping | None = None,
 ) -> tuple[list[str], dict[int, str]]:
     """The emitted feature lines plus ``{id(feature): binding}`` for the names they bind.
 
@@ -1263,6 +1269,21 @@ def _feature_block(
                 line = _feature_line(f, part_envelope, object_ref=object_ref)
             else:
                 line = _feature_line(f, part_envelope)
+            requirement = (decorations or {}).get((f, "diameter", "bore"))
+            if requirement is None:
+                requirement = (decorations or {}).get((f, "diameter"))
+            if isinstance(requirement, ToleranceDecoration):
+                value = requirement.value
+                args = (
+                    f"{_authored_n(value[0])}, {_authored_n(value[1])}"
+                    if isinstance(value, tuple)
+                    else _authored_n(value)
+                )
+                provenance = f", source={requirement.source!r}"
+                if requirement.source_ids:
+                    provenance += f", source_ids={requirement.source_ids!r}"
+                on = ', on="bore"' if f.kind == "pattern" else ""
+                line += f".tolerance({args}{on}{provenance})"
             name = _binding(f, line, counts)
             if name is not None:
                 names[id(f)] = name
@@ -1415,7 +1436,7 @@ def emit_sheet_script(
 
     object_refs = _object_references(model.features, source_part, object_candidates)
     feature_lines, _names = _feature_block(
-        model.features, _envelope_from_bbox(model.bbox), object_refs
+        model.features, _envelope_from_bbox(model.bbox), object_refs, model.decorations
     )
     # Narrowed to what the BODY actually names. The set above is derived from feature kinds,
     # which over-imports the moment a kind stops emitting a constructor: since #976 a

--- a/tests/test_issue_1116_ap242_hole_tolerance_lowering.py
+++ b/tests/test_issue_1116_ap242_hole_tolerance_lowering.py
@@ -1,0 +1,395 @@
+"""#1116 — AP242 hole tolerances enrich canonical feature dimensions exactly once."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+from build123d import Box, import_step
+
+from draftwright import Sheet
+from draftwright.builder import detect_part_model
+from draftwright.model.ir import (
+    AuthoredDimension,
+    Frame,
+    HoleFeature,
+    PartModel,
+    PatternFeature,
+    ToleranceDecoration,
+)
+from draftwright.model.pmi_lowering import lower_ap242_hole_tolerances
+from draftwright.sheet_emit import emit_sheet_script
+
+
+def _hole(at=(0.0, 0.0, 0.0), *, diameter=10.0, members=()):
+    positions = tuple(members)
+    return HoleFeature(
+        frame=Frame(at, "z"),
+        diameter=diameter,
+        depth=8.0,
+        through=True,
+        count=len(positions) or 1,
+        members=positions,
+    )
+
+
+def _dimension(
+    *,
+    value=10.0,
+    lower_tol=None,
+    upper_tol=None,
+    lower_bound=None,
+    upper_bound=None,
+    bbox=(-5.1, -5.1, -0.1, 5.1, 5.1, 8.1),
+    source_id="dimension:test",
+):
+    return AuthoredDimension(
+        frame=Frame((0.0, 0.0, 4.0), "z"),
+        dimension_kind="diameter",
+        value=value,
+        label=f"ø{value:g}",
+        dominant_axis="Z",
+        lower_tol=lower_tol,
+        upper_tol=upper_tol,
+        lower_bound=lower_bound,
+        upper_bound=upper_bound,
+        ref_bbox=bbox,
+        ref_pts=((-5.0, 0.0, 4.0), (5.0, 0.0, 4.0)),
+        source_id=source_id,
+    )
+
+
+def _model(*features):
+    return PartModel(Box(40, 40, 10).bounding_box(), None, list(features))
+
+
+@pytest.mark.parametrize(
+    ("dimension", "expected"),
+    (
+        (_dimension(lower_tol=0.1, upper_tol=0.1), 0.1),
+        (_dimension(lower_tol=0.05, upper_tol=0.1), (0.05, 0.1)),
+        (_dimension(lower_tol=0.1), (0.1, 0.0)),
+        (_dimension(upper_tol=0.1), (0.0, 0.1)),
+        (_dimension(value=10, lower_bound=9.8, upper_bound=10.15), (0.2, 0.15)),
+    ),
+    ids=("symmetric", "asymmetric", "lower-only", "upper-only", "limits"),
+)
+def test_supported_deviation_forms_lower_to_one_bore_decoration(dimension, expected):
+    hole = _hole()
+    lowered = lower_ap242_hole_tolerances(_model(hole, dimension))
+
+    assert not any(feature.kind == "authored_dimension" for feature in lowered.features)
+    owner = next(feature for feature in lowered.features if feature.kind == "hole")
+    requirement = lowered.decorations[(owner, "diameter")]
+    assert requirement == ToleranceDecoration(expected, "ap242_pmi", ("dimension:test",))
+
+
+def test_normalized_inch_source_values_are_not_scaled_a_second_time():
+    """Extraction's public contract is mm; lowering consumes that unit without reinterpretation."""
+    hole = _hole(diameter=25.4)
+    dim = _dimension(
+        value=25.4,
+        lower_tol=0.0254,
+        upper_tol=0.0508,
+        bbox=(-12.8, -12.8, -0.1, 12.8, 12.8, 8.1),
+    )
+    lowered = lower_ap242_hole_tolerances(_model(hole, dim))
+    owner = next(feature for feature in lowered.features if feature.kind == "hole")
+    assert lowered.decorations[(owner, "diameter")].value == (0.0254, 0.0508)
+
+
+def test_member_specific_requirements_split_a_count_group_without_lying_about_siblings():
+    members = ((-20.0, 0.0, 0.0), (0.0, 0.0, 0.0), (20.0, 0.0, 0.0))
+    hole = _hole(at=members[0], members=members)
+    dim = _dimension(
+        lower_tol=0.1,
+        upper_tol=0.2,
+        bbox=(-5.1, -5.1, -0.1, 5.1, 5.1, 8.1),
+    )
+    lowered = lower_ap242_hole_tolerances(_model(hole, dim))
+
+    holes = [feature for feature in lowered.features if feature.kind == "hole"]
+    assert [(feature.count, feature.members) for feature in holes] == [
+        (2, (members[0], members[2])),
+        (1, (members[1],)),
+    ]
+    assert (holes[0], "diameter") not in lowered.decorations
+    assert lowered.decorations[(holes[1], "diameter")].value == (0.1, 0.2)
+
+
+def test_pattern_wide_requirement_preserves_pattern_identity_and_membership():
+    members = ((-10.0, 0.0, 0.0), (10.0, 0.0, 0.0))
+    member = _hole(at=members[0])
+    pattern = PatternFeature(
+        frame=Frame((0.0, 0.0, 0.0), "z"),
+        pattern="linear",
+        count=2,
+        member=member,
+        members=members,
+        pitch=20.0,
+        direction=(1.0, 0.0, 0.0),
+    )
+    dim = _dimension(
+        lower_tol=0.05,
+        upper_tol=0.1,
+        bbox=(-15.1, -5.1, -0.1, 15.1, 5.1, 8.1),
+    )
+    lowered = lower_ap242_hole_tolerances(_model(pattern, dim))
+
+    assert lowered.features == [pattern]
+    assert lowered.decorations[(pattern, "diameter", "bore")].value == (0.05, 0.1)
+
+    source = emit_sheet_script(lowered, "part", "pattern", title="P", number="N")
+    namespace = {"part": Box(40, 40, 10)}
+    exec(  # noqa: S102
+        compile(source[: source.index("drawing = sheet.build()")], "<pattern-emit>", "exec"),
+        namespace,
+    )
+    rebuilt = namespace["sheet"].model()
+    rebuilt_pattern = next(
+        feature for feature in rebuilt.features if isinstance(feature, PatternFeature)
+    )
+    assert rebuilt_pattern.members == pattern.members
+    assert rebuilt_pattern.member.diameter == pattern.member.diameter
+    assert rebuilt.decorations[(rebuilt_pattern, "diameter", "bore")] == ToleranceDecoration(
+        (0.05, 0.1), "ap242_pmi", ("dimension:test",)
+    )
+
+
+def test_partial_pattern_and_ambiguous_matches_fall_back_with_explicit_reasons():
+    members = ((-10.0, 0.0, 0.0), (10.0, 0.0, 0.0))
+    pattern = PatternFeature(
+        frame=Frame((0.0, 0.0, 0.0), "z"),
+        pattern="linear",
+        count=2,
+        member=_hole(at=members[0]),
+        members=members,
+        pitch=20.0,
+        direction=(1.0, 0.0, 0.0),
+    )
+    partial = _dimension(
+        lower_tol=0.1,
+        upper_tol=0.1,
+        bbox=(-15.1, -5.1, -0.1, -4.9, 5.1, 8.1),
+    )
+    partial_model = lower_ap242_hole_tolerances(_model(pattern, partial))
+    fallback = next(f for f in partial_model.features if f.kind == "authored_dimension")
+    assert fallback.lowering_blockers == (
+        "unsupported hole correlation: AP242 requirement covers only part of a canonical hole pattern",
+    )
+    source = emit_sheet_script(partial_model, "part", "fallback", title="P", number="N")
+    assert "lowering_blockers=('unsupported hole correlation:" in source
+    namespace = {"part": Box(40, 40, 10)}
+    exec(  # noqa: S102
+        compile(source[: source.index("drawing = sheet.build()")], "<fallback-emit>", "exec"),
+        namespace,
+    )
+    restored = next(
+        feature
+        for feature in namespace["sheet"].model().features
+        if feature.kind == "authored_dimension"
+    )
+    assert restored.lowering_blockers == fallback.lowering_blockers
+
+    duplicate = replace(_hole(), frame=Frame((0.0, 0.0, 0.0), "z"))
+    ambiguous_model = lower_ap242_hole_tolerances(
+        _model(_hole(), duplicate, _dimension(lower_tol=0.1, upper_tol=0.1))
+    )
+    fallback = next(f for f in ambiguous_model.features if f.kind == "authored_dimension")
+    assert fallback.lowering_blockers[0].startswith("ambiguous hole correlation:")
+
+
+def test_unmatched_requirement_without_any_hole_owner_keeps_an_explicit_reason():
+    lowered = lower_ap242_hole_tolerances(_model(_dimension(lower_tol=0.1, upper_tol=0.1)))
+    (fallback,) = lowered.features
+    assert fallback.lowering_blockers[0].startswith("unmatched hole correlation:")
+
+
+@pytest.mark.parametrize(
+    ("dimension", "reason"),
+    (
+        (
+            replace(_dimension(lower_tol=0.1), ref_bbox=None),
+            "unmatched hole correlation: source diameter has no referenced geometry",
+        ),
+        (
+            replace(_dimension(lower_tol=0.1), dominant_axis="?"),
+            "unsupported hole correlation: source diameter has no principal bore axis",
+        ),
+        (
+            _dimension(lower_bound=9.9),
+            "unsupported hole tolerance: a limit requirement needs both lower and upper bounds",
+        ),
+        (
+            _dimension(lower_tol=-0.1),
+            "unsupported hole tolerance: negative deviation magnitude",
+        ),
+    ),
+)
+def test_unsupported_source_requirements_remain_materialized_with_their_reason(dimension, reason):
+    lowered = lower_ap242_hole_tolerances(_model(_hole(), dimension))
+    fallback = next(
+        feature for feature in lowered.features if feature.kind == "authored_dimension"
+    )
+    assert fallback.lowering_blockers == (reason,)
+
+
+def test_extractor_blockers_and_existing_authored_ownership_win_without_duplication():
+    blocked = replace(_dimension(lower_tol=0.1), lowering_blockers=("source geometry incomplete",))
+    lowered = lower_ap242_hole_tolerances(_model(_hole(), blocked))
+    fallback = next(
+        feature for feature in lowered.features if feature.kind == "authored_dimension"
+    )
+    assert fallback.lowering_blockers == ("source geometry incomplete",)
+
+    hole = _hole()
+    dimension = _dimension(lower_tol=0.1)
+    already_owned = replace(_model(hole, dimension), decorations={(hole, "diameter"): 0.2})
+    lowered = lower_ap242_hole_tolerances(already_owned)
+    fallback = next(
+        feature for feature in lowered.features if feature.kind == "authored_dimension"
+    )
+    assert fallback.lowering_blockers == (
+        "ambiguous hole tolerance ownership: bore already has a tolerance",
+    )
+
+
+def test_conflicting_sources_fall_back_and_other_aspects_follow_a_split_group():
+    members = ((-10.0, 0.0, 0.0), (10.0, 0.0, 0.0))
+    hole = _hole(at=members[0], members=members)
+    first = _dimension(
+        lower_tol=0.1,
+        bbox=(-15.1, -5.1, -0.1, -4.9, 5.1, 8.1),
+        source_id="dimension:first",
+    )
+    second = replace(first, lower_tol=0.2, source_id="dimension:second")
+    conflicted = lower_ap242_hole_tolerances(_model(hole, first, second))
+    fallbacks = [
+        feature for feature in conflicted.features if feature.kind == "authored_dimension"
+    ]
+    assert len(fallbacks) == 2
+    assert all(
+        "conflicting AP242 requirements" in feature.lowering_blockers[0] for feature in fallbacks
+    )
+
+    split = lower_ap242_hole_tolerances(
+        replace(_model(hole, first), decorations={(hole, "depth"): 0.25})
+    )
+    owners = [feature for feature in split.features if feature.kind == "hole"]
+    assert len(owners) == 2
+    assert all(split.decorations[(owner, "depth")] == 0.25 for owner in owners)
+
+
+def test_imported_tolerance_provenance_arguments_fail_loudly_when_incoherent():
+    hole = Sheet(Box(20, 20, 10)).hole(diameter=5, at=(0, 0, 0), axis="z")
+    with pytest.raises(ValueError, match="source_ids require source"):
+        hole.tolerance(0.1, source_ids=("dimension:test",))
+    with pytest.raises(ValueError, match="source must be a non-empty string"):
+        hole.tolerance(0.1, source="  ")
+
+
+def test_emitted_sheet_rebuilds_the_same_owner_value_membership_and_provenance():
+    members = ((-10.0, 0.0, 0.0), (10.0, 0.0, 0.0))
+    direct = lower_ap242_hole_tolerances(
+        _model(
+            _hole(at=members[0], members=members),
+            _dimension(
+                lower_tol=0.05,
+                upper_tol=0.1,
+                bbox=(4.9, -5.1, -0.1, 15.1, 5.1, 8.1),
+            ),
+        )
+    )
+    source = emit_sheet_script(direct, "part", "roundtrip", title="P", number="N")
+    namespace = {"part": Box(40, 40, 10)}
+    body = source[: source.index("drawing = sheet.build()")]
+    exec(compile(body, "<issue-1116-emit>", "exec"), namespace)  # noqa: S102
+    rebuilt = namespace["sheet"].model()
+
+    def requirements(model):
+        output = []
+        for key, value in model.decorations.items():
+            if not isinstance(value, ToleranceDecoration) or key[1:] not in (
+                ("diameter",),
+                ("diameter", "bore"),
+            ):
+                continue
+            owner = key[0]
+            output.append(
+                (
+                    round(float(owner.diameter), 6),
+                    tuple(
+                        tuple(round(c, 6) for c in point)
+                        for point in (owner.members or (owner.frame.origin,))
+                    ),
+                    value.value,
+                    value.source,
+                    value.source_ids,
+                )
+            )
+        return sorted(output)
+
+    assert requirements(rebuilt) == requirements(direct)
+
+
+@pytest.mark.slow
+def test_ctc01_consumes_all_hole_tolerances_once_and_emits_provenance():
+    path = Path(__file__).parent / "fixtures" / "nist_ctc_01_asme1_ap242.stp"
+    model = detect_part_model(path, pmi="annotate")
+    authored = [feature for feature in model.features if feature.kind == "authored_dimension"]
+    requirements = [
+        value for value in model.decorations.values() if isinstance(value, ToleranceDecoration)
+    ]
+
+    assert [(feature.dimension_kind, feature.source_id) for feature in authored] == [
+        ("angular", "dimension:0:1:4:17")
+    ]
+    assert {source_id for requirement in requirements for source_id in requirement.source_ids} == {
+        "dimension:0:1:4:21",
+        "dimension:0:1:4:22",
+        "dimension:0:1:4:23",
+        "dimension:0:1:4:24",
+        "dimension:0:1:4:25",
+        "dimension:0:1:4:26",
+        "dimension:0:1:4:29",
+    }
+    source = emit_sheet_script(model, "part", "ctc01", title="CTC01", number="N")
+    assert source.count("sheet.measured_dimension(") == 1
+    assert source.count("source='ap242_pmi'") == 7
+    assert (
+        sum(".tolerance(" in line for line in source.splitlines() if " = sheet.hole(" in line) == 6
+    )
+    assert 'on="bore"' not in source  # CTC uses count-groups, not a recognised pattern.
+
+    namespace = {"part": import_step(str(path))}
+    exec(  # noqa: S102
+        compile(source[: source.index("drawing = sheet.build()")], "<ctc01-emit>", "exec"),
+        namespace,
+    )
+    rebuilt = namespace["sheet"].model()
+
+    def requirement_signature(part_model):
+        return sorted(
+            (
+                round(key[0].diameter, 6),
+                key[0].frame.axis,
+                tuple(
+                    sorted(
+                        tuple(round(coordinate, 6) for coordinate in member)
+                        for member in (key[0].members or (key[0].frame.origin,))
+                    )
+                ),
+                value.value,
+                value.source_ids,
+            )
+            for key, value in part_model.decorations.items()
+            if isinstance(value, ToleranceDecoration)
+        )
+
+    assert requirement_signature(rebuilt) == requirement_signature(model)
+    assert [
+        (feature.dimension_kind, feature.source_id)
+        for feature in rebuilt.features
+        if feature.kind == "authored_dimension"
+    ] == [("angular", "dimension:0:1:4:17")]

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -997,27 +997,47 @@ class TestBuildDrawingPmi:
         }
 
     def test_pmi_annotate_adds_dims(self, ctc01_annotated):
-        """pmi='annotate' adds at least one pmi_ dimension to the drawing."""
-        pmi_names = [n for n in ctc01_annotated.annotations() if n.startswith("pmi_")]
-        assert len(pmi_names) >= 1, f"expected ≥1 pmi_ annotation, got {pmi_names}"
+        """Supported hole PMI renders through canonical bore callouts, not duplicate pmi_ dims."""
+        from draftwright.model.ir import ToleranceDecoration
+
+        requirements = [
+            (key[0], value)
+            for key, value in ctc01_annotated.model().decorations.items()
+            if isinstance(value, ToleranceDecoration)
+        ]
+        assert {source_id for _owner, value in requirements for source_id in value.source_ids} == {
+            "dimension:0:1:4:21",
+            "dimension:0:1:4:22",
+            "dimension:0:1:4:23",
+            "dimension:0:1:4:24",
+            "dimension:0:1:4:25",
+            "dimension:0:1:4:26",
+            "dimension:0:1:4:29",
+        }
+        assert all(ctc01_annotated.registry.names_for_feature(owner) for owner, _ in requirements)
+        assert not [name for name in ctc01_annotated.annotations() if name.startswith("pmi_")]
 
     def test_pmi_annotate_renders_each_nist_range_requirement_with_both_limits(
         self, ctc01_annotated
     ):
-        from draftwright.model import AuthoredDimension
+        from draftwright.model.ir import ToleranceDecoration
 
         source_ids = {"dimension:0:1:4:25", "dimension:0:1:4:26"}
-        features = {
-            feature.source_id: feature
-            for feature in ctc01_annotated.model().features
-            if isinstance(feature, AuthoredDimension) and feature.source_id in source_ids
-        }
+        requirements = [
+            (key[0], value)
+            for key, value in ctc01_annotated.model().decorations.items()
+            if isinstance(value, ToleranceDecoration) and set(value.source_ids) == source_ids
+        ]
         annotations = dict(ctc01_annotated.iter_annotations())
 
-        assert set(features) == source_ids
-        for feature in features.values():
-            (name,) = ctc01_annotated.registry.names_for_feature(feature)
-            assert annotations[name].label == "ø34.8 - ø35.2"
+        assert len(requirements) == 1
+        owner, requirement = requirements[0]
+        assert owner.diameter == 35.0 and owner.count == 2
+        assert requirement.value == 0.2  # 34.8 / 35.2 retained as -0.2 / +0.2
+        assert any(
+            annotations[name].label == "2× ⌀35 ±0.2 THRU"
+            for name in ctc01_annotated.registry.names_for_feature(owner)
+        )
 
     def test_pmi_annotate_reports_each_incomplete_source_record(self, ctc01_annotated):
         issues = [issue for issue in ctc01_annotated.lint() if issue.code == "pmi_not_extracted"]
@@ -1115,8 +1135,9 @@ class TestBuildDrawingPmi:
         # `dimension:0:1:4:17` is an ANGULAR dimension (label '60 ±0.5'). It used to render
         # through the linear path, producing an annotation whose label states an angle and
         # whose geometry states a length — the #1177 defect, present in a real NIST AP242
-        # fixture. It is now refused by category and reported instead, so the eight authored
-        # records partition into six rendered, one dropped for placement, and one refused.
+        # fixture. It remains materialised and is refused by category. The seven diameter
+        # records are consumed once as canonical hole decorations (#1116), so they no longer
+        # appear in this authored-feature inventory or compete in the PMI placement pass.
         refused = {
             source_id
             for issue in ctc01_annotated.registry.issues
@@ -1126,9 +1147,9 @@ class TestBuildDrawingPmi:
         angular = {
             feature.source_id for feature in authored if feature.dimension_kind == "angular"
         }
-        assert len(authored) == 8
-        assert len(rendered) == 6
-        assert len(dropped) == 1
+        assert len(authored) == 1
+        assert len(rendered) == 0
+        assert len(dropped) == 0
         assert refused == angular, (
             f"category refusals {refused} do not match the angular records {angular}"
         )
@@ -1141,10 +1162,10 @@ class TestBuildDrawingPmi:
             "by_category": {"datum": 11, "dimension": 21, "geometric_tolerance": 6},
             "extracted": 29,
             "lowered": 25,
-            # 24 before #1177: the angular dimension was counted as rendered while what
-            # reached the sheet was a LINEAR annotation asserting a length for an angle.
-            "rendered": 23,
-            "dropped": 1,
+            # Seven diameter sources now ride canonical bore owners. The angular record is
+            # still explicitly refused and the four raw location records remain unlowered.
+            "rendered": 24,
+            "dropped": 0,
         }
 
     def test_a_deleted_render_dispatch_is_reported_by_source_identity(self, monkeypatch):
@@ -1280,13 +1301,31 @@ class TestDeclaredModelPmi:
         declared = build_drawing(
             str(CTC01), out=str(tmp_path / "d"), title="P", model=[], pmi="annotate"
         )
-        auto_pmi = {n for n in auto.annotations() if n.startswith("pmi_")}
-        decl_pmi = {n for n in declared.annotations() if n.startswith("pmi_")}
-        assert auto_pmi
-        # The declared path has fewer auto-generated dimensions competing for strip capacity,
-        # so it may place extra authored PMI. The #472 invariant is no loss: every PMI dim the
-        # detected path placed must also be reproduced by the declared path.
-        assert auto_pmi <= decl_pmi
+
+        def source_ids(drawing):
+            ids = {
+                source_id
+                for feature in drawing.model().features
+                for source_id in (
+                    tuple(getattr(feature, "source_ids", ()))
+                    or (
+                        (getattr(feature, "source_id", ""),)
+                        if getattr(feature, "source_id", "")
+                        else ()
+                    )
+                )
+            }
+            ids.update(
+                source_id
+                for value in drawing.model().decorations.values()
+                for source_id in getattr(value, "source_ids", ())
+            )
+            return ids
+
+        # With geometry features available the automatic path correlates hole requirements;
+        # an empty declared model cannot, so it keeps them materialised. Both still account for
+        # every extracted source identity — #472's no-loss invariant.
+        assert source_ids(auto) == source_ids(declared)
 
     def test_declared_model_pmi_off_stays_clean(self, tmp_path):
         # the synthesis is gated on pmi_mode == 'annotate' — a declared build without PMI stays 0

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -341,7 +341,14 @@ class TestEmit:
         ast.parse(src)
         # `measured_dimension` since #873: a generated script must not emit the
         # transitional overload, or every regenerated AP242 script arrives deprecated.
-        assert "sheet.measured_dimension(" in src
+        # #1116: seven diameter tolerance sources enrich canonical hole features; only the
+        # unrelated angular requirement remains materialised.
+        assert src.count("sheet.measured_dimension(") == 1
+        assert (
+            sum(".tolerance(" in line for line in src.splitlines() if " = sheet.hole(" in line)
+            == 6
+        )
+        assert "source_ids=('dimension:0:1:4:29',)" in src
         # The transitional MEASURED overload (`dimension(kind=…, value=…)`), not the
         # referential verb: a regenerated AP242 script must not arrive pre-deprecated (#873).
         # Bare `sheet.dimension(` stopped meaning that when #938 made every script mirror the


### PR DESCRIPTION
Closes #1116

## Summary

- correlate supported AP242 diameter tolerances with their canonical hole or pattern owner at the completed IR waist
- preserve source provenance in `ToleranceDecoration` and emitted `.tolerance(..., source=..., source_ids=...)` declarations
- fail closed to provenance-preserving measured dimensions for unmatched, ambiguous, conflicting, partial-pattern, or unsupported requirements
- reconcile lint stage accounting with lowered feature ownership and document the narrowed ADR 0016 rule

## Verification

- `scripts/pr-check --full` — 4,523 passed, 5 skipped, 3 xfailed; 99% diff coverage
- focused #1116 suite after independent-review addition — 18 passed (slow CTC fixture excluded)
- `scripts/pr-check --static` — clean
- NIST CTC01 slow fixture verifies all seven hole-tolerance sources are consumed exactly once, the angular source remains angular, generated Sheet provenance round-trips, and no duplicate `pmi_dropped` remains

## Review notes

The lowering pass is semantic only: it does not place annotations or introduce coordinates. The existing planner and placement solve remain the sole rendering/placement owners, consistent with ADRs 0004, 0011, 0014, 0015, and amended 0016.