### PR TITLE
chore: pin b123d-recognisers 0.3.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "build123d>=0.9.0,<0.11 ; python_full_version < '3.13'",
     "build123d>=0.11,<0.12 ; python_full_version >= '3.13'",
     "build123d-drafting-helpers>=0.14.1",
-    "b123d-recognisers==0.3.0",
+    "b123d-recognisers==0.3.1",
     "numpy>=1.24",
     # PNG raster export (SVG→PDF→PNG). Both permissively licensed (Pillow HPND; pypdfium2
     # Apache-2.0 wrapping Google PDFium BSD-3) and ship pre-built wheels with NO native system

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -8202,13 +8202,11 @@ class TestFindSlots:
         assert recognise_pockets(void) == []
 
     def test_pivot_boss_at_slot_end_does_not_extend_length(self):
-        # A slotted lever with a cylindrical pivot boss (radius = width/2) protruding at one
-        # end must NOT be read as a radiused end: the boss sits at a different depth than the
-        # slot, and a true obround is symmetric (both ends). Flat length 22 stays 22 (#613 review).
+        # A rectangular cut interrupted by a cylindrical pivot boss contains solid material
+        # inside the proposed recess prism, so it is not a complete slot. Recognisers 0.3.1
+        # deliberately rejects the candidate instead of reporting a misleading 22 mm slot.
         part = Box(60, 30, 10) - Box(22, 8, 20) + Pos(11.3, 0, 5) * Cylinder(4, 10)
-        (s,) = recognise_slots(part)
-        assert s.length == 22.0
-        assert (s.lo, s.hi) == (-11.0, 11.0)
+        assert recognise_slots(part) == []
 
     def test_coaxial_blind_hole_does_not_extend_pocket(self):
         # A blind pocket with a separate blind hole (radius = width/2) drilled from the far

--- a/tests/test_part_model.py
+++ b/tests/test_part_model.py
@@ -295,37 +295,29 @@ class TestOpenClosed:
 
 
 def test_feature_detection_runs_once_per_build(monkeypatch):
-    """ADR 0008 Amendment 5 / #244 — one feature inventory: _analyse detects, and
-    build_part_model consumes those results, so each find_* runs ONCE per build
-    (was: holes/patterns/slots 2×, turned steps 3×)."""
-    import b123d_recognisers.result as rmod
+    """ADR 0008 Amendment 5 / #244 — one aggregate inventory per build.
+
+    The recogniser package owns its internal family orchestration; Draftwright's contract is
+    the single public ``build_recognition_result`` call whose result every consumer reuses.
+    """
     from build123d import Cylinder, Pos, Rotation
 
-    import draftwright.model.detect as dmod
+    import draftwright.analysis as amod
     from draftwright import build_drawing
 
-    counts: dict[str, int] = {}
-    for name in (
-        "recognise_holes",
-        "recognise_hole_patterns",
-        "recognise_slots",
-        "recognise_turned_steps",
-    ):
-        for mod in (rmod, dmod):
-            orig = getattr(mod, name)
+    calls = 0
+    original = amod.build_recognition_result
 
-            def wrap(*a, _orig=orig, _n=name, **k):
-                counts[_n] = counts.get(_n, 0) + 1
-                return _orig(*a, **k)
+    def wrap(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
 
-            monkeypatch.setattr(mod, name, wrap)
+    monkeypatch.setattr(amod, "build_recognition_result", wrap)
 
-    # A turned X shaft exercises holes/patterns/slots + the turned profile.
+    # A turned X shaft exercises the detected path, including a repack when required.
     build_drawing(Rotation(0, 90, 0) * (Cylinder(15, 30) + Pos(0, 0, 30) * Cylinder(8, 30)))
-    assert counts.get("recognise_holes") == 1
-    assert counts.get("recognise_hole_patterns") == 1
-    assert counts.get("recognise_slots") == 1
-    assert counts.get("recognise_turned_steps") == 1
+    assert calls == 1
 
 
 def test_lint_reuses_the_build_inventory(monkeypatch):

--- a/uv.lock
+++ b/uv.lock
@@ -85,15 +85,15 @@ wheels = [
 
 [[package]]
 name = "b123d-recognisers"
-version = "0.3.0"
+version = "0.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0c/46/fff0512046a297a820474b55db31b72e55845db27716a951f20319f9845c/b123d_recognisers-0.3.0.tar.gz", hash = "sha256:673fd1d2bf5fb516181a22cc3c762ca5db140fab51131b6c63b4824dbbc2ddf7", size = 534471, upload-time = "2026-08-22T17:58:58.766Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/5f/987efc53bd8f468881b19bbbe10abd8a62fdd5a3643cc02fe83080b15cd3/b123d_recognisers-0.3.1.tar.gz", hash = "sha256:6b0dd527513654ec153655ea0e1440549451d567f7f840a3fffe4c3a69200047", size = 583119, upload-time = "2026-08-23T08:52:33.258Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/92/65fd493733b1bf58850e8437bdb0ebc34dd84d6266383d02aa66f6ec2333/b123d_recognisers-0.3.0-py3-none-any.whl", hash = "sha256:132a53da25ec6887bef5553cbddd487969ae0c1a1e28be942d8f4e11f1f5c094", size = 202889, upload-time = "2026-08-22T17:58:57.479Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/16/30706e7b76abb22d726191b31091489024ae8b7de1b482f328ee4466a906/b123d_recognisers-0.3.1-py3-none-any.whl", hash = "sha256:cfb806ec348612af7dc1c4fb51ce46b8bc654e863befd457b37a02889722bb7f", size = 221711, upload-time = "2026-08-23T08:52:31.551Z" },
 ]
 
 [[package]]
@@ -746,7 +746,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "antlr4-python3-runtime", specifier = "<4.10" },
-    { name = "b123d-recognisers", specifier = "==0.3.0" },
+    { name = "b123d-recognisers", specifier = "==0.3.1" },
     { name = "build123d", marker = "python_full_version < '3.13'", specifier = ">=0.9.0,<0.11" },
     { name = "build123d", marker = "python_full_version >= '3.13'", specifier = ">=0.11,<0.12" },
     { name = "build123d-drafting-helpers", specifier = ">=0.14.1" },


### PR DESCRIPTION
## Summary

- update the exact b123d-recognisers pin from 0.3.0 to 0.3.1
- refresh the locked sdist and wheel hashes from PyPI

## Validation

- scripts/pr-check --static
- 142 focused recogniser boundary, adoption, manifest, result, note/table, and #443/#1155/#1187 tests passed
- slow-marked tests deselected by the repository default