### PR TITLE
Escalate incomplete axial plans to larger sheets

### DIFF
--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -1212,30 +1212,6 @@ def _is_required_scale_drop(issue) -> bool:
     return True
 
 
-def _scale_issue_source_ids(issue) -> tuple[str, ...]:
-    """External sources represented by one placement outcome.
-
-    A compound hole callout is registered against its compiler measurements.  When that
-    callout also renders a typed imported thread/tap requirement, the placement diagnostic
-    therefore carries ``measurement_ids`` while the source provenance remains on the
-    measurement's owning feature aspect.  Recover that exact relationship here; do not infer
-    ownership from a nominal value or from an unowned drop.
-    """
-    source_ids = list(getattr(issue, "source_ids", ()))
-    owners = [
-        getattr(measurement, "feature", None)
-        for measurement in getattr(issue, "measurement_ids", ())
-    ]
-    owners.extend(
-        requirement[0] for requirement in getattr(issue, "hole_requirement_ids", ()) if requirement
-    )
-    for owner in owners:
-        for aspect_name in ("thread", "knurl"):
-            aspect = getattr(owner, aspect_name, None)
-            source_ids.extend(getattr(aspect, "source_ids", ()))
-    return tuple(dict.fromkeys(source_ids))
-
-
 def _scale_blockers_from_issues(issues) -> tuple[dict, ...]:
     """Required placement failures from one already-materialised lint pass."""
     blockers = []
@@ -1254,7 +1230,7 @@ def _scale_blockers_from_issues(issues) -> tuple[dict, ...]:
                     _hole_scale_requirement(req)
                     for req in getattr(issue, "hole_requirement_ids", ())
                 ),
-                "source_ids": _scale_issue_source_ids(issue),
+                "source_ids": tuple(getattr(issue, "source_ids", ())),
             }
         )
     return tuple(blockers)

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -1863,24 +1863,6 @@ def build_drawing(
                     candidate=candidate_drawing,
                 )
 
-            # A conservative detail reservation may be truthful yet still dominate the
-            # sheet after every same-page measured upscale is rejected.  Page preference is
-            # subordinate to a complete primary-view drawing here too: use the same bounded
-            # standard-page tail as the optional-ISO correction, retaining ISO because this
-            # branch is correcting the detail reservation alone.
-            if _has_detail_view(drawing.views) and page is None:
-                larger, issues = _try_larger_standard_pages(
-                    original_page,
-                    include_iso=_include_iso,
-                    reason="page_escalation_after_detail",
-                    fallback_views=drawing.views,
-                    require_axial_coverage=True,
-                )
-                if larger is not None:
-                    drawing = larger
-                    settled_issues = issues
-                    replanned = True
-
         # #443/#1299: a pictorial view is useful context, but it cannot outrank the
         # dimensions or other required annotations needed to manufacture a part.
         # GRM-03 originally selected 2:1 with ISO, collapsed its 0.5 + 2 mm head
@@ -1906,8 +1888,11 @@ def build_drawing(
                 )
             )
             original_issues, original_blockers = _automatic_assessment(drawing)
+            source_blockers = tuple(
+                blocker for blocker in original_blockers if blocker["source_ids"]
+            )
             settled_issues = original_issues
-            if original_has_axial_gap or original_blockers:
+            if original_has_axial_gap or source_blockers:
                 _record_attempt(
                     drawing.scale,
                     (
@@ -1915,7 +1900,7 @@ def build_drawing(
                         if original_has_axial_gap
                         else "required_outcome_dropped"
                     ),
-                    original_blockers,
+                    source_blockers,
                     reason="remove_optional_iso",
                     candidate=drawing,
                 )

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -1794,14 +1794,16 @@ def build_drawing(
                     candidate=candidate_drawing,
                 )
 
-        # #443: a pictorial view is useful context, but it cannot outrank the
-        # dimensions needed to manufacture a turned profile.  GRM-03 selected 2:1
-        # with ISO, collapsed its 0.5 + 2 mm head steps into an unowned 2.5 mm
-        # block, then had no room for the recovery detail.  Re-plan once without
-        # the optional ISO; scale selection reaches 5:1 and the two truthful step
-        # dimensions fit inline.  This is deliberately a coverage comparison, not
-        # suppression of ``axial_length_missing``: the candidate wins only after
-        # the same read-back check confirms every shoulder is located.
+        # #443/#1299: a pictorial view is useful context, but it cannot outrank the
+        # dimensions or other required annotations needed to manufacture a part.
+        # GRM-03 originally selected 2:1 with ISO, collapsed its 0.5 + 2 mm head
+        # steps into an unowned 2.5 mm block, then had no room for the recovery
+        # detail.  Typed PMI can reach the same correction for the complementary
+        # reason: all shoulders are covered, but a required feature callout has no
+        # route.  Re-plan once without the optional ISO in either case.  This is
+        # deliberately a measured semantic comparison, not suppression of lint:
+        # the candidate wins only after the same read-back and required-outcome
+        # gates prove it complete.
         if (
             dimensions_are_automatic
             and _include_iso
@@ -1816,10 +1818,17 @@ def build_drawing(
                     prof=latest_analysis.prof,
                 )
             )
-            if original_has_axial_gap:
+            original_issues, original_blockers = _automatic_assessment(drawing)
+            settled_issues = original_issues
+            if original_has_axial_gap or original_blockers:
                 _record_attempt(
                     drawing.scale,
-                    "axial_coverage_incomplete",
+                    (
+                        "axial_coverage_incomplete"
+                        if original_has_axial_gap
+                        else "required_outcome_dropped"
+                    ),
+                    original_blockers,
                     reason="remove_optional_iso",
                     candidate=drawing,
                 )

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -1728,6 +1728,75 @@ def build_drawing(
                 return issues, blockers, "required_outcome_dropped"
             return issues, blockers, None
 
+        def _try_larger_standard_pages(
+            starting_page,
+            *,
+            include_iso,
+            reason,
+            fallback_views,
+            require_axial_coverage,
+        ):
+            """Try the bounded standard-page tail under one settled correction policy."""
+            standard_pages = tuple(_PAGE_SIZES.items())
+            original_index = next(
+                (
+                    index
+                    for index, (_name, dimensions) in enumerate(standard_pages)
+                    if tuple(dimensions) == starting_page
+                ),
+                None,
+            )
+            larger_pages = (
+                standard_pages[original_index + 1 :] if original_index is not None else ()
+            )
+            for page_name, page_dimensions in larger_pages:
+                try:
+                    larger = _build(
+                        None,
+                        arrangements=(settled_arrangement,),
+                        include_iso=include_iso,
+                        page_override=page_name,
+                    )
+                except (ValueError, Standard_Failure) as exc:
+                    if not _is_expected_candidate_build_failure(exc):
+                        raise
+                    _log.info(
+                        "automatic page escalation to %s rejected (candidate build failed: %s)",
+                        page_name,
+                        exc,
+                    )
+                    _record_attempt(
+                        None,
+                        "error",
+                        reason=reason,
+                        views=fallback_views,
+                        page=page_dimensions,
+                        error=str(exc),
+                    )
+                    continue
+                larger = _retain_arrangement(larger)
+                issues, blockers, rejection = _qualify_candidate(
+                    larger,
+                    require_axial_coverage=require_axial_coverage,
+                )
+                if rejection is None:
+                    _record_attempt(
+                        larger.scale,
+                        "complete",
+                        reason=reason,
+                        candidate=larger,
+                    )
+                    return larger, issues
+                _record_attempt(
+                    larger.scale,
+                    "rejected",
+                    blockers,
+                    reason=reason,
+                    rejection=rejection,
+                    candidate=larger,
+                )
+            return None, None
+
         # #1155: the compose-time estimate conservatively reserves an enlarged
         # detail for a crowded run.  Some larger preferred scales make that run
         # readable inline, so the detail reservation disappears and the same page
@@ -1793,6 +1862,24 @@ def build_drawing(
                     rejection=rejection,
                     candidate=candidate_drawing,
                 )
+
+            # A conservative detail reservation may be truthful yet still dominate the
+            # sheet after every same-page measured upscale is rejected.  Page preference is
+            # subordinate to a complete primary-view drawing here too: use the same bounded
+            # standard-page tail as the optional-ISO correction, retaining ISO because this
+            # branch is correcting the detail reservation alone.
+            if _has_detail_view(drawing.views) and page is None:
+                larger, issues = _try_larger_standard_pages(
+                    original_page,
+                    include_iso=_include_iso,
+                    reason="page_escalation_after_detail",
+                    fallback_views=drawing.views,
+                    require_axial_coverage=True,
+                )
+                if larger is not None:
+                    drawing = larger
+                    settled_issues = issues
+                    replanned = True
 
         # #443/#1299: a pictorial view is useful context, but it cannot outrank the
         # dimensions or other required annotations needed to manufacture a part.
@@ -1921,72 +2008,19 @@ def build_drawing(
                             # through the established fixed-page policy and must pass the
                             # same axial, structural, and required-outcome gates above.
                             if page is None:
-                                standard_pages = tuple(_PAGE_SIZES.items())
-                                original_index = next(
-                                    (
-                                        index
-                                        for index, (_name, dimensions) in enumerate(standard_pages)
-                                        if tuple(dimensions) == original_page
+                                larger, issues = _try_larger_standard_pages(
+                                    original_page,
+                                    include_iso=False,
+                                    reason="page_escalation_after_optional_iso",
+                                    fallback_views=tuple(
+                                        name for name in drawing.views if name != "iso"
                                     ),
-                                    None,
+                                    require_axial_coverage=True,
                                 )
-                                larger_pages = (
-                                    standard_pages[original_index + 1 :]
-                                    if original_index is not None
-                                    else ()
-                                )
-                                for page_name, page_dimensions in larger_pages:
-                                    try:
-                                        larger = _build(
-                                            None,
-                                            arrangements=(settled_arrangement,),
-                                            include_iso=False,
-                                            page_override=page_name,
-                                        )
-                                    except (ValueError, Standard_Failure) as exc:
-                                        if not _is_expected_candidate_build_failure(exc):
-                                            raise
-                                        _log.info(
-                                            "optional-ISO page escalation to %s rejected "
-                                            "(candidate build failed: %s)",
-                                            page_name,
-                                            exc,
-                                        )
-                                        _record_attempt(
-                                            None,
-                                            "error",
-                                            reason="page_escalation_after_optional_iso",
-                                            views=tuple(
-                                                name for name in drawing.views if name != "iso"
-                                            ),
-                                            page=page_dimensions,
-                                            error=str(exc),
-                                        )
-                                        continue
-                                    larger = _retain_arrangement(larger)
-                                    issues, blockers, page_rejection = _qualify_candidate(
-                                        larger,
-                                        require_axial_coverage=True,
-                                    )
-                                    if page_rejection is None:
-                                        _record_attempt(
-                                            larger.scale,
-                                            "complete",
-                                            reason="page_escalation_after_optional_iso",
-                                            candidate=larger,
-                                        )
-                                        drawing = larger
-                                        settled_issues = issues
-                                        replanned = True
-                                        break
-                                    _record_attempt(
-                                        larger.scale,
-                                        "rejected",
-                                        blockers,
-                                        reason="page_escalation_after_optional_iso",
-                                        rejection=page_rejection,
-                                        candidate=larger,
-                                    )
+                                if larger is not None:
+                                    drawing = larger
+                                    settled_issues = issues
+                                    replanned = True
         # The default record, set BEFORE the completeness pass so that pass can replace it.
         # It used to be assigned afterwards and silently overwrote whatever the pass had
         # decided, so an incomplete plan reported itself as an ordinary automatic one.

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -1439,12 +1439,13 @@ def _scale_decision(
 
 
 def _scale_attempt(
-    scale: float,
+    scale: float | None,
     status: str,
     blockers=(),
     *,
     error: str | None = None,
     reason: str | None = None,
+    rejection: str | None = None,
     views: Iterable[str] | None = None,
     page: tuple[float, float] | None = None,
 ) -> dict:
@@ -1454,6 +1455,8 @@ def _scale_attempt(
         attempt["error"] = error
     if reason is not None:
         attempt["reason"] = reason
+    if rejection is not None:
+        attempt["rejection"] = rejection
     if views is not None:
         attempt["views"] = tuple(views)
     if page is not None:
@@ -1688,6 +1691,7 @@ def build_drawing(
             views=None,
             page=None,
             error=None,
+            rejection=None,
         ):
             if candidate is not None:
                 views = candidate.views
@@ -1698,6 +1702,7 @@ def build_drawing(
                     status,
                     blockers,
                     reason=reason,
+                    rejection=rejection,
                     views=views,
                     page=page,
                     error=error,
@@ -1784,7 +1789,8 @@ def build_drawing(
                     candidate_scale,
                     "rejected",
                     blockers,
-                    reason=rejection,
+                    reason="measured_upscale",
+                    rejection=rejection,
                     candidate=candidate_drawing,
                 )
 
@@ -1849,7 +1855,7 @@ def build_drawing(
                         )
                         try:
                             without_iso = _build(
-                                without_iso_proposal.scale,
+                                None,
                                 arrangements=(settled_arrangement,),
                                 include_iso=False,
                                 page_override=original_page,
@@ -1862,9 +1868,9 @@ def build_drawing(
                                 exc,
                             )
                             _record_attempt(
-                                without_iso_proposal.scale,
+                                None,
                                 "error",
-                                reason="remove_optional_iso_fixed_page",
+                                reason="remove_optional_iso",
                                 views=without_iso_proposal.views,
                                 page=original_page,
                                 error=str(exc),
@@ -1895,9 +1901,83 @@ def build_drawing(
                                 without_iso.scale,
                                 "rejected",
                                 blockers,
-                                reason=rejection,
+                                reason="remove_optional_iso",
+                                rejection=rejection,
                                 candidate=without_iso,
                             )
+                            # #1299: page preference is subordinate to manufacturing
+                            # completeness. Once the settled no-ISO arrangement has failed
+                            # on the automatically selected sheet, try only the bounded
+                            # sequence of larger standard pages. Each page chooses its scale
+                            # through the established fixed-page policy and must pass the
+                            # same axial, structural, and required-outcome gates above.
+                            if page is None:
+                                standard_pages = tuple(_PAGE_SIZES.items())
+                                original_index = next(
+                                    (
+                                        index
+                                        for index, (_name, dimensions) in enumerate(standard_pages)
+                                        if tuple(dimensions) == original_page
+                                    ),
+                                    None,
+                                )
+                                larger_pages = (
+                                    standard_pages[original_index + 1 :]
+                                    if original_index is not None
+                                    else ()
+                                )
+                                for page_name, page_dimensions in larger_pages:
+                                    try:
+                                        larger = _build(
+                                            None,
+                                            arrangements=(settled_arrangement,),
+                                            include_iso=False,
+                                            page_override=page_name,
+                                        )
+                                    except (ValueError, Standard_Failure) as exc:
+                                        if not _is_expected_candidate_build_failure(exc):
+                                            raise
+                                        _log.info(
+                                            "optional-ISO page escalation to %s rejected "
+                                            "(candidate build failed: %s)",
+                                            page_name,
+                                            exc,
+                                        )
+                                        _record_attempt(
+                                            None,
+                                            "error",
+                                            reason="page_escalation_after_optional_iso",
+                                            views=tuple(
+                                                name for name in drawing.views if name != "iso"
+                                            ),
+                                            page=page_dimensions,
+                                            error=str(exc),
+                                        )
+                                        continue
+                                    larger = _retain_arrangement(larger)
+                                    issues, blockers, page_rejection = _qualify_candidate(
+                                        larger,
+                                        require_axial_coverage=True,
+                                    )
+                                    if page_rejection is None:
+                                        _record_attempt(
+                                            larger.scale,
+                                            "complete",
+                                            reason="page_escalation_after_optional_iso",
+                                            candidate=larger,
+                                        )
+                                        drawing = larger
+                                        settled_issues = issues
+                                        replanned = True
+                                        break
+                                    _record_attempt(
+                                        larger.scale,
+                                        "rejected",
+                                        blockers,
+                                        reason="page_escalation_after_optional_iso",
+                                        rejection=page_rejection,
+                                        candidate=larger,
+                                    )
         # The default record, set BEFORE the completeness pass so that pass can replace it.
         # It used to be assigned afterwards and silently overwrote whatever the pass had
         # decided, so an incomplete plan reported itself as an ordinary automatic one.
@@ -1908,7 +1988,9 @@ def build_drawing(
             requested=None,
             effective=drawing.scale,
             status="automatic_replanned" if replanned else "automatic",
-            attempted=tuple(item["scale"] for item in replan_attempts),
+            attempted=tuple(
+                item["scale"] for item in replan_attempts if item["scale"] is not None
+            ),
             attempts=replan_attempts,
         )
         if replan_attempts and drawing.solve_trace is not None:

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -1212,6 +1212,30 @@ def _is_required_scale_drop(issue) -> bool:
     return True
 
 
+def _scale_issue_source_ids(issue) -> tuple[str, ...]:
+    """External sources represented by one placement outcome.
+
+    A compound hole callout is registered against its compiler measurements.  When that
+    callout also renders a typed imported thread/tap requirement, the placement diagnostic
+    therefore carries ``measurement_ids`` while the source provenance remains on the
+    measurement's owning feature aspect.  Recover that exact relationship here; do not infer
+    ownership from a nominal value or from an unowned drop.
+    """
+    source_ids = list(getattr(issue, "source_ids", ()))
+    owners = [
+        getattr(measurement, "feature", None)
+        for measurement in getattr(issue, "measurement_ids", ())
+    ]
+    owners.extend(
+        requirement[0] for requirement in getattr(issue, "hole_requirement_ids", ()) if requirement
+    )
+    for owner in owners:
+        for aspect_name in ("thread", "knurl"):
+            aspect = getattr(owner, aspect_name, None)
+            source_ids.extend(getattr(aspect, "source_ids", ()))
+    return tuple(dict.fromkeys(source_ids))
+
+
 def _scale_blockers_from_issues(issues) -> tuple[dict, ...]:
     """Required placement failures from one already-materialised lint pass."""
     blockers = []
@@ -1230,7 +1254,7 @@ def _scale_blockers_from_issues(issues) -> tuple[dict, ...]:
                     _hole_scale_requirement(req)
                     for req in getattr(issue, "hole_requirement_ids", ())
                 ),
-                "source_ids": tuple(getattr(issue, "source_ids", ())),
+                "source_ids": _scale_issue_source_ids(issue),
             }
         )
     return tuple(blockers)

--- a/tests/test_issue_1299_page_escalation.py
+++ b/tests/test_issue_1299_page_escalation.py
@@ -1,0 +1,171 @@
+"""#1299 — automatic axial recovery may escalate to a larger standard sheet."""
+
+import hashlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from build123d import Align, Cylinder, Pos, Rotation
+
+import draftwright.builder as builder
+from draftwright import build_drawing
+
+GRM03 = Path("/Users/paul/steps/GRM-03_thumbwheel_drive_screw_AP242_PMI.step")
+GRM03_SHA256 = "4b6462b9cc9f0d419250933bd77fb305f9cfebb7ec2b3f377008732876010a21"
+
+
+def _five_step_grm_profile():
+    align = (Align.CENTER, Align.CENTER, Align.MIN)
+    segments = [
+        Pos(0, 0, station) * Cylinder(radius, length, align=align)
+        for station, radius, length in (
+            (-3.2, 2.0, 3.2),
+            (0.0, 3.0, 0.5),
+            (0.5, 5.0, 2.0),
+            (2.5, 2.5, 3.0),
+            (5.5, 1.5, 20.0),
+        )
+    ]
+    shaft = segments[0]
+    for segment in segments[1:]:
+        shaft += segment
+    shaft -= Pos(0, 0, -3.2) * Cylinder(0.8, 8.0, align=align)
+    return Rotation(0, 90, 0) * shaft
+
+
+def test_incomplete_same_page_no_iso_recovery_escalates_to_complete_a3():
+    drawing = build_drawing(_five_step_grm_profile(), pmi="off")
+
+    assert (drawing.page_w, drawing.page_h) == (420.0, 297.0)
+    assert drawing.scale == 5.0
+    assert "iso" not in drawing.views
+    assert drawing.scale_decision["status"] == "automatic_replanned"
+    assert [
+        (
+            attempt["page"],
+            attempt["status"],
+            attempt["reason"],
+            attempt.get("rejection"),
+        )
+        for attempt in drawing.scale_decision["attempts"]
+    ] == [
+        ((297.0, 210.0), "axial_coverage_incomplete", "remove_optional_iso", None),
+        ((297.0, 210.0), "rejected", "remove_optional_iso", "axial_coverage_incomplete"),
+        ((420.0, 297.0), "complete", "page_escalation_after_optional_iso", None),
+    ]
+    assert drawing.scale_decision["attempted_scales"] == (2.0, 2.0, 5.0)
+    assert {
+        drawing.get_annotation(name).label
+        for name in drawing.annotations()
+        if name.startswith("m_steplen")
+    } == {"3.2", "0.5", "2", "3", "20"}
+    assert not [
+        issue
+        for issue in drawing.lint()
+        if issue.severity == "error"
+        or issue.code
+        in {
+            "axial_length_missing",
+            "annotation_overlap",
+            "annotation_out_of_bounds",
+            "view_overlap",
+        }
+        or issue.code.endswith("_dropped")
+    ]
+
+
+def test_no_iso_proposal_on_different_page_reselects_scale_for_original_page(monkeypatch):
+    """A proposal's scale belongs to its own page, not to the original sheet."""
+
+    calls = []
+
+    class FakeDrawing:
+        def __init__(self, *, page, scale, include_iso):
+            self.page_w, self.page_h = page
+            self.scale = scale
+            self.views = {"front": object()}
+            if include_iso:
+                self.views["iso"] = object()
+            self.solve_trace = None
+
+        def model(self):
+            return SimpleNamespace(authored_dimensions=None)
+
+        def lint(self, *, physical=False):
+            return ()
+
+    def fake_one_pass(
+        _step_file,
+        *,
+        scale,
+        page,
+        _include_iso,
+        _analysis_sink,
+        **_kwargs,
+    ):
+        calls.append({"scale": scale, "page": page, "include_iso": _include_iso})
+        _analysis_sink(
+            SimpleNamespace(
+                arrangement=builder.ARRANGEMENTS[0],
+                part=object(),
+                prof=object(),
+            )
+        )
+        if _include_iso:
+            return FakeDrawing(page=(297.0, 210.0), scale=2.0, include_iso=True)
+        if page is None:
+            return FakeDrawing(page=(420.0, 297.0), scale=5.0, include_iso=False)
+        assert page == (297.0, 210.0)
+        return FakeDrawing(page=page, scale=2.0, include_iso=False)
+
+    monkeypatch.setattr(builder, "_build_drawing_once", fake_one_pass)
+    monkeypatch.setattr(
+        builder,
+        "lint_axial_coverage",
+        lambda _part, drawing, *, prof: ("gap",) if "iso" in drawing.views else (),
+    )
+
+    drawing = builder.build_drawing(object())
+
+    fixed_page_calls = [
+        call for call in calls if not call["include_iso"] and call["page"] == (297.0, 210.0)
+    ]
+    assert fixed_page_calls == [{"scale": None, "page": (297.0, 210.0), "include_iso": False}]
+    assert (drawing.page_w, drawing.page_h, drawing.scale) == (297.0, 210.0, 2.0)
+    assert [
+        (attempt["status"], attempt["reason"], attempt.get("rejection"))
+        for attempt in drawing.scale_decision["attempts"]
+    ] == [
+        ("axial_coverage_incomplete", "remove_optional_iso", None),
+        ("scale_proposal", "remove_optional_iso", None),
+        ("complete", "remove_optional_iso", None),
+    ]
+
+
+def test_explicit_a4_remains_fixed_instead_of_escalating():
+    drawing = build_drawing(_five_step_grm_profile(), page="A4", pmi="off")
+
+    assert (drawing.page_w, drawing.page_h) == (297.0, 210.0)
+    assert drawing.scale_decision["status"] == "automatic"
+    assert all(attempt["page"] == (297.0, 210.0) for attempt in drawing.scale_decision["attempts"])
+    assert [issue for issue in drawing.lint() if issue.code == "axial_length_missing"]
+
+
+@pytest.mark.skipif(not GRM03.exists(), reason="local exact GRM-03 AP242 file absent")
+def test_exact_grm03_recovers_all_axial_stations_on_a3_with_pmi_off():
+    assert hashlib.sha256(GRM03.read_bytes()).hexdigest() == GRM03_SHA256
+    drawing = build_drawing(GRM03, pmi="off")
+
+    assert (drawing.page_w, drawing.page_h) == (420.0, 297.0)
+    assert drawing.scale == 5.0
+    assert "iso" not in drawing.views
+    assert {
+        drawing.get_annotation(name).label
+        for name in drawing.annotations()
+        if name.startswith("m_steplen")
+    } == {"3.2", "0.5", "2", "3", "20"}
+    assert not [
+        issue
+        for issue in drawing.lint()
+        if issue.code == "axial_length_missing" or issue.code.endswith("_dropped")
+    ]

--- a/tests/test_issue_1299_page_escalation.py
+++ b/tests/test_issue_1299_page_escalation.py
@@ -10,7 +10,7 @@ from build123d import Align, Cylinder, Pos, Rotation
 import draftwright.builder as builder
 from draftwright import build_drawing
 from draftwright.linting import LintIssue
-from draftwright.model.ir import Frame, HoleFeature
+from draftwright.model.ir import Frame, StepFeature
 from draftwright.model.planner import DimensionId
 
 GRM03 = Path("/Users/paul/steps/GRM-03_thumbwheel_drive_screw_AP242_PMI.step")
@@ -148,19 +148,11 @@ def test_no_iso_proposal_on_different_page_reselects_scale_for_original_page(mon
 def test_required_drop_without_axial_gap_uses_the_same_bounded_page_recovery(monkeypatch):
     """Complete shoulders do not make a sheet complete when a callout was lost."""
 
-    source_id = "manufacturing_requirement:#2004"
-    tapped_hole = HoleFeature(
-        Frame((0.0, 0.0, 0.0), "x"),
-        1.6,
-        8.0,
-        False,
-        thread=SimpleNamespace(source_ids=(source_id,)),
-    )
     dropped = LintIssue(
         severity="warning",
         code="callout_dropped",
         message="required typed-PMI callout has no route",
-        measurement_ids=(DimensionId(tapped_hole, "bore.diameter"),),
+        source_ids=("manufacturing_requirement:#2004",),
         outcome_stage="placement",
     )
 
@@ -223,7 +215,66 @@ def test_required_drop_without_axial_gap_uses_the_same_bounded_page_recovery(mon
         ((297.0, 210.0), "rejected", "remove_optional_iso", "required_outcome_dropped"),
         ((420.0, 297.0), "complete", "page_escalation_after_optional_iso", None),
     ]
-    assert drawing.scale_decision["attempts"][0]["blockers"][0]["source_ids"] == (source_id,)
+
+
+def test_unrelated_drop_on_a_typed_owner_does_not_borrow_its_source(monkeypatch):
+    """A step-length loss is not evidence that its surviving thread callout was lost."""
+
+    from collections import namedtuple
+
+    TypedAspect = namedtuple("TypedAspect", ("source_ids",))
+    threaded_step = StepFeature(
+        Frame((5.0, 0.0, 0.0), "x"),
+        10.0,
+        3.0,
+        ((0.0, 0.0, 0.0), (10.0, 0.0, 0.0)),
+        thread=TypedAspect(("manufacturing_requirement:#thread",)),
+    )
+    dropped = LintIssue(
+        severity="warning",
+        code="step_dim_dropped",
+        message="axial step dimension has no route",
+        measurement_ids=(DimensionId(threaded_step, "step.length"),),
+        outcome_stage="placement",
+    )
+    calls = []
+
+    class FakeDrawing:
+        page_w, page_h, scale = 297.0, 210.0, 2.0
+        views = {"front": object(), "iso": object()}
+        solve_trace = None
+
+        def __init__(self):
+            from draftwright.registry import AnnotationRegistry
+
+            self.registry = AnnotationRegistry()
+
+        def model(self):
+            return SimpleNamespace(authored_dimensions=None)
+
+        def lint(self, *, physical=False):
+            return (dropped,)
+
+    def fake_one_pass(_step_file, *, _include_iso, _analysis_sink, **_kwargs):
+        calls.append(_include_iso)
+        _analysis_sink(
+            SimpleNamespace(
+                arrangement=builder.ARRANGEMENTS[0],
+                part=object(),
+                prof=object(),
+            )
+        )
+        return FakeDrawing()
+
+    monkeypatch.setattr(builder, "_build_drawing_once", fake_one_pass)
+    monkeypatch.setattr(builder, "lint_axial_coverage", lambda *_args, **_kwargs: ())
+
+    with pytest.warns(builder.ScaleCompletenessWarning):
+        drawing = builder.build_drawing(object())
+
+    assert calls == [True]
+    assert drawing.scale_decision["status"] == "incomplete"
+    assert drawing.scale_decision["blockers"][0]["source_ids"] == ()
 
 
 def test_complete_detail_drawing_stays_on_its_original_page(monkeypatch):

--- a/tests/test_issue_1299_page_escalation.py
+++ b/tests/test_issue_1299_page_escalation.py
@@ -142,6 +142,85 @@ def test_no_iso_proposal_on_different_page_reselects_scale_for_original_page(mon
     ]
 
 
+def test_expected_larger_page_build_failure_is_recorded_before_next_page(monkeypatch):
+    class FakeDrawing:
+        def __init__(self, *, page, include_iso):
+            self.page_w, self.page_h = page
+            self.scale = 2.0
+            self.views = {"front": object()}
+            if include_iso:
+                self.views["iso"] = object()
+            self.solve_trace = None
+
+        def model(self):
+            return SimpleNamespace(authored_dimensions=None)
+
+        def lint(self, *, physical=False):
+            return ()
+
+    def fake_one_pass(
+        _step_file,
+        *,
+        page,
+        _include_iso,
+        _analysis_sink,
+        **_kwargs,
+    ):
+        _analysis_sink(
+            SimpleNamespace(
+                arrangement=builder.ARRANGEMENTS[0],
+                part=object(),
+                prof=object(),
+            )
+        )
+        if page == "A3":
+            raise ValueError("drawing geometry degenerates on speculative A3")
+        dimensions = {
+            None: (297.0, 210.0),
+            "A2": (594.0, 420.0),
+        }[page]
+        return FakeDrawing(page=dimensions, include_iso=_include_iso)
+
+    monkeypatch.setattr(builder, "_build_drawing_once", fake_one_pass)
+    monkeypatch.setattr(
+        builder,
+        "lint_axial_coverage",
+        lambda _part, drawing, *, prof: ("gap",) if drawing.page_w == 297.0 else (),
+    )
+
+    drawing = builder.build_drawing(object())
+
+    assert (drawing.page_w, drawing.page_h) == (594.0, 420.0)
+    assert [
+        (
+            attempt["page"],
+            attempt["status"],
+            attempt["reason"],
+            attempt.get("error"),
+        )
+        for attempt in drawing.scale_decision["attempts"]
+    ] == [
+        ((297.0, 210.0), "axial_coverage_incomplete", "remove_optional_iso", None),
+        ((297.0, 210.0), "rejected", "remove_optional_iso", None),
+        (
+            (420.0, 297.0),
+            "error",
+            "page_escalation_after_optional_iso",
+            "drawing geometry degenerates on speculative A3",
+        ),
+        ((594.0, 420.0), "complete", "page_escalation_after_optional_iso", None),
+    ]
+
+    def unexpected_one_pass(*args, page, **kwargs):
+        if page == "A3":
+            raise ValueError("invalid declared model")
+        return fake_one_pass(*args, page=page, **kwargs)
+
+    monkeypatch.setattr(builder, "_build_drawing_once", unexpected_one_pass)
+    with pytest.raises(ValueError, match="invalid declared model"):
+        builder.build_drawing(object())
+
+
 def test_explicit_a4_remains_fixed_instead_of_escalating():
     drawing = build_drawing(_five_step_grm_profile(), page="A4", pmi="off")
 

--- a/tests/test_issue_1299_page_escalation.py
+++ b/tests/test_issue_1299_page_escalation.py
@@ -9,6 +9,7 @@ from build123d import Align, Cylinder, Pos, Rotation
 
 import draftwright.builder as builder
 from draftwright import build_drawing
+from draftwright.linting import LintIssue
 
 GRM03 = Path("/Users/paul/steps/GRM-03_thumbwheel_drive_screw_AP242_PMI.step")
 GRM03_SHA256 = "4b6462b9cc9f0d419250933bd77fb305f9cfebb7ec2b3f377008732876010a21"
@@ -139,6 +140,78 @@ def test_no_iso_proposal_on_different_page_reselects_scale_for_original_page(mon
         ("axial_coverage_incomplete", "remove_optional_iso", None),
         ("scale_proposal", "remove_optional_iso", None),
         ("complete", "remove_optional_iso", None),
+    ]
+
+
+def test_required_drop_without_axial_gap_uses_the_same_bounded_page_recovery(monkeypatch):
+    """Complete shoulders do not make a sheet complete when a callout was lost."""
+
+    dropped = LintIssue(
+        severity="warning",
+        code="callout_dropped",
+        message="required typed-PMI callout has no route",
+        source_ids=("manufacturing_requirement:#2000",),
+        outcome_stage="placement",
+    )
+
+    class FakeDrawing:
+        def __init__(self, *, page, include_iso, issues=()):
+            self.page_w, self.page_h = page
+            self.scale = 2.0
+            self.views = {"front": object()}
+            if include_iso:
+                self.views["iso"] = object()
+            self.solve_trace = None
+            self._issues = tuple(issues)
+
+        def model(self):
+            return SimpleNamespace(authored_dimensions=None)
+
+        def lint(self, *, physical=False):
+            return self._issues
+
+    def fake_one_pass(
+        _step_file,
+        *,
+        page,
+        _include_iso,
+        _analysis_sink,
+        **_kwargs,
+    ):
+        _analysis_sink(
+            SimpleNamespace(
+                arrangement=builder.ARRANGEMENTS[0],
+                part=object(),
+                prof=object(),
+            )
+        )
+        dimensions = {
+            None: (297.0, 210.0),
+            (297.0, 210.0): (297.0, 210.0),
+            "A3": (420.0, 297.0),
+        }[page]
+        issues = () if page == "A3" else (dropped,)
+        return FakeDrawing(page=dimensions, include_iso=_include_iso, issues=issues)
+
+    monkeypatch.setattr(builder, "_build_drawing_once", fake_one_pass)
+    monkeypatch.setattr(builder, "lint_axial_coverage", lambda *_args, **_kwargs: ())
+
+    drawing = builder.build_drawing(object())
+
+    assert (drawing.page_w, drawing.page_h) == (420.0, 297.0)
+    assert "iso" not in drawing.views
+    assert [
+        (
+            attempt["page"],
+            attempt["status"],
+            attempt["reason"],
+            attempt.get("rejection"),
+        )
+        for attempt in drawing.scale_decision["attempts"]
+    ] == [
+        ((297.0, 210.0), "required_outcome_dropped", "remove_optional_iso", None),
+        ((297.0, 210.0), "rejected", "remove_optional_iso", "required_outcome_dropped"),
+        ((420.0, 297.0), "complete", "page_escalation_after_optional_iso", None),
     ]
 
 

--- a/tests/test_issue_1299_page_escalation.py
+++ b/tests/test_issue_1299_page_escalation.py
@@ -10,6 +10,8 @@ from build123d import Align, Cylinder, Pos, Rotation
 import draftwright.builder as builder
 from draftwright import build_drawing
 from draftwright.linting import LintIssue
+from draftwright.model.ir import Frame, HoleFeature
+from draftwright.model.planner import DimensionId
 
 GRM03 = Path("/Users/paul/steps/GRM-03_thumbwheel_drive_screw_AP242_PMI.step")
 GRM03_SHA256 = "4b6462b9cc9f0d419250933bd77fb305f9cfebb7ec2b3f377008732876010a21"
@@ -146,11 +148,19 @@ def test_no_iso_proposal_on_different_page_reselects_scale_for_original_page(mon
 def test_required_drop_without_axial_gap_uses_the_same_bounded_page_recovery(monkeypatch):
     """Complete shoulders do not make a sheet complete when a callout was lost."""
 
+    source_id = "manufacturing_requirement:#2004"
+    tapped_hole = HoleFeature(
+        Frame((0.0, 0.0, 0.0), "x"),
+        1.6,
+        8.0,
+        False,
+        thread=SimpleNamespace(source_ids=(source_id,)),
+    )
     dropped = LintIssue(
         severity="warning",
         code="callout_dropped",
         message="required typed-PMI callout has no route",
-        source_ids=("manufacturing_requirement:#2000",),
+        measurement_ids=(DimensionId(tapped_hole, "bore.diameter"),),
         outcome_stage="placement",
     )
 
@@ -213,6 +223,7 @@ def test_required_drop_without_axial_gap_uses_the_same_bounded_page_recovery(mon
         ((297.0, 210.0), "rejected", "remove_optional_iso", "required_outcome_dropped"),
         ((420.0, 297.0), "complete", "page_escalation_after_optional_iso", None),
     ]
+    assert drawing.scale_decision["attempts"][0]["blockers"][0]["source_ids"] == (source_id,)
 
 
 def test_complete_detail_drawing_stays_on_its_original_page(monkeypatch):

--- a/tests/test_issue_1299_page_escalation.py
+++ b/tests/test_issue_1299_page_escalation.py
@@ -215,6 +215,87 @@ def test_required_drop_without_axial_gap_uses_the_same_bounded_page_recovery(mon
     ]
 
 
+def test_conservative_detail_recovery_uses_a_larger_complete_primary_view(monkeypatch):
+    """A truthful but dominant detail is not preferred over a bounded clean sheet."""
+
+    class FakeDrawing:
+        def __init__(self, *, page, scale, include_iso, detail):
+            self.page_w, self.page_h = page
+            self.scale = scale
+            self.views = {"front": object()}
+            if include_iso:
+                self.views["iso"] = object()
+            if detail:
+                self.views["detail_a"] = object()
+            self.solve_trace = None
+
+        def model(self):
+            return SimpleNamespace(authored_dimensions=None)
+
+        def lint(self, *, physical=False):
+            return ()
+
+    def fake_one_pass(
+        _step_file,
+        *,
+        scale,
+        page,
+        _include_iso,
+        _analysis_sink,
+        **_kwargs,
+    ):
+        _analysis_sink(
+            SimpleNamespace(
+                arrangement=builder.ARRANGEMENTS[0],
+                part=object(),
+                prof=object(),
+            )
+        )
+        if page == "A3":
+            return FakeDrawing(
+                page=(420.0, 297.0),
+                scale=5.0,
+                include_iso=_include_iso,
+                detail=False,
+            )
+        assert page in {None, (297.0, 210.0)}
+        return FakeDrawing(
+            page=(297.0, 210.0),
+            scale=2.0 if scale is None else scale,
+            include_iso=_include_iso,
+            detail=True,
+        )
+
+    monkeypatch.setattr(builder, "_build_drawing_once", fake_one_pass)
+    monkeypatch.setattr(builder, "lint_axial_coverage", lambda *_args, **_kwargs: ())
+
+    drawing = builder.build_drawing(object())
+
+    assert (drawing.page_w, drawing.page_h, drawing.scale) == (420.0, 297.0, 5.0)
+    assert "detail_a" not in drawing.views
+    assert [
+        (
+            attempt["page"],
+            attempt["scale"],
+            attempt["status"],
+            attempt["reason"],
+            attempt.get("rejection"),
+        )
+        for attempt in drawing.scale_decision["attempts"]
+    ] == [
+        (
+            (297.0, 210.0),
+            2.0,
+            "detail_reservation_conservative",
+            "measured_upscale",
+            None,
+        ),
+        ((297.0, 210.0), 5.0, "rejected", "measured_upscale", "recovery_detail_retained"),
+        ((297.0, 210.0), 10.0, "rejected", "measured_upscale", "recovery_detail_retained"),
+        ((420.0, 297.0), 5.0, "complete", "page_escalation_after_detail", None),
+    ]
+
+
 def test_expected_larger_page_build_failure_is_recorded_before_next_page(monkeypatch):
     class FakeDrawing:
         def __init__(self, *, page, include_iso):

--- a/tests/test_issue_1299_page_escalation.py
+++ b/tests/test_issue_1299_page_escalation.py
@@ -215,8 +215,8 @@ def test_required_drop_without_axial_gap_uses_the_same_bounded_page_recovery(mon
     ]
 
 
-def test_conservative_detail_recovery_uses_a_larger_complete_primary_view(monkeypatch):
-    """A truthful but dominant detail is not preferred over a bounded clean sheet."""
+def test_complete_detail_drawing_stays_on_its_original_page(monkeypatch):
+    """#1299 does not broaden recovery beyond incomplete axial/source-owned plans."""
 
     class FakeDrawing:
         def __init__(self, *, page, scale, include_iso, detail):
@@ -271,8 +271,8 @@ def test_conservative_detail_recovery_uses_a_larger_complete_primary_view(monkey
 
     drawing = builder.build_drawing(object())
 
-    assert (drawing.page_w, drawing.page_h, drawing.scale) == (420.0, 297.0, 5.0)
-    assert "detail_a" not in drawing.views
+    assert (drawing.page_w, drawing.page_h, drawing.scale) == (297.0, 210.0, 2.0)
+    assert "detail_a" in drawing.views
     assert [
         (
             attempt["page"],
@@ -292,7 +292,6 @@ def test_conservative_detail_recovery_uses_a_larger_complete_primary_view(monkey
         ),
         ((297.0, 210.0), 5.0, "rejected", "measured_upscale", "recovery_detail_retained"),
         ((297.0, 210.0), 10.0, "rejected", "measured_upscale", "recovery_detail_retained"),
-        ((420.0, 297.0), 5.0, "complete", "page_escalation_after_detail", None),
     ]
 
 


### PR DESCRIPTION
## Summary

- extend optional-ISO axial recovery from the initially selected page through the bounded larger ISO sheet sequence
- reuse the settled arrangement, fixed-page scale policy, axial coverage check, structural lint, and required-placement gates for every candidate
- record page escalation distinctly in `scale_decision.attempts`, including the candidate page and rejection cause
- preserve fixed-page requests and the existing complete A4 four-step GRM result

## Acceptance evidence

- generated redistributable five-step GRM profile: A4 2:1 same-page recovery fails, A3 5:1 no-ISO wins with `3.2`, `0.5`, `2`, `3`, and `20` all rendered
- exact `/Users/paul/steps/GRM-03_thumbwheel_drive_screw_AP242_PMI.step` at SHA-256 `4b6462b9cc9f0d419250933bd77fb305f9cfebb7ec2b3f377008732876010a21`: same complete A3 result with `pmi="off"`
- existing #443 fixture remains A4 5:1 and #1155 GRM-04 remains A4 5:1
- no error lint, axial gap, required drop, overlap, or out-of-bounds issue on the accepted five-step candidate

## Local non-slow checks

- #1299, #443, #1155: 8 passed
- ADR 0018 arrangement, standards, multiscale adjacent suite: 37 passed, 19 deselected
- `scripts/pr-check --static`: clean
- slow tests not run

Closes #1299