### PR TITLE
Fix linear PMI reference direction and witnesses

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -5088,7 +5088,7 @@ def _authored_with_usable_references(record) -> bool:
         record.kind == "authored_dimension"
         and record.value > 0
         and len(record.ref_pts) >= 2
-        and not getattr(record, "lowering_blockers", ())
+        and not getattr(record, "rendering_blockers", ())
     )
 
 
@@ -5099,18 +5099,18 @@ def _blocked_authored_dimension_records(records):
         for record in records
         if record.kind == "authored_dimension"
         and record.value > 0
-        and getattr(record, "lowering_blockers", ())
+        and getattr(record, "rendering_blockers", ())
     ]
 
 
 def _record_blocked_authored_dimension(ctx, rec):
     source_id = getattr(rec, "source_id", "")
-    reasons = "; ".join(rec.lowering_blockers)
+    reasons = "; ".join(rec.rendering_blockers)
     ctx.record_issue(
         "error" if source_id else "warning",
         "authored_dim_source_unresolved",
         f"authored dimension {getattr(rec, 'label', '')!r} is not drawn because its source "
-        f"intent is unresolved: {reasons}",
+        f"reference geometry is unresolved: {reasons}",
         source=source_id,
         outcome_stage="validation",
     )

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -4979,7 +4979,7 @@ def _record_pmi_drop(ctx, dwg, ax, label, rec):
 
 def _record_pmi_unrenderable(dwg, label, rec, *, ctx):
     """Record an authored dimension whose reference geometry can't form a witness (fewer
-    than two distinct reference points, or a sub-legible span). Distinct from
+    than two distinct reference points, or a zero span). Distinct from
     ``pmi_dropped`` (a *placement* failure): this is a *validation* failure, so a caller
     sees a specific reason instead of a misleading "no room" — an authored dim is only
     ``pmi_dropped`` after a real candidate reaches the corridor solver and cannot fit (#562)."""
@@ -4994,7 +4994,7 @@ def _record_pmi_unrenderable(dwg, label, rec, *, ctx):
         "error" if source_id else "warning",
         "authored_dim_degenerate",
         f"authored dimension {label!r} has degenerate reference geometry (needs two "
-        "distinct reference points spanning a legible distance)",
+        "distinct reference points spanning a nonzero distance)",
         source=source_id,
     )
 
@@ -5084,7 +5084,36 @@ def _authored_with_usable_references(record) -> bool:
     Shared by the renderable and refused filters so they cannot drift: a predicate added to
     one only would make a record silently NEITHER drawn nor reported.
     """
-    return record.kind == "authored_dimension" and record.value > 0 and len(record.ref_pts) >= 2
+    return (
+        record.kind == "authored_dimension"
+        and record.value > 0
+        and len(record.ref_pts) >= 2
+        and not getattr(record, "lowering_blockers", ())
+    )
+
+
+def _blocked_authored_dimension_records(records):
+    """Source dimensions retained in typed IR but unsafe to draw from incomplete evidence."""
+    return [
+        record
+        for record in records
+        if record.kind == "authored_dimension"
+        and record.value > 0
+        and getattr(record, "lowering_blockers", ())
+    ]
+
+
+def _record_blocked_authored_dimension(ctx, rec):
+    source_id = getattr(rec, "source_id", "")
+    reasons = "; ".join(rec.lowering_blockers)
+    ctx.record_issue(
+        "error" if source_id else "warning",
+        "authored_dim_source_unresolved",
+        f"authored dimension {getattr(rec, 'label', '')!r} is not drawn because its source "
+        f"intent is unresolved: {reasons}",
+        source=source_id,
+        outcome_stage="validation",
+    )
 
 
 def _record_unsupported_dimension_kind(ctx, rec):
@@ -5172,11 +5201,13 @@ def _bore_info(rec):
 
 
 def _pmi_witness_from_bbox(rec, view: str, a):
-    """Witness points from the outer edges of the combined reference bbox.
+    """Witness points at authored reference stations, supported by their combined bbox.
 
-    Gives the correct span for linear dims where both ref faces are flush
-    (e.g. two parallel faces of a slot or step).  Not suitable for bore
-    diameters — use _bore_info instead.
+    A bbox describes the size of the referenced faces, not the relationship between them.
+    Its largest extent sent GRM-03's short axial dimensions across the circular end faces.
+    ``ref_pts`` carries the proven linear stations; the bbox remains useful only for the
+    transverse witness-support coordinate. Not suitable for bore diameters — use
+    :func:`_bore_info` instead (#1209).
 
     When the record carries no ``ref_bbox`` (an authored ``Sheet.measured_dimension()`` with
     only ``ref_pts``, #562), the span is derived from the ref points — so a ref_pts-only
@@ -5199,29 +5230,39 @@ def _pmi_witness_from_bbox(rec, view: str, a):
         bb = (min(xs), min(ys), min(zs), max(xs), max(ys), max(zs))
     xmin, ymin, zmin, xmax, ymax, zmax = bb
     ax = rec.dominant_axis
+    pts = rec.ref_pts
+    if len(pts) < 2:
+        return None
 
     if view == "front" and ax == "X":
-        p1 = (FX(xmin), FZ((zmin + zmax) / 2), 0)
-        p2 = (FX(xmax), FZ((zmin + zmax) / 2), 0)
+        lo, hi = min(point[0] for point in pts), max(point[0] for point in pts)
+        p1 = (FX(lo), FZ((zmin + zmax) / 2), 0)
+        p2 = (FX(hi), FZ((zmin + zmax) / 2), 0)
         avg_t = FZ((zmin + zmax) / 2)
     elif view == "front" and ax == "Z":
-        p1 = (FX((xmin + xmax) / 2), FZ(zmin), 0)
-        p2 = (FX((xmin + xmax) / 2), FZ(zmax), 0)
+        lo, hi = min(point[2] for point in pts), max(point[2] for point in pts)
+        p1 = (FX((xmin + xmax) / 2), FZ(lo), 0)
+        p2 = (FX((xmin + xmax) / 2), FZ(hi), 0)
         avg_t = FX((xmin + xmax) / 2)
     elif view == "side" and ax == "Y":
-        p1 = (SX(ymin), SZ((zmin + zmax) / 2), 0)
-        p2 = (SX(ymax), SZ((zmin + zmax) / 2), 0)
+        lo, hi = min(point[1] for point in pts), max(point[1] for point in pts)
+        p1 = (SX(lo), SZ((zmin + zmax) / 2), 0)
+        p2 = (SX(hi), SZ((zmin + zmax) / 2), 0)
         avg_t = SZ((zmin + zmax) / 2)
     elif view == "plan" and ax == "Y":
         avg_x = (xmin + xmax) / 2
-        p1 = (PX(avg_x), PY(ymin), 0)
-        p2 = (PX(avg_x), PY(ymax), 0)
+        lo, hi = min(point[1] for point in pts), max(point[1] for point in pts)
+        p1 = (PX(avg_x), PY(lo), 0)
+        p2 = (PX(avg_x), PY(hi), 0)
         avg_t = PX(avg_x)
     else:
         return None
 
     span = math.hypot(p2[0] - p1[0], p2[1] - p1[1])
-    if span < 3:
+    # The helper draws short dimensions with external arrows/text. Refusing them at an
+    # arbitrary 3 page-mm threshold lost GRM-03's valid 0.5 mm axial station even though
+    # the shared strip solve can place it without changing the measured path (#1209).
+    if span <= 1e-6:
         return None
     return p1, p2, avg_t
 
@@ -5566,8 +5607,8 @@ def render_pmi(dwg, model, a, *, ctx) -> int:
     Replaces the engine's ``_annotate_pmi``.
 
     Called from ``_auto_annotate`` before ``drain_corridors`` so authored PMI
-    co-solves with automatic strip candidates. Skips records whose page
-    projection is degenerate (< 3 mm span).
+    co-solves with automatic strip candidates. Skips only records whose page
+    projection has no measurable span; short dimensions use the helper's external layout.
 
     View assignment:
     - dominant X → front view, fv_zones.above / fv_zones.below
@@ -5579,6 +5620,8 @@ def render_pmi(dwg, model, a, *, ctx) -> int:
     draft = dwg.draft
     pmi = [f for f in model.features if f.kind in ("authored_dimension", "pmi")]
     usable = _renderable_pmi_records(pmi)
+    for blocked in _blocked_authored_dimension_records(pmi):
+        _record_blocked_authored_dimension(ctx, blocked)
     for refused in _unsupported_kind_records(pmi):
         _record_unsupported_dimension_kind(ctx, refused)
     n_gtol = sum(1 for r in pmi if r.pmi_kind not in AUTHORED_DIMENSION_KINDS and r.value > 0)

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -126,13 +126,14 @@ _GEOMETRY_AWARE_CODES = frozenset(
         "unrecognised_defining_geometry",
         "pmi_not_lowered",
         "pmi_not_rendered",
-        # Both REPLACE `pmi_not_rendered` for a record that produced no annotation (#1177);
+        # These REPLACE `pmi_not_rendered` for a record that produced no annotation (#1177);
         # the content is equally missing, so the count must not fall just because the
         # reason improved. `authored_dim_degenerate` suppressed that error without
         # carrying its weight, which is how a lost requirement came to report
         # `geometry_issues: 0` alongside `passed: True`.
         "dimension_kind_unsupported",
         "authored_dim_degenerate",
+        "authored_dim_source_unresolved",
         "axial_length_missing",
         "flat_requirement_suppressed",
         "flat_requirement_missing",

--- a/src/draftwright/linting/pmi_coverage.py
+++ b/src/draftwright/linting/pmi_coverage.py
@@ -220,6 +220,7 @@ _EXPLAINED_OMISSION_CODES = frozenset(
         # the same source. Fixing that only for the code #1177 introduced would have left
         # the defect in place next door.
         "authored_dim_degenerate",
+        "authored_dim_source_unresolved",
     }
 )
 

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -237,6 +237,10 @@ _FIDELITY_CODES = frozenset(
 _UNSCORED_CODES = frozenset(
     {
         "authored_dim_degenerate",
+        # A source relationship withheld because its geometry cannot prove a truthful
+        # witness. Like the adjacent degenerate/unsupported cases, this is an explicit
+        # omission rather than a false claim or a misplaced annotation (#1209).
+        "authored_dim_source_unresolved",
         "authored_omission",
         "axial_length_missing",
         "boss_height_missing",

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -2072,6 +2072,7 @@ def measured_dimension(
     source_kind: str | None = None,
     source_id: str = "",
     lowering_blockers: tuple[str, ...] = (),
+    rendering_blockers: tuple[str, ...] = (),
 ) -> AuthoredDimension:
     """A pre-authored drafting dimension from explicit measured values — the IR constructor
     behind :meth:`Sheet.measured_dimension` (#704: extracted so ``build_drawing(model=…)``
@@ -2081,21 +2082,25 @@ def measured_dimension(
     ``lower_bound`` and ``upper_bound`` carry a limit range and must be supplied together; they
     are mutually exclusive with deviation tolerances. ``source_id`` preserves an external
     record identity; ordinary Sheet declarations leave it blank. ``lowering_blockers`` retains
-    why an imported requirement could not safely enrich a canonical feature parameter."""
+    why an imported requirement could not safely enrich a canonical feature parameter;
+    ``rendering_blockers`` retains why its source geometry cannot truthfully form a witness."""
     _require_positive(value=value)
     dim_kind = str(kind).lower()
     if dim_kind not in AUTHORED_DIMENSION_KINDS:
         allowed = ", ".join(sorted(AUTHORED_DIMENSION_KINDS))
         raise ValueError(f"measured_dimension() kind must be one of: {allowed}")
     pts = tuple(_point3("ref_pts item", p) for p in ref_pts)
-    if len(pts) < 2:
+    imported_blocked = bool(source_id and rendering_blockers)
+    if len(pts) < 2 and not imported_blocked:
         raise ValueError("measured_dimension() needs at least two ref_pts")
     bbox = None if ref_bbox is None else tuple(float(c) for c in ref_bbox)
     if bbox is not None and len(bbox) != 6:
         raise ValueError("measured_dimension() ref_bbox must be a 6-tuple")
     dom = str(dominant_axis).upper()
     if dom not in ("X", "Y", "Z"):
-        if not (dom == "?" and dim_kind in ("diameter", "radius") and bbox is not None):
+        unresolved_import = dom == "?" and imported_blocked
+        unresolved_bore = dom == "?" and dim_kind in ("diameter", "radius") and bbox is not None
+        if not (unresolved_import or unresolved_bore):
             raise ValueError("measured_dimension() dominant_axis must be X, Y, or Z")
     if (lower_bound is None) != (upper_bound is None):
         raise ValueError("measured_dimension() needs both lower_bound and upper_bound")
@@ -2135,4 +2140,5 @@ def measured_dimension(
         source_kind=source_kind or dim_kind,
         source_id=str(source_id),
         lowering_blockers=tuple(str(reason) for reason in lowering_blockers),
+        rendering_blockers=tuple(str(reason) for reason in rendering_blockers),
     )

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -254,6 +254,7 @@ def build_pmi_features(
                     source_kind=r.kind,
                     source_id=r.source_id,
                     lowering_blockers=r.lowering_blockers,
+                    rendering_blockers=r.rendering_blockers,
                 )
             )
             continue

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -1357,6 +1357,10 @@ class AuthoredDimension:
     # canonical geometry feature.  The reason is structured and round-trips, rather than
     # disappearing into a log line or an emitter-only comment (#1116).
     lowering_blockers: tuple[str, ...] = ()
+    # Geometry-evidence failures that prevent truthful rendering. These are distinct from
+    # ``lowering_blockers``: failure to correlate to a canonical owner still permits the
+    # standalone authored-dimension fallback promised by #1116 (#1209 review).
+    rendering_blockers: tuple[str, ...] = ()
     kind: ClassVar[str] = "authored_dimension"
 
     @property

--- a/src/draftwright/pmi.py
+++ b/src/draftwright/pmi.py
@@ -176,22 +176,23 @@ class PmiRecord:
         lower_bound:    Lower limit of a range dimension, in the same units as ``value``.
         upper_bound:    Upper limit of a range dimension, in the same units as ``value``.
         ref_pts:        Reference stations in global STEP space (same coordinate frame as
-                        the imported solid). For a linear dimension these are the centroids
-                        of its two authored reference groups; other records retain the
-                        per-shape bounding-box centroids.
+                        the imported solid). For a linear or thickness dimension these are
+                        the centroids of its authored reference groups; other records retain
+                        the per-shape bounding-box centroids.
         ref_bbox:       Combined axis-aligned bbox of ALL referenced shapes:
                         ``(xmin, ymin, zmin, xmax, ymax, zmax)``. Linear rendering uses
                         it for transverse witness support only; the authored stations,
                         not this outer envelope, own the measured span.
-        dominant_axis:  ``'X'``, ``'Y'``, ``'Z'``, or ``'?'`` — a linear dimension's
-                        proven reference-station direction; for other records, the
-                        referenced geometry's largest bbox extent.
+        dominant_axis:  ``'X'``, ``'Y'``, ``'Z'``, or ``'?'`` — a linear/thickness
+                        dimension's proven reference-station direction; for other records,
+                        the referenced geometry's largest bbox extent.
         label:          Ready-to-use annotation label (e.g. ``"ø35"``, ``"60"``).
         datum_refs:     Ordered datum letters referenced by a geometric tolerance.
         part21_id:      Part21 entity id supplying an overlaid tolerance magnitude.
         source_category: Source inventory category; structural evidence for concept lowering.
         gtol_modifiers: Stable names for the source geometric-tolerance modifier sequence.
         lowering_blockers: Missing/unrepresented facts that make concept lowering unsafe.
+        rendering_blockers: Source-geometry facts that make a typed dimension unsafe to draw.
         source_ids:     All source occurrences represented by one projected definition.
         datum_contexts: Tolerance semantic names in which a datum definition is referenced.
         reference_item_ids: Exact Part21 representation items bound to a datum feature.
@@ -228,6 +229,9 @@ class PmiRecord:
     reference_axis: str = ""
     semantic_name: str = ""
     shape_aspect_ids: tuple[str, ...] = ()
+    # Kept separate from ``lowering_blockers``: an imported requirement may fail to enrich a
+    # canonical owner yet remain a truthful standalone dimension (#1116/#1209).
+    rendering_blockers: tuple[str, ...] = ()
 
 
 PmiExtractionOutcome = Literal[
@@ -868,10 +872,19 @@ def _dimension_record(
     )
     partial_reasons.extend(reference_reasons)
     kind = _DIM_TYPE.get(type_code, f"type{type_code}")
-    if kind == "linear":
+    rendering_blockers: tuple[str, ...] = ()
+    if kind in ("linear", "thickness"):
         points, dominant_axis, station_reasons = _linear_reference_stations(group_stations, value)
-        partial_reasons.extend(station_reasons)
-    blockers = tuple(dict.fromkeys(partial_reasons))
+        if kind == "thickness":
+            station_reasons = tuple(
+                reason.replace("linear dimension", "thickness dimension").replace(
+                    "linear reference", "thickness reference"
+                )
+                for reason in station_reasons
+            )
+        rendering_blockers = tuple(dict.fromkeys(station_reasons))
+    lowering_blockers = tuple(dict.fromkeys(partial_reasons))
+    blockers = tuple(dict.fromkeys((*lowering_blockers, *rendering_blockers)))
     return (
         PmiRecord(
             kind=kind,
@@ -894,7 +907,8 @@ def _dimension_record(
             ),
             source_id=source_id,
             source_category="dimension",
-            lowering_blockers=blockers,
+            lowering_blockers=lowering_blockers,
+            rendering_blockers=rendering_blockers,
         ),
         blockers,
     )

--- a/src/draftwright/pmi.py
+++ b/src/draftwright/pmi.py
@@ -175,16 +175,17 @@ class PmiRecord:
         lower_tol:      Lower tolerance in mm, or ``None``.
         lower_bound:    Lower limit of a range dimension, in the same units as ``value``.
         upper_bound:    Upper limit of a range dimension, in the same units as ``value``.
-        ref_pts:        Bounding-box centroids of referenced geometry in global
-                        STEP space (same coordinate frame as the imported solid).
+        ref_pts:        Reference stations in global STEP space (same coordinate frame as
+                        the imported solid). For a linear dimension these are the centroids
+                        of its two authored reference groups; other records retain the
+                        per-shape bounding-box centroids.
         ref_bbox:       Combined axis-aligned bbox of ALL referenced shapes:
-                        ``(xmin, ymin, zmin, xmax, ymax, zmax)``.  Used by
-                        ``_annotate_pmi`` for witness-point placement — the outer
-                        edges of the referenced geometry give the correct measurement
-                        span rather than the shorter centroid-to-centroid distance.
-        dominant_axis:  ``'X'``, ``'Y'``, ``'Z'``, or ``'?'`` — the direction
-                        in which the dimension primarily spans (based on the outer
-                        bbox extent, not the centroid difference).
+                        ``(xmin, ymin, zmin, xmax, ymax, zmax)``. Linear rendering uses
+                        it for transverse witness support only; the authored stations,
+                        not this outer envelope, own the measured span.
+        dominant_axis:  ``'X'``, ``'Y'``, ``'Z'``, or ``'?'`` — a linear dimension's
+                        proven reference-station direction; for other records, the
+                        referenced geometry's largest bbox extent.
         label:          Ready-to-use annotation label (e.g. ``"ø35"``, ``"60"``).
         datum_refs:     Ordered datum letters referenced by a geometric tolerance.
         part21_id:      Part21 entity id supplying an overlaid tolerance magnitude.
@@ -289,6 +290,65 @@ def _dominant_from_bbox(bbox: tuple[float, float, float, float, float, float]) -
     return dom[0] if dom[1] > 1e-6 else "?"
 
 
+_LINEAR_AXIS_ABS_TOL = 0.005
+_LINEAR_AXIS_REL_TOL = 1e-3
+_LINEAR_VALUE_ABS_TOL = 0.01
+_LINEAR_VALUE_REL_TOL = 5e-4
+
+
+def _linear_reference_stations(
+    stations: tuple[tuple[float, float, float] | None, ...], nominal: float
+) -> tuple[tuple[tuple[float, float, float], ...], str, tuple[str, ...]]:
+    """Prove a truthful principal-axis span from the two authored reference groups.
+
+    A merged bbox answers how large the referenced faces are, not which direction relates
+    them. Circular end faces in GRM-03 are wider than their axial separation, which made
+    short X dimensions render across Y. Conversely, CTC-04 includes a genuinely oblique
+    relationship and one dimension whose second group XCAF does not transfer. Those must
+    remain explicit omissions rather than being guessed from the nominal value (#1209).
+    """
+    measurable = tuple(station for station in stations if station is not None)
+    if len(stations) != 2 or len(measurable) != 2:
+        return (
+            measurable,
+            "?",
+            ("linear dimension needs two measurable authored reference groups",),
+        )
+
+    first, second = measurable
+    delta = tuple(second[index] - first[index] for index in range(3))
+    magnitudes = tuple(abs(value) for value in delta)
+    axis_index = max(range(3), key=magnitudes.__getitem__)
+    primary = magnitudes[axis_index]
+    if primary <= 1e-9:
+        return measurable, "?", ("linear reference groups occupy the same station",)
+
+    transverse = max(value for index, value in enumerate(magnitudes) if index != axis_index)
+    direction_tol = max(_LINEAR_AXIS_ABS_TOL, primary * _LINEAR_AXIS_REL_TOL)
+    if transverse > direction_tol:
+        return (
+            measurable,
+            "?",
+            (
+                "linear reference relationship is not principal-axis aligned "
+                f"(delta=({delta[0]:.6g}, {delta[1]:.6g}, {delta[2]:.6g}) mm)",
+            ),
+        )
+
+    axis = "XYZ"[axis_index]
+    value_tol = max(_LINEAR_VALUE_ABS_TOL, abs(nominal) * _LINEAR_VALUE_REL_TOL)
+    if abs(primary - nominal) > value_tol:
+        return (
+            measurable,
+            axis,
+            (
+                f"linear reference-station span {primary:.6g} mm differs from nominal "
+                f"{nominal:.6g} mm",
+            ),
+        )
+    return measurable, axis, ()
+
+
 def _make_label(
     kind: str,
     value: float,
@@ -357,16 +417,18 @@ def _failure_reason(exc: Exception) -> str:
     return f"{type(exc).__name__}: {exc}"
 
 
-def _reference_geometry(label, shape_tool):
+def _reference_geometry_with_groups(label, shape_tool):
     """Measure the geometry relationships shared by dimensions and tolerances."""
     first_refs = TDF_LabelSequence()
     second_refs = TDF_LabelSequence()
     XCAFDoc_DimTolTool.GetRefShapeLabel_s(label, first_refs, second_refs)
     points: list[tuple[float, float, float]] = []
     boxes: list[tuple[float, float, float, float, float, float]] = []
+    group_stations: list[tuple[float, float, float] | None] = []
     partial_reasons: list[str] = []
     reference_count = first_refs.Length() + second_refs.Length()
     for refs in (first_refs, second_refs):
+        group_boxes: list[tuple[float, float, float, float, float, float]] = []
         for index in range(1, refs.Length() + 1):
             shape = shape_tool.GetShape_s(refs.Value(index))
             if shape is None or shape.IsNull():
@@ -375,11 +437,17 @@ def _reference_geometry(label, shape_tool):
             try:
                 bbox = _shape_bbox(shape)
                 boxes.append(bbox)
-                points.append(_bbox_centroid(bbox))
+                point = _bbox_centroid(bbox)
+                points.append(point)
+                group_boxes.append(bbox)
             except Exception as exc:
                 partial_reasons.append(
                     f"one referenced shape could not be measured ({_failure_reason(exc)})"
                 )
+        # One logical reference group may be split into any number of topology items. The
+        # merged-envelope centre is invariant to that segmentation; averaging item centres
+        # would move merely because one face was split into two (#1209).
+        group_stations.append(_bbox_centroid(_merge_bboxes(group_boxes)) if group_boxes else None)
     if reference_count == 0:
         partial_reasons.append("referenced geometry is unavailable")
 
@@ -390,7 +458,16 @@ def _reference_geometry(label, shape_tool):
         ref_bbox,
         dominant_axis,
         tuple(dict.fromkeys(partial_reasons)),
+        tuple(group_stations),
     )
+
+
+def _reference_geometry(label, shape_tool):
+    """Compatible flattened geometry projection shared by non-dimensional PMI."""
+    points, ref_bbox, dominant_axis, reasons, _groups = _reference_geometry_with_groups(
+        label, shape_tool
+    )
+    return points, ref_bbox, dominant_axis, reasons
 
 
 def _datum_geometry_from_shapes(shapes):
@@ -786,11 +863,15 @@ def _dimension_record(
         except Exception as exc:
             partial_reasons.append(f"upper range bound is unavailable ({_failure_reason(exc)})")
 
-    # The outer edges of the referenced geometry give the correct measurement span (e.g.
-    # the two far sides of a diameter) rather than the shorter centroid-to-centroid distance.
-    points, ref_bbox, dominant_axis, reference_reasons = _reference_geometry(label, shape_tool)
+    points, ref_bbox, dominant_axis, reference_reasons, group_stations = (
+        _reference_geometry_with_groups(label, shape_tool)
+    )
     partial_reasons.extend(reference_reasons)
     kind = _DIM_TYPE.get(type_code, f"type{type_code}")
+    if kind == "linear":
+        points, dominant_axis, station_reasons = _linear_reference_stations(group_stations, value)
+        partial_reasons.extend(station_reasons)
+    blockers = tuple(dict.fromkeys(partial_reasons))
     return (
         PmiRecord(
             kind=kind,
@@ -813,8 +894,9 @@ def _dimension_record(
             ),
             source_id=source_id,
             source_category="dimension",
+            lowering_blockers=blockers,
         ),
-        tuple(dict.fromkeys(partial_reasons)),
+        blockers,
     )
 
 

--- a/src/draftwright/pmi.py
+++ b/src/draftwright/pmi.py
@@ -353,6 +353,24 @@ def _linear_reference_stations(
     return measurable, axis, ()
 
 
+def _dimension_geometry_blockers(
+    kind: str,
+    reference_reasons: tuple[str, ...],
+    station_reasons: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Rendering blockers owned by incomplete source geometry, not later correlation.
+
+    A group station computed from the measurable subset is not proof that the authored
+    relationship is complete when another referenced shape was unavailable. Keep those XCAF
+    extraction failures in ``lowering_blockers`` for source accounting *and* in this distinct
+    render gate. Correlation blockers added later by model lowering never pass through here,
+    so #1116's standalone fallback remains drawable (#1209 re-review).
+    """
+    if kind not in ("linear", "thickness"):
+        return ()
+    return tuple(dict.fromkeys((*reference_reasons, *station_reasons)))
+
+
 def _make_label(
     kind: str,
     value: float,
@@ -882,7 +900,7 @@ def _dimension_record(
                 )
                 for reason in station_reasons
             )
-        rendering_blockers = tuple(dict.fromkeys(station_reasons))
+        rendering_blockers = _dimension_geometry_blockers(kind, reference_reasons, station_reasons)
     lowering_blockers = tuple(dict.fromkeys(partial_reasons))
     blockers = tuple(dict.fromkeys((*lowering_blockers, *rendering_blockers)))
     return (

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -1119,6 +1119,7 @@ class Sheet:
         source_kind: str | None = None,
         source_id: str = "",
         lowering_blockers: tuple[str, ...] = (),
+        rendering_blockers: tuple[str, ...] = (),
     ) -> _Params:
         """Declare a drafting dimension from explicit **measured** values.
 
@@ -1136,7 +1137,8 @@ class Sheet:
         ``upper_tol``/``lower_tol`` for a limit range. ``source_id`` is the external record
         identity retained by generated imported-PMI scripts; hand-authored dimensions normally
         leave it blank. ``lowering_blockers`` carries the explicit reason a supported imported
-        requirement could not safely enrich a canonical feature parameter.
+        requirement could not safely enrich a canonical feature parameter;
+        ``rendering_blockers`` carries the source-geometry reason it cannot be drawn truthfully.
         Delegates to :func:`draftwright.model.declare.measured_dimension` (#704), so
         ``build_drawing(model=…)`` callers can author the same feature without the façade.
         """
@@ -1158,6 +1160,7 @@ class Sheet:
                 source_kind=source_kind,
                 source_id=source_id,
                 lowering_blockers=lowering_blockers,
+                rendering_blockers=rendering_blockers,
             )
         )
         # A handle like every other declaration verb (#922). A measured dimension carries its

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -369,6 +369,8 @@ def _measured_dimension_line(f) -> str:
         kw.append(f"source_id={f.source_id!r}")
     if getattr(f, "lowering_blockers", ()):
         kw.append(f"lowering_blockers={f.lowering_blockers!r}")
+    if getattr(f, "rendering_blockers", ()):
+        kw.append(f"rendering_blockers={f.rendering_blockers!r}")
     # `measured_dimension` since #873 — a generated script must not emit the transitional
     # overload, or every regenerated AP242 script would arrive pre-deprecated.
     return "sheet.measured_dimension(" + ", ".join(kw) + ")"

--- a/tests/test_issue_1177_angular_dimensions.py
+++ b/tests/test_issue_1177_angular_dimensions.py
@@ -47,9 +47,9 @@ _DOVETAIL = ((0, -25, 0), (0, -9, 0), (0, -13.619, 8))
 #: the right renderer for them. That is a statement about the category, not a guarantee
 #: that today's renderer draws each correctly. `radius` did not — it drew a full-diameter
 #: line — and is fixed in this PR (#1208), which is what membership of this set earns
-#: rather than assumes. `linear` still does not on CTC-04, where two PMI records draw
-#: 260 mm for values of 20 and 25 (#1209): a rendering bug to fix, which is precisely why
-#: it is here and not in the refusal set.
+#: rather than assumes. AP242 `linear` now additionally needs two proven authored-group
+#: stations whose principal-axis separation agrees with the nominal (#1209); declarations
+#: carrying their own truthful endpoints remain in this category.
 _RENDERABLE = frozenset({"linear", "thickness", "diameter", "radius"})
 
 

--- a/tests/test_issue_1209_linear_pmi_witnesses.py
+++ b/tests/test_issue_1209_linear_pmi_witnesses.py
@@ -7,7 +7,7 @@ import pytest
 
 from draftwright import extract_pmi_report
 from draftwright.annotations.from_model import _pmi_witness_from_bbox
-from draftwright.pmi import _linear_reference_stations
+from draftwright.pmi import _dimension_geometry_blockers, _linear_reference_stations
 
 CTC04 = Path(__file__).parent / "fixtures" / "nist_ctc_04_asme1_ap242.stp"
 CTC03 = Path(__file__).parent / "fixtures" / "nist_ctc_03_asme1_ap242.stp"
@@ -52,6 +52,17 @@ def test_an_oblique_or_one_sided_relationship_fails_closed_without_nominal_guess
     assert len(points) == 2
     assert axis == "X"
     assert blockers == ("linear reference-station span 10 mm differs from nominal 20 mm",)
+
+
+def test_a_partially_measured_group_cannot_render_from_its_incomplete_subset():
+    missing = "one referenced shape is unavailable"
+    assert _dimension_geometry_blockers("linear", (missing,), ()) == (missing,)
+    assert _dimension_geometry_blockers(
+        "thickness", (missing,), ("thickness reference groups occupy the same station",)
+    ) == (missing, "thickness reference groups occupy the same station")
+    # Canonical-correlation blockers are added after extraction and deliberately never enter
+    # this source-geometry gate; #1116's standalone fallback therefore remains renderable.
+    assert _dimension_geometry_blockers("diameter", (missing,), ()) == ()
 
 
 def test_ctc04_uses_authored_groups_and_reports_the_two_untruthful_records():

--- a/tests/test_issue_1209_linear_pmi_witnesses.py
+++ b/tests/test_issue_1209_linear_pmi_witnesses.py
@@ -10,6 +10,7 @@ from draftwright.annotations.from_model import _pmi_witness_from_bbox
 from draftwright.pmi import _linear_reference_stations
 
 CTC04 = Path(__file__).parent / "fixtures" / "nist_ctc_04_asme1_ap242.stp"
+CTC03 = Path(__file__).parent / "fixtures" / "nist_ctc_03_asme1_ap242.stp"
 
 
 @pytest.mark.parametrize(
@@ -65,12 +66,14 @@ def test_ctc04_uses_authored_groups_and_reports_the_two_untruthful_records():
 
     oblique = records["dimension:0:1:4:26"]
     assert oblique.dominant_axis == "?"
-    assert "not principal-axis aligned" in oblique.lowering_blockers[0]
+    assert oblique.lowering_blockers == ()
+    assert "not principal-axis aligned" in oblique.rendering_blockers[0]
 
     one_sided = records["dimension:0:1:4:29"]
     assert one_sided.dominant_axis == "?"
     assert len(one_sided.ref_pts) == 1
-    assert one_sided.lowering_blockers == (
+    assert one_sided.lowering_blockers == ()
+    assert one_sided.rendering_blockers == (
         "linear dimension needs two measurable authored reference groups",
     )
 
@@ -78,6 +81,58 @@ def test_ctc04_uses_authored_groups_and_reports_the_two_untruthful_records():
     assert outcomes[truthful.source_id].outcome == "extracted"
     assert outcomes[oblique.source_id].outcome == "partially_extracted"
     assert outcomes[one_sided.source_id].outcome == "partially_extracted"
+
+
+def test_ap242_thickness_without_two_proven_groups_fails_closed():
+    record = next(
+        record for record in extract_pmi_report(CTC03).records if record.kind == "thickness"
+    )
+
+    assert record.source_id == "dimension:0:1:4:47"
+    assert record.value == pytest.approx(0.82)
+    assert record.dominant_axis == "?"
+    assert record.lowering_blockers == ()
+    assert record.rendering_blockers == (
+        "thickness dimension needs two measurable authored reference groups",
+    )
+
+
+def test_render_gate_distinguishes_correlation_from_geometry_blockers():
+    from build123d import Box
+
+    from draftwright import Sheet
+
+    sheet = Sheet(Box(40, 30, 20), number="1209")
+    sheet.measured_dimension(
+        kind="linear",
+        value=16,
+        label="16",
+        dominant_axis="Y",
+        ref_pts=((0, -8, 0), (0, 8, 0)),
+        source_id="dimension:correlation-fallback",
+        lowering_blockers=("unmatched hole correlation: no canonical owner",),
+    )
+    sheet.measured_dimension(
+        kind="linear",
+        value=25,
+        label="25",
+        dominant_axis="?",
+        ref_pts=((0, 0, 0),),
+        source_id="dimension:geometry-blocked",
+        rendering_blockers=("linear dimension needs two measurable authored reference groups",),
+    )
+    sheet.authored_dimensions()
+    drawing = sheet.build()
+
+    features = {feature.source_id: feature for feature in drawing.model().features}
+    fallback_feature = features["dimension:correlation-fallback"]
+    blocked_feature = features["dimension:geometry-blocked"]
+    assert drawing.registry.names_for_feature(fallback_feature)
+    assert drawing.registry.names_for_feature(blocked_feature) == []
+    unresolved = [
+        issue for issue in drawing.lint() if issue.code == "authored_dim_source_unresolved"
+    ]
+    assert [issue.source_ids for issue in unresolved] == [("dimension:geometry-blocked",)]
 
 
 def test_linear_witness_uses_stations_while_bbox_supplies_only_transverse_support():

--- a/tests/test_issue_1209_linear_pmi_witnesses.py
+++ b/tests/test_issue_1209_linear_pmi_witnesses.py
@@ -1,0 +1,115 @@
+"""Regression coverage for truthful AP242 linear-reference witnesses (#1209)."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from draftwright import extract_pmi_report
+from draftwright.annotations.from_model import _pmi_witness_from_bbox
+from draftwright.pmi import _linear_reference_stations
+
+CTC04 = Path(__file__).parent / "fixtures" / "nist_ctc_04_asme1_ap242.stp"
+
+
+@pytest.mark.parametrize(
+    "value, stations",
+    [
+        (3.2, ((-3.2, 0.0, 0.0), (0.0, 0.0, 0.0))),
+        (0.5, ((0.0, 0.0, 0.0), (0.5, 0.0, 0.0))),
+        (2.0, ((0.5, 0.0, 0.0), (2.5, 0.0, 0.0))),
+        (3.0, ((2.5, 0.0, 0.0), (5.5, 0.0, 0.0))),
+        (20.0, ((5.5, 0.0, 0.0), (25.5, 0.0, 0.0))),
+    ],
+)
+def test_grm03_coaxial_end_faces_establish_their_x_station_span(value, stations):
+    points, axis, blockers = _linear_reference_stations(stations, value)
+
+    assert points == stations
+    assert axis == "X"
+    assert blockers == ()
+    assert abs(points[1][0] - points[0][0]) == pytest.approx(value)
+
+
+def test_an_oblique_or_one_sided_relationship_fails_closed_without_nominal_guessing():
+    points, axis, blockers = _linear_reference_stations(
+        ((0.0, 149.98174079291, -70.32125981157614), (0.0, 141.5491012236, -52.1456568216)),
+        20.0,
+    )
+    assert len(points) == 2
+    assert axis == "?"
+    assert blockers and "not principal-axis aligned" in blockers[0]
+
+    points, axis, blockers = _linear_reference_stations(
+        ((0.0, 149.98174079291, -70.32125981157614), None), 25.0
+    )
+    assert len(points) == 1
+    assert axis == "?"
+    assert blockers == ("linear dimension needs two measurable authored reference groups",)
+
+    points, axis, blockers = _linear_reference_stations(((0.0, 0.0, 0.0), (10.0, 0.0, 0.0)), 20.0)
+    assert len(points) == 2
+    assert axis == "X"
+    assert blockers == ("linear reference-station span 10 mm differs from nominal 20 mm",)
+
+
+def test_ctc04_uses_authored_groups_and_reports_the_two_untruthful_records():
+    report = extract_pmi_report(CTC04)
+    records = {record.source_id: record for record in report.records if record.kind == "linear"}
+
+    truthful = records["dimension:0:1:4:22"]
+    assert truthful.value == 75.0
+    assert truthful.dominant_axis == "Y"
+    assert truthful.ref_pts == ((230.0, 285.0, 13.5), (230.0, 210.0, 13.5))
+    assert truthful.lowering_blockers == ()
+
+    oblique = records["dimension:0:1:4:26"]
+    assert oblique.dominant_axis == "?"
+    assert "not principal-axis aligned" in oblique.lowering_blockers[0]
+
+    one_sided = records["dimension:0:1:4:29"]
+    assert one_sided.dominant_axis == "?"
+    assert len(one_sided.ref_pts) == 1
+    assert one_sided.lowering_blockers == (
+        "linear dimension needs two measurable authored reference groups",
+    )
+
+    outcomes = {source.source_id: source for source in report.sources}
+    assert outcomes[truthful.source_id].outcome == "extracted"
+    assert outcomes[oblique.source_id].outcome == "partially_extracted"
+    assert outcomes[one_sided.source_id].outcome == "partially_extracted"
+
+
+def test_linear_witness_uses_stations_while_bbox_supplies_only_transverse_support():
+    def identity(value):
+        return value
+
+    analysis = SimpleNamespace(
+        proj=SimpleNamespace(
+            front_x=identity,
+            front_z=identity,
+            side_x=identity,
+            side_z=identity,
+            plan_x=identity,
+            plan_y=identity,
+        )
+    )
+    record = SimpleNamespace(
+        dominant_axis="Y",
+        ref_pts=((230.0, 285.0, 13.5), (230.0, 210.0, 13.5)),
+        # The old witness used this outer Y span: 292 - 203 = 89, contradicting label 75.
+        ref_bbox=(223.0, 203.0, 0.0, 237.0, 292.0, 27.0),
+    )
+
+    p1, p2, support = _pmi_witness_from_bbox(record, "side", analysis)
+
+    assert abs(p2[0] - p1[0]) == 75.0
+    assert support == 13.5
+
+    short = SimpleNamespace(
+        dominant_axis="X",
+        ref_pts=((0.0, 0.0, 0.0), (0.5, 0.0, 0.0)),
+        ref_bbox=(0.0, -5.0, -5.0, 0.5, 5.0, 5.0),
+    )
+    p1, p2, _support = _pmi_witness_from_bbox(short, "front", analysis)
+    assert abs(p2[0] - p1[0]) == 0.5

--- a/tests/test_private_test_imports.py
+++ b/tests/test_private_test_imports.py
@@ -80,6 +80,12 @@ _ALLOW: frozenset[tuple[str, str]] = frozenset(
         # Pure geometry/selection helpers with unit-level coverage.
         ("from_model", "_bore_span_offsets"),
         ("from_model", "_diameter_column_left"),
+        # _pmi_witness_from_bbox: #1209 requires a direct geometry assertion that the
+        # measured path comes from the two authored reference-group stations while the
+        # merged bbox contributes only transverse support.  A built drawing cannot expose
+        # those two inputs independently (and page projection/placement can mask the old
+        # outer-bbox-span bug), so this pure helper is mutation-relevant unit coverage.
+        ("from_model", "_pmi_witness_from_bbox"),
         # _diameter_step_anchor: the shared-⌀ leader anchor (#794). The non-coaxial
         # same-⌀ case can't be reached through the public build seam, so its unit
         # test reads the pure helper directly (like _bore_span_offsets above).

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -433,6 +433,43 @@ class TestEmit:
         assert (feature.lower_bound, feature.upper_bound) == (34.8, 35.2)
         assert feature.label == "ø34.8 - ø35.2"
 
+    def test_unresolved_imported_dimension_round_trips_both_blocker_classes(self):
+        """A one-sided AP242 relationship remains typed and reproducible while fail-closed."""
+        from draftwright import Sheet
+        from draftwright.sheet_emit import emit_sheet_script
+
+        part = Box(40, 20, 10)
+        sheet = Sheet(part, title="P").authored_dimensions()
+        sheet.measured_dimension(
+            kind="linear",
+            value=25,
+            label="25",
+            dominant_axis="?",
+            ref_pts=((0, 0, 0),),
+            source="ap242_pmi",
+            source_id="dimension:one-sided",
+            lowering_blockers=("canonical correlation unavailable",),
+            rendering_blockers=(
+                "linear dimension needs two measurable authored reference groups",
+            ),
+        )
+
+        src = emit_sheet_script(sheet.model(), "part", "blocked", title="P", number="N")
+        namespace = {"part": part}
+        body = src[: src.index("drawing = sheet.build()")]
+        exec(compile(body, "<blocked-dimension-emit>", "exec"), namespace)  # noqa: S102
+        feature = next(
+            feature
+            for feature in namespace["sheet"].model().features
+            if feature.source_id == "dimension:one-sided"
+        )
+
+        assert feature.ref_pts == ((0.0, 0.0, 0.0),)
+        assert feature.lowering_blockers == ("canonical correlation unavailable",)
+        assert feature.rendering_blockers == (
+            "linear dimension needs two measurable authored reference groups",
+        )
+
     def test_raw_pmi_round_trips_part21_identity(self):
         """Execute the generated declaration; emitted text alone is not the contract."""
         import dataclasses


### PR DESCRIPTION
Closes #1209

## Outcome

Linear AP242 dimensions now derive semantic measurement direction and witness stations from the two authored XCAF reference groups, rather than the largest extent of their merged face envelope.

- group stations are segmentation-stable merged-envelope centroids;
- only a principal-axis relationship whose station span agrees with the nominal is renderable;
- oblique, missing-side, coincident, or contradictory relationships remain typed and source-owned but fail closed with an explicit geometry reason;
- geometry rendering blockers are typed separately from canonical-correlation/lowering blockers, preserving #1116 standalone fallback dimensions;
- the combined bbox remains transverse witness support only;
- short truthful dimensions use external-arrow/text layout instead of disappearing below an arbitrary 3 page-mm threshold;
- AP242 thickness records use the same conservative two-group proof and otherwise fail closed.

Both blocker classes, one-sided references, typed intent, and source IDs survive emitted Sheet-script round-trip. No nominal-only correspondence or raw annotation coordinates are introduced.

## Real-file evidence

Exact GRM-03 source:
`/Users/paul/steps/GRM-03_thumbwheel_drive_screw_AP242_PMI.step`
SHA-256 `4b6462b9cc9f0d419250933bd77fb305f9cfebb7ec2b3f377008732876010a21`

All five axial values resolve from independent authored reference groups:

| value | axis | station span | blockers |
| ---: | :---: | ---: | :---: |
| 3.2 | X | 3.2 | none |
| 0.5 | X | 0.5 | none |
| 2.0 | X | 2.0 | none |
| 3.0 | X | 3.0 | none |
| 20.0 | X | 20.0 | none |

An annotate build produces no `label_vs_measured`. Four of five currently place on A4; the remaining source is a structured `pmi_dropped` capacity outcome tracked by #1299.

NIST CTC-04 now:

- renders the 75 mm record from Y=285 to Y=210, not the old 89 mm bbox span;
- preserves and renders unmatched hole-correlation fallbacks :23, :24, :25, and :28;
- omits only the oblique :26 and one-sided :29 relationships with exact typed reasons;
- produces no `label_vs_measured`.

NIST CTC-03 source :47 no longer draws a roughly 383 mm path labelled 0.8; its one-sided thickness relationship is explicitly refused and produces no `label_vs_measured`.

## Independent review

The first review found two P1 regressions: correlation blockers suppressed valid fallbacks, and thickness lacked proven endpoints. Both are fixed by the typed rendering/lowering blocker split and the thickness station proof. Re-review is requested on current head.

## Validation

- relevant PMI/render/round-trip selection: 567 passed, 2 deselected, 2 xfailed;
- platform canary selection: 203 passed;
- `scripts/pr-check --static`: passed;
- Ruff and diff check: passed;
- exact GRM-03, CTC-04, and CTC-03 extraction/render probes: passed as described above.

The repository's slow-marked suite was not run.