### PR TITLE
Use work stealing for local full preflight

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,11 +139,15 @@ checks. Target is 100% passing. Tiers (#153):
 - **`uv run pytest -m smoke`** (~30 s) — curated build-light subset for a quick
   local "did I break something obvious" check.
 - **`uv run pytest`** — full fast tier (`-m 'not slow'`; nearly every test does a
-  real OCC build). Prefer **targeted** selections (`-k`, node ids) locally; a full
-  local run with **`-n auto --dist loadscope`** (pytest-xdist) measured ~17 min for
-  4260 tests on 4 cores (2026-08, #656 — the tier grows with every trust fix; a
-  critique-style test should share a module-scoped built drawing, not mint a new
-  dense fixture).
+  real OCC build). Prefer **targeted** selections (`-k`, node ids) locally;
+  `scripts/pr-check --full` uses **`-n auto --dist worksteal`** to balance the long
+  tail on many-core developer machines. At 4734 collected tests this measured
+  159–172 s across three green 18-core runs, versus 266 s with `loadscope`
+  (2026-08, #1311). The advantage does not carry to CI-shaped machines: at four
+  cores the same comparison was 358 s versus 348 s, so CI deliberately retains
+  `loadscope` and its module-order/fixture guarantees. The tier grows with every
+  trust fix; a critique-style test should share a module-scoped built drawing,
+  not mint a new dense fixture.
 - **`-m slow`** (CTC fixture builds) — CI-only.
 
 Coverage is kept out of the default addopts (it adds ~13% locally); the CI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,9 +143,10 @@ checks. Target is 100% passing. Tiers (#153):
   `scripts/pr-check --full` uses **`-n auto --dist worksteal`** to balance the long
   tail on many-core developer machines. At 4734 collected tests this measured
   159–172 s across three green 18-core runs, versus 266 s with `loadscope`
-  (2026-08, #1311). The advantage does not carry to CI-shaped machines: at four
-  cores the same comparison was 358 s versus 348 s, so CI deliberately retains
-  `loadscope` and its module-order/fixture guarantees. The tier grows with every
+  (2026-08, #1311). On the same 18-core host, limiting pytest to four workers
+  measured 358 s with `worksteal` versus 348 s with `loadscope`; that does not
+  model CPU affinity or a hosted runner. CI deliberately retains its established
+  class/module scope grouping with `loadscope`. The tier grows with every
   trust fix; a critique-style test should share a module-scoped built drawing,
   not mint a new dense fixture.
 - **`-m slow`** (CTC fixture builds) — CI-only.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,9 @@ scripts/pr-check --quick      # smoke tier plus every static PR gate
 scripts/pr-check              # final preflight: full coverage plus changed-line gate
 ```
 
-For a full local run, spread it across cores with
+For the faster local final preflight, use `scripts/pr-check --full`; it spreads
+the fast tier across available workers with work stealing. To reproduce the
+hosted fast-tier distribution instead, use
 `uv run pytest -n auto --dist loadscope`. See [CLAUDE.md](CLAUDE.md) for the test
 tiers and the architecture overview, and `docs/adr/` for the design decisions
 behind layout, scaling, and annotation placement — please read the relevant ADRs

--- a/scripts/pr-check
+++ b/scripts/pr-check
@@ -42,7 +42,7 @@ case "$mode" in
         fi
 
         static_checks
-        uv run pytest tests/ -n auto --dist loadscope \
+        uv run pytest tests/ -n auto --dist worksteal \
             --cov=src/draftwright \
             --cov-report=term-missing \
             --cov-report=xml

--- a/tests/test_layout_property.py
+++ b/tests/test_layout_property.py
@@ -22,9 +22,9 @@ separate shrinking machinery needed. Case count is deliberately modest (15 per
 check) to keep the fast tier quick, per the issue's own guidance — each
 collision-check case is a single OCC build (~3-6s locally), each determinism
 case builds twice (~9-15s locally). The two checks live in separate classes so
-`pytest-xdist --dist loadscope` (this project's recommended local full-suite
-invocation) can schedule them on different workers instead of serializing all
-30 cases behind one module-level scope."""
+CI's retained `pytest-xdist --dist loadscope` invocation can schedule them on
+different workers instead of serializing all 30 cases behind one module-level
+scope."""
 
 from __future__ import annotations
 
@@ -179,7 +179,7 @@ def _generate(seed: int, index: int):
     return template(rng)
 
 
-# Each check lives in its own class (not a bare module-level function) so
+# Each check lives in its own class (not a bare module-level function) so CI's
 # `pytest-xdist --dist loadscope` treats them as two independently-schedulable
 # scopes instead of serializing all 30 cases behind one module-level group.
 class TestGeneratedPartCollisions:


### PR DESCRIPTION
## Outcome

Local `scripts/pr-check --full` now uses pytest-xdist `worksteal` to balance the fast-tier long tail on many-worker developer machines. CI remains on `loadscope` with its established class/module scope grouping.

Closes #1311. Part of #1307.

## Current-main measurements

Clean base: `61d36e9`; macOS, Python 3.14.7, 18 logical cores. Every run collected 4,734 items and finished with 4,727 passed, 5 skipped, and 2 xfailed.

| workers / mode | wall |
|---|---:|
| `-n auto --dist loadscope` | 265.84 s |
| `-n auto --dist worksteal` run 1 | 171.77 s |
| `-n auto --dist worksteal` run 2 | 163.74 s |
| `-n auto --dist worksteal` run 3 | 159.01 s |
| `-n 4 --dist loadscope` | 347.90 s |
| `-n 4 --dist worksteal` | 358.26 s |

This is a 35–40% local improvement when pytest uses the host's automatic worker count. The `-n 4` rows limit pytest to four workers on the same 18-core host; they are not CPU-affinity tests and do not model a four-core or hosted runner. Because that control showed no gain, `.github/workflows/ci.yml` is intentionally unchanged.

## Verification

- Three consecutive full fast-tier `-n auto --dist worksteal` runs green.
- Matching full fast-tier `-n auto --dist loadscope` baseline green.
- Both four-pytest-worker controls green.
- `scripts/pr-check --static` green.
- `uv run pytest tests/test_workflows.py -q` green (10 passed).
- `bash -n scripts/pr-check` and `git diff --check` green.
- Slow tests not run.

After #1309 adds module-scoped fixtures, #1307 retains an explicit remeasurement gate; if the distribution ranking changes, this choice will be revised.
