### PR TITLE
perf(tests): avoid repeated model-only cross-pass builds

### DIFF
--- a/tests/test_issue_1166_cross_pass_feature_leaders.py
+++ b/tests/test_issue_1166_cross_pass_feature_leaders.py
@@ -46,13 +46,13 @@ from draftwright.annotations.leaders import (
     feature_leader_fixed_conflicts,
 )
 from draftwright.annotations.orchestrator import _PASS_SEQUENCE
-from draftwright.builder import _is_required_scale_drop
+from draftwright.builder import _is_required_scale_drop, detect_part_model
 from draftwright.layout import _assign_leader_candidates
 from draftwright.linting.issues import is_placement_drop
 from draftwright.model import fillet
 
 
-def _narrow_cross_pass_part():
+def _narrow_cross_pass_solid():
     """Public GRM-class geometry: two side bores, a long pocket and end rounds."""
 
     part = Box(13.55, 11, 80, align=(Align.MIN, Align.CENTER, Align.MIN))
@@ -72,7 +72,12 @@ def _narrow_cross_pass_part():
                 align=(Align.CENTER, Align.CENTER, Align.MIN),
             )
         )
-    detected = build_drawing(part, auto_dims=False).model()
+    return part
+
+
+def _narrow_cross_pass_part():
+    part = _narrow_cross_pass_solid()
+    detected = detect_part_model(part)
     rounded = [
         fillet(axis="x", radius=1, at=(0, -5.5, 0)),
         fillet(axis="x", radius=1, at=(13.55, -5.5, 0)),
@@ -81,6 +86,13 @@ def _narrow_cross_pass_part():
         fillet(axis="z", radius=1, at=(13.55, 5.5, 0)),
     ]
     return part, replace(detected, features=[*detected.features, *rounded])
+
+
+def test_direct_detection_matches_built_model_features_for_narrow_cross_pass_part():
+    """The repeated helper's direct model path must retain its recognised inventory."""
+    built = tuple(build_drawing(_narrow_cross_pass_solid(), auto_dims=False).model().features)
+    detected = tuple(detect_part_model(_narrow_cross_pass_solid()).features)
+    assert detected == built
 
 
 def _overfull_distinct_hole_strip_part():


### PR DESCRIPTION
## Summary

Fourth focused #1310 slice, stacked on #1318.

- split the reusable narrow cross-pass solid factory from its detected-model helper;
- replace six full `build_drawing(..., auto_dims=False).model()` executions inside that helper with `detect_part_model`;
- add a permanent fresh-solid `tuple(features)` equivalence gate;
- leave every downstream rendered feature-leader drawing and assertion unchanged.

One equivalence build replaces six model-only builds: five net full builds removed.

## Measurement

Same 18-core macOS/Python 3.14.7 host.

Whole module, serial:

```console
/usr/bin/time -p uv run pytest tests/test_issue_1166_cross_pass_feature_leaders.py -q
```

- base: 143 passed, 42.38 / 42.71 s wall;
- head: 144 passed, 42.71 s warm wall (an initial 85.02 s wall / 49.18 s CPU host stall is disclosed);
- result: no whole-module wall change distinguishable from noise—the layout-heavy downstream builds dominate.

Isolated helper, ten calls in one process (geometry construction included on both sides):

- base: 1.049729 / 1.089552 s;
- head: 0.305086 / 0.327216 s;
- midpoint: 1.069641 -> 0.316151 s, **70.4% faster**.

## Validation

- changed module: 144 passed;
- permanent fresh-part feature-equivalence gate;
- `scripts/pr-check --static`;
- `git diff --check`.

Slow tests were not run.

Part of #1310 and #1307. The audit remains open.
