### PR TITLE
perf(tests): avoid model-only builds in callout reservation coverage

### DIFF
--- a/tests/test_issue_1216_callout_reservation_measures_ink.py
+++ b/tests/test_issue_1216_callout_reservation_measures_ink.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import pytest
 from build123d import Box, Cone, Cylinder, Pos
 
-from draftwright.builder import build_drawing
+from draftwright.builder import build_drawing, detect_part_model
 from draftwright.compose import _est_planned_bore_callout_width
 from draftwright.model.callout import hole_callout_spec
 from draftwright.model.planner import plan_dimensions
@@ -44,6 +44,18 @@ def _blind_plate():
     for x in (-20, 20):
         part -= Pos(x, 0, 5) * Cylinder(5, 4)
     return part
+
+
+@pytest.mark.parametrize(
+    "part_fn",
+    [_recessed_plate, _blind_plate],
+    ids=["recessed", "blind"],
+)
+def test_direct_detection_matches_built_model_features(part_fn):
+    """The model-only fast path must preserve both geometries used by this module."""
+    built = tuple(build_drawing(part_fn(), title="T", number="N").model().features)
+    detected = tuple(detect_part_model(part_fn()).features)
+    assert detected == built
 
 
 def _widest_drawn_callout(drawing) -> float:
@@ -81,8 +93,7 @@ def _decorations(model, *, kinds):
     ],
 )
 def test_the_reservation_is_never_narrower_than_the_ink(name, part_fn, kinds):
-    base = build_drawing(part_fn(), title="T", number="N")
-    model = base.model()
+    model = detect_part_model(part_fn())
     decorations = _decorations(model, kinds=kinds)
     assert decorations, f"{name}: precondition — this part has no parameter of {kinds}"
 
@@ -123,8 +134,7 @@ def test_a_recess_tolerance_alone_widens_the_reservation():
     Toleranced here through the ROLE key, on the counterbore's diameter alone, so the bore is
     bare and any movement must come from `_term`.
     """
-    base = build_drawing(_recessed_plate(), title="T", number="N")
-    model = base.model()
+    model = detect_part_model(_recessed_plate())
     recess = {
         (feature, param.kind, param.role): _TOL
         for feature in model.features


### PR DESCRIPTION
## Summary

Third focused slice of #1310, stacked on #1316.

- replace the four full drawings used only to obtain a recognised model in `test_issue_1216_callout_reservation_measures_ink.py` with `detect_part_model`;
- add permanent fresh-part `tuple(features)` equivalence gates for both geometries used by those conversions;
- retain every drawing that measures rendered ink, draft reservations, callout specs, or toleranced/bare output.

The two gates replace four model-only builds, for a net removal of two full drawing builds.

## Measurement

Same 18-core macOS/Python 3.14.7 host and serial command:

```console
/usr/bin/time -p uv run pytest tests/test_issue_1216_callout_reservation_measures_ink.py -q
```

- base: 4 passed; 9.54 s and 9.19 s wall;
- head: 6 passed; 6.69 s and 6.52 s wall;
- midpoint: 9.365 s -> 6.605 s, **29.5% faster**.

One first post-change run stalled in host scheduling: 50.36 s wall but 9.98 s user CPU. It is disclosed and excluded from the midpoint rather than hidden or treated as a regression.

## Validation

- changed module: 6 passed on both retained timing runs;
- `scripts/pr-check --static`;
- `git diff --check`.

Slow tests were not run.

Part of #1310 and #1307. This does not close the remaining audit.
