### PR TITLE
perf(tests): avoid a model-only slanted profile build

### DIFF
--- a/tests/test_slanted_blind_step.py
+++ b/tests/test_slanted_blind_step.py
@@ -32,11 +32,11 @@ from build123d import (
 )
 
 from draftwright import build_drawing
+from draftwright.builder import detect_part_model
 from draftwright.model.declare import envelope
 
 
-@pytest.fixture(scope="module")
-def slanted_blind_step():
+def _slanted_blind_step():
     align_min = (Align.MIN, Align.MIN, Align.MIN)
     with BuildPart() as part:
         with BuildSketch(Plane.XZ):
@@ -59,6 +59,11 @@ def slanted_blind_step():
 
 
 @pytest.fixture(scope="module")
+def slanted_blind_step():
+    return _slanted_blind_step()
+
+
+@pytest.fixture(scope="module")
 def bounded_slanted_recess():
     """A partial-width ramp whose ends are defining profile transitions."""
     align_min = (Align.MIN, Align.MIN, Align.MIN)
@@ -72,9 +77,9 @@ def bounded_slanted_recess():
 
 @pytest.mark.timeout(120)
 def test_slanted_profile_and_blind_interruptions_are_recognised(slanted_blind_step):
-    dwg = build_drawing(slanted_blind_step, detail_view=True)
-    pockets = [f for f in dwg.model().features if f.kind == "pocket"]
-    steps = [f for f in dwg.model().features if f.kind == "step_level"]
+    model = detect_part_model(slanted_blind_step)
+    pockets = [f for f in model.features if f.kind == "pocket"]
+    steps = [f for f in model.features if f.kind == "step_level"]
 
     assert len(pockets) == 2
     assert all(p.edge_anchored for p in pockets)
@@ -87,6 +92,8 @@ def test_slanted_profile_and_blind_interruptions_are_recognised(slanted_blind_st
 @pytest.mark.timeout(120)
 def test_slanted_blind_step_gets_reconstructable_dimension_plan(slanted_blind_step):
     dwg = build_drawing(slanted_blind_step, detail_view=True)
+    detected = detect_part_model(_slanted_blind_step())
+    assert tuple(detected.features) == tuple(dwg.model().features)
     names = set(dwg.annotations())
 
     assert "m_env_width" in names


### PR DESCRIPTION
## Summary

Fifth focused #1310 slice, stacked on #1319.

- extract a reusable factory for the expensive slanted/blind solid;
- use `detect_part_model` in the recognition-only test instead of building a full detail drawing solely for `.model()`;
- prove exact `tuple(features)` equivalence against a separately constructed fresh solid inside the existing full rendered-drawing test;
- retain that full build and every annotation/view/lint assertion.

The other three model-only geometries in this module are deliberately unchanged: each is a singleton with no existing detected full build, so the mandatory equivalence gate would replace one full build with one full build and save nothing.

## Measurement

Same 18-core macOS/Python 3.14.7 host and serial command:

```console
/usr/bin/time -p uv run pytest tests/test_slanted_blind_step.py -q
```

- base: 12 passed, 16.97 / 17.12 s wall;
- head: 12 passed, 12.98 / 13.06 s warm wall;
- midpoint: 17.045 -> 13.020 s, **23.6% faster**.

The first head run stalled at 61.81 s wall with 18.04 s user CPU. It is disclosed and excluded from the midpoint.

## Validation

- changed module: 12 passed on both retained head runs;
- fresh-part exact feature-equivalence assertion;
- `scripts/pr-check --static`;
- `git diff --check`.

Slow tests were not run.

Part of #1310 and #1307. The remaining audit stays open.
