### PR TITLE
Accept turned record schema transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Changed
 
+- Accept the additive Chamfer and Fillet schema-2 recognizer contract alongside schema 1 ahead of
+  the `b123d-recognisers` 0.3.0 cutover; all other record schemas remain fail-closed at version 1
+  (#1276).
+
 - Updated the exact `b123d-recognisers` production lock from 0.2.6 to 0.2.9.
   The immutable PyPI wheel/sdist hashes and capability-manifest digest `805876905d548fd0ef1301e2cf24427a86d34bc2e592b8d2d0cb43db94e1d3bd` are
   recorded in `.github/recogniser-release.json`; focused compatibility evidence and the

--- a/docs/recogniser-development-workflow.md
+++ b/docs/recogniser-development-workflow.md
@@ -23,7 +23,10 @@ The package's hosted downstream canary runs the same wheel harness against the r
 Draftwright `main`. Its job summary records that SHA, so a failure is reproducible even if `main`
 moves later. This is deliberately a narrow contract canary, not another full Draftwright matrix.
 The package matrix proves geometry/platform behavior; Draftwright's own PR and release gates prove
-consumer/platform behavior.
+consumer/platform behavior. For an approved schema transition, the harness passes the wheel's exact
+version as `candidate_version=` to the consumer validator via the focused test seam. That explicit
+argument may match only the single reviewed transition release; normal validation never reads an
+environment override and remains on the exact production pin.
 
 ## Compatibility and landing order
 
@@ -38,12 +41,19 @@ manifest drift, or a non-registry installation. An open version interval is not 
 ### Additive package change
 
 1. Freeze independent package fixtures, negative cases, goldens, schema, and performance evidence.
-2. Land the package change while released Draftwright remains on its exact previous pin.
-3. Publish an `X.Y.ZrcN` only when consumer validation genuinely needs a prerelease; otherwise
+2. If an existing record's schema increments, first land a Draftwright declaration that accepts
+   exactly the installed and candidate schemas while retaining the previous exact dependency pin.
+   The package canary must then pass against that committed compatibility point. An additive family
+   or behavior change whose existing schemas remain valid needs no preparatory consumer PR.
+3. Land the package change while released Draftwright remains on its exact previous pin.
+4. Publish an `X.Y.ZrcN` only when consumer validation genuinely needs a prerelease; otherwise
    publish the audited stable patch directly.
-4. Add Draftwright policy/support against the candidate wheel, then publish the stable package
-   patch and dispatch **Bump recogniser dependency** with that version.
-5. Merge the generated Draftwright PR only after its exact hashes, manifest, focused join tests,
+5. Add Draftwright policy/support against the candidate wheel, then publish the stable package
+   version and dispatch **Bump recogniser dependency** with that version. Narrow any temporary
+   dual-schema declaration to the released schema in that PR. The dependency updater performs and
+   tests this narrowing when its target matches the reviewed transition release; it also disables
+   the candidate-version seam so the compatibility window cannot remain open after cutover.
+6. Merge the generated Draftwright PR only after its exact hashes, manifest, focused join tests,
    canonical coverage run, Codecov checks, and `ci-ok` are green.
 
 ### Breaking package change

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -26,7 +26,9 @@ Validation fails closed and names the family and boundary whenever possible:
   CI instead — adoption is still required, and is enforced where the decision is made. Provide the
   downstream behavior or an explicit non-supported state as before.
 - **record schema mismatch** — a consumed record schema changed. Review the record fields and
-  compatibility notes, update the relevant adapter and tests, then pin the accepted schema version.
+  compatibility notes, update the relevant adapter and tests, then explicitly list the accepted
+  schema version. A bounded dual-readable list may name the current and next additive schemas
+  during a provider-first release; it is never an open-ended range.
 - **stale implementation** — a declared adapter, `Sheet` method, emitter, renderer, or completeness
   function no longer resolves. Repair the implementation reference and its independent behavior
   evidence; do not merely rename the string.
@@ -47,12 +49,19 @@ Validation fails closed and names the family and boundary whenever possible:
 
 ## Adding or changing a recogniser
 
-Land the package record, independent geometry evidence, manifest update, and compatible package
-release first. Then update Draftwright against that immutable release. For each applicable stage,
-add the adapter, declaration, emitted-Sheet round trip, drawing behavior, and completeness evidence;
-for an inapplicable or deferred stage, state why and link its tracking issue. The contract test
-derives package record outputs, converter registries, live `Sheet` methods, and emitter branches
-independently, so copying a new name into the declaration alone cannot make CI pass.
+For an additive field that increments an existing record schema, first land a narrow Draftwright
+declaration accepting both the installed schema and the named candidate schema. The existing adapter
+must remain valid when the new field is ignored, and tests must prove the next schema is accepted
+only by that explicit declaration while later schemas still fail. The package canary then proves
+the real candidate wheel against that committed consumer point. After the package release, the
+Draftwright dependency/behavior PR locks the immutable artifact, adopts the field, and narrows the
+declaration to the new schema.
+
+For each applicable stage, add the adapter, declaration, emitted-Sheet round trip, drawing behavior,
+and completeness evidence; for an inapplicable or deferred stage, state why and link its tracking
+issue. The contract test derives package record outputs, converter registries, live `Sheet` methods,
+and emitter branches independently, so copying a new name into the declaration alone cannot make CI
+pass.
 
 `bosses` is the fully consumed reference family. `repeating-radial-profiles` is the opposite
 reference: it remains geometry-only critique evidence for a separately authored gear declaration,

--- a/scripts/update-recogniser-dependency
+++ b/scripts/update-recogniser-dependency
@@ -13,6 +13,34 @@ from pathlib import Path
 _VERSION = re.compile(r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$")
 
 
+def _close_schema_transition(contract: Path, target: str) -> None:
+    """Narrow the one reviewed dual-schema window when its stable release is adopted."""
+    text = contract.read_text(encoding="utf-8")
+    active = re.search(
+        r'^_CANDIDATE_PACKAGE_VERSION: str \| None = "([^"]+)"$', text, re.MULTILINE
+    )
+    if active is None:
+        return
+    transition_parts = tuple(int(part) for part in active.group(1).split("."))
+    target_parts = tuple(int(part) for part in target.split("."))
+    if target_parts < transition_parts:
+        return
+    replacements = {
+        f'_CANDIDATE_PACKAGE_VERSION: str | None = "{active.group(1)}"': (
+            "_CANDIDATE_PACKAGE_VERSION: str | None = None"
+        ),
+        '("chamfers", "Chamfer"): (1, 2),': '("chamfers", "Chamfer"): (2,),',
+        '("fillets", "Fillet"): (1, 2),': '("fillets", "Fillet"): (2,),',
+    }
+    for before, after in replacements.items():
+        if text.count(before) != 1:
+            raise RuntimeError(
+                f"cannot close recogniser {target} schema transition: expected one {before!r}"
+            )
+        text = text.replace(before, after)
+    contract.write_text(text, encoding="utf-8")
+
+
 def _replace_once(path: Path, before: str, after: str) -> None:
     text = path.read_text(encoding="utf-8")
     if text.count(before) != 1:
@@ -179,6 +207,7 @@ def main() -> int:
                 f'_PACKAGE_VERSION = "{current}"',
                 f'_PACKAGE_VERSION = "{args.version}"',
             )
+        _close_schema_transition(contract, args.version)
         subprocess.run(
             ["uv", "lock", "--upgrade-package", "b123d-recognisers"], cwd=root, check=True
         )

--- a/src/draftwright/recogniser_contract.py
+++ b/src/draftwright/recogniser_contract.py
@@ -20,6 +20,11 @@ from b123d_recognisers import capability_manifest
 CONSUMER_CAPABILITY_FORMAT = "draftwright-recogniser-capabilities"
 CONSUMER_CAPABILITY_FORMAT_VERSION = 1
 _PACKAGE_VERSION = "0.2.9"
+# The only package identity the cross-repository canary may substitute for the exact production
+# pin.  Passing a candidate is explicit at the validator call site; normal imports and released
+# checks never consult environment state and therefore remain locked to ``_PACKAGE_VERSION``.
+# ``scripts/update-recogniser-dependency`` disables this window when 0.3.0 becomes the pin.
+_CANDIDATE_PACKAGE_VERSION: str | None = "0.3.0"
 _BOUNDARIES = (
     "ir_adapter",
     "dsl_declaration",
@@ -106,6 +111,19 @@ _FAMILIES: dict[str, _FamilySpec] = {
     ),
 }
 
+# ADR 0017 permits a consumer to land dual-readable schema support before the provider publishes
+# an additive record change. This is deliberately record-specific: accepting every future schema
+# would turn the fail-closed join into an open version range. Package PR #151 adds only optional
+# ``turned`` fields; the existing adapters remain valid while #1276 adopts those fields.
+_RECORD_SCHEMA_VERSIONS: dict[tuple[str, str], tuple[int, ...]] = {
+    ("chamfers", "Chamfer"): (1, 2),
+    ("fillets", "Fillet"): (1, 2),
+}
+
+
+def _record_schema_versions(family_id: str, names: tuple[str, ...]) -> dict[str, list[int]]:
+    return {name: list(_RECORD_SCHEMA_VERSIONS.get((family_id, name), (1,))) for name in names}
+
 
 def _supported(implementation: str, evidence: str) -> dict[str, Any]:
     return {"state": "supported", "implementation": implementation, "evidence": [evidence]}
@@ -131,7 +149,7 @@ def _family_declaration(family_id: str, spec: _FamilySpec) -> dict[str, Any]:
         )
     return {
         "id": family_id,
-        "record_schemas": {name: 1 for name in spec.records},
+        "record_schemas": _record_schema_versions(family_id, spec.records),
         "disposition": "supported",
         "ir_adapter": _supported(
             f"draftwright.model.detect.{spec.ir}", "tests/test_detect_registry.py"
@@ -173,7 +191,9 @@ def _geometry_only_declaration() -> dict[str, Any]:
     }
     return {
         "id": "repeating-radial-profiles",
-        "record_schemas": {"RepeatingRadialProfile": 1},
+        "record_schemas": _record_schema_versions(
+            "repeating-radial-profiles", ("RepeatingRadialProfile",)
+        ),
         "disposition": "geometry-only",
         "rationale": rationale,
         "package_evidence": ["tests/golden/repeating_radial_profile/expected.json"],
@@ -239,7 +259,7 @@ def _unsupported_declaration(family_id: str) -> dict[str, Any]:
     unsupported = {"state": "unsupported", "rationale": rationale}
     return {
         "id": family_id,
-        "record_schemas": {name: 1 for name in records},
+        "record_schemas": _record_schema_versions(family_id, records),
         "disposition": "unsupported",
         "rationale": rationale,
         "tracking": tracking,
@@ -388,8 +408,15 @@ def validate_recogniser_capabilities(
     *,
     package: object | None = None,
     source_root: Path | None = None,
+    candidate_version: str | None = None,
 ) -> None:
-    """Fail closed when installed package truth and Draftwright policy do not exactly join."""
+    """Fail closed when installed package truth and Draftwright policy do not exactly join.
+
+    ``candidate_version`` is the explicit two-checkout-canary seam.  It changes only the package
+    identity expected from ``package``; the checked-in production declaration stays pinned to
+    :data:`_PACKAGE_VERSION`.  The value must be an exact prerelease/stable spelling on the one
+    reviewed transition release, so it cannot become an open dependency interval.
+    """
     current = consumer_capability_declaration() if declaration is None else declaration
     manifest = capability_manifest(format_version=1) if package is None else package
     if not isinstance(current, dict) or set(current) != {
@@ -433,11 +460,36 @@ def validate_recogniser_capabilities(
         or manifest.get("format_version") != 1
     ):
         raise RecogniserCapabilityError("installed recogniser manifest format is unsupported")
+    expected_package_version = _PACKAGE_VERSION
+    if candidate_version is not None:
+        candidate_pattern = (
+            None
+            if _CANDIDATE_PACKAGE_VERSION is None
+            else re.compile(
+                rf"{re.escape(_CANDIDATE_PACKAGE_VERSION)}"
+                r"(?:(?:a|b|rc)\d+|\.dev\d+)?"
+            )
+        )
+        if (
+            type(candidate_version) is not str
+            or candidate_pattern is None
+            or candidate_pattern.fullmatch(candidate_version) is None
+        ):
+            raise RecogniserCapabilityError(
+                f"candidate package version {candidate_version!r} is outside the reviewed "
+                f"{_CANDIDATE_PACKAGE_VERSION!r} transition"
+            )
+        expected_package_version = candidate_version
     package_info = manifest.get("package")
-    if not isinstance(package_info, dict) or package_info.get("version") != _PACKAGE_VERSION:
+    if (
+        not isinstance(package_info, dict)
+        or package_info.get("name") != "b123d-recognisers"
+        or package_info.get("version") != expected_package_version
+    ):
         raise RecogniserCapabilityError(
-            f"installed package version {getattr(package_info, 'get', lambda _key: None)('version')!r} "
-            f"does not satisfy =={_PACKAGE_VERSION}; update the pin and declaration together"
+            f"installed package identity {package_info!r} does not satisfy "
+            f"b123d-recognisers=={expected_package_version}; update the pin and declaration "
+            "together"
         )
     package_families = manifest.get("families")
     families = current["families"]
@@ -513,10 +565,30 @@ def validate_recogniser_capabilities(
             if isinstance(records, list)
             else {}
         )
-        if family["record_schemas"] != actual_schemas:
+        accepted_schemas = family["record_schemas"]
+        valid_schema_declaration = (
+            isinstance(accepted_schemas, dict)
+            and set(accepted_schemas) == set(actual_schemas)
+            and all(
+                isinstance(versions, list)
+                and versions
+                and all(type(version) is int and version > 0 for version in versions)
+                and versions == sorted(set(versions))
+                for versions in accepted_schemas.values()
+            )
+        )
+        valid_actual_schemas = all(
+            type(version) is int and version > 0 for version in actual_schemas.values()
+        )
+        incompatible = (
+            not valid_schema_declaration
+            or not valid_actual_schemas
+            or any(actual_schemas[name] not in accepted_schemas[name] for name in actual_schemas)
+        )
+        if incompatible:
             raise RecogniserCapabilityError(
                 f"family {family_id!r} record schema mismatch; expected {actual_schemas!r}, "
-                f"declared {family['record_schemas']!r}; update the adapter and pin deliberately"
+                f"accepted {accepted_schemas!r}; update the adapter and pin deliberately"
             )
         disposition = family["disposition"]
         if disposition not in {"deferred", "geometry-only", "supported", "unsupported"}:

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -8,6 +8,7 @@ import dataclasses
 import importlib.metadata
 import inspect
 import json
+import os
 import typing
 from pathlib import Path
 
@@ -36,6 +37,17 @@ ROOT = Path(__file__).parents[1]
 PINNED_VERSION = json.loads(
     (ROOT / ".github/recogniser-release.json").read_text(encoding="utf-8")
 )["version"]
+CANDIDATE_VERSION = os.environ.get("DRAFTWRIGHT_RECOGNISER_CANDIDATE_VERSION")
+EXPECTED_PACKAGE_VERSION = CANDIDATE_VERSION or PINNED_VERSION
+
+
+def _validate(*args, **kwargs) -> None:
+    """Run the same contract under the explicitly selected two-checkout candidate, if any."""
+    validate_recogniser_capabilities(
+        *args,
+        **kwargs,
+        candidate_version=CANDIDATE_VERSION,
+    )
 
 
 def test_installed_wheel_layout_validates_portable_contract_without_source_evidence(
@@ -44,7 +56,7 @@ def test_installed_wheel_layout_validates_portable_contract_without_source_evide
     installed_module = tmp_path / "lib/python/site-packages/draftwright/recogniser_contract.py"
     monkeypatch.setattr(contract_module, "__file__", str(installed_module))
 
-    validate_recogniser_capabilities()
+    _validate()
 
 
 @pytest.mark.parametrize("reference", [None, "", "/tmp/evidence.py", "../evidence.py"])
@@ -107,14 +119,17 @@ def _emitter_literal_kinds() -> set[str]:
     return kinds
 
 
-def test_installed_released_package_contract_validates_without_a_sibling_checkout() -> None:
+def test_installed_package_contract_validates_without_a_sibling_checkout() -> None:
     distribution = importlib.metadata.distribution("b123d-recognisers")
-    assert distribution.version == PINNED_VERSION
-    assert distribution.read_text("direct_url.json") is None
+    assert distribution.version == EXPECTED_PACKAGE_VERSION
+    if CANDIDATE_VERSION is None:
+        assert distribution.read_text("direct_url.json") is None
+    else:
+        assert distribution.read_text("direct_url.json") is not None
     package_path = Path(inspect.getfile(recognition)).resolve()
     assert package_path.is_relative_to(ROOT / ".venv")
 
-    validate_recogniser_capabilities()
+    _validate()
     package = recognition.capability_manifest(format_version=1)
     declaration = consumer_capability_declaration()
     # 25 since 0.2.6 added angled-steps, passages and prismatic-pockets (#1244). A literal,
@@ -293,7 +308,7 @@ def _supported(value: dict) -> dict:
             "stale=",
         ),
         (
-            lambda value: _supported(value)["record_schemas"].update({"BossRecord": 99}),
+            lambda value: _supported(value)["record_schemas"].update({"BossRecord": [99]}),
             "record schema mismatch",
         ),
         (
@@ -320,7 +335,7 @@ def test_consumer_declaration_fails_closed_on_stale_or_malformed_claims(
     declaration = consumer_capability_declaration()
     mutate(declaration)
     with pytest.raises(RecogniserCapabilityError, match=message):
-        validate_recogniser_capabilities(declaration)
+        _validate(declaration)
 
 
 def test_a_package_family_we_have_not_declared_yet_does_not_fail_the_join() -> None:
@@ -338,7 +353,7 @@ def test_a_package_family_we_have_not_declared_yet_does_not_fail_the_join() -> N
     package["families"].append(copy.deepcopy(package["families"][0]))
     package["families"][-1]["id"] = "future-thread"
 
-    validate_recogniser_capabilities(package=package)
+    _validate(package=package)
 
     # `in`, not equality: any family the installed package has genuinely grown since the
     # last declaration is legitimately pending too, and this test is not about those.
@@ -367,7 +382,7 @@ def test_family_declarations_must_be_unique_and_sorted(mutate) -> None:
     mutate(declaration["families"])
 
     with pytest.raises(RecogniserCapabilityError, match="unique and sorted"):
-        validate_recogniser_capabilities(declaration)
+        _validate(declaration)
 
 
 def test_pending_declarations_reject_a_malformed_manifest() -> None:
@@ -388,7 +403,97 @@ def test_schema_format_fails_closed() -> None:
     package = recognition.capability_manifest()
     package["format_version"] = 2
     with pytest.raises(RecogniserCapabilityError, match="manifest format"):
-        validate_recogniser_capabilities(package=package)
+        _validate(package=package)
+
+
+def test_only_chamfer_and_fillet_use_the_declared_additive_schema_2_state() -> None:
+    """The 0.3.0 transition is dual-readable before cutover and schema-2-only afterward.
+
+    Package PR #151 adds one optional ``turned`` field to these two records. The existing
+    converters consume only the unchanged schema-1 fields, so accepting schema 2 before the
+    dependency cutover is compatible. The dependency updater closes the window to schema 2;
+    schema 3 remains unknown in both states and must fail closed.
+    """
+    declaration = consumer_capability_declaration()
+    families = _families(declaration)
+    transition_open = contract_module._CANDIDATE_PACKAGE_VERSION is not None
+    expected_transition_schemas = [1, 2] if transition_open else [2]
+    assert families["chamfers"]["record_schemas"] == {"Chamfer": expected_transition_schemas}
+    assert families["fillets"]["record_schemas"] == {"Fillet": expected_transition_schemas}
+    assert all(
+        versions == [1]
+        for family_id, family in families.items()
+        if family_id not in {"chamfers", "fillets"}
+        for versions in family["record_schemas"].values()
+    )
+
+    package = recognition.capability_manifest()
+    package_families = _families(package)
+    package_families["chamfers"]["records"][0]["schema_version"] = 2
+    package_families["fillets"]["records"][0]["schema_version"] = 2
+    _validate(declaration, package=package)
+
+    package_families["chamfers"]["records"][0]["schema_version"] = 3
+    with pytest.raises(RecogniserCapabilityError, match="record schema mismatch"):
+        _validate(declaration, package=package)
+
+
+def test_candidate_validation_changes_only_the_explicit_reviewed_package_identity() -> None:
+    package = recognition.capability_manifest()
+    transition = contract_module._CANDIDATE_PACKAGE_VERSION
+    if transition is not None:
+        candidate = f"{transition}.dev0"
+        package["package"]["version"] = candidate
+        package_families = _families(package)
+        package_families["chamfers"]["records"][0]["schema_version"] = 2
+        package_families["fillets"]["records"][0]["schema_version"] = 2
+        validate_recogniser_capabilities(package=package, candidate_version=candidate)
+
+        with pytest.raises(
+            RecogniserCapabilityError,
+            match=rf"b123d-recognisers=={PINNED_VERSION}",
+        ):
+            validate_recogniser_capabilities(package=package)
+
+    with pytest.raises(RecogniserCapabilityError, match="outside the reviewed"):
+        validate_recogniser_capabilities(package=package, candidate_version="99.99.99")
+
+    package = recognition.capability_manifest()
+    package["package"]["name"] = "lookalike"
+    with pytest.raises(RecogniserCapabilityError, match="package identity"):
+        _validate(package=package)
+
+
+def test_removing_schema_2_from_the_transition_guard_rejects_the_candidate() -> None:
+    """Mutation guard: schema-2 compatibility depends on the explicit declaration."""
+    declaration = consumer_capability_declaration()
+    _families(declaration)["chamfers"]["record_schemas"]["Chamfer"] = [1]
+    package = recognition.capability_manifest()
+    _families(package)["chamfers"]["records"][0]["schema_version"] = 2
+
+    with pytest.raises(RecogniserCapabilityError, match="record schema mismatch"):
+        _validate(declaration, package=package)
+
+
+@pytest.mark.parametrize(
+    "versions",
+    [1, [], [1, 1], [True], [1, "2"], [[1]], [1, None]],
+)
+def test_record_schema_acceptance_lists_fail_closed_when_malformed(versions: object) -> None:
+    declaration = consumer_capability_declaration()
+    _families(declaration)["bosses"]["record_schemas"]["BossRecord"] = versions
+
+    with pytest.raises(RecogniserCapabilityError, match="record schema mismatch"):
+        _validate(declaration)
+
+
+@pytest.mark.parametrize("version", [0, True, 2.0, "2"])
+def test_provider_record_schema_versions_must_be_positive_integers(version: object) -> None:
+    package = recognition.capability_manifest()
+    _families(package)["chamfers"]["records"][0]["schema_version"] = version
+
+    with pytest.raises(RecogniserCapabilityError, match="record schema mismatch"):
+        _validate(package=package)
 
 
 def test_geometry_only_cannot_acquire_invented_drafting_semantics() -> None:
@@ -396,14 +501,14 @@ def test_geometry_only_cannot_acquire_invented_drafting_semantics() -> None:
     family = _families(declaration)["repeating-radial-profiles"]
     family["ir_adapter"] = copy.deepcopy(_families(declaration)["bosses"]["ir_adapter"])
     with pytest.raises(RecogniserCapabilityError, match="invents ir_adapter semantics"):
-        validate_recogniser_capabilities(declaration)
+        _validate(declaration)
 
 
 def test_state_transition_requires_version_release_notes_and_compatibility_evidence() -> None:
     declaration = consumer_capability_declaration()
     declaration["transitions"] = [{"family": "bosses", "from": "deferred", "to": "supported"}]
     with pytest.raises(RecogniserCapabilityError, match="transition lacks"):
-        validate_recogniser_capabilities(declaration)
+        _validate(declaration)
 
     declaration["transitions"] = [
         {
@@ -416,7 +521,7 @@ def test_state_transition_requires_version_release_notes_and_compatibility_evide
             "version": "0.4.7",
         }
     ]
-    validate_recogniser_capabilities(declaration)
+    _validate(declaration)
 
 
 @pytest.mark.parametrize(
@@ -479,7 +584,7 @@ def test_state_transition_requires_version_release_notes_and_compatibility_evide
         ),
         (
             lambda _declaration, package: package["package"].update({"version": "99.99.99"}),
-            f"does not satisfy =={PINNED_VERSION}",
+            f"does not satisfy b123d-recognisers=={EXPECTED_PACKAGE_VERSION}",
         ),
         (
             lambda _declaration, package: package.update({"families": {}}),
@@ -544,7 +649,7 @@ def test_every_malformed_consumer_contract_fails_at_its_own_boundary(mutate, mes
     package = recognition.capability_manifest()
     mutate(declaration, package)
     with pytest.raises(RecogniserCapabilityError, match=message):
-        validate_recogniser_capabilities(declaration, package=package)
+        _validate(declaration, package=package)
 
 
 def _transition() -> dict[str, object]:
@@ -588,14 +693,14 @@ def test_each_unevidenced_transition_shape_fails_closed(field: str, value: objec
     transition[field] = value
     declaration["transitions"] = [transition]
     with pytest.raises(RecogniserCapabilityError, match="transition lacks"):
-        validate_recogniser_capabilities(declaration)
+        _validate(declaration)
 
 
 def test_transition_keys_must_be_unique() -> None:
     declaration = consumer_capability_declaration()
     declaration["transitions"] = [_transition(), _transition()]
     with pytest.raises(RecogniserCapabilityError, match="unique and sorted"):
-        validate_recogniser_capabilities(declaration)
+        _validate(declaration)
 
 
 def test_deferred_family_cannot_claim_supported_downstream_semantics() -> None:
@@ -611,7 +716,7 @@ def test_deferred_family_cannot_claim_supported_downstream_semantics() -> None:
         }
     )
     with pytest.raises(RecogniserCapabilityError, match="claims supported downstream semantics"):
-        validate_recogniser_capabilities(declaration)
+        _validate(declaration)
 
     for boundary in (
         "ir_adapter",
@@ -625,7 +730,7 @@ def test_deferred_family_cannot_claim_supported_downstream_semantics() -> None:
             "rationale": "Consumer support is deliberately scheduled later.",
             "tracking": "https://github.com/pzfreo/draftwright/issues/1169",
         }
-    validate_recogniser_capabilities(declaration)
+    _validate(declaration)
 
 
 def test_documentation_names_each_failure_and_contributor_repair_action() -> None:

--- a/tests/test_two_repository_workflow.py
+++ b/tests/test_two_repository_workflow.py
@@ -201,6 +201,41 @@ def test_dependency_updater_starts_the_next_unreleased_section_after_a_release()
         assert updated.index("0.2.6 to 0.2.8") < updated.index("## v0.4.9")
 
 
+@pytest.mark.parametrize("target", ("0.3.0", "0.3.1", "1.0.0"))
+def test_dependency_updater_closes_an_adopted_schema_transition(
+    tmp_path: Path, target: str
+) -> None:
+    loader = SourceFileLoader(
+        "draftwright_recogniser_schema_transition_update",
+        str(ROOT / "scripts/update-recogniser-dependency"),
+    )
+    spec = spec_from_loader(loader.name, loader)
+    assert spec is not None
+    module = module_from_spec(spec)
+    loader.exec_module(module)
+    contract = tmp_path / "recogniser_contract.py"
+    contract.write_text(
+        '_CANDIDATE_PACKAGE_VERSION: str | None = "0.3.0"\n'
+        "_RECORD_SCHEMA_VERSIONS = {\n"
+        '    ("chamfers", "Chamfer"): (1, 2),\n'
+        '    ("fillets", "Fillet"): (1, 2),\n'
+        "}\n",
+        encoding="utf-8",
+    )
+
+    module._close_schema_transition(contract, "0.2.10")
+    assert '("chamfers", "Chamfer"): (1, 2)' in contract.read_text(encoding="utf-8")
+
+    module._close_schema_transition(contract, target)
+    narrowed = contract.read_text(encoding="utf-8")
+    assert "_CANDIDATE_PACKAGE_VERSION: str | None = None" in narrowed
+    assert '("chamfers", "Chamfer"): (2,)' in narrowed
+    assert '("fillets", "Fillet"): (2,)' in narrowed
+
+    module._close_schema_transition(contract, "0.3.0")
+    assert contract.read_text(encoding="utf-8") == narrowed
+
+
 @pytest.mark.parametrize(
     ("mutation", "message"),
     [


### PR DESCRIPTION
## What

- accept list-shaped record schema declarations while keeping every family fail-closed
- allow only Chamfer and Fillet schemas 1 and 2 during the reviewed 0.3.0 transition
- add an explicit candidate-version seam for the package-owned real-wheel canary
- make the dependency updater close the temporary window when adopting 0.3.0 or a later stable release
- document and test the two-repository landing order

## Why

The recogniser package adds an optional `turned` discriminator to Chamfer and Fillet records in 0.3.0. Draftwright's existing adapters safely ignore additive fields, but its capability contract must explicitly accept schema 2 before the provider PR can pass its downstream canary. The production dependency remains exactly pinned to 0.2.9 in this PR.

## Validation

- 116 focused Draftwright tests passed
- quick PR gate passed, including 91 smoke tests, Ruff, mypy, and docs checks
- real `b123d-recognisers==0.3.0.dev0` wheel canary passed: 95 provider contract tests and 89 Draftwright contract tests
- independent review of this commit: no actionable findings
- independent review of the exact provider companion commit: no actionable findings

Related to #1276 and pzfreo/b123d-recognisers#150.
