### PR TITLE
Add reproducible build profiling harness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,7 @@ Compact map, bottom to top:
 - **Facades / top layer** — `make_drawing.py` + `annotate.py` (thin compat),
   `sheet.py` (the fluent `Sheet` facade, ADR 0011), `sheet_emit.py` (the `--script`
   emitter), `cli.py` (Typer; engine imported lazily inside command bodies, #313),
+  `_build_profile.py` (developer-only pytest/runner profiling support),
   `evaluation/` (the versioned STEP-analysis benchmark — production code must never
   depend on benchmark expectations or scores), `recogniser_contract.py` (the
   fail-closed cross-repository capability join).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,20 @@ checks. Target is 100% passing. Tiers (#153):
   not mint a new dense fixture.
 - **`-m slow`** (CTC fixture builds) — CI-only.
 
+For reproducible build-cost profiling, use a fresh output directory and state the expected
+collection census explicitly:
+
+```bash
+scripts/profile-builds --output /tmp/draftwright-profile \
+  --expect-collected 4740 -- tests/ -n auto --dist loadscope
+```
+
+The runner passes every module/option as a literal argv entry, writes one JSON file per xdist
+worker, and refuses to report success when any worker's collected count differs. It times the
+public builder binding, `Sheet`'s import-time builder binding, and `_build_drawing_once`, and
+records pytest phases of at least 5 ms for attribution. Do not reuse an output directory that
+already contains worker profiles.
+
 Coverage is kept out of the default addopts (it adds ~13% locally); the CI
 workflow passes the `--cov` flags. CI runs the full fast tier (3×3 OS/Python
 matrix, parallelised with `-n auto`) on every PR; the **slow tier runs post-merge

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,7 +17,9 @@ top: leaf modules (`layout.py`, `registry.py`, `fonts.py`, `_geometry.py`,
 user-facing surfaces: the `make_drawing.py` / `annotate.py` compat facades, the
 fluent `Sheet` facade (`sheet.py`), the Sheet-script emitter
 (`sheet_emit.py`), the recognition-evaluation package (`evaluation/`), and the
-`cli.py` entry point. No lower module imports an
+`cli.py` entry point. Developer-only `_build_profile.py` sits at the same top layer: it
+patches the public builder and Sheet bindings lazily for pytest measurement, and no engine
+module depends on it. No lower module imports an
 upper one. (All surfaces are front doors onto the one engine,
 `build_drawing` → `_auto_annotate` — there is no second engine.)
 

--- a/scripts/profile-builds
+++ b/scripts/profile-builds
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Run pytest with Draftwright build profiling and verify the collection census."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+from draftwright._build_profile import build_pytest_command, summarise_profiles
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--expect-collected", type=int, required=True)
+    parser.add_argument("pytest_args", nargs=argparse.REMAINDER)
+    args = parser.parse_args(argv)
+    pytest_args = args.pytest_args[1:] if args.pytest_args[:1] == ["--"] else args.pytest_args
+    if not pytest_args:
+        parser.error("pass pytest modules/options after `--`")
+    if args.expect_collected <= 0:
+        parser.error("--expect-collected must be positive")
+
+    output = args.output.resolve()
+    stale = sorted(output.glob("profile-*.json")) if output.exists() else []
+    if stale:
+        print(
+            f"refusing to mix this run with {len(stale)} existing worker profile(s) in {output}",
+            file=sys.stderr,
+        )
+        return 2
+    output.mkdir(parents=True, exist_ok=True)
+
+    completed = subprocess.run(build_pytest_command(output, pytest_args), check=False, cwd=ROOT)
+    try:
+        summary = summarise_profiles(output, args.expect_collected)
+    except ValueError as error:
+        print(error, file=sys.stderr)
+        return 3
+    (output / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return completed.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/draftwright/_build_profile.py
+++ b/src/draftwright/_build_profile.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import re
+import sys
 from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -90,16 +91,16 @@ def pytest_configure(config) -> None:
     worker_id = worker_input.get("workerid", "worker") if worker_input else "main"
     _STATE = _ProfileState(Path(output).resolve(), worker_id)
 
-    import draftwright
     import draftwright.builder as builder
     import draftwright.sheet as sheet
 
+    draftwright = sys.modules["draftwright"]
     builder_public = _timed("builder.build_drawing", builder.build_drawing)
     builder.build_drawing = builder_public
     # The public lazy package attribute and Sheet's import-time binding otherwise bypass a
     # patch installed only on builder.py. That omission made the first #1307 census a lower
     # bound, so all three bindings are explicit here.
-    draftwright.build_drawing = builder_public
+    setattr(draftwright, "build_drawing", builder_public)
     sheet.build_drawing = _timed("sheet.build_drawing", sheet.build_drawing)
     builder._build_drawing_once = _timed(
         "builder._build_drawing_once", builder._build_drawing_once

--- a/src/draftwright/_build_profile.py
+++ b/src/draftwright/_build_profile.py
@@ -1,0 +1,185 @@
+"""Pytest plugin and runner support for reproducible build-cost profiles (#1307)."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections import defaultdict
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from functools import wraps
+from pathlib import Path
+from time import perf_counter
+from typing import Any
+
+_MIN_REPORT_SECONDS = 0.005
+_STATE: _ProfileState | None = None
+_CURRENT_NODEID = "<collection>"
+
+
+@dataclass
+class _ProfileState:
+    output_dir: Path
+    worker_id: str
+    collected: int | None = None
+    calls: dict[tuple[str, str], list[float]] = field(
+        default_factory=lambda: defaultdict(lambda: [0, 0.0])
+    )
+    phases: list[dict[str, Any]] = field(default_factory=list)
+
+    def record_call(self, seam: str, seconds: float) -> None:
+        aggregate = self.calls[(_CURRENT_NODEID, seam)]
+        aggregate[0] += 1
+        aggregate[1] += seconds
+
+    def write(self, exitstatus: int) -> Path:
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+        safe_worker = re.sub(r"[^A-Za-z0-9_.-]", "_", self.worker_id)
+        path = self.output_dir / f"profile-{safe_worker}.json"
+        payload = {
+            "worker_id": self.worker_id,
+            "collected": self.collected,
+            "exitstatus": exitstatus,
+            "calls": [
+                {
+                    "nodeid": nodeid,
+                    "seam": seam,
+                    "count": int(values[0]),
+                    "seconds": values[1],
+                }
+                for (nodeid, seam), values in sorted(self.calls.items())
+            ],
+            "phases": self.phases,
+        }
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        return path
+
+
+def _timed(seam: str, function: Callable[..., Any]) -> Callable[..., Any]:
+    @wraps(function)
+    def wrapper(*args, **kwargs):
+        started = perf_counter()
+        try:
+            return function(*args, **kwargs)
+        finally:
+            assert _STATE is not None
+            _STATE.record_call(seam, perf_counter() - started)
+
+    return wrapper
+
+
+def pytest_addoption(parser) -> None:
+    group = parser.getgroup("draftwright-build-profile")
+    group.addoption(
+        "--build-profile-dir",
+        help="write one Draftwright build profile JSON file per pytest-xdist worker",
+    )
+
+
+def pytest_configure(config) -> None:
+    global _STATE
+    output = config.getoption("--build-profile-dir")
+    if not output:
+        return
+
+    worker_input = getattr(config, "workerinput", None)
+    # Under xdist the controller executes no tests; worker processes write the useful files.
+    if worker_input is None and getattr(config.option, "numprocesses", None):
+        return
+
+    worker_id = worker_input.get("workerid", "worker") if worker_input else "main"
+    _STATE = _ProfileState(Path(output).resolve(), worker_id)
+
+    import draftwright
+    import draftwright.builder as builder
+    import draftwright.sheet as sheet
+
+    builder_public = _timed("builder.build_drawing", builder.build_drawing)
+    builder.build_drawing = builder_public
+    # The public lazy package attribute and Sheet's import-time binding otherwise bypass a
+    # patch installed only on builder.py. That omission made the first #1307 census a lower
+    # bound, so all three bindings are explicit here.
+    draftwright.build_drawing = builder_public
+    sheet.build_drawing = _timed("sheet.build_drawing", sheet.build_drawing)
+    builder._build_drawing_once = _timed(
+        "builder._build_drawing_once", builder._build_drawing_once
+    )
+
+
+def pytest_collection_finish(session) -> None:
+    if _STATE is not None:
+        _STATE.collected = len(session.items)
+
+
+def pytest_runtest_logstart(nodeid, location) -> None:
+    del location
+    global _CURRENT_NODEID
+    _CURRENT_NODEID = nodeid
+
+
+def pytest_runtest_logfinish(nodeid, location) -> None:
+    del nodeid, location
+    global _CURRENT_NODEID
+    _CURRENT_NODEID = "<between-tests>"
+
+
+def pytest_runtest_logreport(report) -> None:
+    if _STATE is not None and report.duration >= _MIN_REPORT_SECONDS:
+        _STATE.phases.append(
+            {
+                "nodeid": report.nodeid,
+                "phase": report.when,
+                "seconds": report.duration,
+                "outcome": report.outcome,
+            }
+        )
+
+
+def pytest_sessionfinish(session, exitstatus) -> None:
+    del session
+    if _STATE is not None:
+        _STATE.write(int(exitstatus))
+
+
+def build_pytest_command(output_dir: Path, pytest_args: list[str]) -> list[str]:
+    """Return argv without joining *pytest_args* into a shell-expanded module string."""
+    return [
+        "uv",
+        "run",
+        "pytest",
+        "-p",
+        "draftwright._build_profile",
+        f"--build-profile-dir={output_dir}",
+        *pytest_args,
+    ]
+
+
+def summarise_profiles(output_dir: Path, expected_collected: int) -> dict[str, Any]:
+    paths = sorted(output_dir.glob("profile-*.json"))
+    if not paths:
+        raise ValueError(f"no worker profiles were written to {output_dir}")
+
+    by_seam: dict[str, list[float]] = defaultdict(lambda: [0, 0.0])
+    workers = []
+    for path in paths:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        collected = payload.get("collected")
+        if collected != expected_collected:
+            raise ValueError(
+                f"{path.name} collected {collected!r}, expected {expected_collected}; "
+                "refusing to report a successful empty or partial profile"
+            )
+        workers.append(payload["worker_id"])
+        for call in payload["calls"]:
+            aggregate = by_seam[call["seam"]]
+            aggregate[0] += call["count"]
+            aggregate[1] += call["seconds"]
+
+    return {
+        "expected_collected": expected_collected,
+        "workers": workers,
+        "seams": {
+            seam: {"count": int(values[0]), "seconds": values[1]}
+            for seam, values in sorted(by_seam.items())
+        },
+    }

--- a/tests/test_build_profile_harness.py
+++ b/tests/test_build_profile_harness.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -83,3 +84,111 @@ def test_worker_profile_contains_call_and_slow_phase_evidence(tmp_path, monkeypa
         }
     ]
     assert payload["phases"][0]["seconds"] == 0.5
+
+
+@pytest.mark.parametrize(
+    ("worker_input", "worker_id"),
+    (({"workerid": "gw0"}, "gw0"), (None, "main")),
+)
+def test_plugin_profiles_every_build_binding_and_test_phase(
+    tmp_path, monkeypatch, worker_input, worker_id
+):
+    import draftwright
+    import draftwright._build_profile as profile
+    import draftwright.builder as builder
+    import draftwright.sheet as sheet
+
+    monkeypatch.setattr(profile, "_STATE", None)
+    monkeypatch.setattr(profile, "_CURRENT_NODEID", "<collection>")
+    monkeypatch.setattr(builder, "build_drawing", lambda value: ("builder", value))
+    monkeypatch.setattr(builder, "_build_drawing_once", lambda value: ("once", value))
+    monkeypatch.setattr(sheet, "build_drawing", lambda value: ("sheet", value))
+    monkeypatch.setattr(draftwright, "build_drawing", builder.build_drawing)
+    config = SimpleNamespace(
+        workerinput=worker_input,
+        option=SimpleNamespace(numprocesses=None),
+        getoption=lambda _name: str(tmp_path),
+    )
+
+    profile.pytest_configure(config)
+    profile.pytest_collection_finish(SimpleNamespace(items=[object(), object()]))
+    profile.pytest_runtest_logstart("tests/test_part.py::test_build", ("test_part.py", 1, ""))
+    assert draftwright.build_drawing("public") == ("builder", "public")
+    assert builder.build_drawing("builder") == ("builder", "builder")
+    assert sheet.build_drawing("sheet") == ("sheet", "sheet")
+    assert builder._build_drawing_once("once") == ("once", "once")
+    profile.pytest_runtest_logreport(
+        SimpleNamespace(
+            duration=0.25,
+            nodeid="tests/test_part.py::test_build",
+            when="call",
+            outcome="passed",
+        )
+    )
+    profile.pytest_runtest_logreport(
+        SimpleNamespace(
+            duration=0.001,
+            nodeid="tests/test_part.py::test_build",
+            when="teardown",
+            outcome="passed",
+        )
+    )
+    profile.pytest_runtest_logfinish("tests/test_part.py::test_build", ("test_part.py", 1, ""))
+    profile.pytest_sessionfinish(SimpleNamespace(), 0)
+
+    payload = json.loads((tmp_path / f"profile-{worker_id}.json").read_text())
+    assert payload["worker_id"] == worker_id
+    assert payload["collected"] == 2
+    assert {(call["seam"], call["count"]) for call in payload["calls"]} == {
+        ("builder.build_drawing", 2),
+        ("sheet.build_drawing", 1),
+        ("builder._build_drawing_once", 1),
+    }
+    assert payload["phases"] == [
+        {
+            "nodeid": "tests/test_part.py::test_build",
+            "phase": "call",
+            "seconds": 0.25,
+            "outcome": "passed",
+        }
+    ]
+
+
+def test_plugin_stays_inactive_without_output_or_in_the_xdist_controller(tmp_path, monkeypatch):
+    import draftwright._build_profile as profile
+
+    monkeypatch.setattr(profile, "_STATE", None)
+    no_output = SimpleNamespace(getoption=lambda _name: None)
+    profile.pytest_configure(no_output)
+    assert profile._STATE is None
+
+    controller = SimpleNamespace(
+        option=SimpleNamespace(numprocesses=4),
+        getoption=lambda _name: str(tmp_path),
+    )
+    profile.pytest_configure(controller)
+    assert profile._STATE is None
+
+
+def test_plugin_registers_its_output_option():
+    import draftwright._build_profile as profile
+
+    options = []
+    group = SimpleNamespace(addoption=lambda *args, **kwargs: options.append((args, kwargs)))
+    parser = SimpleNamespace(
+        getgroup=lambda name: group if name == "draftwright-build-profile" else None
+    )
+
+    profile.pytest_addoption(parser)
+
+    assert options == [
+        (
+            ("--build-profile-dir",),
+            {"help": "write one Draftwright build profile JSON file per pytest-xdist worker"},
+        )
+    ]
+
+
+def test_summary_rejects_a_directory_without_worker_profiles(tmp_path):
+    with pytest.raises(ValueError, match="no worker profiles were written"):
+        summarise_profiles(tmp_path, 42)

--- a/tests/test_build_profile_harness.py
+++ b/tests/test_build_profile_harness.py
@@ -1,0 +1,85 @@
+"""Executable honesty guards for the #1307 build profiler."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from draftwright._build_profile import _ProfileState, build_pytest_command, summarise_profiles
+
+
+def _worker(path: Path, worker: str, collected: int, *, count: int = 2, seconds: float = 1.5):
+    payload = {
+        "worker_id": worker,
+        "collected": collected,
+        "exitstatus": 0,
+        "calls": [
+            {
+                "nodeid": "tests/test_example.py::test_it",
+                "seam": "builder.build_drawing",
+                "count": count,
+                "seconds": seconds,
+            }
+        ],
+        "phases": [],
+    }
+    (path / f"profile-{worker}.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_pytest_command_preserves_each_module_as_a_literal_argument(tmp_path):
+    modules = ["tests/test_a.py", "tests/a module with spaces.py", "-n", "auto"]
+    command = build_pytest_command(tmp_path, modules)
+    assert command[-len(modules) :] == modules
+    assert " ".join(modules) not in command
+
+
+def test_summary_aggregates_workers_only_after_their_collection_counts_match(tmp_path):
+    _worker(tmp_path, "gw0", 42)
+    _worker(tmp_path, "gw1", 42, count=3, seconds=2.25)
+
+    summary = summarise_profiles(tmp_path, 42)
+
+    assert summary == {
+        "expected_collected": 42,
+        "workers": ["gw0", "gw1"],
+        "seams": {"builder.build_drawing": {"count": 5, "seconds": 3.75}},
+    }
+
+
+@pytest.mark.parametrize("collected", (0, 41, None))
+def test_summary_rejects_empty_partial_or_missing_collection_censuses(tmp_path, collected):
+    _worker(tmp_path, "gw0", collected)
+    with pytest.raises(ValueError, match=r"collected .* expected 42"):
+        summarise_profiles(tmp_path, 42)
+
+
+def test_worker_profile_contains_call_and_slow_phase_evidence(tmp_path, monkeypatch):
+    import draftwright._build_profile as profile
+
+    state = _ProfileState(tmp_path, "gw/unsafe")
+    state.collected = 7
+    monkeypatch.setattr(profile, "_CURRENT_NODEID", "tests/test_part.py::test_build")
+    state.record_call("builder._build_drawing_once", 0.25)
+    state.phases.append(
+        {
+            "nodeid": "tests/test_part.py::test_build",
+            "phase": "call",
+            "seconds": 0.5,
+            "outcome": "passed",
+        }
+    )
+
+    path = state.write(0)
+    payload = json.loads(path.read_text())
+
+    assert path.name == "profile-gw_unsafe.json"
+    assert payload["collected"] == 7
+    assert payload["calls"] == [
+        {
+            "count": 1,
+            "nodeid": "tests/test_part.py::test_build",
+            "seam": "builder._build_drawing_once",
+            "seconds": 0.25,
+        }
+    ]
+    assert payload["phases"][0]["seconds"] == 0.5

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -101,6 +101,9 @@ _LAYERS: dict[str, int] = {
     "make_drawing": 7,
     "sheet": 7,
     "sheet_emit": 7,
+    # Developer-only pytest/runner support. It patches the user-facing builder bindings at
+    # runtime and is therefore a top-layer consumer, never an engine dependency.
+    "_build_profile": 7,
     # Cross-repository CI contract: dynamically resolves declared implementations at every
     # lower layer, so it deliberately sits above the whole engine beside the user surfaces.
     "recogniser_contract": 7,


### PR DESCRIPTION
## Outcome

The #1307 performance claims now have a reproducible, fail-closed measurement path instead of an ad hoc local plugin. `scripts/profile-builds` runs an explicitly enumerated pytest selection, writes one profile per xdist worker, verifies every worker's collection census, and emits an aggregate summary.

Part of #1307. Stacked on #1314; independent of the #1310 conversion stack.

## Coverage of the real call paths

The plugin installs before test-module collection and wraps:

- `draftwright.builder.build_drawing` and the public lazy `draftwright.build_drawing` binding;
- `draftwright.sheet.build_drawing`, which `sheet.py` binds at import time and the original census missed;
- `draftwright.builder._build_drawing_once`.

Calls are aggregated by test node id and seam. Pytest setup/call/teardown phases taking at least 5 ms are retained for attribution. Public/Sheet times and `_build_drawing_once` are intentionally separate nested measurements rather than summed as unrelated work.

## Honesty properties

- Pytest modules/options remain distinct argv entries; no shell string is constructed, so zsh word splitting cannot silently collect zero tests.
- `--expect-collected` is required and positive.
- Every worker must report exactly that selected count; zero, partial, missing, or inconsistent profiles fail the runner even when pytest's exit status is zero.
- Each xdist worker writes a distinct JSON file. The controller does not emit an empty pseudo-worker.
- An output directory containing worker profiles is rejected rather than mixed with a new run.

## Verification

- Unit guards: 6 passed (literal argv, worker aggregation, zero/partial/missing census rejection, JSON evidence).
- Focused harness + workflow tests: 16 passed.
- Serial runner integration: one selected test produced `profile-main.json` and `summary.json` with collected count 1.
- Sheet integration: recorded one `sheet.build_drawing` and one `_build_drawing_once` call for the selected test.
- Public-builder integration: recorded five `builder.build_drawing` and five `_build_drawing_once` calls for the selected test.
- xdist integration (`-n 2 --dist loadscope`): two workers each reported the literal two-test collection; controller emitted no profile.
- `scripts/pr-check --static`, focused Ruff check/format, `git diff --check`, and executable mode check: green.
- Slow tests not run.
