### PR TITLE
feat(sheet): expose authored view constraints

### DIFF
--- a/docs/adr/0018-requirement-driven-view-planning-and-editable-sheet-layout.md
+++ b/docs/adr/0018-requirement-driven-view-planning-and-editable-sheet-layout.md
@@ -1,22 +1,42 @@
 # ADR 0018 — Requirement-driven view planning and editable sheet layout
 
-- **Status:** **Accepted** (2026-08-16), **partially implemented** — see Amendment 1
-  (2026-08-21) for the authored surface. Delivery is phased through #1130. What exists:
-  `ViewSpec`, `ResolvedViewPlan` and `ViewCoverage` (`view_plan.py`); the layout choice as a
-  candidate over scale x sheet x **arrangement**, with §5's first hard gate applied by real
-  compile; a view-set-aware dimension plan that re-homes eligible requirements or raises
-  `ViewPlanIncomplete` before projection; and a chosen view set that is buildable, refusable
-  and reclaims the paper it frees.
-  What does not: `ViewConstraints` and the `Sheet` verbs, automatic view SELECTION (nothing
-  drops a view on its own — the case study reaches its A2 target and costs six annotations, so
-  a gate weighing it refuses), and any planning of sections or details. `_views` is an engine
-  seam, not a public option.
+- **Status:** **Accepted** (2026-08-16), **partially implemented** — see Amendments 1 and 2.
+  Delivery is phased through #1130. What exists: `ViewSpec`, `ViewConstraints`,
+  `ResolvedViewPlan` and `ViewCoverage` (`view_plan.py`); the public `Sheet` authored/augmenting
+  principal, section and detail verbs; relational whole-view constraints and principal
+  projection-origin pins; exact detail/isometric factors with unequal principal scales refused; the layout choice
+  as a candidate over scale x sheet x **arrangement**, with §5's first hard gate applied by real
+  compile; and a view-set-aware dimension plan that re-homes eligible requirements or raises
+  `ViewPlanIncomplete` before projection. A chosen authored view set is buildable, refusable and
+  reclaims the paper it frees.
+  What does not: automatic view SELECTION (nothing drops a view on its own — the case study
+  reaches its A2 target and costs six annotations, so a gate weighing it refuses), or resolved
+  view-plan script emission. `_views` remains an engine seam, not a public option.
   The "Required evidence before acceptance" list below is retained verbatim as the
   **delivery gate** each slice is measured against — accepting the direction does not
   waive it, and automatic semantic view selection lands only once those invariants are
   guarded.
 - **Date:** 2026-08-11 (proposed), 2026-08-16 (accepted)
 - **Deciders:** Paul Fremantle (pzfreo)
+
+## Amendment 2 — typed `ViewConstraints` and the `Sheet` view verbs ship (2026-08-22)
+
+Phase 2 (#1260) delivers Amendment 1's authored surface. `Sheet.view_constraints` is an
+immutable authored request, deliberately distinct from the immutable `ResolvedViewPlan` on the
+built drawing. `view`/`section_view`/`detail_view` author complete sets; their `add_` forms
+augment an explicit `auto_views()` source. View handles declare whole-view relations, pins and
+eligible independent scale factors without exposing feature-annotation coordinates.
+
+Authored principal removal replans requirement coverage before projection. Contradictory or
+unsupported layout relationships, infeasible pins and infeasible exact scales fail with the
+source line and are never relaxed. Named feature-targeted sections and details participate in
+the same resolved plan and layout reservation. The legacy `Sheet.section()` and
+`Sheet.detail()` switches are deprecated for removal in 0.6.0; they remain compatibility shims
+onto the same engine during that window.
+
+This amendment does not claim automatic semantic view selection or resolved-plan script
+emission. Those remain later delivery slices and continue to be governed by the evidence gates
+below.
 
 ## Amendment 1 — the authored surface mirrors the dimension model, and bans one combination (2026-08-21)
 

--- a/docs/deprecations.md
+++ b/docs/deprecations.md
@@ -59,7 +59,7 @@ exit. The extraction epic is the tracker; private historical submodules were not
 | Surface | Use instead | Deprecated in | Removed in |
 |---|---|---|---|
 | `Drawing.add()` | the placement verbs (`callout` / `dimension` / `note` / `add_table`) | 0.3.8 (#817) | 0.5.0 |
-| `Drawing.add_view()` | the section verb; the raw projector is private | 0.3.8 (#817) | 0.5.0 |
+| `Drawing.add_view()` | `Sheet.section_view()` / `detail_view()` (or their `add_` forms); the raw projector is private | 0.3.8 (#817) | 0.5.0 |
 | `Drawing.clear_annotations()` | the feature-scoped verbs (`drop` / `remove`) | 0.3.8 (#817) | 0.5.0 |
 | `Drawing.set_view_coordinates()` | — (engine plumbing, now private) | 0.3.8 (#817) | 0.5.0 |
 | `Drawing.drop_view_coordinates()` | — (engine plumbing, now private) | 0.3.8 (#817) | 0.5.0 |
@@ -69,6 +69,8 @@ exit. The extraction epic is the tracker; private historical submodules were not
 | `Drawing.export(svg=, dxf=)` keywords | `export(out, formats=[...])` → `{format: path}` | 0.3.1 (warns since 0.4.0) | 0.5.0 |
 | `Drawing.export()` with `formats` omitted **or `None`** → `(svg, dxf)` tuple | `export(out, formats=[...])` → `{format: path}` | 0.3.1 (warns since 0.4.0) | 0.5.0 — **see below** |
 | `Drawing.place_dim()` | `dimension(feature, param, pin=True)` / `locate(…, pin=True)` | **0.2.12** (0.3.8 added the PEP 702 shim) | gated on #707, target 0.6.0 |
+| `Sheet.section()` | `add_section_view("A", through=feature)` or `add_section_view("A", at=y)` | 0.4.10 (#1260) | 0.6.0 |
+| `Sheet.detail()` | `add_detail_view("A", around=feature)` | 0.4.10 (#1260) | 0.6.0 |
 
 ### The legacy `export` shapes warn from 0.4.0 — and why that needed `make_drawing` moved first
 

--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -10,6 +10,42 @@ with an underscore.
     options:
       filters: public
 
+### Authored views and layout
+
+View declarations are semantic constraints. They name projections, relationships and whole-view
+anchors; the layout solve owns the resulting page positions. Authored views must be paired with
+authored dimensions so a deliberately omitted view cannot strand planner-selected annotations:
+
+```python
+s = Sheet(part).authored_dimensions().authored_views()
+front = s.view("front")
+plan = s.view("plan").above(front, gap=4).align_x(front)
+s.view("iso").scale(0.75)
+
+section = s.section_view("A", through=hole)
+detail = s.detail_view("B", around=hole).scale(2)
+dwg = s.build()
+```
+
+`view(...)`, `section_view(...)` and `detail_view(...)` define complete authored sets;
+omission suppresses a view. `add_view(...)`, `add_section_view(...)` and
+`add_detail_view(...)` augment an explicitly selected `auto_views()` source. `row(...)` and
+`column(...)` are shorthand for whole-view relations. A principal-view handle's `pin((x, y))`
+anchors its projection origin in page millimetres; it never positions an annotation.
+
+Principal orthographic views share the sheet scale and reject `.scale(...)`. Detail and
+isometric handles may carry an independent positive factor. Infeasible relations, scales and
+pins raise with their declaration source; unsupported pins on derived or pictorial views are
+refused at declaration and constraints are never silently relaxed. The immutable authored
+snapshot is available as `sheet.view_constraints`, while `drawing.view_plan` is the distinct
+resolved result.
+
+## View handle
+
+::: draftwright.sheet._View
+    options:
+      filters: public
+
 ## Hole handle
 
 ::: draftwright.sheet._Hole

--- a/src/draftwright/__init__.py
+++ b/src/draftwright/__init__.py
@@ -37,6 +37,8 @@ _LAZY = {
     "extract_pmi_report": "draftwright.pmi",
     "choose_scale": "draftwright.compose",
     "ViewPlanIncomplete": "draftwright.view_plan",
+    "ViewConstraints": "draftwright.view_plan",
+    "ViewSpec": "draftwright.view_plan",
     # A warning category users are told to filter must be importable without reaching into a
     # private module (#1043 review) — and without paying for the CAD kernel. It lives in the
     # dependency-free `_warnings` leaf for that second reason: defined in `_core` it cost ~6 s
@@ -92,7 +94,7 @@ if TYPE_CHECKING:  # static analysers / IDEs — no runtime import, no kernel co
         extract_pmi_report,
     )
     from draftwright.sheet import Sheet
-    from draftwright.view_plan import ViewPlanIncomplete
+    from draftwright.view_plan import ViewConstraints, ViewPlanIncomplete, ViewSpec
 
 
 def __dir__():
@@ -113,6 +115,8 @@ __all__ = [
     "ScaleIncompatibilityError",
     "ScaleCompletenessWarning",
     "ViewPlanIncomplete",
+    "ViewConstraints",
+    "ViewSpec",
     "build_drawing",
     "choose_scale",
     "extract_pmi",

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -811,8 +811,8 @@ class DetailRequest:
                       footprint that depends on the chosen scale (the prismatic
                       ladder reserves one rung per *legible-at-that-scale* step, so it
                       shrinks with the scale during the fit). Overrides ``pad_top``.
-        source_view:  orthographic direction to preserve in the detail (``"front"``
-                      or ``"side"``). The latter is used for Y-turned axial profiles.
+        source_view:  orthographic direction to preserve in the detail (``"front"``,
+                      ``"plan"`` or ``"side"``).
         crop_lo/crop_hi: optional crop bounds along ``axis`` when the projected
                       detail must include context outside the marked feature band.
                       Prismatic absolute-height details use this to retain their
@@ -830,13 +830,23 @@ class DetailRequest:
     redraw: Callable[..., int]
     pad_top: float = 0.0
     pads: Callable[[float], tuple[float, float]] | None = None
-    source_view: Literal["front", "side"] = "front"
+    source_view: Literal["front", "plan", "side"] = "front"
     crop_lo: float | None = None
     crop_hi: float | None = None
     cross_axis: Literal["x", "y", "z"] | None = None
     cross_lo: float | None = None
     cross_hi: float | None = None
     kind: str = "detail"
+    #: Authored detail identity/label. ``None`` lets the automatic resolver assign A-H.
+    view_name: str | None = None
+    label: str | None = None
+    #: Exact authored multiple of sheet scale; automatic requests keep ``None`` and use the
+    #: legibility-derived preferred series.
+    scale_factor: float | None = None
+    #: An authored orientation crop is defining geometry even when it carries no redrawn
+    #: dimension. Automatic recovery details retain the historical "no dimension, no view" gate.
+    keep_without_annotations: bool = False
+    source: object | None = None
 
 
 @dataclass(frozen=True)
@@ -1028,7 +1038,7 @@ class Analysis:
     step_zs: list[float]
     layout_strips: StripDepths
     layout_n_steps: int
-    layout_section: bool
+    layout_section: int
     layout_table_sizes: tuple[tuple[float, float], ...]
     layout_required_tables: tuple[tuple[tuple[float, float], str], ...]
     sv_right: float
@@ -1110,6 +1120,15 @@ class Analysis:
     #: layout must reserve space for exactly the views the builder creates, or dropping one
     #: costs its annotations without reclaiming its paper.
     planned_views: tuple[str, ...] | None = None
+    #: Whether the orientation isometric participates in this authored plan. It is separate
+    #: from ``planned_views`` because that tuple is the principal set consumed by the
+    #: requirement compiler.
+    planned_iso: bool = True
+    #: ``None`` lets the orientation iso auto-fit; a number is an authored exact factor.
+    planned_iso_scale: float | None = None
+    #: Immutable ADR 0018 authored input, retained for the resolver/diagnostics without making
+    #: this low-level module depend on the view-planning leaf at runtime.
+    view_constraints: object | None = None
 
     @property
     def pmi(self) -> list:
@@ -1296,6 +1315,11 @@ def _add_zone_grid(dwg, a: Analysis):
 
 def _iso_bbox(dwg):
     """(min_x, min_y, max_x, max_y) of the placed iso view, hidden lines included."""
+    if "iso" not in dwg.views:
+        # A deliberately omitted orientation view contributes no obstacle. Infinity makes
+        # every existing iso-clearance comparison a no-op without teaching annotation passes
+        # a second page-edge convention.
+        return (math.inf, math.inf, math.inf, math.inf)
     return dwg.view_bounds("iso")
 
 

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -55,7 +55,7 @@ from draftwright.compose import (
 from draftwright.model import build_part_model
 from draftwright.model.ir import Datum, PartModel, StepFeature, StepLevelFeature
 from draftwright.model.planner import plan_dimensions
-from draftwright.view_plan import arrangement_of
+from draftwright.view_plan import ViewConstraints, arrangement_of
 
 _log = logging.getLogger(__name__)
 
@@ -66,6 +66,118 @@ _SQUARENESS_TOL = 0.05
 _OD_FILL_MIN = 0.8
 _OD_AXIS_TOL = 0.05
 _ScalePick = tuple[float, float, float, float]
+
+
+def _apply_principal_view_pins(
+    geometry,
+    constraints,
+    *,
+    scale: float,
+    centre: tuple[float, float, float],
+    page: tuple[float, float],
+    margin: float,
+    views: tuple[str, ...] | None,
+) -> None:
+    """Translate the conventional orthographic group to satisfy authored origin pins.
+
+    Third-angle front/plan/side relationships are hard constraints.  Their layout therefore
+    has two translational degrees of freedom, not six independent coordinates: pinning any one
+    projection origin translates the complete group, and multiple pins must imply the same
+    translation.  This runs before projection/zones, so every annotation strip follows the
+    resolved view blocks.
+    """
+
+    if not isinstance(constraints, ViewConstraints) or not constraints.pins:
+        return
+    planned = set(views or ("front", "plan", "side"))
+    centres = {
+        "front": (geometry.FV_X, geometry.FV_Y),
+        "plan": (geometry.PV_X, geometry.PV_Y),
+        "side": (geometry.SV_X, geometry.SV_Y),
+    }
+    cx, cy, cz = centre
+    projected_centre = {
+        "front": (cx * scale, cz * scale),
+        "plan": (cx * scale, cy * scale),
+        "side": (cy * scale, cz * scale),
+    }
+    translations = []
+    for pin in constraints.pins:
+        if pin.view not in centres:
+            where = f" at {pin.source}" if pin.source is not None else ""
+            raise ValueError(
+                f"whole-view pin{where} targets {pin.view!r}; this slice can anchor principal "
+                "orthographic projection origins only"
+            )
+        if pin.view not in planned:
+            raise ValueError(f"whole-view pin targets absent view {pin.view!r}")
+        centre_at_pin = (
+            pin.at[0] + projected_centre[pin.view][0],
+            pin.at[1] + projected_centre[pin.view][1],
+        )
+        current = centres[pin.view]
+        translations.append((centre_at_pin[0] - current[0], centre_at_pin[1] - current[1], pin))
+    dx, dy, first = translations[0]
+    for other_dx, other_dy, pin in translations[1:]:
+        if max(abs(other_dx - dx), abs(other_dy - dy)) > 0.05:
+            raise ValueError(
+                f"whole-view pins at {first.source} and {pin.source} contradict the fixed "
+                "third-angle relationships; they imply different group translations"
+            )
+
+    geometry.FV_X += dx
+    geometry.FV_Y += dy
+    geometry.PV_X += dx
+    geometry.PV_Y += dy
+    geometry.SV_X += dx
+    geometry.SV_Y += dy
+    geometry.sv_right += dx
+    geometry.sv_right_wall += dx
+    # Geometry bounds are the minimum pre-projection feasibility gate. Annotation bands use
+    # the shifted anchors below and remain subject to the ordinary completeness/lint gates.
+    extents = {
+        "front": (geometry.FV_X, geometry.FV_Y, geometry.fv_hw, geometry.fv_hh),
+        "plan": (geometry.PV_X, geometry.PV_Y, geometry.fv_hw, geometry.pv_hh),
+        "side": (geometry.SV_X, geometry.SV_Y, geometry.sv_hw, geometry.fv_hh),
+    }
+    page_w, page_h = page
+    for name in planned:
+        x, y, hw, hh = extents[name]
+        if (
+            x - hw < margin
+            or x + hw > page_w - margin
+            or y - hh < margin
+            or y + hh > page_h - margin
+        ):
+            pin = translations[0][2]
+            raise ValueError(
+                f"whole-view pin at {pin.source} is infeasible: translating the conventional "
+                f"view group puts {name!r} outside the drawable page; the anchor was not relaxed"
+            )
+
+
+def _planned_section_count(model, constraints, *, is_rotational=False, cx=0.0, cy=0.0) -> int:
+    """Number of section blocks the outer compose pass must reserve."""
+
+    automatic = int(_will_section(model, is_rotational=is_rotational, cx=cx, cy=cy))
+    if not isinstance(constraints, ViewConstraints):
+        return automatic
+    requested = (
+        constraints.derived
+        if constraints.derived_source == "authored"
+        else constraints.added_derived
+    )
+    authored = sum(item.spec.kind == "section" for item in requested)
+    return authored if constraints.derived_source == "authored" else automatic + authored
+
+
+def _planned_iso_scale(constraints) -> float | None:
+    if not isinstance(constraints, ViewConstraints):
+        return None
+    for item in (*constraints.principals, *constraints.added_principals):
+        if item.spec.name == "iso" and item.spec.scale_factor is not None:
+            return item.spec.scale_factor
+    return None
 
 
 def _sizing_bores(z_cyls, z_diams, od_diam, cx, cy) -> list:
@@ -96,6 +208,8 @@ def _will_section(model, *, is_rotational=False, cx=0.0, cy=0.0) -> bool:
     # hole gate qualifies — a blind pocket's floor/depth section has no driving Z hole.
     if getattr(model, "decorations", {}).get("section") is not None:
         return True
+    if getattr(model, "decorations", {}).get("auto_sections") is False:
+        return False
     features = getattr(model, "features", model)
 
     def feature_member(pt) -> bool:
@@ -447,6 +561,9 @@ def _validate_explicit_scale(
     layout_required_tables=(),
     margin=_MARGIN,
     warn_advisory: bool = True,
+    views: tuple[str, ...] | None = None,
+    include_iso: bool = True,
+    iso_scale_factor: float | None = None,
 ) -> None:
     """Enforce the two scale floors when the caller pinned an explicit *scale* (#489, #590 split
     of :func:`_analyse`). An explicit scale is the user's call — honour it, subject to:
@@ -483,6 +600,9 @@ def _validate_explicit_scale(
         table_sizes=layout_table_sizes,
         required_tables=layout_required_tables,
         margin=margin,
+        views=views,
+        include_iso=include_iso,
+        iso_scale_factor=iso_scale_factor,
     )
     # Warn only when omitting the scale would truly give a legible fit (auto scale itself is
     # legible) but the requested scale is below the floor. A part illegible at every
@@ -523,6 +643,8 @@ def _analyse(
     _required_tables=(),
     _arrangements: tuple[str, ...] | None = None,
     _views: tuple[str, ...] | None = None,
+    _include_iso: bool = True,
+    _view_constraints=None,
 ) -> Analysis:
     """Load STEP or use a build123d Shape, analyse geometry, compute layout.
 
@@ -725,11 +847,21 @@ def _analyse(
     bore_callout_width = _est_planned_bore_callout_width(
         sizing_groups, _draft_est, font_size=_FONT_SIZE, pad_around_text=_pad_around_text
     )
-    layout_section = _will_section(sizing_model, is_rotational=is_rotational, cx=cx, cy=cy)
+    section_count = _planned_section_count(
+        sizing_model,
+        _view_constraints,
+        is_rotational=is_rotational,
+        cx=cx,
+        cy=cy,
+    )
+    # Preserve the long-standing public diagnostic shape for the common zero/one case while
+    # carrying an integer only when authored constraints genuinely reserve multiple sections.
+    layout_section = section_count if section_count > 1 else bool(section_count)
     layout_table_sizes = _est_hole_table_sizes(
         sizing_model, bb, font_size=_FONT_SIZE, pad_around_text=_pad_around_text
     )
     layout_required_tables = tuple(_required_tables)
+    planned_iso_scale = _planned_iso_scale(_view_constraints)
 
     # Choose scale/page, iterating so the reserved step corridor matches the
     # number of steps the legibility gate will actually place (#1) — not the raw
@@ -762,6 +894,8 @@ def _analyse(
             margin=margin,
             arrangements=_arrangements,
             views=_views,
+            include_iso=_include_iso,
+            iso_scale_factor=planned_iso_scale,
         )
 
     scale_pick, strips_i, n_for_sizing = _converge_step_sizing(
@@ -790,6 +924,9 @@ def _analyse(
         layout_required_tables,
         margin=margin,
         warn_advisory=_reuse is None,
+        views=_views,
+        include_iso=_include_iso,
+        iso_scale_factor=planned_iso_scale,
     )
     DIM_PAD = _DIM_PAD
     # margin was computed up front (_content_margin(frame)) so scale selection already saw it.
@@ -821,6 +958,17 @@ def _analyse(
         required_tables=layout_required_tables,
         margin=margin,
         arrangement=ARRANGEMENT,
+        views=_views,
+        include_iso=_include_iso,
+        iso_scale_factor=planned_iso_scale,
+    )
+    _apply_principal_view_pins(
+        _g,
+        _view_constraints,
+        scale=SCALE,
+        centre=(cx, cy, cz),
+        page=(PAGE_W, PAGE_H),
+        margin=margin,
         views=_views,
     )
     fv_hw = _g.fv_hw
@@ -871,6 +1019,9 @@ def _analyse(
     return Analysis(
         arrangement=ARRANGEMENT,
         planned_views=_views,
+        planned_iso=_include_iso,
+        planned_iso_scale=planned_iso_scale,
+        view_constraints=_view_constraints,
         part=part,
         recognition=recognition,
         bb=bb,

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -16,10 +16,12 @@ bore set, side-drilled locations, the hole table) + the section/PMI passes.
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Literal
 
 from draftwright._core import (
     _TABULATE_MIN_HOLES,
     Analysis,
+    DetailRequest,
     HoleRef,
     _add_projection_symbol,
     _add_sheet_frame,
@@ -96,12 +98,126 @@ from draftwright.model import (
     HoleFeature,
     PatternFeature,
     RotationalFeature,
+    SectionPlan,
     build_part_model,
     plan_dimensions,
     plan_sections,
 )
 from draftwright.model.compiled import compile_dimensions, resolve_feature
 from draftwright.repair import reconcile_witness_labels
+from draftwright.view_plan import ViewConstraints
+
+
+def _planned_sections(a, model, feature_keys) -> tuple[SectionPlan, ...]:
+    """Combine the automatic section candidate with ADR 0018 authored/add requests."""
+
+    constraints = a.view_constraints
+    if not isinstance(constraints, ViewConstraints):
+        automatic = plan_sections(model, feature_keys)
+        return (automatic,) if automatic is not None else ()
+
+    requested = (
+        constraints.derived
+        if constraints.derived_source == "authored"
+        else constraints.added_derived
+    )
+    section_requests = [item for item in requested if item.spec.kind == "section"]
+    plans = []
+    for item in section_requests:
+        target = item.spec.target
+        if not (isinstance(target, tuple) and len(target) == 2):
+            raise ValueError(f"section {item.spec.name!r} has no semantic cut target")
+        if target[0] == "at":
+            cut_y = float(target[1])
+        elif target[0] == "feature":
+            cut_y = float(target[1].frame.origin[1])
+        else:
+            raise ValueError(f"section {item.spec.name!r} has unknown target {target!r}")
+        if not a.bb.min.Y < cut_y < a.bb.max.Y:
+            raise ValueError(
+                f"section {item.spec.name!r} from {item.source} cuts at y={cut_y:g}, outside "
+                f"the part interior ({a.bb.min.Y:g}, {a.bb.max.Y:g})"
+            )
+        slug = item.spec.name.removeprefix("section_")
+        label = slug[0].upper() if len(set(slug)) == 1 else slug.upper()
+        plans.append(SectionPlan(cut_y, label=label, source=item.source))
+
+    if constraints.derived_source != "authored":
+        automatic = plan_sections(model, feature_keys)
+        if automatic is not None:
+            used = {plan.label for plan in plans}
+            auto_label = next((letter for letter in "ABCDEFGH" if letter not in used), None)
+            if auto_label is None:
+                raise ValueError(
+                    "automatic section cannot be named: authored labels A-H are exhausted"
+                )
+            plans.insert(0, SectionPlan(automatic.cut_y, label=auto_label))
+    return tuple(plans)
+
+
+def _queue_authored_details(a, ctx) -> None:
+    """Lower semantic ``detail_view(..., around=feature)`` constraints to crop requests."""
+
+    constraints = a.view_constraints
+    if not isinstance(constraints, ViewConstraints):
+        return
+    requested = (
+        constraints.derived
+        if constraints.derived_source == "authored"
+        else constraints.added_derived
+    )
+    for item in requested:
+        if item.spec.kind != "detail":
+            continue
+        target = item.spec.target
+        if not (isinstance(target, tuple) and len(target) == 2 and target[0] == "feature"):
+            raise ValueError(f"detail {item.spec.name!r} has no semantic feature target")
+        feature = target[1]
+        origin = feature.frame.origin
+        axis = feature.frame.axis
+        view_for_axis: dict[
+            str,
+            tuple[
+                Literal["front", "plan", "side"],
+                tuple[Literal["x", "y", "z"], Literal["x", "y", "z"]],
+            ],
+        ] = {
+            "z": ("plan", ("x", "y")),
+            "x": ("side", ("y", "z")),
+            "y": ("front", ("x", "z")),
+        }
+        source_view, crop_axes = view_for_axis[axis]
+        sizes = [
+            abs(float(value))
+            for name in ("diameter", "width", "length", "height", "depth", "radius")
+            if (value := getattr(feature, name, None)) is not None
+            and isinstance(value, (int, float))
+        ]
+        half = max(3.0, (max(sizes) if sizes else 6.0) * 0.75)
+        first, second = crop_axes
+        fi, si = "xyz".index(first), "xyz".index(second)
+        label = item.spec.name.removeprefix("detail_").upper()
+        factor = item.spec.scale_factor or 2.0
+        ctx.detail_requests.append(
+            DetailRequest(
+                axis=first,
+                lo=origin[fi] - half,
+                hi=origin[fi] + half,
+                scale_needed=a.SCALE * factor,
+                redraw=lambda *_args: 0,
+                source_view=source_view,
+                cross_axis=second,
+                cross_lo=origin[si] - half,
+                cross_hi=origin[si] + half,
+                kind="authored-feature",
+                view_name=item.spec.name,
+                label=label,
+                scale_factor=factor,
+                keep_without_annotations=True,
+                source=item.source,
+            )
+        )
+
 
 # ── the ONE auto-pass stage sequence (#699 slice b) ──────────────────────────
 # The canonical order of the annotation stages. `_auto_annotate` executes it, and
@@ -441,7 +557,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # Decide the section trigger + cut-plane row now (pure function of _model/
     # feature_keys, no placement dependency); the "reserve_section" stage reserves
     # its row and the "section" stage renders it.
-    _section = plan_sections(_model, feature_keys)
+    _sections = _planned_sections(a, _model, feature_keys)
 
     # ── the stage thunks, run in _PASS_SEQUENCE order (#699 slice b) ─────────
     def _s_rotational():
@@ -467,7 +583,8 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # than pay that cost or drop it (holes.py); the `bracket` fixture's known
         # hc_plan0/section_arrow_right overlap (tests/test_layout_cleanliness.py)
         # is exactly this accepted case.
-        _reserve_section_row(dwg, a, _section, ctx=ctx)
+        for section in _sections:
+            _reserve_section_row(dwg, a, section, ctx=ctx)
 
     def _s_hole_callouts():
         # Any hole/pattern member (declared holes render even where detection missed them).
@@ -667,8 +784,9 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # its full strip_obstacles room check can see side callouts, envelope dims,
         # slots, GD&T/PMI, and drained ladder outputs as one occupancy set. Details
         # still render after it and avoid the section view.
-        if _section is not None:
-            _add_section_view(dwg, a, _section, ctx=ctx)
+        if _sections:
+            for section in _sections:
+                _add_section_view(dwg, a, section, ctx=ctx)
         else:
             # Recorded, not left at the initial `not_evaluated`: the planner DID run and
             # found no counterbore/spotface/blind Z-hole, which is a different fact from
@@ -682,6 +800,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # Resolve every queued enlarged-detail request (#307) — prismatic step bands and
         # crowded turned heads alike — through the one generic detailer, now that all
         # views and main-view annotations are placed (so the detail avoids them).
+        _queue_authored_details(a, ctx)
         _resolve_details(dwg, a, ctx=ctx)
 
     def _s_title_block():

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -53,6 +53,33 @@ from draftwright.projection import project_view_geometry
 _DETAIL_LETTERS = "ABCDEFGH"
 
 
+def _section_identity(section) -> tuple[str, str, str]:
+    """``(label, view_name, annotation_prefix)``; preserve A–A's historic names."""
+
+    label = str(getattr(section, "label", "A")).strip().upper()
+    if not label or not label.isalnum():
+        raise ValueError(f"section label must be alphanumeric, got {label!r}")
+    if label == "A":
+        return label, "section_aa", "section"
+    slug = label.lower()
+    return label, f"section_{slug}{slug}", f"section_{slug}"
+
+
+def _section_annotation_names(section, *, reservation=False) -> tuple[str, ...]:
+    _label, _view, prefix = _section_identity(section)
+    line = f"{prefix}_line_reservation" if reservation else f"{prefix}_line"
+    letter = _label.lower()
+    return (
+        line,
+        f"{prefix}_arrow_left",
+        f"{prefix}_arrow_right",
+        f"{prefix}_wing_left",
+        f"{prefix}_wing_right",
+        f"{prefix}_{letter}_left",
+        f"{prefix}_{letter}_right",
+    )
+
+
 def feature_hole_keys(model, a: Analysis) -> set[HoleRef]:
     """The :class:`HoleRef` position keys of the part's feature holes — the membership
     set the callout/furniture passes and ``plan_sections`` gate on (#420).
@@ -209,6 +236,12 @@ def _add_section_view(dwg, a: Analysis, section, *, ctx):
     the plan view, and filled with ISO 128-50 45° hatching on the cut face.
     """
     y_star = section.cut_y
+    label, view_name, prefix = _section_identity(section)
+    if "plan" not in dwg.views:
+        raise ValueError(
+            f"section {label}–{label} from {section.source} needs the plan view to carry its "
+            "cutting-plane line; add view('plan')"
+        )
 
     # room check: same row as the front/side views, to the right — past any
     # side-view callout labels already placed there.
@@ -216,10 +249,12 @@ def _add_section_view(dwg, a: Analysis, section, *, ctx):
     # have enough room for the "SECTION A–A" caption and arrows.
     half_w = max(a.x_size * a.SCALE / 2, 12.0)
     half_h = a.z_size * a.SCALE / 2
-    side_vis, side_hid = dwg.views["side"]
-    side_right = side_vis.bounding_box().max.X
-    if side_hid:
-        side_right = max(side_right, side_hid.bounding_box().max.X)
+    row_views = [name for name in ("front", "side") if name in dwg.views]
+    if not row_views:
+        raise ValueError(
+            f"section {label}–{label} from {section.source} needs front or side as its parent row"
+        )
+    side_right = max(dwg.view_bounds(name)[2] for name in row_views)
     row_y0 = a.FV_Y - half_h - 10
     row_y1 = a.FV_Y + half_h + 6
     iso_x0, iso_y0, _, _ = _iso_bbox(dwg)
@@ -247,6 +282,7 @@ def _add_section_view(dwg, a: Analysis, section, *, ctx):
             "no_room",
             f"no free segment right of the side view wide enough for the "
             f"{2 * half_w:.1f} mm section within x<={right_limit:.1f}",
+            section=section,
         )
         return
     # The section's row dips into the title-block band only when its CAPTION does —
@@ -269,6 +305,7 @@ def _add_section_view(dwg, a: Analysis, section, *, ctx):
             "would collide with the title block; the caption sits at "
             f"y={a.FV_Y - half_h - 7:.1f} and the title block reaches "
             f"y={_TB_CLEAR + _TB_H:.1f} out to x={tb_left:.1f}",
+            section=section,
         )
         return
     pos_x = usable[0][0] + half_w
@@ -279,7 +316,7 @@ def _add_section_view(dwg, a: Analysis, section, *, ctx):
     # never let a failed boolean abort the whole drawing
     solids = a.part.solids()
     if not solids:
-        _skip_section(dwg, ctx, "no_solids", "no solid bodies to cut")
+        _skip_section(dwg, ctx, "no_solids", "no solid bodies to cut", section=section)
         return
     body = solids[0] if len(solids) == 1 else Compound(children=list(solids))
     try:
@@ -287,10 +324,10 @@ def _add_section_view(dwg, a: Analysis, section, *, ctx):
         # (Standard_DomainError) on some cast geometry — see _fuzzy_cut / #20.
         keep_behind = _fuzzy_cut(body, Pos(a.cx, y_star - big / 2, a.cz) * Box(big, big, big))
     except Exception as exc:  # noqa: BLE001 — OCC booleans raise broadly
-        _skip_section(dwg, ctx, "cut_failed", f"cut failed: {exc}")
+        _skip_section(dwg, ctx, "cut_failed", f"cut failed: {exc}", section=section)
         return
     if keep_behind is None:
-        _skip_section(dwg, ctx, "cut_empty", "boolean cut produced no solid")
+        _skip_section(dwg, ctx, "cut_empty", "boolean cut produced no solid", section=section)
         return
     # Resolve the final cutting-plane ink before committing the section view.
     # Optional section furniture yields if a required landed feature leader
@@ -309,18 +346,10 @@ def _add_section_view(dwg, a: Analysis, section, *, ctx):
                 ext_x0 = min(ext_x0, cb.min.X)
                 ext_x1 = max(ext_x1, cb.max.X)
     x0, x1 = ext_x0 - 4, ext_x1 + 4
-    section_names = (
-        "section_line",
-        "section_arrow_left",
-        "section_arrow_right",
-        "section_wing_left",
-        "section_wing_right",
-        "section_a_left",
-        "section_a_right",
-    )
-    _clear_section_reservation(dwg)
+    section_names = _section_annotation_names(section)
+    _clear_section_reservation(dwg, section)
 
-    _place_cutting_plane(dwg, y_page, x0, x1, ctx=ctx)
+    _place_cutting_plane(dwg, y_page, x0, x1, section=section, ctx=ctx)
     conflicts = feature_leader_fixed_conflicts(dwg, section_names)
     if conflicts:
         # The cut row is semantically fixed, but its end symbols may extend
@@ -347,8 +376,8 @@ def _add_section_view(dwg, a: Analysis, section, *, ctx):
             and repaired_x1 <= a.PAGE_W - a.margin - page_clearance
         )
         if repair_is_bounded:
-            _clear_section_reservation(dwg)
-            _place_cutting_plane(dwg, y_page, repaired_x0, repaired_x1, ctx=ctx)
+            _clear_section_reservation(dwg, section)
+            _place_cutting_plane(dwg, y_page, repaired_x0, repaired_x1, section=section, ctx=ctx)
             conflicts = feature_leader_fixed_conflicts(dwg, section_names)
     if conflicts:
         _skip_section(
@@ -357,15 +386,18 @@ def _add_section_view(dwg, a: Analysis, section, *, ctx):
             "leader_conflict",
             "final cutting-plane ink crosses required feature leaders: "
             + ", ".join(f"{leader}/{component}" for leader, component in conflicts),
+            section=section,
         )
         return
 
     camera = (dwg.look_at[0], dwg.look_at[1] - dwg.dist, dwg.look_at[2])
-    dwg._add_view("section_aa", keep_behind, camera, (0, 0, 1), (pos_x, a.FV_Y))
-    dwg.record_section_decision("placed", detail=f"placed at x={pos_x:.1f}")
+    dwg._add_view(view_name, keep_behind, camera, (0, 0, 1), (pos_x, a.FV_Y))
+    dwg.record_section_decision(
+        "placed", detail=f"section {label}–{label} placed at x={pos_x:.1f}"
+    )
     ctx.place(
-        Note("SECTION A–A", (pos_x, a.FV_Y - half_h - 7), dwg.draft),
-        "section_caption",
+        Note(f"SECTION {label}–{label}", (pos_x, a.FV_Y - half_h - 7), dwg.draft),
+        f"{prefix}_caption",
     )
 
     # ISO 128-50: 45° hatching on the cut face, in page coordinates. The section
@@ -384,24 +416,26 @@ def _add_section_view(dwg, a: Analysis, section, *, ctx):
     if hatch_edges:
         hatch = Compound(children=hatch_edges)
         hatch.is_section_hatch = True  # exempt from view_annotation_overlap lint
-        ctx.place(hatch, "section_hatch")
+        ctx.place(hatch, f"{prefix}_hatch")
 
 
-def _place_cutting_plane(dwg, y_page, x0, x1, *, ctx):
+def _place_cutting_plane(dwg, y_page, x0, x1, *, section, ctx):
     """Place one complete, unmeasured cutting-plane furniture candidate."""
 
-    ctx.place(Centerline((x0, y_page, 0), (x1, y_page, 0)), "section_line")
-    _add_cutting_plane_arrows(dwg, y_page, x0, x1, ctx=ctx)
-    _add_section_letters(dwg, y_page, x0, x1, ctx=ctx)
+    _label, _view, prefix = _section_identity(section)
+    ctx.place(Centerline((x0, y_page, 0), (x1, y_page, 0)), f"{prefix}_line")
+    _add_cutting_plane_arrows(dwg, y_page, x0, x1, section=section, ctx=ctx)
+    _add_section_letters(dwg, y_page, x0, x1, section=section, ctx=ctx)
 
 
-def _add_cutting_plane_arrows(dwg, y_page, x0, x1, *, ctx):
+def _add_cutting_plane_arrows(dwg, y_page, x0, x1, *, section, ctx):
     """ISO 128-44 cutting-plane end indicators at ``(x0, y_page)``/``(x1, y_page)`` —
     thick wing stubs with solid filled arrowheads pointing in the viewing direction
     (−Y). Named ``section_arrow_{left,right}``/``section_wing_{left,right}``, shared
     between the early row reservation (:func:`_reserve_section_row`) and the final
     section render (:func:`_add_section_view`, ADR 0009 P5 strand 3)."""
     arrow_sz = dwg.draft.arrow_length
+    _label, _view, prefix = _section_identity(section)
     wing_h = 2.5 * arrow_sz  # perpendicular stub length
     for x_end, side in ((x0, "left"), (x1, "right")):
         tip_y = y_page - wing_h
@@ -416,7 +450,7 @@ def _add_cutting_plane_arrows(dwg, y_page, x0, x1, *, ctx):
             arrow_length=arrow_sz,
             line_width=0.0,
         )[-1:]
-        ctx.place(arrow, f"section_arrow_{side}")
+        ctx.place(arrow, f"{prefix}_arrow_{side}")
         shaft_end_y = tip_y + arrow_sz
         wing_segment = ((x_end, y_page), (x_end, shaft_end_y))
         wing = Compound(
@@ -425,11 +459,11 @@ def _add_cutting_plane_arrows(dwg, y_page, x0, x1, *, ctx):
         wing.fixed_ink_polygons = (_stroke_polygon(*wing_segment, dwg.draft.line_width),)
         ctx.place(
             wing,
-            f"section_wing_{side}",
+            f"{prefix}_wing_{side}",
         )
 
 
-def _add_section_letters(dwg, y_page, x0, x1, *, ctx):
+def _add_section_letters(dwg, y_page, x0, x1, *, section, ctx):
     """The 'A' identification letters above the cutting-plane line ends, clear of
     any callout leaders. Named ``section_a_{left,right}`` — shared between the
     early row reservation and the final section render, same as
@@ -437,8 +471,10 @@ def _add_section_letters(dwg, y_page, x0, x1, *, ctx):
     footprint can land on the letters just as easily as on the arrows, so both
     need to be visible to the plan-view callout carve before it places."""
     lift = dwg.draft.font_size * 1.4
-    ctx.place(Note("A", (x0 - 3, y_page + lift), dwg.draft), "section_a_left")
-    ctx.place(Note("A", (x1 + 3, y_page + lift), dwg.draft), "section_a_right")
+    label, _view, prefix = _section_identity(section)
+    slug = label.lower()
+    ctx.place(Note(label, (x0 - 3, y_page + lift), dwg.draft), f"{prefix}_{slug}_left")
+    ctx.place(Note(label, (x1 + 3, y_page + lift), dwg.draft), f"{prefix}_{slug}_right")
 
 
 def _segments_clearing_title_block(fitting, half_w, *, shares_title_row, tb_left):
@@ -458,7 +494,9 @@ def _segments_clearing_title_block(fitting, half_w, *, shares_title_row, tb_left
     return [(lo, hi) for lo, hi in fitting if lo + 2 * half_w <= tb_left - 4]
 
 
-def _skip_section(dwg, ctx, reason: str, detail: str, *, severity: str = "warning") -> None:
+def _skip_section(
+    dwg, ctx, reason: str, detail: str, *, section=None, severity: str = "warning"
+) -> None:
     """Abandon section A–A, recording the outcome the same way on every path (#1190).
 
     The one exit for a warranted-but-unplaced section. Before this, each skip logged
@@ -491,32 +529,31 @@ def _skip_section(dwg, ctx, reason: str, detail: str, *, severity: str = "warnin
     *unexplained*, and a caller reading `section_decision` at 2.5 now sees
     ``skipped/no_room`` rather than an unaccountable absence.
     """
-    _log.warning("Section A–A skipped (%s)", detail)
-    dwg.record_section_decision("skipped", reason=reason, detail=detail)
+    label, _view, _prefix = _section_identity(section)
+    if label == "A":
+        _log.warning("Section A–A skipped (%s)", detail)
+    else:
+        _log.warning("Section %s–%s skipped (%s)", label, label, detail)
+    dwg.record_section_decision(
+        "skipped", reason=reason, detail=f"section {label}–{label}: {detail}"
+    )
     ctx.record_issue(
         severity,
         "section_dropped",
-        f"section A–A not placed ({detail})",
+        f"section {label}–{label} not placed ({detail})",
         outcome_stage="validation",
     )
-    _clear_section_reservation(dwg)
+    _clear_section_reservation(dwg, section)
 
 
-def _clear_section_reservation(dwg) -> None:
+def _clear_section_reservation(dwg, section=None) -> None:
     """Remove the placeholder :func:`_reserve_section_row` may have added, if
     present (idempotent — a no-op once :func:`_add_section_view` has already
     replaced it, or if no section ever triggered)."""
     existing = dwg.annotations()
-    for name in (
-        "section_line",
-        "section_line_reservation",
-        "section_arrow_left",
-        "section_arrow_right",
-        "section_wing_left",
-        "section_wing_right",
-        "section_a_left",
-        "section_a_right",
-    ):
+    final = _section_annotation_names(section)
+    reserved = _section_annotation_names(section, reservation=True)
+    for name in dict.fromkeys((*final, *reserved)):
         if name in existing:
             dwg.remove(name)
 
@@ -553,26 +590,19 @@ def _reserve_section_row(dwg, a: Analysis, section, *, ctx) -> None:
     PX, PY = a.proj.plan_x, a.proj.plan_y
     y_page = PY(section.cut_y)
     x0, x1 = PX(a.bb.min.X) - 4, PX(a.bb.max.X) + 4
+    _label, _view, prefix = _section_identity(section)
     ctx.place(
         Centerline((x0, y_page, 0), (x1, y_page, 0)),
-        "section_line_reservation",
+        f"{prefix}_line_reservation",
     )
-    _add_cutting_plane_arrows(dwg, y_page, x0, x1, ctx=ctx)
-    _add_section_letters(dwg, y_page, x0, x1, ctx=ctx)
+    _add_cutting_plane_arrows(dwg, y_page, x0, x1, section=section, ctx=ctx)
+    _add_section_letters(dwg, y_page, x0, x1, section=section, ctx=ctx)
     # These are provisional geometry rather than final annotation objects. The
     # row is hard future ink for clear alternatives; if a required leader must
     # retain its producer floor across it under Policy B, the optional section
     # yields. Otherwise the final pass replaces the same names with ordinary,
     # non-provisional annotations without re-solving around late leaders.
-    for name in (
-        "section_line_reservation",
-        "section_arrow_left",
-        "section_arrow_right",
-        "section_wing_left",
-        "section_wing_right",
-        "section_a_left",
-        "section_a_right",
-    ):
+    for name in _section_annotation_names(section, reservation=True):
         annotation = dwg.get_annotation(name)
         annotation.is_provisional_layout_reservation = True
 
@@ -590,15 +620,25 @@ def _render_detail(
     placed. Mirrors :func:`_add_section_view`'s skip-with-log discipline."""
     # Detail scale: smallest standard multiple in [2, 5, 10] of sheet scale that
     # makes the region legible (>= the requested scale), always >= 2x.
-    detail_scale = a.SCALE * 2
-    for factor in (2, 5, 10):
-        detail_scale = a.SCALE * factor
-        if detail_scale >= req.scale_needed:
-            break
-
-    min_detail_scale = max(req.scale_needed, a.SCALE * 1.2 + 1e-6)
+    if req.scale_factor is not None:
+        detail_scale = a.SCALE * req.scale_factor
+        min_detail_scale = detail_scale
+    else:
+        detail_scale = a.SCALE * 2
+        for factor in (2, 5, 10):
+            detail_scale = a.SCALE * factor
+            if detail_scale >= req.scale_needed:
+                break
+        min_detail_scale = max(req.scale_needed, a.SCALE * 1.2 + 1e-6)
     if not math.isfinite(min_detail_scale):
         _log.info("Detail %s skipped (non-finite scale required)", letter)
+        return False
+    if req.source_view not in dwg.views:
+        if req.keep_without_annotations:
+            raise ValueError(
+                f"authored detail {letter!r} from {req.source} needs parent view "
+                f"{req.source_view!r}; add that principal view"
+            )
         return False
 
     # Crop to the band along req.axis (two fuzzy cuts). Solids only — a mixed
@@ -642,8 +682,12 @@ def _render_detail(
     # the iso helper's square-default optimum can reject a wide, short detail even
     # when a different empty rectangle fits it (#915).
     cb = cropped.bounding_box()
-    view_w = cb.max.Y - cb.min.Y if req.source_view == "side" else cb.max.X - cb.min.X
-    view_h = cb.max.Z - cb.min.Z
+    if req.source_view == "side":
+        view_w, view_h = cb.max.Y - cb.min.Y, cb.max.Z - cb.min.Z
+    elif req.source_view == "plan":
+        view_w, view_h = cb.max.X - cb.min.X, cb.max.Y - cb.min.Y
+    else:
+        view_w, view_h = cb.max.X - cb.min.X, cb.max.Z - cb.min.Z
     cap_h = 8.0
 
     def _pads(s):  # annotation bands may depend on the scale (the prismatic ladder)
@@ -684,7 +728,11 @@ def _render_detail(
     # whole sheet scale skipped 3:1 on a 2:1 sheet (4→2), even when 3:1 both fit
     # and exceeded the requested legibility scale (#897).
     fit_step = a.SCALE * 0.5
-    while detail_scale - fit_step >= min_detail_scale and not _fits(detail_scale):
+    while (
+        req.scale_factor is None
+        and detail_scale - fit_step >= min_detail_scale
+        and not _fits(detail_scale)
+    ):
         detail_scale -= fit_step
     if not _fits(detail_scale) and detail_scale > min_detail_scale:
         detail_scale = min_detail_scale
@@ -705,11 +753,11 @@ def _render_detail(
     dcz = (cb.min.Z + cb.max.Z) / 2
     la = (dcx * detail_scale, dcy * detail_scale, dcz * detail_scale)
     dist_d = a.bbox_max * detail_scale + 100
-    camera = (
-        (la[0] + dist_d, la[1], la[2])
-        if req.source_view == "side"
-        else (la[0], la[1] - dist_d, la[2])
-    )
+    camera, up = {
+        "side": ((la[0] + dist_d, la[1], la[2]), (0, 0, 1)),
+        "plan": ((la[0], la[1], la[2] + dist_d), (0, 1, 0)),
+        "front": ((la[0], la[1] - dist_d, la[2]), (0, 0, 1)),
+    }[req.source_view]
     # Project the cropped band front-on into a SCRATCH (no Drawing mutation) at the detail scale —
     # project_view_geometry takes the scale directly, so its coordinates ARE the detail's (the old
     # _add_view + override existed only because _add_view hard-codes the sheet scale). Trying the
@@ -718,7 +766,7 @@ def _render_detail(
     try:
         band_s = cropped.scale(detail_scale)
         placed, placed_hid, coords = project_view_geometry(
-            detail_scale, view_name, band_s, camera, (0, 0, 1), (DX, DY), look_at=la, scaled=True
+            detail_scale, view_name, band_s, camera, up, (DX, DY), look_at=la, scaled=True
         )
     except Exception as exc:  # noqa: BLE001 — projection raises broadly on cast geometry
         _log.warning("Detail %s skipped (projection failed: %s)", letter, exc)
@@ -732,7 +780,8 @@ def _render_detail(
     # place-then-drop). The main view always locates the head/block inline, so lint reports any
     # un-located interior.
     dwg.views[view_name] = (placed, placed_hid)
-    if not req.redraw(dwg, view_name, coords, detail_scale):
+    redrawn = req.redraw(dwg, view_name, coords, detail_scale)
+    if not redrawn and not req.keep_without_annotations:
         dwg.views.pop(view_name, None)
         _log.info("Detail %s skipped (no legible dims at the detail scale)", letter)
         return False
@@ -743,6 +792,17 @@ def _render_detail(
         zlo = req.cross_lo if req.cross_lo is not None else a.bb.min.Z
         zhi = req.cross_hi if req.cross_hi is not None else a.bb.max.Z
         corners = [dwg.at("side", a.bb.max.X, y, z) for y in (req.lo, req.hi) for z in (zlo, zhi)]
+        mx0, mx1 = min(p[0] for p in corners), max(p[0] for p in corners)
+        my0, my1 = min(p[1] for p in corners), max(p[1] for p in corners)
+    elif req.source_view == "plan":
+        corners = [
+            dwg.at("plan", x, y, a.bb.max.Z)
+            for x in (req.lo, req.hi)
+            for y in (
+                req.cross_lo if req.cross_lo is not None else a.bb.min.Y,
+                req.cross_hi if req.cross_hi is not None else a.bb.max.Y,
+            )
+        ]
         mx0, mx1 = min(p[0] for p in corners), max(p[0] for p in corners)
         my0, my1 = min(p[1] for p in corners), max(p[1] for p in corners)
     else:
@@ -790,13 +850,19 @@ def _resolve_details(dwg, a: Analysis, *, ctx) -> None:
     the queue."""
     reqs = list(ctx.detail_requests)
     ctx.detail_requests = []
-    n_placed = 0  # letters advance only on a successful placement — no A/B gaps (#307 review)
+    reserved = {req.label for req in reqs if req.label is not None}
+    if len(reserved) != sum(req.label is not None for req in reqs):
+        raise ValueError("authored detail labels must be unique")
+    used: set[str] = set()
     for req in reqs:
-        if n_placed >= len(_DETAIL_LETTERS):
+        letter = req.label or next(
+            (candidate for candidate in _DETAIL_LETTERS if candidate not in reserved | used), None
+        )
+        if letter is None:
             _log.info("detail request '%s' dropped: detail letters A–H exhausted", req.kind)
             continue
-        letter = _DETAIL_LETTERS[n_placed]
-        placed = _render_detail(dwg, a, req, f"detail_{letter.lower()}", letter, ctx=ctx)
+        view_name = req.view_name or f"detail_{letter.lower()}"
+        placed = _render_detail(dwg, a, req, view_name, letter, ctx=ctx)
         hname = (
             _overall_height_name(dwg, a) if not placed and req.kind == "prismatic-steps" else None
         )
@@ -809,7 +875,7 @@ def _resolve_details(dwg, a: Analysis, *, ctx) -> None:
             # explicit and logged) and retry the detail once.
             ident = dwg.registry.identity_of(hname)
             hobj = dwg.remove(hname)
-            placed = _render_detail(dwg, a, req, f"detail_{letter.lower()}", letter, ctx=ctx)
+            placed = _render_detail(dwg, a, req, view_name, letter, ctx=ctx)
             if placed:
                 _log.warning(
                     "%s demoted: the requested crowded-step detail view takes its room", hname
@@ -826,7 +892,12 @@ def _resolve_details(dwg, a: Analysis, *, ctx) -> None:
                 ctx.place(hobj, hname)
                 dwg.registry.reapply(hname, ident)
         if placed:
-            n_placed += 1
+            used.add(letter)
+        elif req.keep_without_annotations:
+            raise ValueError(
+                f"authored detail {letter!r} from {req.source} is infeasible on this sheet; "
+                "its target, scale, or whole-view footprint was not relaxed"
+            )
         elif req.kind == "prismatic-steps":
             # (#630) The prismatic-steps request is queued when detail recovery is enabled
             # (_request_prismatic_detail's gate), so a bail-out here means the requested

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -44,7 +44,7 @@ from draftwright._core import (
     _tb_width,
 )
 from draftwright._warnings import ScaleCompletenessWarning
-from draftwright.analysis import Analysis, _analyse
+from draftwright.analysis import Analysis, _analyse, _apply_principal_view_pins
 from draftwright.annotations._common import (
     SolveTrace,
     annotation_ink_obstacles,
@@ -75,16 +75,98 @@ from draftwright.model import (
     build_pmi_features,
 )
 from draftwright.projection import (
+    _bbox_within,
     _fit_iso_view,
     _project_iso,
 )
-from draftwright.view_plan import ARRANGEMENTS, resolve_from_analysis
+from draftwright.view_plan import ARRANGEMENTS, ViewConstraints, resolve_from_analysis
 
 # A view centre must move by more than this (mm) for the measure-and-repack
 # pass to re-assemble.  Below it, the estimate already matched the measured
 # footprint and pass 1 stands (the common, non-ballooned case).
 _REPACK_TOL = 0.75
 _REPACK_MAX_ITER = 3
+
+
+def _validate_authored_view_layout(dwg: Drawing, constraints) -> None:
+    """Apply the hard, non-relaxing half of ADR 0018's authored layout contract.
+
+    Current arrangements remain the planner's candidates; this validator accepts one only
+    when it satisfies every relation/pin.  A constraint that would require a candidate the
+    engine cannot yet generate is therefore an explicit infeasibility, never inert metadata.
+    """
+
+    if not isinstance(constraints, ViewConstraints):
+        return
+
+    def bounds(name: str):
+        placement = dwg.view_plan.placements.get(name)
+        if placement is not None:
+            return placement.bounds
+        if name in dwg.views:
+            return dwg.view_bounds(name)
+        raise ValueError(f"authored layout names absent view {name!r}")
+
+    for relation in constraints.relations:
+        sb = bounds(relation.subject)
+        rb = bounds(relation.reference)
+        gap = relation.gap or 0.0
+        checks = {
+            "left_of": sb[2] + gap <= rb[0] + 1e-6,
+            "right_of": sb[0] + 1e-6 >= rb[2] + gap,
+            "above": sb[1] + 1e-6 >= rb[3] + gap,
+            "below": sb[3] + gap <= rb[1] + 1e-6,
+            "align_x": abs((sb[0] + sb[2]) - (rb[0] + rb[2])) <= 1e-6,
+            "align_y": abs((sb[1] + sb[3]) - (rb[1] + rb[3])) <= 1e-6,
+        }
+        if not checks[relation.relation]:
+            where = f" at {relation.source}" if relation.source is not None else ""
+            raise ValueError(
+                f"authored view constraint{where} is infeasible: {relation.subject!r} "
+                f"must be {relation.relation} {relation.reference!r}"
+                + (f" with gap {gap:g} mm" if relation.gap is not None else "")
+            )
+
+    for pin in constraints.pins:
+        if pin.view not in dwg.views:
+            raise ValueError(f"authored view pin names absent view {pin.view!r}")
+        actual = dwg.at(pin.view, 0.0, 0.0, 0.0)
+        if max(abs(actual[i] - pin.at[i]) for i in range(2)) > 0.05:
+            where = f" at {pin.source}" if pin.source is not None else ""
+            raise ValueError(
+                f"authored whole-view pin{where} is infeasible: {pin.view!r} projection "
+                f"origin resolved to ({actual[0]:.3f}, {actual[1]:.3f}) mm, not "
+                f"({pin.at[0]:.3f}, {pin.at[1]:.3f}) mm; the pin was not moved or relaxed"
+            )
+
+
+def _settle_iso_view(dwg: Drawing, a: Analysis, *, obstacles=()):
+    """Finish the iso without relaxing an authored per-view scale."""
+
+    if a.planned_iso_scale is None:
+        return _fit_iso_view(dwg, a, obstacles=obstacles)
+
+    bb = _iso_bbox(dwg)
+    region = (
+        a.iso_left_limit,
+        a.iso_bottom_limit,
+        a.iso_right_limit,
+        a.iso_top_limit,
+    )
+    if not _bbox_within(bb, region):
+        source = None
+        constraints = a.view_constraints
+        if isinstance(constraints, ViewConstraints):
+            for item in (*constraints.principals, *constraints.added_principals):
+                if item.spec.name == "iso" and item.spec.scale_factor is not None:
+                    source = item.source
+                    break
+        where = f" at {source}" if source is not None else ""
+        raise ValueError(
+            f"authored iso scale{where} is infeasible in its composed view zone; "
+            "the requested scale was not reduced"
+        )
+    return bb
 
 
 def _cross_view_overlaps(dwg, a) -> int:
@@ -465,10 +547,9 @@ def _assemble(
     # ADR 0018: the views this drawing has, and where they go, come from ONE resolved plan
     # instead of three hardcoded calls whose cameras, page fields and layout meaning were
     # spread across this function, `Analysis` and `compose.choose_scale`'s docstring. The plan
-    # still describes exactly the third-angle front/plan/side set the engine has always built —
-    # this slice is representation, not selection — but it is now a value that a later slice can
-    # vary, and the projection convention is stated where the views are named rather than
-    # implied by three camera literals.
+    # describes the selected subset of the conventional third-angle set. The projection
+    # convention is stated where the views are named rather than implied by three camera
+    # literals.
     #
     # Cameras are attached here because they need the scaled part's centre and the projection
     # distance, which the plan deliberately knows nothing about: a `ViewSpec` is a request in
@@ -483,7 +564,11 @@ def _assemble(
         camera, up = _CAMERAS[spec.name]
         place = view_plan.placements[spec.name]
         dwg._add_view(spec.name, part_s, camera, up, (place.cx, place.cy), scaled=True)
-    _project_iso(dwg, a, a.SCALE, shape_s=part_s)
+    if a.planned_iso:
+        if a.planned_iso_scale is None:
+            _project_iso(dwg, a, a.SCALE, shape_s=part_s)
+        else:
+            _project_iso(dwg, a, a.SCALE * a.planned_iso_scale)
 
     _diagnostics = None  # the audit ledger; filled once at the end of this function (#996)
     if auto_dims:
@@ -508,42 +593,48 @@ def _assemble(
         # altogether — no growth, no NTS caption, fast tier green. It also broke script/CLI
         # parity, since the `auto_dims=False` branch below computes its obstacles before the
         # frame is added and so kept growing (#1240 review r2).
-        _nts_bb = _fit_iso_view(dwg, a, obstacles=annotation_ink_obstacles(dwg))
-        _ix0, _iy0, _, _iy1 = _iso_bbox(dwg)
-        _final_iso_x_lim = _ix0 - 4
-        a.fv_zones.right.outer_limit = min(_fv_ol, _final_iso_x_lim)
-        a.pv_zones.right.outer_limit = min(_pv_ol, _final_iso_x_lim)
-        # Only re-cap the SV right strip when the iso shares its y-range (see the
-        # matching guard in _auto_annotate); otherwise restore its full width.
-        if (a.SV_Y - a.fv_hh) < _iy1 and _iy0 < (a.SV_Y + a.fv_hh):
-            a.sv_zones.right.outer_limit = min(_sv_ol, _final_iso_x_lim)
-        else:
-            a.sv_zones.right.outer_limit = _sv_ol
-        # Mirror for the ABOVE strips (#1240): restore, then re-cap below the FINAL iso only
-        # where the fitted iso horizontally overlaps that view — the transposition of the
-        # right-strip re-cap above, for the same customer (deferred edits place through these
-        # strips after the build).
-        _ix1 = _iso_bbox(dwg)[2]
-        _iso_y_lim = _iy0 - 4
-        for _strip, _x0, _x1 in (
-            (a.pv_zones.above, a.PV_X - a.fv_hw, a.PV_X + a.fv_hw),
-            (a.sv_zones.above, a.SV_X - a.sv_hw, a.SV_X + a.sv_hw),
-        ):
-            # TIGHTEN ONLY — no restore-from-snapshot, unlike the right strips above. Their
-            # snapshot exists to give back space `_auto_annotate` took against a transient,
-            # possibly-overflowing iso; the above strips have no such pre-existing
-            # over-tightening to undo, and restoring would DISCARD the `m_locy` approach-buffer
-            # clamp (`from_model`), which is a different constraint that must survive
-            # (#1240 review F4). Same anchor guard as the initial clamp: an iso x-overlapping
-            # the view from BELOW must not push the limit beneath the anchor and kill the strip.
-            if _x0 < _ix1 and _ix0 < _x1 and _iso_y_lim > _strip.anchor:
-                _strip.outer_limit = min(_strip.outer_limit, _iso_y_lim)
+        _nts_bb = None
+        if a.planned_iso:
+            _nts_bb = _settle_iso_view(dwg, a, obstacles=annotation_ink_obstacles(dwg))
+            _ix0, _iy0, _, _iy1 = _iso_bbox(dwg)
+            _final_iso_x_lim = _ix0 - 4
+            a.fv_zones.right.outer_limit = min(_fv_ol, _final_iso_x_lim)
+            a.pv_zones.right.outer_limit = min(_pv_ol, _final_iso_x_lim)
+            # Only re-cap the SV right strip when the iso shares its y-range (see the
+            # matching guard in _auto_annotate); otherwise restore its full width.
+            if (a.SV_Y - a.fv_hh) < _iy1 and _iy0 < (a.SV_Y + a.fv_hh):
+                a.sv_zones.right.outer_limit = min(_sv_ol, _final_iso_x_lim)
+            else:
+                a.sv_zones.right.outer_limit = _sv_ol
+            # Mirror for the ABOVE strips (#1240): restore, then re-cap below the FINAL iso only
+            # where the fitted iso horizontally overlaps that view — the transposition of the
+            # right-strip re-cap above, for the same customer (deferred edits place through these
+            # strips after the build).
+            _ix1 = _iso_bbox(dwg)[2]
+            _iso_y_lim = _iy0 - 4
+            for _strip, _x0, _x1 in (
+                (a.pv_zones.above, a.PV_X - a.fv_hw, a.PV_X + a.fv_hw),
+                (a.sv_zones.above, a.SV_X - a.sv_hw, a.SV_X + a.sv_hw),
+            ):
+                # TIGHTEN ONLY — no restore-from-snapshot, unlike the right strips above. Their
+                # snapshot exists to give back space `_auto_annotate` took against a transient,
+                # possibly-overflowing iso; the above strips have no such pre-existing
+                # over-tightening to undo, and restoring would DISCARD the `m_locy` approach-buffer
+                # clamp (`from_model`), which is a different constraint that must survive
+                # (#1240 review F4). Same anchor guard as the initial clamp: an iso x-overlapping
+                # the view from BELOW must not push the limit beneath the anchor and kill the strip.
+                if _x0 < _ix1 and _ix0 < _x1 and _iso_y_lim > _strip.anchor:
+                    _strip.outer_limit = min(_strip.outer_limit, _iso_y_lim)
     else:
         # Fit + label the iso as the auto path does (annotate defaults True): the NTS
         # note is sheet furniture — like the title block below — that states the iso is
         # not to scale. Suppressing it here silently diverged the emitted-script drawing
         # (auto_dims=False) from the direct CLI, which always labels it (script↔CLI parity).
-        _nts_bb = _fit_iso_view(dwg, a, obstacles=annotation_ink_obstacles(dwg))
+        _nts_bb = (
+            _settle_iso_view(dwg, a, obstacles=annotation_ink_obstacles(dwg))
+            if a.planned_iso
+            else None
+        )
         _add_title_block(dwg, a)
         if a.frame:  # sheet border (#767) — auto path adds it via the orchestrator
             _add_sheet_frame(dwg, a)
@@ -648,7 +739,7 @@ def _repack(
 
     def _geom(cand):
         s, pw, ph, tb = cand
-        return _layout_geometry(
+        geometry = _layout_geometry(
             a.x_size,
             a.y_size,
             a.z_size,
@@ -680,7 +771,19 @@ def _repack(
             # assertion cannot be met by a constant.
             arrangement=a.arrangement,
             views=a.planned_views,
+            include_iso=a.planned_iso,
+            iso_scale_factor=a.planned_iso_scale,
         )
+        _apply_principal_view_pins(
+            geometry,
+            a.view_constraints,
+            scale=s,
+            centre=(a.cx, a.cy, a.cz),
+            page=(pw, ph),
+            margin=a.margin,
+            views=a.planned_views,
+        )
+        return geometry
 
     candidates = _repack_candidates(a, scale, page)
     auto_search = scale is None and page is None
@@ -893,6 +996,8 @@ def _build_drawing_once(
     _critique_recognition=None,
     _arrangements: tuple[str, ...] | None = None,
     _views: tuple[str, ...] | None = None,
+    _include_iso: bool = True,
+    _view_constraints=None,
     _required_tables=(),
 ) -> Drawing:
     """Build a customisable 4-view :class:`Drawing` without exporting it.
@@ -997,6 +1102,8 @@ def _build_drawing_once(
         _required_tables=_required_tables,
         _arrangements=_arrangements,
         _views=_views,
+        _include_iso=_include_iso,
+        _view_constraints=_view_constraints,
     )
 
     # Pass 1: place + annotate from the estimated layout, then measure the real
@@ -1372,6 +1479,8 @@ def build_drawing(
     _post_build: Callable[[Drawing], Drawing] | None = None,
     _required_tables=(),
     _views: tuple[str, ...] | None = None,
+    _include_iso: bool = True,
+    _view_constraints=None,
 ) -> Drawing:
     """Build a drawing, protecting required annotations under an explicit scale.
 
@@ -1415,6 +1524,8 @@ def build_drawing(
         projection=projection,
         zones=zones,
         _required_tables=_required_tables,
+        _include_iso=_include_iso,
+        _view_constraints=_view_constraints,
     )
     analysis_base = None
     critique_recognition = None
@@ -1462,7 +1573,10 @@ def build_drawing(
             _critique_recognition=critique_recognition,
             _arrangements=arrangements,
             _views=views,
+            _include_iso=_include_iso,
+            _view_constraints=_view_constraints,
         )
+        _validate_authored_view_layout(built, _view_constraints)
         return _post_build(built) if _post_build is not None else built
 
     def scale_blockers_for(built: Drawing) -> tuple[dict, ...]:

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -16,6 +16,7 @@ measure-and-repack pass (`_repack`, coupled to `_assemble`) stays in the builder
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass
 from types import SimpleNamespace
 
@@ -465,12 +466,14 @@ def _fits(
     n_steps: int = 0,
     strips: StripDepths | None = None,
     pack_iso_2d: bool = False,
-    section: bool = False,
+    section: int | bool = False,
     table_sizes=(),
     required_tables=(),
     margin: float = _MARGIN,
     arrangement: str = "columns",
     views: tuple[str, ...] | None = None,
+    include_iso: bool = True,
+    iso_scale_factor: float | None = None,
 ) -> bool:
     """True if the composed 4-view footprint fits the page at this scale.
 
@@ -496,6 +499,8 @@ def _fits(
         margin=margin,
         arrangement=arrangement,
         views=views,
+        include_iso=include_iso,
+        iso_scale_factor=iso_scale_factor,
     )
     return bool(g.fits if pack_iso_2d else g.auto_fits)
 
@@ -510,10 +515,12 @@ def _bisect_fit_scale(
     n_steps,
     strips,
     pack_iso_2d,
-    section=False,
+    section: int | bool = False,
     table_sizes=(),
     required_tables=(),
     margin=_MARGIN,
+    include_iso: bool = True,
+    iso_scale_factor: float | None = None,
 ):
     """Largest scale at which the 4-view layout fits ``(pw, ph)``, found by bisection —
     the layout is monotone in scale (a smaller scale never fits worse). Used only as the
@@ -539,6 +546,8 @@ def _bisect_fit_scale(
             table_sizes=table_sizes,
             required_tables=required_tables,
             margin=margin,
+            include_iso=include_iso,
+            iso_scale_factor=iso_scale_factor,
         ):
             lo = mid
         else:
@@ -554,12 +563,14 @@ def choose_scale(
     scale=None,
     page=None,
     strips: StripDepths | None = None,
-    section: bool = False,
+    section: int | bool = False,
     table_sizes=(),
     required_tables=(),
     margin: float = _MARGIN,
     arrangements: tuple[str, ...] | None = None,
     views: tuple[str, ...] | None = None,
+    include_iso: bool = True,
+    iso_scale_factor: float | None = None,
 ) -> tuple:
     """Return (SCALE, PAGE_W, PAGE_H, TB_W) for a 4-view layout.
 
@@ -599,6 +610,8 @@ def choose_scale(
             table_sizes=table_sizes,
             required_tables=required_tables,
             margin=margin,
+            include_iso=include_iso,
+            iso_scale_factor=iso_scale_factor,
         ):
             _log.warning(
                 "Requested scale %s on %s page may not fit the 4-view layout", scale, page
@@ -646,6 +659,8 @@ def choose_scale(
             margin=margin,
             arrangement=candidate.arrangement,
             views=views,
+            include_iso=include_iso,
+            iso_scale_factor=iso_scale_factor,
         )
 
     def _candidate(cand, arrangement):
@@ -725,6 +740,8 @@ def choose_scale(
             table_sizes=table_sizes,
             required_tables=required_tables,
             margin=margin,
+            include_iso=include_iso,
+            iso_scale_factor=iso_scale_factor,
         )
         if s is not None:
             _log.warning(
@@ -838,7 +855,7 @@ def _compose_view_blocks(
     strips: StripDepths | None,
     n_steps: int = 0,
     *,
-    section: bool = False,
+    section: int | bool = False,
 ) -> dict[str, ViewBlock]:
     """Compose estimated orthographic view footprints (#112).
 
@@ -900,13 +917,15 @@ def _layout_geometry(
     strips,
     n_steps=0,
     blocks=None,
-    section: bool = False,
+    section: int | bool = False,
     table_sizes=(),
     required_tables=(),
     warn_no_iso=True,
     margin: float = _MARGIN,
     arrangement: str = "columns",
     views: tuple[str, ...] | None = None,
+    include_iso: bool = True,
+    iso_scale_factor: float | None = None,
 ):
     """Compute the 4-view layout geometry for a part at a given scale/page.
 
@@ -999,7 +1018,10 @@ def _layout_geometry(
     total_h = 2 * margin + max(column_h, side_h)
     y_offset = max(0.0, (page_h - total_h) / 2)
 
-    section_right_band = (sv.right + 10.0 + 2 * section_hw + DIM_PAD) if section else 0.0
+    section_count = int(section)
+    section_right_band = (
+        sv.right + section_count * (10.0 + 2 * section_hw + DIM_PAD) if section_count else 0.0
+    )
     # The orthographic band: everything in the row that is NOT the isometric. Split out
     # because the ARRANGEMENT is exactly the question of where the iso goes relative to
     # it (ADR 0018 §5's fourth dimension), and both arrangements share this part.
@@ -1010,7 +1032,12 @@ def _layout_geometry(
         + (y_size * scale if has_side else 0.0)
         + max(2 * DIM_PAD, (sv.right + DIM_PAD) if has_side else 0.0, section_right_band)
     )
-    iso_row_budget = bbox_max * scale * _ISO_WIDTH_BUDGET
+    iso_exact = iso_scale_factor is not None
+    iso_factor = iso_scale_factor if iso_scale_factor is not None else 1.0
+    iso_natural = (
+        bbox_max * scale * (math.sqrt(2.0) * iso_factor if iso_exact else _ISO_WIDTH_BUDGET)
+    )
+    iso_row_budget = iso_natural if include_iso else 0.0
     # Does the orthographic band clear the title-block column vertically? Needed before the
     # arrangement choice, since it decides whether the tb width is part of the row at all.
     # (Recomputed below as `_auto_clears_tb` for the auto-fit verdict; same expression.)
@@ -1120,7 +1147,8 @@ def _layout_geometry(
             *([_padded_box(SV_X, SV_Y, sv_hw, fv_hh)] if has_side else []),
             title_block.footprint(tb_cx, tb_cy),
         ]
-    if section:
+    section_blocks = []
+    if section_count:
         section_block = ViewBlock(
             section_hw,
             section_hh,
@@ -1129,7 +1157,10 @@ def _layout_geometry(
             bottom=DIM_PAD + _FONT_SIZE + 4.0,
             left=DIM_PAD,
         )
-        obstacles.append(section_block.footprint(SECTION_X, SECTION_Y))
+        for index in range(section_count):
+            section_x = SECTION_X + index * (2 * section_hw + DIM_PAD)
+            section_blocks.append(section_block.footprint(section_x, SECTION_Y))
+        obstacles.extend(section_blocks)
     # Authored Sheet tables are required fixed-size furniture, not alternative fallback shapes.
     # Place their estimated footprints before allocating the iso so page selection can grow the
     # sheet while preserving the requested scale (#1146). Each placement becomes an obstacle for
@@ -1168,8 +1199,7 @@ def _layout_geometry(
         *([pv.footprint(PV_X, PV_Y)] if has_plan else []),
         *([sv.footprint(SV_X, SV_Y)] if has_side else []),
     ]
-    if section:
-        _view_boxes.append(section_block.footprint(SECTION_X, SECTION_Y))
+    _view_boxes.extend(section_blocks)
     cx0 = min(b[0] for b in _view_boxes)
     cy0 = min(b[1] for b in _view_boxes)
     cx1 = max(b[2] for b in _view_boxes)
@@ -1182,7 +1212,8 @@ def _layout_geometry(
     _auto_row_w = total_content_w + 2 * margin + (0.0 if _auto_clears_tb else tb_w)
     auto_row_fits = _auto_row_w <= page_w + _tol
     iso_fit = min(iso_right - iso_left, iso_top - iso_bottom)
-    iso_fits = iso_valid and iso_fit >= _ISO_MIN_FIT_FRAC * bbox_max * scale * _ISO_WIDTH_BUDGET
+    iso_min_fit = iso_natural if iso_exact else _ISO_MIN_FIT_FRAC * iso_natural
+    iso_fits = (not include_iso) or (iso_valid and iso_fit >= iso_min_fit)
     # Tables are late furniture and must reserve against the same composed view
     # footprints the fit model validates, not the iso's byte-identity padded-box
     # obstacles. Otherwise a table can be accepted in space already reserved for
@@ -1193,9 +1224,8 @@ def _layout_geometry(
         *([sv.footprint(SV_X, SV_Y)] if has_side else []),
         title_block.footprint(tb_cx, tb_cy),
     ]
-    if section:
-        table_obstacles.append(section_block.footprint(SECTION_X, SECTION_Y))
-    if iso_valid:
+    table_obstacles.extend(section_blocks)
+    if include_iso and iso_valid:
         table_obstacles.append((iso_left, iso_bottom, iso_right, iso_top))
     table_obstacles.extend(required_table_boxes)
     table_fits = not table_sizes or any(
@@ -1245,7 +1275,7 @@ def _layout_geometry(
         iso_fit=iso_fit,
         iso_fits=iso_fits,
         table_fits=table_fits,
-        iso_natural=bbox_max * scale * _ISO_WIDTH_BUDGET,
+        iso_natural=iso_natural,
         auto_views_bottom=_auto_views_bottom,
         auto_clears_tb=_auto_clears_tb,
         auto_row_fits=auto_row_fits,

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -2664,17 +2664,19 @@ class Drawing:
                 from draftwright.projection import _fit_iso_view, _project_iso
 
                 # Mirror the auto pass's iso ordering (#661): there, details resolve
-                # while the iso still stands at sheet scale (it is fitted into its
+                # while the ordinary iso still stands at sheet scale (it is fitted into its
                 # zone only after _auto_annotate returns), so the free-rectangle
                 # search is not blocked by the grown iso. The finalize path inherits
                 # the already-fitted iso from the build — re-project it at sheet
-                # scale for the resolve, then refit it into its zone (deterministic:
+                # scale for the resolve, then refit it into its zone. An authored iso
+                # scale is hard, so it is reprojected and retained at that exact factor.
+                # The ordinary refit is deterministic:
                 # same zone + geometry reproduce the build's fit; the #647 snapshot
                 # covers views/_coords, so a raise mid-stage rolls the iso back too).
                 if "iso" in self.views:
-                    _project_iso(self, a, a.SCALE)
+                    _project_iso(self, a, a.SCALE * (a.planned_iso_scale or 1.0))
                 _resolve_details(self, a, ctx=ctx)
-                if "iso" in self.views:
+                if "iso" in self.views and a.planned_iso_scale is None:
                     # Obstacles as on the build path (#1240) — inert today, since a details
                     # refit disables the grow branch, but the call must not drift from the
                     # builder's shape or the next grow-path change silently loses the cap.

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -1315,6 +1315,8 @@ class SectionPlan:
     infrastructure that consumes this (ADR 0008 Amendment 4 / #207)."""
 
     cut_y: float
+    label: str = "A"
+    source: object | None = None
 
 
 def plan_sections(model: PartModel, feature_keys: set[HoleRef]) -> SectionPlan | None:
@@ -1334,6 +1336,8 @@ def plan_sections(model: PartModel, feature_keys: set[HoleRef]) -> SectionPlan |
     requested = model.decorations.get("section")
     if requested is not None:
         return SectionPlan(cut_y=float(requested))
+    if model.decorations.get("auto_sections") is False:
+        return None
     qual_ys: list[float] = []
     for f in model.features:
         if not isinstance(f, HoleFeature | PatternFeature) or f.frame.axis != "z":

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -50,11 +50,12 @@ feature itself) so you can ``.fit(...)`` / ``.tolerance(...)`` it without re-dec
 
 from __future__ import annotations
 
+import inspect
 import math
 import warnings
 from collections.abc import MutableSequence
 from dataclasses import replace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from draftwright._geometry import _solids_body
 from draftwright._warnings import SoftDeprecationWarning
@@ -101,6 +102,15 @@ from draftwright.model.declare import read_countersink as _read_countersink
 from draftwright.model.ir import RequestedDimension, ToleranceDecoration
 from draftwright.model.planner import LOCATION_ROLE as _LOCATION_ROLE
 from draftwright.model.planner import location_role as _location_role
+from draftwright.view_plan import (
+    ConstraintSource,
+    ViewConstraint,
+    ViewConstraints,
+    ViewPin,
+    ViewPlanIncomplete,
+    ViewRelation,
+    ViewSpec,
+)
 
 #: "Not supplied" for `Sheet.dimension`'s positional parameters. They cannot simply be
 #: required: a keyword-only legacy call has to reach the removal message rather than die on
@@ -737,6 +747,108 @@ class _Control:
         return self._add("total_runout", tol, to=to, modifier=modifier)
 
 
+def _constraint_source() -> ConstraintSource:
+    """Return the first caller frame outside this façade module."""
+
+    frame = inspect.currentframe()
+    try:
+        caller = frame.f_back if frame is not None else None
+        while caller is not None and caller.f_code.co_filename == __file__:
+            caller = caller.f_back
+        if caller is None:
+            return ConstraintSource("<unknown>", 0)
+        return ConstraintSource(caller.f_code.co_filename, caller.f_lineno)
+    finally:
+        del frame
+
+
+class _View:
+    """A fluent handle for one semantic whole-view constraint.
+
+    Its layout verbs relate or pin the complete view block.  They never address a feature
+    annotation, so ADR 0014 remains the sole owner of dimension/callout/GD&T coordinates.
+    """
+
+    def __init__(self, sheet: Sheet, bucket: str, index: int) -> None:
+        self._sheet = sheet
+        self._bucket = bucket
+        self._index = index
+
+    @property
+    def _record(self) -> dict:
+        return cast(dict, getattr(self._sheet, self._bucket)[self._index])
+
+    @property
+    def name(self) -> str:
+        return cast(str, self._record["name"])
+
+    def _relation(self, relation: str, other, gap=None) -> _View:
+        other_name = other.name if isinstance(other, _View) else str(other)
+        self._sheet._view_relations.append(
+            ViewRelation(
+                self.name,
+                relation,
+                other_name,
+                None if gap is None else float(gap),
+                _constraint_source(),
+            )
+        )
+        return self
+
+    def left_of(self, other, *, gap=None) -> _View:
+        """Keep this whole view block left of *other*."""
+        return self._relation("left_of", other, gap)
+
+    def right_of(self, other, *, gap=None) -> _View:
+        """Keep this whole view block right of *other*."""
+        return self._relation("right_of", other, gap)
+
+    def above(self, other, *, gap=None) -> _View:
+        """Keep this whole view block above *other*."""
+        return self._relation("above", other, gap)
+
+    def below(self, other, *, gap=None) -> _View:
+        """Keep this whole view block below *other*."""
+        return self._relation("below", other, gap)
+
+    def align_x(self, other) -> _View:
+        """Align this view's projection origin horizontally with *other*."""
+        return self._relation("align_x", other)
+
+    def align_y(self, other) -> _View:
+        """Align this view's projection origin vertically with *other*."""
+        return self._relation("align_y", other)
+
+    def pin(self, at) -> _View:
+        """Pin a principal view's projection origin at ``(x, y)`` page millimetres."""
+        if self._record["kind"] != "principal":
+            raise ValueError(
+                "projection-origin pins currently support principal front/plan/side views only; "
+                f"cannot pin {self.name!r}"
+            )
+        values = tuple(float(value) for value in at)
+        if len(values) != 2:
+            raise ValueError(f"view pin needs two page coordinates, got {at!r}")
+        point = (values[0], values[1])
+        self._sheet._view_pins = [pin for pin in self._sheet._view_pins if pin.view != self.name]
+        self._sheet._view_pins.append(ViewPin(self.name, point, _constraint_source()))
+        return self
+
+    def scale(self, factor) -> _View:
+        """Set an independent detail/orientation scale; principal views reject it."""
+        record = self._record
+        if record["kind"] == "principal":
+            raise ValueError(
+                f"principal view {self.name!r} cannot have an independent scale; "
+                "front/plan/side share the drawing scale"
+            )
+        factor = float(factor)
+        if not math.isfinite(factor) or factor <= 0:
+            raise ValueError(f"view scale factor must be finite and positive, got {factor!r}")
+        record["scale_factor"] = factor
+        return self
+
+
 class Sheet:
     """Reference features, declare their drawing aspects, export.
 
@@ -813,6 +925,19 @@ class Sheet:
         # assignments — which is how the first cut of this broke the identity suite (#921
         # review round 7). Only ``"explicit"`` conflicts with an authored set.
         self._auto_dimensions: str | None = None
+        # ADR 0018 authored view input.  These mutable declaration records are private
+        # construction state; :attr:`view_constraints` exposes a fresh immutable snapshot so
+        # request state cannot be confused with or edited like a ResolvedViewPlan.
+        self._principal_view_source: str | None = None
+        self._derived_view_source: str | None = None
+        self._principal_view_source_at: ConstraintSource | None = None
+        self._derived_view_source_at: ConstraintSource | None = None
+        self._principal_views: list[dict] = []
+        self._added_principal_views: list[dict] = []
+        self._derived_views: list[dict] = []
+        self._added_derived_views: list[dict] = []
+        self._view_relations: list[ViewRelation] = []
+        self._view_pins: list[ViewPin] = []
         # A requested section A–A (#841): ``None`` = no request, else a resolver tuple
         # (``kind``, ``payload``) materialized to a cut-plane Y in ``_decorations`` — ``at``
         # a literal Y, ``feature`` a declared-feature index, ``auto`` the part-centre Y.
@@ -1330,6 +1455,210 @@ class Sheet:
         self._append_gdt(_declare_note(text, target, self._part, view=view, side=side), src)
         return self
 
+    # -- view declaration (ADR 0018) ---------------------------------------
+
+    @staticmethod
+    def _principal_view_name(name) -> tuple[str, str]:
+        name = str(name).strip().lower()
+        kinds = {
+            "front": "principal",
+            "plan": "principal",
+            "side": "principal",
+            "iso": "pictorial",
+        }
+        if name not in kinds:
+            raise ValueError(
+                f"unknown view {name!r}; expected one of {tuple(kinds)}. "
+                "Use section_view()/detail_view() for derived views."
+            )
+        return name, kinds[name]
+
+    @staticmethod
+    def _derived_view_name(kind: str, label) -> str:
+        label = str(label).strip()
+        if len(label) != 1 or not label.isalnum():
+            raise ValueError(f"{kind}_view() needs one alphanumeric drawing label, got {label!r}")
+        slug = label.lower()
+        return f"section_{slug}{slug}" if kind == "section" else f"detail_{slug}"
+
+    def _all_view_names(self) -> set[str]:
+        return {
+            record["name"]
+            for bucket in (
+                self._principal_views,
+                self._added_principal_views,
+                self._derived_views,
+                self._added_derived_views,
+            )
+            for record in bucket
+        }
+
+    def _append_view_record(
+        self, bucket: str, *, name: str, kind: str, target=None, source: ConstraintSource
+    ) -> _View:
+        if name in self._all_view_names():
+            raise ValueError(f"view {name!r} is declared more than once")
+        records = getattr(self, bucket)
+        records.append(
+            {
+                "name": name,
+                "kind": kind,
+                "target": target,
+                "scale_factor": None,
+                "source": source,
+            }
+        )
+        return _View(self, bucket, len(records) - 1)
+
+    def _reject_authored_view_auto_dimensions(self, verb: str) -> None:
+        if self._auto_dimensions is not None:
+            raise ValueError(
+                f"{verb} authors the view set, but this sheet already called "
+                "auto_dimensions(). ADR 0018 makes requirements determine views, not the "
+                "reverse: use authored_dimensions() with explicit dimension(...) lines, or "
+                "keep auto_views() and use add_view()/add_section_view()/add_detail_view()."
+            )
+
+    def authored_views(self) -> Sheet:
+        """Declare that subsequent :meth:`view` lines are the complete principal set.
+
+        Calling this with no ``view(...)`` lines makes the empty authored set explicit.  It
+        remains a request even when a later build finds that no projectable drawing can satisfy
+        it; absence of the verb retains the behaviourally-compatible automatic default.
+        """
+        self._reject_authored_view_auto_dimensions("authored_views()")
+        if self._principal_view_source == "automatic":
+            raise ValueError(
+                "a sheet has one principal-view source: authored_views()/view(...) or "
+                "auto_views()/add_view(), not both"
+            )
+        self._principal_view_source = "authored"
+        self._principal_view_source_at = self._principal_view_source_at or _constraint_source()
+        return self
+
+    def auto_views(self) -> Sheet:
+        """Select automatic principal and derived views, optionally augmented by add verbs."""
+        if self._principal_view_source == "authored" or self._derived_view_source == "authored":
+            raise ValueError(
+                "auto_views() cannot be combined with an authored principal or derived view "
+                "set; use add_view()/add_section_view()/add_detail_view() to augment automatic views"
+            )
+        warnings.warn(
+            "Sheet.auto_views() is soft deprecated: still supported and NOT scheduled for "
+            "removal, but authored_views() plus view(...) lines is the editable surface.",
+            SoftDeprecationWarning,
+            stacklevel=2,
+        )
+        self._principal_view_source = "automatic"
+        self._derived_view_source = "automatic"
+        source = _constraint_source()
+        self._principal_view_source_at = self._principal_view_source_at or source
+        self._derived_view_source_at = self._derived_view_source_at or source
+        return self
+
+    def view(self, name) -> _View:
+        """Add one view to the complete authored principal/orientation set."""
+        self._reject_authored_view_auto_dimensions("view()")
+        if self._principal_view_source == "automatic":
+            raise ValueError(
+                "view() defines the complete authored set and cannot follow auto_views(); "
+                "use add_view() to augment the automatic set"
+            )
+        self._principal_view_source = "authored"
+        self._principal_view_source_at = self._principal_view_source_at or _constraint_source()
+        name, kind = self._principal_view_name(name)
+        return self._append_view_record(
+            "_principal_views", name=name, kind=kind, source=_constraint_source()
+        )
+
+    def add_view(self, name) -> _View:
+        """Require one additional principal/orientation view in an automatic set."""
+        if self._principal_view_source == "authored":
+            raise ValueError("add_view() augments auto_views(); use view() inside an authored set")
+        name, kind = self._principal_view_name(name)
+        return self._append_view_record(
+            "_added_principal_views", name=name, kind=kind, source=_constraint_source()
+        )
+
+    def _derived_target(self, verb: str, *, feature=None, at=None):
+        if (feature is None) == (at is None):
+            raise ValueError(f"{verb} needs exactly one of its feature target or at=")
+        if at is not None:
+            value = float(at)
+            if not math.isfinite(value):
+                raise ValueError(f"{verb}(at=…) needs a finite Y, got {at!r}")
+            return ("at", value)
+        _target, token = self._gdt_ref(feature)
+        if token is None:
+            raise ValueError(
+                f"{verb} needs a declared feature handle/index/Feature; use at= for a bare cut"
+            )
+        return ("feature", token)
+
+    def section_view(self, label, through=None, *, at=None) -> _View:
+        """Author a named section view through a declared feature or explicit Y cut plane."""
+        self._reject_authored_view_auto_dimensions("section_view()")
+        if self._derived_view_source == "automatic":
+            raise ValueError(
+                "section_view() defines the authored derived set and cannot follow auto_views(); "
+                "use add_section_view() to augment automatic derived views"
+            )
+        self._derived_view_source = "authored"
+        self._derived_view_source_at = self._derived_view_source_at or _constraint_source()
+        return self._append_view_record(
+            "_derived_views",
+            name=self._derived_view_name("section", label),
+            kind="section",
+            target=self._derived_target("section_view()", feature=through, at=at),
+            source=_constraint_source(),
+        )
+
+    def add_section_view(self, label, through=None, *, at=None) -> _View:
+        """Augment automatic derived views with one named section."""
+        if self._derived_view_source == "authored":
+            raise ValueError(
+                "add_section_view() augments auto_views(); use section_view() in an authored set"
+            )
+        return self._append_view_record(
+            "_added_derived_views",
+            name=self._derived_view_name("section", label),
+            kind="section",
+            target=self._derived_target("add_section_view()", feature=through, at=at),
+            source=_constraint_source(),
+        )
+
+    def detail_view(self, label, around) -> _View:
+        """Author a named detail view around a declared feature."""
+        self._reject_authored_view_auto_dimensions("detail_view()")
+        if self._derived_view_source == "automatic":
+            raise ValueError(
+                "detail_view() defines the authored derived set and cannot follow auto_views(); "
+                "use add_detail_view() to augment automatic derived views"
+            )
+        self._derived_view_source = "authored"
+        self._derived_view_source_at = self._derived_view_source_at or _constraint_source()
+        return self._append_view_record(
+            "_derived_views",
+            name=self._derived_view_name("detail", label),
+            kind="detail",
+            target=self._derived_target("detail_view()", feature=around, at=None),
+            source=_constraint_source(),
+        )
+
+    def add_detail_view(self, label, around) -> _View:
+        """Augment automatic derived views with one named detail around a declared feature."""
+        if self._derived_view_source == "authored":
+            raise ValueError(
+                "add_detail_view() augments auto_views(); use detail_view() in an authored set"
+            )
+        return self._append_view_record(
+            "_added_derived_views",
+            name=self._derived_view_name("detail", label),
+            kind="detail",
+            target=self._derived_target("add_detail_view()", feature=around, at=None),
+            source=_constraint_source(),
+        )
+
     def section(self, feature=None, *, at=None) -> Sheet:
         """Request a full **section A–A** (#841) — the part-level verb behind the auto section.
 
@@ -1342,6 +1671,12 @@ class Sheet:
         pocket"); ``at=<y>`` cuts at an explicit Y; bare ``section()`` cuts through the
         part centre. The section renders last (its room check clears the right-of-side-view
         band), so declare it after the per-feature verbs. Chainable."""
+        warnings.warn(
+            "Sheet.section() is deprecated; use add_section_view('A', through=...) or "
+            "add_section_view('A', at=...). Removal target 0.6.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if at is not None:
             if not math.isfinite(at):
                 raise ValueError(f"section(at=…) needs a finite Y, got {at!r}")
@@ -1366,6 +1701,12 @@ class Sheet:
         choice explicitly. Adds a magnified crop of the step-height region when warranted
         (a no-op otherwise). Chainable. Not feature-targeted — for a blind pocket's
         floor/depth prefer :meth:`section`."""
+        warnings.warn(
+            "Sheet.detail() is deprecated; use add_detail_view('A', around=feature). "
+            "Removal target 0.6.0.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._opts["detail_view"] = True
         return self
 
@@ -1506,6 +1847,115 @@ class Sheet:
 
     # -- inspection / output --------------------------------------------------
 
+    def _materialized_view_constraint(self, record: dict) -> ViewConstraint:
+        target = record["target"]
+        if target is not None and target[0] == "feature":
+            target = ("feature", self._features[self._index_of_token(target[1])])
+        return ViewConstraint(
+            ViewSpec(
+                name=record["name"],
+                kind=record["kind"],
+                target=target,
+                scale_factor=record["scale_factor"],
+            ),
+            record["source"],
+        )
+
+    @property
+    def view_constraints(self) -> ViewConstraints:
+        """The immutable pre-projection view request authored on this sheet."""
+
+        materialize = self._materialized_view_constraint
+        return ViewConstraints(
+            principal_source=self._principal_view_source,
+            principal_source_location=self._principal_view_source_at,
+            principals=tuple(map(materialize, self._principal_views)),
+            added_principals=tuple(map(materialize, self._added_principal_views)),
+            derived_source=self._derived_view_source,
+            derived_source_location=self._derived_view_source_at,
+            derived=tuple(map(materialize, self._derived_views)),
+            added_derived=tuple(map(materialize, self._added_derived_views)),
+            relations=tuple(self._view_relations),
+            pins=tuple(self._view_pins),
+        )
+
+    def row(self, *views, gap=None) -> Sheet:
+        """Constrain complete view blocks into a left-to-right row."""
+        names = [view.name if isinstance(view, _View) else str(view) for view in views]
+        if len(names) < 2:
+            raise ValueError("row() needs at least two views")
+        source = _constraint_source()
+        for left, right in zip(names, names[1:]):
+            self._view_relations.append(
+                ViewRelation(right, "right_of", left, None if gap is None else float(gap), source)
+            )
+        return self
+
+    def column(self, *views, gap=None) -> Sheet:
+        """Constrain complete view blocks into a bottom-to-top column."""
+        names = [view.name if isinstance(view, _View) else str(view) for view in views]
+        if len(names) < 2:
+            raise ValueError("column() needs at least two views")
+        source = _constraint_source()
+        for below, above in zip(names, names[1:]):
+            self._view_relations.append(
+                ViewRelation(above, "above", below, None if gap is None else float(gap), source)
+            )
+        return self
+
+    def _view_build_request(self) -> tuple[tuple[str, ...] | None, bool]:
+        """Validate source coherence and lower the principal request to the engine seam."""
+
+        if self._added_principal_views and self._principal_view_source != "automatic":
+            source = self._added_principal_views[0]["source"]
+            raise ValueError(
+                f"add_view() at {source} augments the automatic set; call auto_views() first"
+            )
+        if self._added_derived_views and self._derived_view_source != "automatic":
+            source = self._added_derived_views[0]["source"]
+            raise ValueError(
+                f"add_section_view()/add_detail_view() at {source} augment automatic derived "
+                "views; call auto_views() first"
+            )
+        if self._principal_view_source != "authored":
+            return None, True
+        names = tuple(record["name"] for record in self._principal_views)
+        principals = tuple(name for name in names if name in {"front", "plan", "side"})
+        if not principals:
+            source = (
+                self._principal_views[0]["source"]
+                if self._principal_views
+                else self._principal_view_source_at or "the authored_views() declaration"
+            )
+            raise ValueError(
+                f"the authored view set from {source} has no principal orthographic view; "
+                "add view('front'), view('plan'), or view('side')"
+            )
+        return principals, "iso" in names
+
+    def _view_source_description(self) -> str:
+        sources = [record["source"] for record in self._principal_views]
+        if not sources:
+            return f"authored at {self._principal_view_source_at}"
+        return "authored at " + ", ".join(str(source) for source in sources)
+
+    def _derived_build_request(self) -> tuple[tuple | None, bool]:
+        """Validate derived targets and return legacy decoration/detail compatibility state."""
+
+        records = [*self._derived_views, *self._added_derived_views]
+        sections = [record for record in records if record["kind"] == "section"]
+        if self._section is not None and records:
+            raise ValueError(
+                "deprecated section() cannot be combined with section_view()/detail_view() "
+                "constraints; migrate the legacy call to add_section_view()"
+            )
+        for record in sections:
+            target = record["target"]
+            if target[0] == "at":
+                self._section_cut_y(target)
+        detail_auto = self._derived_view_source != "authored"
+        return None, detail_auto
+
     @property
     def features(self) -> MutableSequence:
         """The declared IR features — mutable: override, drop or reorder before
@@ -1549,6 +1999,13 @@ class Sheet:
         ``build_drawing(part)``'s automatic path is unaffected and carries no warning — that
         is the detected front door, and being automatic is its whole point.
         """
+        if self._principal_view_source == "authored" or self._derived_view_source == "authored":
+            raise ValueError(
+                "auto_dimensions() cannot be combined with authored views. ADR 0018 makes "
+                "requirements determine views, not views determine requirements: use "
+                "authored_dimensions() with explicit dimension(...) lines, or keep "
+                "auto_views() and augment it with add_view()/add_section_view()/add_detail_view()."
+            )
         warnings.warn(
             "Sheet.auto_dimensions() is soft deprecated: still supported and NOT scheduled "
             "for removal, but authored dimensions are the going-forward surface. Prefer "
@@ -1839,7 +2296,7 @@ class Sheet:
             for e in self._authored
         )
 
-    def _decorations(self) -> dict:
+    def _decorations(self, section_request=_UNSET, *, suppress_auto_sections=False) -> dict:
         """Materialize the token-keyed ± tolerances against the FINAL features (a handle may
         have been recorded before a later .depth()/… replaced the feature) → the
         ``(feature, kind)`` (or role-keyed ``(feature, kind, role)``, #746) decoration map
@@ -1851,12 +2308,16 @@ class Sheet:
         }
         if self._section is not None:
             deco["section"] = self._section_cut_y()  # the #841 cut-plane Y (scalar key)
+        if section_request is not _UNSET and section_request is not None:
+            deco["section"] = self._section_cut_y(section_request)
+        if suppress_auto_sections and "section" not in deco:
+            deco["auto_sections"] = False
         return deco
 
-    def _section_cut_y(self) -> float:
+    def _section_cut_y(self, request=None) -> float:
         """Resolve the requested :meth:`section` to a cut-plane Y (materialized at build so a
         handle recorded before a later size verb resolves against the FINAL feature)."""
-        kind, payload = self._section  # type: ignore[misc]  # guarded by the caller
+        kind, payload = self._section if request is None else request  # type: ignore[misc]
         if kind == "feature":
             return float(self._features[self._index_of_token(payload)].frame.origin[1])
         if kind == "auto":
@@ -1906,6 +2367,9 @@ class Sheet:
         # order-independent: declaring the augment before the source must read the same
         # as declaring it after.
         self._check_dimension_source()
+        principal_views, include_iso = self._view_build_request()
+        section_request, automatic_details = self._derived_build_request()
+        constraints = self.view_constraints
         required_tables = tuple(
             (size, table["prefer"])
             for table in self._tables
@@ -1943,16 +2407,34 @@ class Sheet:
                     used.add(name)
             return dwg
 
-        return build_drawing(
-            self._part,
-            model=self._features,
-            decorations=self._decorations(),
-            requested=self._requested_dimensions(),
-            authored=self._authored_set(),
-            _post_build=place_declared_tables,
-            _required_tables=required_tables,
-            **self._opts,
-        )
+        opts = dict(self._opts)
+        if not automatic_details:
+            opts["detail_view"] = False
+        try:
+            return build_drawing(
+                self._part,
+                model=self._features,
+                decorations=self._decorations(
+                    section_request,
+                    suppress_auto_sections=self._derived_view_source == "authored",
+                ),
+                requested=self._requested_dimensions(),
+                authored=self._authored_set(),
+                _post_build=place_declared_tables,
+                _required_tables=required_tables,
+                _views=principal_views,
+                _include_iso=include_iso,
+                _view_constraints=constraints,
+                **opts,
+            )
+        except ViewPlanIncomplete as exc:
+            if self._principal_view_source != "authored":
+                raise
+            raise ViewPlanIncomplete(
+                exc.planned,
+                exc.uncovered,
+                source=self._view_source_description(),
+            ) from None
 
     def export(self, stem=None, *, formats=("pdf",), dpi=150):
         """Build the drawing and write the requested *formats* — a format name or an

--- a/src/draftwright/view_plan.py
+++ b/src/draftwright/view_plan.py
@@ -1,4 +1,4 @@
-"""The views a drawing has, and where they sit — ADR 0018's representation slice.
+"""The views a drawing requests and resolves — ADR 0018's planning value vocabulary.
 
 Until now nothing owned the question *which views should exist*. The four orthographic views
 were named at one site in `builder` with hardcoded cameras, their page positions came from
@@ -14,20 +14,18 @@ vocabulary, distinct request and result states"), and it is a split rather than 
 object because a resolved plan that can be edited in place is indistinguishable from a request,
 which is how a layout comes to be silently relaxed.
 
-**This slice changes no behaviour.** It describes the fixed front/plan/side/iso topology the
-engine already builds, and the golden placement snapshots are the gate. Semantic view SELECTION
-— dropping a view because nothing needs it, which is what the thin rotational plate in
-`tests/test_issue_1130_view_planning_evidence.py` is waiting for — comes only once the
-lifecycle, projection-convention and requirement-coverage invariants in ADR 0018's evidence list
-are guarded. A representation nobody can yet vary is the point of the first slice: everything
-above it stops reading the topology out of scattered fields, so the later change has one place
-to happen.
+`ViewConstraints` is the immutable authored request and `ResolvedViewPlan` the immutable result.
+The Sheet surface can vary and constrain the selected views; automatic semantic view selection
+— dropping a view because nothing needs it — remains a later planning slice. Keeping those two
+states distinct prevents a resolved snapshot from being edited in place and mistaken for a
+constraint the planner must honour.
 
 Rank 0: this is a leaf. It describes views; it cannot reach the code that draws them.
 """
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping
 from dataclasses import dataclass
 from types import MappingProxyType
@@ -96,9 +94,10 @@ _PRINCIPAL_PAGE_AXES = {
 class ViewSpec:
     """One view a drawing should contain, in model terms.
 
-    Deliberately says nothing about the page: no position, no size, no scale. A spec is what a
-    planner decides and a user may edit; where it lands is the resolver's answer, and mixing the
-    two is what ADR 0018 §1 separates. `camera` and `up` are the projection request as
+    Deliberately says nothing about page position or size. A spec is what a planner decides and a
+    user may edit; where it lands is the resolver's answer, and mixing the two is what ADR 0018
+    §1 separates. Detail and pictorial specs may request an independent semantic scale factor;
+    principal views instead share the drawing scale. `camera` and `up` are the projection request as
     `Drawing._add_view` already expresses it — a direction from the part and an up vector —
     while `page_axes` states which model extents the view's block spans, which is the fact
     layout arithmetic needs and cameras only imply.
@@ -114,13 +113,135 @@ class ViewSpec:
     camera: tuple[float, float, float] | None = None
     up: tuple[float, float, float] | None = None
     page_axes: tuple[str, str] | None = None
+    #: Semantic feature/cut target for a derived view. Opaque here so this leaf does not
+    #: depend on the model IR; Sheet materialises its stable feature token before building.
+    target: Any = None
+    #: Independent scale factor for a detail or orientation view. Principal views share the
+    #: sheet scale and therefore reject this field.
+    scale_factor: float | None = None
 
     def __post_init__(self) -> None:
         if self.kind not in _KINDS:
             raise ValueError(f"unknown view kind {self.kind!r}; expected one of {sorted(_KINDS)}")
+        if self.scale_factor is not None:
+            if self.kind not in {"detail", "pictorial"}:
+                raise ValueError(
+                    "independent scale is only valid for detail or pictorial views; "
+                    "principal orthographic views share the drawing scale"
+                )
+            if not math.isfinite(self.scale_factor) or self.scale_factor <= 0:
+                raise ValueError(
+                    f"view scale factor must be finite and positive, got {self.scale_factor!r}"
+                )
 
 
 _KINDS = frozenset({"principal", "pictorial", "section", "detail"})
+
+
+@dataclass(frozen=True)
+class ConstraintSource:
+    """The user-code line that authored one pre-projection constraint."""
+
+    filename: str
+    lineno: int
+
+    def __str__(self) -> str:
+        return f"{self.filename}:{self.lineno}"
+
+
+@dataclass(frozen=True)
+class ViewConstraint:
+    """One requested view plus the line that requested it.
+
+    ``target`` is deliberately opaque at this rank.  A section/detail may target a Sheet
+    feature identity, but the view-planning leaf must not import the feature IR merely to
+    retain that semantic reference.
+    """
+
+    spec: ViewSpec
+    source: ConstraintSource | None = None
+
+
+_RELATIONS = frozenset({"left_of", "right_of", "above", "below", "align_x", "align_y"})
+
+
+@dataclass(frozen=True)
+class ViewRelation:
+    """A relational constraint between two complete view blocks."""
+
+    subject: str
+    relation: str
+    reference: str
+    gap: float | None = None
+    source: ConstraintSource | None = None
+
+    def __post_init__(self) -> None:
+        if self.relation not in _RELATIONS:
+            raise ValueError(
+                f"unknown view relation {self.relation!r}; expected one of {sorted(_RELATIONS)}"
+            )
+        if self.subject == self.reference:
+            raise ValueError("a view cannot be positioned relative to itself")
+        if self.gap is not None and (not math.isfinite(self.gap) or self.gap < 0):
+            raise ValueError(
+                f"view relation gap must be finite and non-negative, got {self.gap!r}"
+            )
+
+
+@dataclass(frozen=True)
+class ViewPin:
+    """An authored projection-origin pin for a whole view block, in page mm."""
+
+    view: str
+    at: tuple[float, float]
+    source: ConstraintSource | None = None
+
+    def __post_init__(self) -> None:
+        if len(self.at) != 2 or not all(math.isfinite(value) for value in self.at):
+            raise ValueError(f"view pin needs two finite page coordinates, got {self.at!r}")
+
+
+@dataclass(frozen=True)
+class ViewConstraints:
+    """Immutable authored input to view planning (ADR 0018).
+
+    This is intentionally not a partly-resolved :class:`ResolvedViewPlan`.  It records the
+    two independent source choices from Amendment 1 (principal/orientation views and derived
+    views), automatic augmentations, whole-block relations, and projection-origin pins.  A
+    ``None`` source means the legacy-compatible automatic default was not explicitly authored.
+    """
+
+    principal_source: str | None = None
+    principal_source_location: ConstraintSource | None = None
+    principals: tuple[ViewConstraint, ...] = ()
+    added_principals: tuple[ViewConstraint, ...] = ()
+    derived_source: str | None = None
+    derived_source_location: ConstraintSource | None = None
+    derived: tuple[ViewConstraint, ...] = ()
+    added_derived: tuple[ViewConstraint, ...] = ()
+    relations: tuple[ViewRelation, ...] = ()
+    pins: tuple[ViewPin, ...] = ()
+
+    def __post_init__(self) -> None:
+        for field_name in ("principal_source", "derived_source"):
+            value = getattr(self, field_name)
+            if value not in (None, "automatic", "authored"):
+                raise ValueError(f"{field_name} must be None, 'automatic', or 'authored'")
+
+    @property
+    def is_empty(self) -> bool:
+        return not any(
+            (
+                self.principal_source,
+                self.principals,
+                self.added_principals,
+                self.derived_source,
+                self.derived,
+                self.added_derived,
+                self.relations,
+                self.pins,
+            )
+        )
 
 
 @dataclass(frozen=True)
@@ -232,7 +353,36 @@ def resolve_from_analysis(analysis) -> ResolvedViewPlan:
     wanted = getattr(analysis, "planned_views", None)
     if wanted is not None:
         principals = tuple(spec for spec in principals if spec.name in set(wanted))
-    specs = principals + (ViewSpec(name="iso", kind="pictorial"),)
+        placements = {name: place for name, place in placements.items() if name in set(wanted)}
+    constraints = getattr(analysis, "view_constraints", None)
+    requested_by_name = {}
+    if isinstance(constraints, ViewConstraints):
+        requested_by_name = {
+            item.spec.name: item.spec
+            for item in (*constraints.principals, *constraints.added_principals)
+        }
+        principals = tuple(
+            ViewSpec(
+                name=spec.name,
+                kind=spec.kind,
+                camera=spec.camera,
+                up=spec.up,
+                page_axes=spec.page_axes,
+                target=requested_by_name.get(spec.name, spec).target,
+                scale_factor=requested_by_name.get(spec.name, spec).scale_factor,
+            )
+            for spec in principals
+        )
+    specs = principals
+    if getattr(analysis, "planned_iso", True):
+        specs += (requested_by_name.get("iso", ViewSpec(name="iso", kind="pictorial")),)
+    if isinstance(constraints, ViewConstraints):
+        requested_derived = (
+            constraints.derived
+            if constraints.derived_source == "authored"
+            else constraints.added_derived
+        )
+        specs += tuple(item.spec for item in requested_derived)
     return ResolvedViewPlan(
         specs=specs,
         placements=placements,

--- a/tests/test_issue_1260_view_constraints.py
+++ b/tests/test_issue_1260_view_constraints.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 import warnings
+from types import SimpleNamespace
 
 import pytest
 from build123d import Box, Cylinder
@@ -11,7 +12,11 @@ from build123d import Box, Cylinder
 import draftwright.builder as builder_mod
 import draftwright.projection as projection_mod
 from draftwright import Sheet, SoftDeprecationWarning, ViewConstraints
+from draftwright.analysis import _apply_principal_view_pins
+from draftwright.builder import _validate_authored_view_layout
+from draftwright.model import plan_sections
 from draftwright.view_plan import (
+    ConstraintSource,
     ResolvedViewPlan,
     ViewPin,
     ViewRelation,
@@ -145,6 +150,8 @@ class TestSourceCoherence:
             sheet.view("front")
         with pytest.raises(ValueError, match="relative to itself"):
             ViewRelation("front", "above", "front")
+        with pytest.raises(ValueError, match="unknown view relation"):
+            ViewRelation("front", "diagonal", "plan")
         with pytest.raises(ValueError, match="non-negative"):
             ViewRelation("front", "above", "plan", gap=-1)
         with pytest.raises(ValueError, match="finite page coordinates"):
@@ -155,6 +162,8 @@ class TestSourceCoherence:
             ViewSpec("front", "principal", scale_factor=2)
         with pytest.raises(ValueError, match="principal_source"):
             ViewConstraints(principal_source="guess")
+        assert ViewConstraints().is_empty
+        assert not ViewConstraints(principal_source="automatic").is_empty
 
     def test_view_source_and_target_conflicts_fail_at_the_second_verb(self):
         automatic = _sheet()
@@ -253,6 +262,24 @@ class TestBuildEffects:
             "section_bb",
         }
         assert not [issue for issue in drawing.lint() if issue.severity != "info"]
+
+    def test_feature_section_targets_and_parent_rows_are_hard_constraints(self):
+        through = _sheet()
+        hole = through.hole(diameter=6, at=(0, 0, 0), axis="z")
+        through.section_view("A", through=hole)
+        assert "section_aa" in through.build().views
+
+        outside = _sheet()
+        remote_hole = outside.hole(diameter=6, at=(0, 1000, 0), axis="z")
+        outside.section_view("A", through=remote_hole)
+        with pytest.raises(ValueError, match="outside the part interior"):
+            outside.build()
+
+        parentless = _sheet()
+        parentless.view("plan")
+        parentless.section_view("A", at=0)
+        with pytest.raises(ValueError, match="needs front or side as its parent row"):
+            parentless.build()
 
     def test_a_feature_targeted_detail_uses_its_authored_name_and_scale(self):
         part = Box(50, 30, 10) - Cylinder(3, 20)
@@ -361,6 +388,70 @@ class TestBuildEffects:
         detail.detail_view("A", around=hole).scale(100)
         with pytest.raises(ValueError, match="authored detail.*not relaxed"):
             detail.build()
+
+
+class TestDefensiveTypedBoundaries:
+    def test_pin_lowering_rejects_unsupported_and_absent_views(self):
+        def geometry():
+            return SimpleNamespace(
+                FV_X=40.0,
+                FV_Y=40.0,
+                PV_X=40.0,
+                PV_Y=80.0,
+                SV_X=80.0,
+                SV_Y=40.0,
+            )
+
+        for source in (ConstraintSource("test.py", 1), None):
+            constraints = ViewConstraints(pins=(ViewPin("iso", (10, 10), source),))
+            with pytest.raises(ValueError, match="principal orthographic"):
+                _apply_principal_view_pins(
+                    geometry(),
+                    constraints,
+                    scale=1,
+                    centre=(0, 0, 0),
+                    page=(297, 210),
+                    margin=10,
+                    views=("front",),
+                )
+
+        absent = ViewConstraints(pins=(ViewPin("front", (10, 10)),))
+        with pytest.raises(ValueError, match="absent view"):
+            _apply_principal_view_pins(
+                geometry(),
+                absent,
+                scale=1,
+                centre=(0, 0, 0),
+                page=(297, 210),
+                margin=10,
+                views=("plan",),
+            )
+
+    def test_resolved_layout_validation_rejects_absent_views_and_moved_pins(self):
+        bounds = {"front": (20, 20, 40, 40), "plan": (20, 50, 40, 70)}
+        drawing = SimpleNamespace(
+            view_plan=SimpleNamespace(placements={}),
+            views=bounds,
+            view_bounds=bounds.__getitem__,
+            at=lambda *_args: (1.0, 0.0, 0.0),
+        )
+
+        missing = ViewConstraints(relations=(ViewRelation("front", "above", "side"),))
+        with pytest.raises(ValueError, match="absent view"):
+            _validate_authored_view_layout(drawing, missing)
+
+        absent_pin = ViewConstraints(pins=(ViewPin("side", (0, 0)),))
+        with pytest.raises(ValueError, match="pin names absent view"):
+            _validate_authored_view_layout(drawing, absent_pin)
+
+        for source in (ConstraintSource("test.py", 2), None):
+            moved = ViewConstraints(pins=(ViewPin("front", (0, 0), source),))
+            with pytest.raises(ValueError, match="pin.*infeasible"):
+                _validate_authored_view_layout(drawing, moved)
+
+    def test_auto_section_suppression_reaches_the_planner_boundary(self):
+        model = SimpleNamespace(decorations={"auto_sections": False}, features=[])
+        assert plan_sections(model, set()) is None
 
 
 class TestLegacyDerivedVerbs:

--- a/tests/test_issue_1260_view_constraints.py
+++ b/tests/test_issue_1260_view_constraints.py
@@ -1,0 +1,409 @@
+"""ADR 0018 Phase 2: typed authored view requests and Sheet verbs (#1260)."""
+
+from __future__ import annotations
+
+import dataclasses
+import warnings
+from types import SimpleNamespace
+
+import pytest
+from build123d import Box, Cylinder
+
+import draftwright.builder as builder_mod
+import draftwright.projection as projection_mod
+from draftwright import Sheet, SoftDeprecationWarning, ViewConstraints
+from draftwright.annotations.orchestrator import _planned_sections, _queue_authored_details
+from draftwright.annotations.sections import _section_identity
+from draftwright.model import plan_sections
+from draftwright.view_plan import (
+    ConstraintSource,
+    ResolvedViewPlan,
+    ViewConstraint,
+    ViewPin,
+    ViewRelation,
+    ViewSpec,
+)
+
+
+def _sheet(part=None):
+    return Sheet(part or Box(50, 30, 10)).authored_dimensions()
+
+
+class TestTypedRequestState:
+    def test_constraints_are_immutable_and_not_a_resolved_plan(self):
+        sheet = _sheet()
+        sheet.authored_views().view("front")
+
+        constraints = sheet.view_constraints
+        assert isinstance(constraints, ViewConstraints)
+        assert not isinstance(constraints, ResolvedViewPlan)
+        assert constraints.principal_source == "authored"
+        assert [item.spec.name for item in constraints.principals] == ["front"]
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            constraints.principal_source = "automatic"  # type: ignore[misc]
+
+    def test_every_principal_verb_changes_the_corresponding_request(self):
+        authored = _sheet()
+        front = authored.view("front")
+        authored.view("iso")
+        assert front.name == "front"
+        assert [item.spec.name for item in authored.view_constraints.principals] == [
+            "front",
+            "iso",
+        ]
+
+        automatic = _sheet()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", SoftDeprecationWarning)
+            automatic.auto_views()
+        automatic.add_view("side")
+        assert automatic.view_constraints.principal_source == "automatic"
+        assert [item.spec.name for item in automatic.view_constraints.added_principals] == ["side"]
+
+    def test_derived_verbs_retain_semantic_targets_and_scale(self):
+        sheet = _sheet()
+        hole = sheet.hole(diameter=6, at=(0, 0, 0), axis="z")
+        section = sheet.section_view("A", through=hole)
+        detail = sheet.detail_view("B", around=hole).scale(2)
+
+        constraints = sheet.view_constraints
+        assert section.name == "section_aa"
+        assert detail.name == "detail_b"
+        assert [item.spec.kind for item in constraints.derived] == ["section", "detail"]
+        assert constraints.derived[0].spec.target[0] == "feature"
+        assert constraints.derived[1].spec.scale_factor == 2
+
+    def test_relations_rows_columns_and_pins_are_whole_view_constraints(self):
+        sheet = _sheet()
+        front = sheet.view("front")
+        plan = sheet.view("plan")
+        side = sheet.view("side")
+        plan.above(front, gap=3).align_x(front)
+        sheet.row(front, side, gap=4)
+        sheet.column(front, plan)
+        side.pin((120, 80))
+
+        constraints = sheet.view_constraints
+        assert [item.relation for item in constraints.relations] == [
+            "above",
+            "align_x",
+            "right_of",
+            "above",
+        ]
+        assert constraints.pins[0].view == "side"
+        assert constraints.pins[0].at == (120.0, 80.0)
+
+
+class TestSourceCoherence:
+    def test_unknown_view_fails_at_the_verb(self):
+        with pytest.raises(ValueError, match="expected one of"):
+            _sheet().view("elevation")
+
+    def test_principal_independent_scale_fails_at_the_handle(self):
+        with pytest.raises(ValueError, match="principal.*independent scale"):
+            _sheet().view("front").scale(2)
+
+    def test_authored_views_then_auto_dimensions_fails_at_the_second_verb(self):
+        sheet = Sheet(Box(30, 20, 10))
+        sheet.view("front")
+        with pytest.raises(ValueError, match="auto_dimensions.*authored views"):
+            sheet.auto_dimensions()
+
+    def test_auto_dimensions_then_authored_views_fails_at_the_second_verb(self):
+        sheet = Sheet(Box(30, 20, 10))
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", SoftDeprecationWarning)
+            sheet.auto_dimensions()
+        with pytest.raises(ValueError, match="authors the view set"):
+            sheet.view("front")
+
+    def test_from_part_implicit_automatic_dimensions_also_refuse_authored_views(self):
+        sheet = Sheet.from_part(Box(30, 20, 10))
+        with pytest.raises(ValueError, match="authors the view set"):
+            sheet.view("front")
+
+    def test_add_forms_require_auto_views_at_build(self):
+        sheet = _sheet()
+        sheet.add_view("side")
+        with pytest.raises(ValueError, match=r"call auto_views\(\) first"):
+            sheet.build()
+
+    def test_source_location_reaches_an_infeasibility(self):
+        sheet = _sheet()
+        sheet.view("front").above("plan")
+        sheet.view("plan")
+        with pytest.raises(ValueError) as caught:
+            sheet.build()
+        assert __file__ in str(caught.value)
+
+    def test_handle_and_value_validation_is_fail_closed(self):
+        sheet = _sheet()
+        front, plan = sheet.view("front"), sheet.view("plan")
+        front.left_of(plan).right_of(plan).below(plan).align_y(plan)
+
+        with pytest.raises(ValueError, match="two page coordinates"):
+            front.pin((1,))
+        with pytest.raises(ValueError, match="finite and positive"):
+            sheet.view("iso").scale(float("nan"))
+        with pytest.raises(ValueError, match="one alphanumeric"):
+            sheet.section_view("A-A", at=0)
+        with pytest.raises(ValueError, match="more than once"):
+            sheet.view("front")
+        with pytest.raises(ValueError, match="relative to itself"):
+            ViewRelation("front", "above", "front")
+        with pytest.raises(ValueError, match="non-negative"):
+            ViewRelation("front", "above", "plan", gap=-1)
+        with pytest.raises(ValueError, match="finite page coordinates"):
+            ViewPin("front", (float("inf"), 0))
+        with pytest.raises(ValueError, match="finite and positive"):
+            ViewSpec("iso", "pictorial", scale_factor=0)
+        with pytest.raises(ValueError, match="only valid"):
+            ViewSpec("front", "principal", scale_factor=2)
+        with pytest.raises(ValueError, match="principal_source"):
+            ViewConstraints(principal_source="guess")
+
+    def test_view_source_and_target_conflicts_fail_at_the_second_verb(self):
+        automatic = _sheet()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", SoftDeprecationWarning)
+            automatic.auto_views()
+        with pytest.raises(ValueError, match="one principal-view source"):
+            automatic.authored_views()
+        with pytest.raises(ValueError, match="cannot follow auto_views"):
+            automatic.view("front")
+        with pytest.raises(ValueError, match="cannot follow auto_views"):
+            automatic.section_view("A", at=0)
+        with pytest.raises(ValueError, match="cannot follow auto_views"):
+            automatic.detail_view("A", object())
+
+        authored = _sheet()
+        authored.view("front")
+        with pytest.raises(ValueError, match="cannot be combined"):
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", SoftDeprecationWarning)
+                authored.auto_views()
+        with pytest.raises(ValueError, match="augments auto_views"):
+            authored.add_view("side")
+
+        derived = _sheet()
+        derived.section_view("A", at=0)
+        with pytest.raises(ValueError, match="augments auto_views"):
+            derived.add_section_view("B", at=1)
+        with pytest.raises(ValueError, match="augments auto_views"):
+            derived.add_detail_view("B", object())
+
+        for call in (
+            lambda: _sheet().section_view("A"),
+            lambda: _sheet().section_view("A", object(), at=0),
+            lambda: _sheet().section_view("A", at=float("inf")),
+            lambda: _sheet().detail_view("A", object()),
+        ):
+            with pytest.raises(ValueError):
+                call()
+
+    def test_row_column_and_build_source_refusals_are_explicit(self):
+        with pytest.raises(ValueError, match="at least two"):
+            _sheet().row("front")
+        with pytest.raises(ValueError, match="at least two"):
+            _sheet().column("front")
+        with pytest.raises(ValueError, match="no principal orthographic"):
+            _sheet().authored_views().build()
+        only_iso = _sheet()
+        only_iso.view("iso")
+        with pytest.raises(ValueError, match="no principal orthographic"):
+            only_iso.build()
+        added = _sheet()
+        added.add_detail_view("A", added.hole(diameter=4, at=(0, 0, 0), axis="z"))
+        with pytest.raises(ValueError, match=r"call auto_views\(\) first"):
+            added.build()
+        legacy = _sheet()
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            legacy.section(at=0)
+        legacy.section_view("A", at=0)
+        with pytest.raises(ValueError, match="deprecated section"):
+            legacy.build()
+
+
+class TestBuildEffects:
+    def test_no_constraints_preserve_the_automatic_four_view_sheet(self):
+        drawing = _sheet().build()
+        assert set(drawing.views) == {"front", "plan", "side", "iso"}
+        assert not drawing.lint()
+
+    def test_authored_omission_removes_views_and_replans_before_projection(self):
+        sheet = _sheet()
+        sheet.view("front")
+        drawing = sheet.build()
+        assert set(drawing.views) == {"front"}
+        assert drawing.view_plan.principal_names == ("front",)
+        assert drawing.view_plan.of_kind("pictorial") == ()
+
+    def test_a_natural_relation_is_honoured(self):
+        sheet = _sheet()
+        front = sheet.view("front")
+        plan = sheet.view("plan")
+        plan.above(front).align_x(front)
+        drawing = sheet.build()
+        assert set(drawing.views) == {"front", "plan"}
+
+    def test_named_sections_coexist_and_enter_the_resolved_plan(self):
+        sheet = Sheet(Box(50, 30, 10), page="A2").authored_dimensions()
+        sheet.section_view("A", at=-8)
+        sheet.section_view("B", at=8)
+        drawing = sheet.build()
+
+        assert {"section_aa", "section_bb"} <= set(drawing.views)
+        assert {spec.name for spec in drawing.view_plan.of_kind("section")} == {
+            "section_aa",
+            "section_bb",
+        }
+        assert not [issue for issue in drawing.lint() if issue.severity != "info"]
+
+    def test_a_feature_targeted_detail_uses_its_authored_name_and_scale(self):
+        part = Box(50, 30, 10) - Cylinder(3, 20)
+        sheet = Sheet(part, page="A3").authored_dimensions()
+        hole = sheet.hole(diameter=6, at=(0, 0, 0), axis="z")
+        sheet.dimension(hole, "bore.diameter")
+        sheet.dimension(hole, "location")
+        sheet.detail_view("B", around=hole).scale(2)
+        drawing = sheet.build()
+
+        assert "detail_b" in drawing.views
+        detail = drawing.view_plan.spec("detail_b")
+        assert detail is not None
+        assert detail.kind == "detail"
+        assert detail.scale_factor == 2
+        assert not [issue for issue in drawing.lint() if issue.severity != "info"]
+
+    def test_an_authored_iso_scale_is_rendered_exactly_and_never_auto_fitted(self, monkeypatch):
+        projected_scales = []
+
+        def project(drawing, analysis, scale, shape_s=None):
+            projected_scales.append(scale)
+            return projection_mod._project_iso(drawing, analysis, scale, shape_s=shape_s)
+
+        def unexpected_fit(*_args, **_kwargs):
+            raise AssertionError("an authored iso scale must not enter the automatic fit")
+
+        monkeypatch.setattr(builder_mod, "_project_iso", project)
+        monkeypatch.setattr(builder_mod, "_fit_iso_view", unexpected_fit)
+
+        sheet = Sheet(Box(50, 30, 10), page="A2").authored_dimensions()
+        sheet.view("front")
+        sheet.view("iso").scale(1.25)
+        drawing = sheet.build()
+
+        front_origin = drawing.at("front", 0, 0, 0)
+        front_x = drawing.at("front", 10, 0, 0)
+        sheet_scale = abs(front_x[0] - front_origin[0]) / 10
+        assert projected_scales == pytest.approx([sheet_scale * 1.25])
+        assert drawing.view_plan.spec("iso").scale_factor == 1.25
+
+    def test_a_pin_is_never_relaxed(self):
+        baseline_sheet = _sheet()
+        baseline_sheet.view("front")
+        baseline = baseline_sheet.build()
+        origin = baseline.at("front", 0, 0, 0)
+
+        exact = _sheet()
+        exact.view("front").pin(origin[:2])
+        exact_drawing = exact.build()
+        assert exact_drawing.at("front", 0, 0, 0)[:2] == pytest.approx(origin[:2])
+
+        moved = _sheet()
+        moved.view("front").pin((origin[0] + 1, origin[1]))
+        moved_drawing = moved.build()
+        assert moved_drawing.at("front", 0, 0, 0)[:2] == pytest.approx((origin[0] + 1, origin[1]))
+        assert not moved_drawing.lint()
+
+        impossible = _sheet()
+        impossible.view("front").pin((-1000, origin[1]))
+        with pytest.raises(ValueError, match="pin.*infeasible.*not relaxed"):
+            impossible.build()
+
+    def test_contradictory_and_nonprincipal_pins_are_refused(self):
+        baseline_sheet = _sheet()
+        baseline_sheet.view("front")
+        baseline_sheet.view("plan")
+        baseline = baseline_sheet.build()
+
+        contradictory = _sheet()
+        contradictory.view("front").pin(baseline.at("front", 0, 0, 0)[:2])
+        plan_at = baseline.at("plan", 0, 0, 0)
+        contradictory.view("plan").pin((plan_at[0] + 1, plan_at[1]))
+        with pytest.raises(ValueError, match="contradict.*translations"):
+            contradictory.build()
+
+        nonprincipal = _sheet()
+        nonprincipal.view("front")
+        with pytest.raises(ValueError, match="principal front/plan/side views only"):
+            nonprincipal.view("iso").pin((100, 100))
+
+    def test_derived_views_require_their_semantic_parent_views(self):
+        section = _sheet()
+        section.view("front")
+        section.section_view("A", at=0)
+        with pytest.raises(ValueError, match="needs the plan view"):
+            section.build()
+
+        detail = _sheet()
+        hole = detail.hole(diameter=6, at=(0, 0, 0), axis="z")
+        detail.view("front")
+        detail.detail_view("A", around=hole)
+        with pytest.raises(ValueError, match="cannot be shown"):
+            detail.build()
+
+    def test_exact_view_scales_fail_instead_of_relaxing(self, monkeypatch):
+        monkeypatch.setattr(builder_mod, "_bbox_within", lambda *_args, **_kwargs: False)
+        iso = Sheet(Box(50, 30, 10), page="A2").authored_dimensions()
+        iso.view("front")
+        iso.view("iso").scale(1.25)
+        with pytest.raises(ValueError, match="authored iso scale.*not reduced"):
+            iso.build()
+
+        detail = Sheet(Box(50, 30, 10), page="A4").authored_dimensions()
+        hole = detail.hole(diameter=6, at=(0, 0, 0), axis="z")
+        detail.detail_view("A", around=hole).scale(100)
+        with pytest.raises(ValueError, match="authored detail.*not relaxed"):
+            detail.build()
+
+
+class TestDefensiveTypedBoundaries:
+    def test_malformed_typed_inputs_are_rejected_without_relaxation(self):
+        source = ConstraintSource("test.py", 1)
+        malformed_section = ViewConstraints(
+            derived_source="authored",
+            derived=(ViewConstraint(ViewSpec("section_aa", "section"), source),),
+        )
+        a = SimpleNamespace(
+            view_constraints=malformed_section,
+            bb=SimpleNamespace(min=SimpleNamespace(Y=-10.0), max=SimpleNamespace(Y=10.0)),
+        )
+        model = SimpleNamespace(decorations={}, features=[])
+        with pytest.raises(ValueError, match="no semantic cut target"):
+            _planned_sections(a, model, set())
+
+        malformed_detail = ViewConstraints(
+            derived_source="authored",
+            derived=(ViewConstraint(ViewSpec("detail_a", "detail"), source),),
+        )
+        with pytest.raises(ValueError, match="no semantic feature target"):
+            _queue_authored_details(
+                SimpleNamespace(view_constraints=malformed_detail),
+                SimpleNamespace(detail_requests=[]),
+            )
+        with pytest.raises(ValueError, match="alphanumeric"):
+            _section_identity(SimpleNamespace(label="-"))
+
+    def test_auto_section_suppression_reaches_the_planner_boundary(self):
+        model = SimpleNamespace(decorations={"auto_sections": False}, features=[])
+        assert plan_sections(model, set()) is None
+
+
+class TestLegacyDerivedVerbs:
+    @pytest.mark.parametrize("verb", ["section", "detail"])
+    def test_legacy_verbs_warn_with_the_removal_target(self, verb):
+        sheet = _sheet()
+        with pytest.warns(DeprecationWarning, match="0.6.0"):
+            getattr(sheet, verb)()

--- a/tests/test_issue_1260_view_constraints.py
+++ b/tests/test_issue_1260_view_constraints.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import dataclasses
 import warnings
-from types import SimpleNamespace
 
 import pytest
 from build123d import Box, Cylinder
@@ -12,13 +11,8 @@ from build123d import Box, Cylinder
 import draftwright.builder as builder_mod
 import draftwright.projection as projection_mod
 from draftwright import Sheet, SoftDeprecationWarning, ViewConstraints
-from draftwright.annotations.orchestrator import _planned_sections, _queue_authored_details
-from draftwright.annotations.sections import _section_identity
-from draftwright.model import plan_sections
 from draftwright.view_plan import (
-    ConstraintSource,
     ResolvedViewPlan,
-    ViewConstraint,
     ViewPin,
     ViewRelation,
     ViewSpec,
@@ -367,38 +361,6 @@ class TestBuildEffects:
         detail.detail_view("A", around=hole).scale(100)
         with pytest.raises(ValueError, match="authored detail.*not relaxed"):
             detail.build()
-
-
-class TestDefensiveTypedBoundaries:
-    def test_malformed_typed_inputs_are_rejected_without_relaxation(self):
-        source = ConstraintSource("test.py", 1)
-        malformed_section = ViewConstraints(
-            derived_source="authored",
-            derived=(ViewConstraint(ViewSpec("section_aa", "section"), source),),
-        )
-        a = SimpleNamespace(
-            view_constraints=malformed_section,
-            bb=SimpleNamespace(min=SimpleNamespace(Y=-10.0), max=SimpleNamespace(Y=10.0)),
-        )
-        model = SimpleNamespace(decorations={}, features=[])
-        with pytest.raises(ValueError, match="no semantic cut target"):
-            _planned_sections(a, model, set())
-
-        malformed_detail = ViewConstraints(
-            derived_source="authored",
-            derived=(ViewConstraint(ViewSpec("detail_a", "detail"), source),),
-        )
-        with pytest.raises(ValueError, match="no semantic feature target"):
-            _queue_authored_details(
-                SimpleNamespace(view_constraints=malformed_detail),
-                SimpleNamespace(detail_requests=[]),
-            )
-        with pytest.raises(ValueError, match="alphanumeric"):
-            _section_identity(SimpleNamespace(label="-"))
-
-    def test_auto_section_suppression_reaches_the_planner_boundary(self):
-        model = SimpleNamespace(decorations={"auto_sections": False}, features=[])
-        assert plan_sections(model, set()) is None
 
 
 class TestLegacyDerivedVerbs:

--- a/tests/test_sheet_identity_invariant.py
+++ b/tests/test_sheet_identity_invariant.py
@@ -55,7 +55,7 @@ _SRC = Path(__file__).resolve().parent.parent / "src" / "draftwright" / "sheet.p
 #: what makes a new kind of handle impossible to add unnoticed (#963). If it ever gains state
 #: or is returned by a verb, it needs a scenario in `_SCENARIOS` like the rest.
 _HANDLE_CLASSES = frozenset(
-    {"_Hole", "_Dim", "_Params", "_Control", "DimensionIntent", "_Nameable"}
+    {"_Hole", "_Dim", "_Params", "_Control", "_View", "DimensionIntent", "_Nameable"}
 )
 
 
@@ -85,6 +85,12 @@ def _canonical(model) -> tuple:
     decorations = sorted((repr(k), repr(v)) for k, v in getattr(model, "decorations", {}).items())
     requested = sorted(repr(r) for r in getattr(model, "requested_dimensions", ()))
     return (features, decorations, requested)
+
+
+def _canonical_sheet(sheet) -> tuple:
+    """The model plus authored view input, whose feature targets materialise separately."""
+
+    return (_canonical(sheet.model()), sheet.view_constraints)
 
 
 # --------------------------------------------------------------------------------------------
@@ -181,6 +187,35 @@ def _scn_add_dimension(s):
     return a, lambda a: s.add_dimension(a, "bore.diameter")
 
 
+def _scn_view(s):
+    """A retained whole-view handle carries a view name, never a feature position."""
+
+    s._auto_dimensions = None
+    s.authored_dimensions()
+    s.hole(diameter=10, at=(-25, 0, 20), axis="z").depth(12)
+    s.hole(diameter=6, at=(25, 0, 20), axis="z").depth(8)
+    view = s.view("front")
+    return view, lambda view: view.pin((100, 80))
+
+
+def _scn_section_view(s):
+    """The complete derived set stores a feature token until constraints materialise."""
+
+    s._auto_dimensions = None
+    s.authored_dimensions()
+    a = s.hole(diameter=10, at=(-25, -18, 20), axis="z").depth(12)
+    s.hole(diameter=6, at=(25, 18, 20), axis="z").depth(8)
+    return a, lambda a: s.section_view("A", through=a)
+
+
+def _scn_add_section_view(s):
+    """The automatic-derived augmentation has the same identity contract."""
+
+    a = s.hole(diameter=10, at=(-25, -18, 20), axis="z").depth(12)
+    s.hole(diameter=6, at=(25, 18, 20), axis="z").depth(8)
+    return a, lambda a: s.add_section_view("A", through=a)
+
+
 #: verb name -> (prepare, drive). The ratchet below asserts this covers every handle-returning
 #: verb, so a new one cannot ship without an author deciding what it does across a reorder.
 _SCENARIOS = {
@@ -190,6 +225,7 @@ _SCENARIOS = {
     "step": _scn_step,
     "envelope": _scn_envelope,
     "control": _scn_control,
+    "view": _scn_view,
     "add_dimension": _scn_add_dimension,
     # Verbs that return `Sheet` but retain a feature reference. Not handle-returning, so the
     # verb ratchet cannot see them — the state-field ratchet below is what makes them mandatory.
@@ -197,6 +233,8 @@ _SCENARIOS = {
     "datum": _scn_datum,
     "note": _scn_note,
     "dimension": _scn_dimension,
+    "section_view": _scn_section_view,
+    "add_section_view": _scn_add_section_view,
 }
 
 #: Verbs that hand back a `_Params` by exactly the same route `envelope` does — declare the
@@ -318,7 +356,7 @@ class TestRetainedBuilders:
         )
         drive2(obj2)
 
-        assert _canonical(mutated.model()) == _canonical(baseline.model()), (
+        assert _canonical_sheet(mutated) == _canonical_sheet(baseline), (
             f"{verb}() retained an object that did not survive `{mutation}` — the mutation "
             "moved its target and the object followed the position instead of the feature"
         )
@@ -339,7 +377,7 @@ def test_a_mutation_between_declaration_and_build_is_invisible(verb):
     mutated.features.reverse()
     assert _order(mutated) != before, "the mutation must actually reorder, or this asserts nothing"
 
-    assert _canonical(mutated.model()) == _canonical(baseline.model())
+    assert _canonical_sheet(mutated) == _canonical_sheet(baseline)
 
 
 @pytest.mark.parametrize("verb", sorted(_SCENARIOS))
@@ -349,9 +387,9 @@ def test_materialisation_is_idempotent(verb):
     s = _sheet()
     obj, drive = _SCENARIOS[verb](s)
     drive(obj)
-    first = _canonical(s.model())
-    assert _canonical(s.model()) == first
-    assert _canonical(s.model()) == first
+    first = _canonical_sheet(s)
+    assert _canonical_sheet(s) == first
+    assert _canonical_sheet(s) == first
 
 
 class TestDeliberateInvalidation:
@@ -618,7 +656,15 @@ def _handle_returning_verbs() -> set[str]:
 #: `Sheet` state that stores a reference to a declared feature. Each must be reached by at least
 #: one scenario, proven at runtime below rather than asserted by eye.
 _STATE_CARRYING_FEATURE_REFS = frozenset(
-    {"_tolerances", "_gdt_src", "_section", "_added_dimensions", "_authored"}
+    {
+        "_tolerances",
+        "_gdt_src",
+        "_section",
+        "_added_dimensions",
+        "_authored",
+        "_derived_views",
+        "_added_derived_views",
+    }
 )
 
 #: `Sheet` state that stores no feature reference, so a reorder cannot affect it.
@@ -635,6 +681,14 @@ _STATE_WITHOUT_FEATURE_REFS = frozenset(
         # for the same reason (#933). The set's MEMBERS live in `_authored`, which is
         # classified as reference-carrying and has its own scenario.
         "_authored_source",
+        "_principal_view_source",
+        "_derived_view_source",
+        "_principal_view_source_at",
+        "_derived_view_source_at",
+        "_principal_views",
+        "_added_principal_views",
+        "_view_relations",
+        "_view_pins",
     }
 )
 


### PR DESCRIPTION
## Symptom and evidence

- User-visible problem: `Sheet` could not author a typed view set or express whole-view layout constraints without dropping below the sanctioned semantic surface.
- Fixture/reproducer: `tests/test_issue_1260_view_constraints.py` exercises authored/automatic modes, named derived views, relations, pins, scales, refusal paths, and lint probes.
- Before/after result: authored view intent is now captured as immutable `ViewConstraints` and compiled into a distinct `ResolvedViewPlan`; supported constraints are enforced and unsupported or infeasible requests fail at their declaration source.
- Mutation that makes the guard fail: relaxing source coherence, independent principal scales, missing semantic parents, contradictory pins, exact derived scales, or automatic compatibility fails the focused adversarial tests.

## Contract and scope

- Smallest contract this change tests: public `Sheet` verbs declare semantic whole-view constraints; the shared compiler either resolves them exactly or refuses them without silently relaxing placement.
- Relevant ADRs: 0011, 0014, 0018.
- Explicitly deferred: automatic semantic view selection and resolved-plan script emission, as stated in #1260.

## Validation

- [x] `scripts/pr-check --quick` (covered by the stricter full local suite and static checks)
- [x] `scripts/pr-check` before final review — 4,573 passed, 5 skipped, 3 xfailed; total coverage 94.71%
- [x] Cross-repository recogniser changes: N/A — no recogniser repository change
- [x] The named mutation was observed failing before the implementation passed it
- [x] Automatic, declared, and generated-script paths were checked where affected — generated-script output is explicitly out of scope; automatic and declared paths pass
- [x] Recognition and repeated-lint call counts were checked where affected — recognition unchanged; automatic and authored lint probes pass
- [x] Changed-line coverage: 95% (93% required)
- [x] `scripts/pr-check --static`

## Stop check

- [x] No two consecutive review rounds invalidated the same core association strategy
- [x] New prerequisites were split or the work was explicitly reclassified as discovery — N/A; no new prerequisite emerged

Closes #1260
