### PR TITLE
Accept b123d-recognisers 0.3.1 candidate transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Changed
 
+- Advance the bounded cross-repository canary window from `b123d-recognisers` 0.3.0 to the exact
+  0.3.1 candidate line. Package PR #149 changes recess-recognition behaviour without changing
+  Draftwright's consumed record schemas; production remains pinned to the reviewed 0.2.9 artifact
+  until the normal immutable dependency-update workflow runs.
+
 - Accept the additive Chamfer and Fillet schema-2 recognizer contract alongside schema 1 ahead of
   the `b123d-recognisers` 0.3.0 cutover; all other record schemas remain fail-closed at version 1
   (#1276).

--- a/src/draftwright/recogniser_contract.py
+++ b/src/draftwright/recogniser_contract.py
@@ -23,8 +23,11 @@ _PACKAGE_VERSION = "0.2.9"
 # The only package identity the cross-repository canary may substitute for the exact production
 # pin.  Passing a candidate is explicit at the validator call site; normal imports and released
 # checks never consult environment state and therefore remain locked to ``_PACKAGE_VERSION``.
-# ``scripts/update-recogniser-dependency`` disables this window when 0.3.0 becomes the pin.
-_CANDIDATE_PACKAGE_VERSION: str | None = "0.3.0"
+# The 0.3.0 artifact has shipped while Draftwright remains deliberately pinned to 0.2.9. Package
+# PR #149 is the first 0.3.1 candidate and changes recognition behaviour without changing the
+# capability schema consumed here. Keep the canary window exact rather than accepting the whole
+# 0.3 line. ``scripts/update-recogniser-dependency`` disables it at the eventual pin cutover.
+_CANDIDATE_PACKAGE_VERSION: str | None = "0.3.1"
 _BOUNDARIES = (
     "ir_adapter",
     "dsl_declaration",

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -407,7 +407,7 @@ def test_schema_format_fails_closed() -> None:
 
 
 def test_only_chamfer_and_fillet_use_the_declared_additive_schema_2_state() -> None:
-    """The 0.3.0 transition is dual-readable before cutover and schema-2-only afterward.
+    """The 0.3 transition is dual-readable before cutover and schema-2-only afterward.
 
     Package PR #151 adds one optional ``turned`` field to these two records. The existing
     converters consume only the unchanged schema-1 fields, so accepting schema 2 before the


### PR DESCRIPTION
## Summary

Advance Draftwright's bounded cross-repository canary from the exact `b123d-recognisers` 0.3.0 candidate line to the exact 0.3.1 candidate line required by pzfreo/b123d-recognisers#149.

Production remains pinned to the reviewed 0.2.9 artifact. This does not open a version range and does not change any consumed record schema.

## Evidence

- 105 focused capability/workflow tests pass
- Ruff and mypy pass
- The full bounded two-repository harness passes with the #149 wheel:
  - package contract: 95 passed
  - Draftwright contract: 89 passed

Depends on / enables pzfreo/b123d-recognisers#149.