### PR TITLE
Fix recogniser bumps after changelog finalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- Recogniser dependency automation now starts a fresh `Unreleased` section when the previous
+  Draftwright release has finalized the changelog, so a published recogniser can enter through
+  the documented immutable update workflow instead of failing before it opens a PR (#1279).
+
 ## v0.4.9 — 2026-08-21
 
 ### Added

--- a/scripts/update-recogniser-dependency
+++ b/scripts/update-recogniser-dependency
@@ -105,7 +105,14 @@ def _add_changelog(root: Path, old: str, new: str, manifest_hash: str) -> None:
     )
     heading = re.search(r"^## (?:Unreleased|\[Unreleased\])$", text, re.MULTILINE)
     if heading is None:
-        raise RuntimeError("CHANGELOG.md has no Unreleased section")
+        prefix = "# Changelog\n\n"
+        if not text.startswith(prefix):
+            raise RuntimeError("CHANGELOG.md has no canonical title")
+        path.write_text(
+            prefix + "## Unreleased\n\n### Changed\n\n" + bullet + "\n" + text[len(prefix) :],
+            encoding="utf-8",
+        )
+        return
     unreleased_start = heading.start()
     next_heading = re.search(r"^## ", text[heading.end() :], re.MULTILINE)
     unreleased_end = (

--- a/tests/test_two_repository_workflow.py
+++ b/tests/test_two_repository_workflow.py
@@ -174,6 +174,33 @@ def test_dependency_updater_reuses_existing_unreleased_changed_heading(heading: 
         assert updated.index("0.2.0 to 0.2.1") < updated.index("### Fixed")
 
 
+def test_dependency_updater_starts_the_next_unreleased_section_after_a_release() -> None:
+    loader = SourceFileLoader(
+        "draftwright_recogniser_dependency_update_after_release",
+        str(ROOT / "scripts/update-recogniser-dependency"),
+    )
+    spec = spec_from_loader(loader.name, loader)
+    assert spec is not None
+    module = module_from_spec(spec)
+    loader.exec_module(module)
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        changelog = root / "CHANGELOG.md"
+        changelog.write_text(
+            "# Changelog\n\n## v0.4.9 — 2026-08-21\n\n### Fixed\n\n- Released fix.\n",
+            encoding="utf-8",
+        )
+
+        module._add_changelog(root, "0.2.6", "0.2.8", "a" * 64)
+        module._add_changelog(root, "0.2.6", "0.2.8", "a" * 64)
+
+        updated = changelog.read_text(encoding="utf-8")
+        assert updated.count("## Unreleased") == 1
+        assert updated.count("0.2.6 to 0.2.8") == 1
+        assert updated.index("## Unreleased") < updated.index("## v0.4.9")
+        assert updated.index("0.2.6 to 0.2.8") < updated.index("## v0.4.9")
+
+
 @pytest.mark.parametrize(
     ("mutation", "message"),
     [


### PR DESCRIPTION
Closes #1279.

## What changed

- create a fresh top-level `Unreleased` / `Changed` section when the previous Draftwright release has finalized the changelog
- retain fail-closed behavior for malformed changelog titles
- cover the post-release case and idempotence
- restore the current changelog to its valid post-release state

## ADR / workflow assessment

This is release-boundary maintenance rather than drawing architecture. It preserves the immutable package workflow in `docs/recogniser-development-workflow.md`: the updater remains the only writer of the dependency evidence diff and still rejects malformed state.

## Validation

- `uv run pytest -q tests/test_two_repository_workflow.py` — 24 passed
- `scripts/pr-check --static` — passed
- `git diff --check` — passed

## Reproduction

The original 0.2.8 dispatch failed before opening a PR because v0.4.9 correctly had no `Unreleased` section: https://github.com/pzfreo/draftwright/actions/runs/32564274963
