### PR TITLE
Inventory AP242 semantic manufacturing requirements

### DIFF
--- a/src/draftwright/_pmi_part21.py
+++ b/src/draftwright/_pmi_part21.py
@@ -1,13 +1,15 @@
 """Structured Part21 facts that OCCT's XCAF PMI transfer currently drops.
 
 This is deliberately a leaf adapter: it understands ISO 10303-21 entities and units, but
-knows nothing about XCAF labels, drafting IR, or placement.  ``pmi.py`` owns the overlay and
-may use a fact only after :func:`match_geometric_tolerance` proves exact correspondence.
+knows nothing about XCAF labels, drafting IR, or placement.  ``pmi.py`` owns the overlay.
+Geometric-tolerance facts require exact XCAF correspondence; manufacturing-requirement facts
+retain their own complete property -> representation -> shape-aspect source chain.
 """
 
 from __future__ import annotations
 
 import math
+import re
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -53,6 +55,13 @@ _SI_METRE_TO_MM: dict[str, float] = {
     ".ATTO.": 1e-15,
 }
 
+# Entity names are invariant ASCII Part21 syntax; string parameters are not.  Keying this
+# guard on the literal category text silently missed valid ``\X2\...\X0\`` encodings before
+# steputils had a chance to decode them.  A file with no property definitions cannot carry
+# the requirement chain, while any file that does is parsed conservatively (#1297).  Match
+# only the invariant token: Part 21 comments may legally separate it from the opening ``(``.
+_PROPERTY_DEFINITION_MARKER = re.compile(rb"\bPROPERTY_DEFINITION\b", re.IGNORECASE)
+
 
 @dataclass(frozen=True)
 class GeometricToleranceFact:
@@ -84,7 +93,31 @@ class DatumOccurrenceFact:
     reason: str = ""
 
 
+@dataclass(frozen=True)
+class ManufacturingRequirementFact:
+    """One authoritative semantic manufacturing requirement from Part 21.
+
+    ``entity_id`` is the ``PROPERTY_DEFINITION`` identity, while ``text`` comes from the
+    linked ``DESCRIPTIVE_REPRESENTATION_ITEM`` rather than presentation glyphs.  The
+    remaining IDs preserve the semantic-callout -> shape-aspect -> representation-item
+    association for concept lowering; this leaf adapter deliberately does not interpret
+    those items as drafting features.
+    """
+
+    entity_id: str
+    semantic_name: str
+    text: str
+    representation_id: str = ""
+    descriptive_item_id: str = ""
+    callout_ids: tuple[str, ...] = ()
+    shape_aspect_ids: tuple[str, ...] = ()
+    reference_item_ids: tuple[str, ...] = ()
+    reason: str = ""
+
+
 def _entities(instance) -> tuple:
+    if instance is None:
+        return ()
     entity = getattr(instance, "entity", None)
     if entity is not None:
         return (entity,)
@@ -156,6 +189,205 @@ def _datum_feature_items(step) -> dict[str, tuple[str, ...]]:
                     continue
                 result.setdefault(str(feature), []).extend(_references(usage.params[4]))
     return {key: tuple(dict.fromkeys(values)) for key, values in result.items()}
+
+
+def _text(value) -> str:
+    return str(value).strip() if isinstance(value, str) else ""
+
+
+def _name_tokens(value: str) -> frozenset[str]:
+    """Normalise semantic names for callout correspondence, not requirement inference."""
+    words = []
+    for raw in value.lower().replace("_", " ").replace("-", " ").split():
+        word = "".join(character for character in raw if character.isalnum())
+        if len(word) > 3 and word.endswith("s") and not word.endswith("ss"):
+            word = word[:-1]
+        if word and word != "requirement":
+            words.append(word)
+    return frozenset(words)
+
+
+def _manufacturing_graph(step):
+    """Collect the Part21 indexes shared by manufacturing-requirement facts."""
+    definitions: list[tuple[str, object]] = []
+    representations: dict[str, list[str]] = {}
+    callout_names: dict[str, str] = {}
+    callout_aspects: dict[str, list[str]] = {}
+    aspect_items: dict[str, list[str]] = {}
+
+    for section in step.data:
+        for entity_id, instance in section.instances.items():
+            definition = _entity_named(instance, "PROPERTY_DEFINITION")
+            if (
+                definition is not None
+                and len(definition.params) >= 2
+                and _text(definition.params[0]).lower() == "manufacturing requirement"
+            ):
+                definitions.append((entity_id, definition))
+
+            relationship = _entity_named(instance, "PROPERTY_DEFINITION_REPRESENTATION")
+            if relationship is not None and len(relationship.params) >= 2:
+                definition_ref, representation_ref = relationship.params[:2]
+                if isinstance(definition_ref, p21.Reference) and isinstance(
+                    representation_ref, p21.Reference
+                ):
+                    representations.setdefault(str(definition_ref), []).append(
+                        str(representation_ref)
+                    )
+
+            callout = _entity_named(instance, "DRAUGHTING_CALLOUT")
+            if callout is not None and callout.params:
+                callout_names[entity_id] = _text(callout.params[0])
+
+            association = _entity_named(instance, "DRAUGHTING_MODEL_ITEM_ASSOCIATION")
+            if association is not None and len(association.params) >= 5:
+                aspect_ref = association.params[2]
+                if isinstance(aspect_ref, p21.Reference) and _instance_is(
+                    step, str(aspect_ref), "SHAPE_ASPECT"
+                ):
+                    for callout_ref in _references(association.params[4]):
+                        if _instance_is(step, callout_ref, "DRAUGHTING_CALLOUT"):
+                            callout_aspects.setdefault(callout_ref, []).append(str(aspect_ref))
+
+            usage = _entity_named(instance, "GEOMETRIC_ITEM_SPECIFIC_USAGE")
+            if usage is not None and len(usage.params) >= 5:
+                aspect_ref = usage.params[2]
+                if isinstance(aspect_ref, p21.Reference) and _instance_is(
+                    step, str(aspect_ref), "SHAPE_ASPECT"
+                ):
+                    aspect_items.setdefault(str(aspect_ref), []).extend(
+                        _references(usage.params[4])
+                    )
+
+    return definitions, representations, callout_names, callout_aspects, aspect_items
+
+
+def read_manufacturing_requirements(
+    step_file: str | Path,
+) -> tuple[ManufacturingRequirementFact, ...]:
+    """Read authoritative semantic requirements and retain their geometry associations.
+
+    The property-definition chain owns the full requirement text.  A draughting callout
+    with the same representation name (or, where the presentation adds a qualifier such as
+    ``Straight``, the same semantic-name tokens) supplies the shape-aspect association.
+    This is correspondence between two source semantic identities; no nominal value or
+    B-rep measurement is guessed here.
+    """
+    # A file with no property-definition entity cannot carry this semantic chain, so avoid a
+    # third full Part21 parse there.  Once any property definition exists, parse
+    # conservatively: its string category may use a valid escape encoding that a byte-level
+    # literal check cannot interpret.
+    if _PROPERTY_DEFINITION_MARKER.search(Path(step_file).read_bytes()) is None:
+        return ()
+    step = p21.readfile(step_file)
+    (
+        definitions,
+        representations,
+        callout_names,
+        callout_aspects,
+        aspect_items,
+    ) = _manufacturing_graph(step)
+    facts: list[ManufacturingRequirementFact] = []
+
+    for entity_id, definition in definitions:
+        semantic_name = _text(definition.params[1])
+        reasons: list[str] = []
+        if not semantic_name:
+            reasons.append("manufacturing requirement has no semantic name")
+
+        representation_ids = tuple(dict.fromkeys(representations.get(entity_id, ())))
+        representation_id = representation_ids[0] if len(representation_ids) == 1 else ""
+        if len(representation_ids) != 1:
+            reasons.append(
+                f"manufacturing requirement has {len(representation_ids)} linked representations"
+            )
+
+        representation_name = ""
+        descriptive_ids: tuple[str, ...] = ()
+        if representation_id:
+            representation = _entity_named(step.get(representation_id), "REPRESENTATION")
+            if representation is None or len(representation.params) < 2:
+                reasons.append(
+                    f"linked representation {representation_id} is unavailable or malformed"
+                )
+            else:
+                representation_name = _text(representation.params[0])
+                descriptive_ids = tuple(
+                    dict.fromkeys(
+                        ref
+                        for ref in _references(representation.params[1])
+                        if _instance_is(step, ref, "DESCRIPTIVE_REPRESENTATION_ITEM")
+                    )
+                )
+
+        descriptive_item_id = descriptive_ids[0] if len(descriptive_ids) == 1 else ""
+        text = ""
+        if representation_id and len(descriptive_ids) != 1:
+            reasons.append(f"linked representation has {len(descriptive_ids)} descriptive items")
+        if descriptive_item_id:
+            item = _entity_named(step.get(descriptive_item_id), "DESCRIPTIVE_REPRESENTATION_ITEM")
+            if item is None or len(item.params) < 2:
+                reasons.append(f"descriptive item {descriptive_item_id} is malformed")
+            else:
+                text = _text(item.params[1])
+                if not text:
+                    reasons.append("manufacturing requirement has no authoritative text")
+
+        exact_callouts = tuple(
+            callout_id
+            for callout_id, name in callout_names.items()
+            if representation_name and name.casefold() == representation_name.casefold()
+        )
+        semantic_tokens = _name_tokens(semantic_name)
+        callout_ids = exact_callouts or tuple(
+            callout_id
+            for callout_id, name in callout_names.items()
+            if semantic_tokens and semantic_tokens <= _name_tokens(name)
+        )
+        missing_callout_associations = tuple(
+            callout_id for callout_id in callout_ids if not callout_aspects.get(callout_id)
+        )
+        if missing_callout_associations:
+            reasons.append(
+                "matched semantic callout(s) have no shape-aspect association: "
+                + ", ".join(missing_callout_associations)
+            )
+        shape_aspect_ids = tuple(
+            dict.fromkeys(
+                aspect_id
+                for callout_id in callout_ids
+                for aspect_id in callout_aspects.get(callout_id, ())
+            )
+        )
+        missing_aspect_items = tuple(
+            aspect_id for aspect_id in shape_aspect_ids if not aspect_items.get(aspect_id)
+        )
+        if missing_aspect_items:
+            reasons.append(
+                "associated shape aspect(s) have no representation items: "
+                + ", ".join(missing_aspect_items)
+            )
+        reference_item_ids = tuple(
+            dict.fromkeys(
+                item_id
+                for aspect_id in shape_aspect_ids
+                for item_id in aspect_items.get(aspect_id, ())
+            )
+        )
+        facts.append(
+            ManufacturingRequirementFact(
+                entity_id=entity_id,
+                semantic_name=semantic_name,
+                text=text,
+                representation_id=representation_id,
+                descriptive_item_id=descriptive_item_id,
+                callout_ids=tuple(dict.fromkeys(callout_ids)),
+                shape_aspect_ids=shape_aspect_ids,
+                reference_item_ids=reference_item_ids,
+                reason="; ".join(dict.fromkeys(reasons)),
+            )
+        )
+    return tuple(facts)
 
 
 def _unit_factor_mm(step, unit_ref: str) -> tuple[float | None, str]:

--- a/src/draftwright/linting/pmi_coverage.py
+++ b/src/draftwright/linting/pmi_coverage.py
@@ -49,6 +49,7 @@ def lint_pmi_ignored(
         "dimension": "dimension",
         "geometric_tolerance": "geometric tolerance",
         "datum": "datum reference",
+        "manufacturing_requirement": "manufacturing requirement",
     }
     inventory = ", ".join(
         f"{count} {names[category]}{'s' if count != 1 else ''}"

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -275,6 +275,8 @@ def build_pmi_features(
             datum_contexts=r.datum_contexts,
             reference_item_ids=r.reference_item_ids,
             reference_axis=r.reference_axis,
+            semantic_name=r.semantic_name,
+            shape_aspect_ids=r.shape_aspect_ids,
         )
         if r.source_category == "geometric_tolerance" and not r.lowering_blockers:
             item = control_frame(

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -1400,6 +1400,8 @@ class PmiFeature:
     datum_contexts: tuple[str, ...] = ()
     reference_item_ids: tuple[str, ...] = ()
     reference_axis: str = ""
+    semantic_name: str = ""
+    shape_aspect_ids: tuple[str, ...] = ()
     kind: ClassVar[str] = "pmi"
 
     def parameters(self) -> list[DimParameter]:

--- a/src/draftwright/pmi.py
+++ b/src/draftwright/pmi.py
@@ -31,6 +31,7 @@ from draftwright._pmi_part21 import (
     match_geometric_tolerance,
     read_datum_occurrences,
     read_geometric_tolerances,
+    read_manufacturing_requirements,
 )
 
 _log = logging.getLogger(__name__)
@@ -156,7 +157,9 @@ _SUPPORTED_GTOL_SCOPE_MODIFIERS = frozenset(("all_around", "all_over"))
 # Data classes
 # ---------------------------------------------------------------------------
 
-PmiSourceCategory = Literal["dimension", "geometric_tolerance", "datum"]
+PmiSourceCategory = Literal[
+    "dimension", "geometric_tolerance", "datum", "manufacturing_requirement"
+]
 
 
 @dataclass(frozen=True)
@@ -165,7 +168,7 @@ class PmiRecord:
 
     Attributes:
         kind:           Human-readable category (``"linear"``, ``"diameter"``,
-                        ``"angular"``, ``"gtol"``, ``"datum"``).
+                        ``"angular"``, ``"gtol"``, ``"datum"``, ``"external_thread"``).
         type_code:      Raw OCCT enum integer.
         value:          Nominal value in mm (or degrees for angular).
         upper_tol:      Upper tolerance in mm, or ``None``.
@@ -192,6 +195,8 @@ class PmiRecord:
         datum_contexts: Tolerance semantic names in which a datum definition is referenced.
         reference_item_ids: Exact Part21 representation items bound to a datum feature.
         reference_axis: Axis normal to a proven datum reference plane.
+        semantic_name: Stable source name for a semantic manufacturing requirement.
+        shape_aspect_ids: Part21 shape aspects associating a semantic requirement to geometry.
     """
 
     kind: str
@@ -220,6 +225,8 @@ class PmiRecord:
     datum_contexts: tuple[str, ...] = ()
     reference_item_ids: tuple[str, ...] = ()
     reference_axis: str = ""
+    semantic_name: str = ""
+    shape_aspect_ids: tuple[str, ...] = ()
 
 
 PmiExtractionOutcome = Literal[
@@ -878,26 +885,101 @@ def _geometric_tolerance_record(
 # ---------------------------------------------------------------------------
 
 
+def _manufacturing_requirement_projection(
+    step_file: str | Path,
+) -> tuple[tuple[PmiSourceEntity, ...], tuple[PmiRecord, ...]]:
+    """Build the Part21-only source/record projection independently of XCAF availability."""
+    sources: list[PmiSourceEntity] = []
+    records: list[PmiRecord] = []
+    try:
+        requirement_facts = read_manufacturing_requirements(step_file)
+    except Exception as exc:
+        reason = f"Part21 manufacturing-requirement read failed: {_failure_reason(exc)}"
+        sources.append(
+            PmiSourceEntity(
+                source_id="manufacturing_requirement:part21",
+                category="manufacturing_requirement",
+                type_code=None,
+                outcome="not_extracted",
+                reason=reason,
+            )
+        )
+        _log.debug("PMI manufacturing-requirement inventory unavailable: %s", exc)
+        return tuple(sources), ()
+
+    for requirement in requirement_facts:
+        source_id = f"manufacturing_requirement:{requirement.entity_id}"
+        if requirement.text:
+            kind = (
+                "_".join(requirement.semantic_name.lower().split()) or "manufacturing_requirement"
+            )
+            blockers = (requirement.reason,) if requirement.reason else ()
+            records.append(
+                PmiRecord(
+                    kind=kind,
+                    type_code=None,
+                    value=0.0,
+                    label=requirement.text,
+                    source_id=source_id,
+                    part21_id=requirement.entity_id,
+                    source_category="manufacturing_requirement",
+                    lowering_blockers=blockers,
+                    reference_item_ids=requirement.reference_item_ids,
+                    semantic_name=requirement.semantic_name,
+                    shape_aspect_ids=requirement.shape_aspect_ids,
+                )
+            )
+        sources.append(
+            PmiSourceEntity(
+                source_id=source_id,
+                category="manufacturing_requirement",
+                type_code=None,
+                outcome=(
+                    "partially_extracted"
+                    if requirement.text and requirement.reason
+                    else "extracted"
+                    if requirement.text
+                    else "not_extracted"
+                ),
+                reason=requirement.reason,
+            )
+        )
+    return tuple(sources), tuple(records)
+
+
 def extract_pmi_report(step_file: str | Path) -> PmiExtractionReport:
     """Inventory and extract semantic PMI from an AP242 STEP file in one XCAF pass.
 
-    The report retains one source outcome for every dimension, geometric tolerance and
-    datum-reference occurrence. Graphical presentation-only dimension labels are inventoried
-    but are not manufacturing requirements. Repeated datum occurrences project onto their
-    authored datum-feature definition without shrinking the source denominator.
+    The report retains one source outcome for every dimension, geometric tolerance,
+    datum-reference occurrence and semantic manufacturing requirement. Graphical
+    presentation-only dimension labels are inventoried but are not manufacturing requirements.
+    Repeated datum occurrences project onto their authored datum-feature definition without
+    shrinking the source denominator.
 
-    Returns an empty report (with a report-level error where applicable) when:
+    Returns an empty report (with a report-level error where applicable) when no source
+    identities can be recovered and:
 
-    - the file contains no GDT data;
-    - OCP's GDT support is unavailable (``_PMI_AVAILABLE`` is False);
+    - the file contains neither XCAF GDT data nor semantic manufacturing requirements;
     - the file uses AP203/AP214 which carry no semantic PMI.
+
+    Part21-only manufacturing requirements remain inventoried even when OCP's GDT support is
+    unavailable or the XCAF transfer fails; the report also retains that global XCAF error.
 
     Does **not** modify the solid geometry — purely a read-only second pass.
     """
+    requirement_sources, requirement_records = _manufacturing_requirement_projection(step_file)
+
+    def failed(reason: str) -> PmiExtractionReport:
+        return PmiExtractionReport(
+            sources=requirement_sources,
+            records=requirement_records,
+            error=reason,
+        )
+
     if not _PMI_AVAILABLE:
         reason = "OCP SetGDTMode is unavailable"
         _log.debug("PMI extraction unavailable (%s)", reason)
-        return PmiExtractionReport(error=reason)
+        return failed(reason)
 
     path = str(step_file)
     doc = TDocStd_Document(TCollection_ExtendedString("XCAF"))
@@ -909,21 +991,21 @@ def extract_pmi_report(step_file: str | Path) -> PmiExtractionReport:
     except Exception as exc:
         reason = f"ReadFile failed: {_failure_reason(exc)}"
         _log.warning("PMI extraction: %s for %s", reason, Path(step_file).name)
-        return PmiExtractionReport(error=reason)
+        return failed(reason)
     if status != IFSelect_RetDone:
         reason = f"ReadFile failed with status {status}"
         _log.warning("PMI extraction: %s for %s", reason, Path(step_file).name)
-        return PmiExtractionReport(error=reason)
+        return failed(reason)
     try:
         transferred = reader.Transfer(doc)
     except Exception as exc:
         reason = f"Transfer failed: {_failure_reason(exc)}"
         _log.warning("PMI extraction: %s for %s", reason, Path(step_file).name)
-        return PmiExtractionReport(error=reason)
+        return failed(reason)
     if transferred is False:
         reason = "Transfer failed"
         _log.warning("PMI extraction: %s for %s", reason, Path(step_file).name)
-        return PmiExtractionReport(error=reason)
+        return failed(reason)
 
     main = doc.Main()
     shape_tool = XCAFDoc_DocumentTool.ShapeTool_s(main)
@@ -1128,6 +1210,12 @@ def extract_pmi_report(step_file: str | Path) -> PmiExtractionReport:
             )
     records.extend(_coalesce_datum_records(datum_records))
 
+    # XCAF exposes neither authoritative descriptive text nor its shape-aspect association.
+    # The independent Part21 projection was collected before XCAF so it survives every early
+    # transfer failure; append it after XCAF categories to keep the established report order.
+    sources.extend(requirement_sources)
+    records.extend(requirement_records)
+
     semantic_dimensions = sum(
         source.category == "dimension" and source.outcome != "presentation_only"
         for source in sources
@@ -1158,11 +1246,23 @@ def extract_pmi_report(step_file: str | Path) -> PmiExtractionReport:
         source.category == "datum" and source.outcome == "partially_extracted"
         for source in sources
     )
+    extracted_requirements = sum(
+        source.category == "manufacturing_requirement" and source.outcome == "extracted"
+        for source in sources
+    )
+    partial_requirements = sum(
+        source.category == "manufacturing_requirement" and source.outcome == "partially_extracted"
+        for source in sources
+    )
+    requirement_source_count = sum(
+        source.category == "manufacturing_requirement" for source in sources
+    )
 
     _log.info(
         "PMI extracted from %s: %d/%d complete semantic dims (%d partial, "
         "%d presentation-only), "
-        "%d/%d complete gtols (%d partial), %d/%d datum occurrences (%d partial)",
+        "%d/%d complete gtols (%d partial), %d/%d datum occurrences (%d partial), "
+        "%d/%d manufacturing requirements (%d partial)",
         Path(step_file).name,
         extracted_dimensions,
         semantic_dimensions,
@@ -1174,6 +1274,9 @@ def extract_pmi_report(step_file: str | Path) -> PmiExtractionReport:
         extracted_datums,
         datums.Length(),
         partial_datums,
+        extracted_requirements,
+        requirement_source_count,
+        partial_requirements,
     )
     return PmiExtractionReport(sources=tuple(sources), records=tuple(records))
 

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -395,6 +395,12 @@ def _raw_pmi_expr(f) -> str:
     reference_axis = (
         f", reference_axis={f.reference_axis!r}" if getattr(f, "reference_axis", "") else ""
     )
+    semantic_name = (
+        f", semantic_name={f.semantic_name!r}" if getattr(f, "semantic_name", "") else ""
+    )
+    shape_aspect_ids = (
+        f", shape_aspect_ids={f.shape_aspect_ids!r}" if getattr(f, "shape_aspect_ids", ()) else ""
+    )
     return (
         "PmiFeature("
         f"frame=Frame({_pt(f.frame.origin)}, {f.frame.axis!r}), "
@@ -402,7 +408,7 @@ def _raw_pmi_expr(f) -> str:
         f"dominant_axis={f.dominant_axis!r}, ref_bbox={_bbox_arg(f.ref_bbox)}, "
         f"ref_pts=tuple({_pts_arg(f.ref_pts)}){source_id}{datum_refs}{part21_id}"
         f"{source_category}{gtol_modifiers}{lowering_blockers}{source_ids}{datum_contexts}"
-        f"{reference_item_ids}{reference_axis}"
+        f"{reference_item_ids}{reference_axis}{semantic_name}{shape_aspect_ids}"
         ")"
     )
 

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -8,7 +8,7 @@ import pytest
 from build123d import Box, export_step
 
 from draftwright import build_drawing, extract_pmi, extract_pmi_report
-from draftwright._pmi_part21 import GeometricToleranceFact
+from draftwright._pmi_part21 import GeometricToleranceFact, ManufacturingRequirementFact
 from draftwright.pmi import _PMI_AVAILABLE, PmiExtractionReport, PmiRecord
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -254,6 +254,97 @@ class TestExtractPmi:
             for source in report.sources
             if source.outcome in ("extracted", "partially_extracted")
         }
+
+    def test_report_inventories_semantic_manufacturing_requirements(self, monkeypatch):
+        import draftwright.pmi as pmi_module
+
+        fact = ManufacturingRequirementFact(
+            entity_id="#probe",
+            semantic_name="external thread",
+            text="M3 x 0.5-6g RH",
+            representation_id="#representation",
+            descriptive_item_id="#description",
+            callout_ids=("#callout",),
+            shape_aspect_ids=("#aspect",),
+            reference_item_ids=("#face",),
+        )
+        monkeypatch.setattr(
+            pmi_module, "read_manufacturing_requirements", lambda _step_file: (fact,)
+        )
+
+        report = extract_pmi_report(CTC01)
+        source = next(
+            item for item in report.sources if item.source_id == "manufacturing_requirement:#probe"
+        )
+        record = next(
+            item for item in report.records if item.source_id == "manufacturing_requirement:#probe"
+        )
+
+        assert (source.category, source.outcome, source.reason) == (
+            "manufacturing_requirement",
+            "extracted",
+            "",
+        )
+        assert (
+            record.kind,
+            record.label,
+            record.part21_id,
+            record.source_category,
+            record.semantic_name,
+            record.shape_aspect_ids,
+            record.reference_item_ids,
+        ) == (
+            "external_thread",
+            "M3 x 0.5-6g RH",
+            "#probe",
+            "manufacturing_requirement",
+            "external thread",
+            ("#aspect",),
+            ("#face",),
+        )
+
+    def test_requirement_part21_failure_is_a_fail_closed_source_outcome(self, monkeypatch):
+        import draftwright.pmi as pmi_module
+
+        def fail(_step_file):
+            raise RuntimeError("mutation: requirement parser failed")
+
+        monkeypatch.setattr(pmi_module, "read_manufacturing_requirements", fail)
+
+        report = extract_pmi_report(CTC01)
+        source = next(
+            item for item in report.sources if item.source_id == "manufacturing_requirement:part21"
+        )
+
+        assert source.category == "manufacturing_requirement"
+        assert source.outcome == "not_extracted"
+        assert source.reason == (
+            "Part21 manufacturing-requirement read failed: "
+            "RuntimeError: mutation: requirement parser failed"
+        )
+
+    def test_part21_requirements_survive_when_xcaf_is_unavailable(self, monkeypatch):
+        import draftwright.pmi as pmi_module
+
+        fact = ManufacturingRequirementFact(
+            entity_id="#probe",
+            semantic_name="knurl",
+            text="Straight knurl, 1.0 mm pitch",
+        )
+        monkeypatch.setattr(
+            pmi_module, "read_manufacturing_requirements", lambda _step_file: (fact,)
+        )
+        monkeypatch.setattr(pmi_module, "_PMI_AVAILABLE", False)
+
+        report = extract_pmi_report(CTC01)
+
+        assert report.error == "OCP SetGDTMode is unavailable"
+        assert [source.source_id for source in report.sources] == [
+            "manufacturing_requirement:#probe"
+        ]
+        assert [(record.source_id, record.label) for record in report.records] == [
+            ("manufacturing_requirement:#probe", "Straight knurl, 1.0 mm pitch")
+        ]
 
     def test_ctc01_datum_occurrences_project_to_three_feature_definitions(
         self, ctc01_extraction_report

--- a/tests/test_pmi_part21.py
+++ b/tests/test_pmi_part21.py
@@ -7,10 +7,12 @@ import pytest
 from draftwright._pmi_part21 import (
     DatumOccurrenceFact,
     GeometricToleranceFact,
+    ManufacturingRequirementFact,
     match_datum_occurrence,
     match_geometric_tolerance,
     read_datum_occurrences,
     read_geometric_tolerances,
+    read_manufacturing_requirements,
 )
 
 CTC01 = Path(__file__).parent / "fixtures" / "nist_ctc_01_asme1_ap242.stp"
@@ -43,6 +45,12 @@ def _read_datums(tmp_path, name: str, *instances: str):
     step = tmp_path / f"{name}.step"
     step.write_text(_step(*instances), encoding="utf-8")
     return read_datum_occurrences(step)
+
+
+def _read_requirements(tmp_path, name: str, *instances: str):
+    step = tmp_path / f"{name}.step"
+    step.write_text(_step(*instances), encoding="utf-8")
+    return read_manufacturing_requirements(step)
 
 
 def test_ctc01_geometric_tolerance_facts_are_exact():
@@ -136,6 +144,159 @@ def test_ctc01_datum_occurrences_preserve_context_and_feature_identity():
         ),
     ]
     assert {fact.datum_feature_id for fact in facts} == {"#34", "#35", "#36"}
+
+
+def test_ctc01_has_no_custom_manufacturing_requirement_properties():
+    assert read_manufacturing_requirements(CTC01) == ()
+
+
+def test_manufacturing_requirement_preserves_authoritative_text_and_geometry_chain(tmp_path):
+    facts = _read_requirements(
+        tmp_path,
+        "associated-requirement",
+        "#1=DESCRIPTIVE_REPRESENTATION_ITEM('knurl','Straight knurl, 1.0 mm pitch');",
+        "#2=REPRESENTATION('knurl requirement',(#1),#99);",
+        "#3=PROPERTY_DEFINITION('manufacturing requirement','knurl',#98);",
+        "#4=PROPERTY_DEFINITION_REPRESENTATION(#3,#2);",
+        "#5=SHAPE_ASPECT('KNURL, 1.0 PITCH','',#98,.T.);",
+        "#6=GEOMETRIC_ITEM_SPECIFIC_USAGE('KNURL, 1.0 PITCH','',#5,#97,#96);",
+        "#7=DRAUGHTING_MODEL_ITEM_ASSOCIATION('semantic link','',#5,#95,#8);",
+        "#8=DRAUGHTING_CALLOUT('Straight knurl requirement',(#94));",
+    )
+
+    assert facts == (
+        ManufacturingRequirementFact(
+            entity_id="#3",
+            semantic_name="knurl",
+            text="Straight knurl, 1.0 mm pitch",
+            representation_id="#2",
+            descriptive_item_id="#1",
+            callout_ids=("#8",),
+            shape_aspect_ids=("#5",),
+            reference_item_ids=("#96",),
+        ),
+    )
+
+
+def test_escaped_part21_requirement_category_cannot_bypass_the_inventory_guard(tmp_path):
+    encoded_category = (
+        r"\X2\006D0061006E00750066006100630074007500720069006E006700200072006500710075006900720065006D0065006E0074\X0"
+        + "\\"
+    )
+    facts = _read_requirements(
+        tmp_path,
+        "encoded-requirement-category",
+        "#1=DESCRIPTIVE_REPRESENTATION_ITEM('thread','M3 x 0.5-6g RH');",
+        "#2=REPRESENTATION('external thread requirement',(#1),#99);",
+        f"#3=PROPERTY_DEFINITION('{encoded_category}','external thread',#98);",
+        "#4=PROPERTY_DEFINITION_REPRESENTATION(#3,#2);",
+    )
+
+    assert [(fact.entity_id, fact.semantic_name, fact.text) for fact in facts] == [
+        ("#3", "external thread", "M3 x 0.5-6g RH")
+    ]
+
+
+def test_comment_between_entity_name_and_parameters_cannot_bypass_inventory_guard(tmp_path):
+    facts = _read_requirements(
+        tmp_path,
+        "commented-property-definition",
+        "#1=DESCRIPTIVE_REPRESENTATION_ITEM('thread','M3 x 0.5-6g RH');",
+        "#2=REPRESENTATION('external thread requirement',(#1),#99);",
+        "#3=PROPERTY_DEFINITION/* valid Part 21 comment */('manufacturing requirement','external thread',#98);",
+        "#4=PROPERTY_DEFINITION_REPRESENTATION(#3,#2);",
+    )
+
+    assert [(fact.entity_id, fact.semantic_name, fact.text) for fact in facts] == [
+        ("#3", "external thread", "M3 x 0.5-6g RH")
+    ]
+
+
+def test_unassociated_general_requirement_remains_authoritative_source_intent(tmp_path):
+    facts = _read_requirements(
+        tmp_path,
+        "general-requirement",
+        "#1=DESCRIPTIVE_REPRESENTATION_ITEM('general tolerances','ISO 2768-m');",
+        "#2=REPRESENTATION('general tolerances requirement',(#1),#99);",
+        "#3=PROPERTY_DEFINITION('manufacturing requirement','general tolerances',#98);",
+        "#4=PROPERTY_DEFINITION_REPRESENTATION(#3,#2);",
+    )
+
+    assert facts == (
+        ManufacturingRequirementFact(
+            entity_id="#3",
+            semantic_name="general tolerances",
+            text="ISO 2768-m",
+            representation_id="#2",
+            descriptive_item_id="#1",
+        ),
+    )
+
+
+def test_each_matched_callout_and_shape_aspect_must_have_a_complete_association(tmp_path):
+    (fact,) = _read_requirements(
+        tmp_path,
+        "partially-associated-requirement",
+        "#1=DESCRIPTIVE_REPRESENTATION_ITEM('knurl','Straight knurl');",
+        "#2=REPRESENTATION('knurl requirement',(#1),#99);",
+        "#3=PROPERTY_DEFINITION('manufacturing requirement','knurl',#98);",
+        "#4=PROPERTY_DEFINITION_REPRESENTATION(#3,#2);",
+        "#5=SHAPE_ASPECT('first','',#98,.T.);",
+        "#6=GEOMETRIC_ITEM_SPECIFIC_USAGE('first','',#5,#97,#96);",
+        "#7=DRAUGHTING_MODEL_ITEM_ASSOCIATION('first','',#5,#95,#8);",
+        "#8=DRAUGHTING_CALLOUT('Head knurl requirement',(#94));",
+        "#9=DRAUGHTING_CALLOUT('Shaft knurl requirement',(#93));",
+        "#10=DRAUGHTING_MODEL_ITEM_ASSOCIATION('third','',#12,#95,#11);",
+        "#11=DRAUGHTING_CALLOUT('Backup knurl requirement',(#92));",
+        "#12=SHAPE_ASPECT('third','',#98,.T.);",
+    )
+
+    assert fact.callout_ids == ("#8", "#9", "#11")
+    assert fact.shape_aspect_ids == ("#5", "#12")
+    assert fact.reference_item_ids == ("#96",)
+    assert fact.reason == (
+        "matched semantic callout(s) have no shape-aspect association: #9; "
+        "associated shape aspect(s) have no representation items: #12"
+    )
+
+
+def test_dangling_representation_keeps_its_identity_without_hiding_valid_siblings(tmp_path):
+    facts = _read_requirements(
+        tmp_path,
+        "dangling-representation",
+        "#1=DESCRIPTIVE_REPRESENTATION_ITEM('thread','M3 x 0.5-6g RH');",
+        "#2=REPRESENTATION('external thread requirement',(#1),#99);",
+        "#3=PROPERTY_DEFINITION('manufacturing requirement','external thread',#98);",
+        "#4=PROPERTY_DEFINITION_REPRESENTATION(#3,#2);",
+        "#5=PROPERTY_DEFINITION('manufacturing requirement','knurl',#98);",
+        "#6=PROPERTY_DEFINITION_REPRESENTATION(#5,#404);",
+    )
+
+    assert [(fact.entity_id, fact.text) for fact in facts] == [
+        ("#3", "M3 x 0.5-6g RH"),
+        ("#5", ""),
+    ]
+    assert facts[1].reason == (
+        "linked representation #404 is unavailable or malformed; "
+        "linked representation has 0 descriptive items"
+    )
+
+
+def test_malformed_manufacturing_requirement_is_retained_with_explicit_reason(tmp_path):
+    (fact,) = _read_requirements(
+        tmp_path,
+        "ambiguous-requirement",
+        "#1=REPRESENTATION('first',(),#99);",
+        "#2=REPRESENTATION('second',(),#99);",
+        "#3=PROPERTY_DEFINITION('manufacturing requirement','thread',#98);",
+        "#4=PROPERTY_DEFINITION_REPRESENTATION(#3,#1);",
+        "#5=PROPERTY_DEFINITION_REPRESENTATION(#3,#2);",
+    )
+
+    assert fact.entity_id == "#3"
+    assert fact.semantic_name == "thread"
+    assert fact.text == ""
+    assert fact.reason == "manufacturing requirement has 2 linked representations"
 
 
 def test_datum_correspondence_requires_exact_context_and_letter():

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -455,6 +455,8 @@ class TestEmit:
             source_category="geometric_tolerance",
             gtol_modifiers=("common_zone",),
             lowering_blockers=("geometric-tolerance modifier 'common_zone' is not supported",),
+            semantic_name="probe requirement",
+            shape_aspect_ids=("#456",),
         )
         model = dataclasses.replace(model, features=[*model.features, source])
 
@@ -475,6 +477,8 @@ class TestEmit:
         assert restored.lowering_blockers == (
             "geometric-tolerance modifier 'common_zone' is not supported",
         )
+        assert restored.semantic_name == "probe requirement"
+        assert restored.shape_aspect_ids == ("#456",)
 
     def test_measured_dimension_rejects_unrenderable_kind(self):
         from draftwright import Sheet


### PR DESCRIPTION
## Summary

- inventory Part21 `manufacturing requirement` property chains with stable source identities and authoritative descriptive text
- preserve semantic-callout → shape-aspect → representation-item associations through `PmiRecord`, raw typed IR, and emitted Sheet scripts
- fail closed on malformed/unreadable requirement graphs while avoiding a full Part21 parse for ordinary STEP files with no requirement marker

Closes #1297. Part of #1300.

## GRM-03 evidence

Tested against `/Users/paul/steps/GRM-03_thumbwheel_drive_screw_AP242_PMI.step` (SHA-256 `4b6462b9cc9f0d419250933bd77fb305f9cfebb7ec2b3f377008732876010a21`).

The source census changes from 18 dimension entities to 26 accounted sources:

- 10 extracted semantic dimensions
- 8 presentation-only dimensions
- 8 extracted manufacturing requirements

The extracted requirements are external thread, internal thread, knurl, surface texture, general tolerances, datum scheme, chamfers, and model-representation intent. External/internal thread, knurl, texture, general tolerances, and chamfers retain their source shape-aspect/reference-item associations.

`pmi="report"` now reports the eight requirements as explicit raw typed IR and emits eight informational `pmi_not_lowered` outcomes. `pmi="annotate"` raises those outcomes to errors until #1298 supplies typed lowering/rendering. They no longer vanish before the source denominator.

## Tests

- `scripts/pr-check --static`
- `uv run pytest -q tests/test_pmi_part21.py` — 29 passed
- `uv run pytest -q tests/test_pmi.py` — 55 passed
- `uv run pytest -q tests/test_sheet_emit.py` — 392 passed, 1 deselected, 2 xfailed
- exact GRM-03 `off` / `report` / `annotate` census and lint probe

No slow-marked tests were run locally.
