### PR TITLE
Finish model-only drawing audit

### DIFF
--- a/tests/test_adr0018_view_selection.py
+++ b/tests/test_adr0018_view_selection.py
@@ -24,15 +24,31 @@ import pytest
 from build123d import Box, Cylinder, Pos, Rot
 
 from draftwright import ViewPlanIncomplete, build_drawing
+from draftwright.builder import detect_part_model
 from draftwright.compose import _layout_geometry
 from draftwright.view_plan import VIEW_AXES, VIEWS_SHOWING, views_showing
 
 ALL_THREE = ("front", "plan", "side")
 
 
+def _plain_box():
+    return Box(90, 60, 25)
+
+
 def _z_hole():
     """A part whose only feature reads face-on in PLAN — so plan is necessary."""
     return Box(90, 60, 25) - Pos(20, 15, 0) * Cylinder(4, 30)
+
+
+@pytest.mark.parametrize(
+    "part_fn",
+    (_plain_box, _z_hole),
+    ids=("plain-box", "z-hole"),
+)
+def test_direct_detection_matches_built_model_features_for_view_planning_parts(part_fn):
+    built = tuple(build_drawing(part_fn()).model().features)
+    detected = tuple(detect_part_model(part_fn()).features)
+    assert detected == built
 
 
 def _x_hole():
@@ -213,7 +229,7 @@ class TestTheAsymmetricCounterexample:
         from draftwright.model.ir import RequestedDimension
 
         part = _z_hole()
-        detected = build_drawing(part).model()
+        detected = detect_part_model(part)
         assert detected is not None
         envelope = next(feature for feature in detected.features if feature.kind == "envelope")
         hole = next(feature for feature in detected.features if feature.kind == "hole")
@@ -287,7 +303,7 @@ class TestAnExtentMovesOrIsReported:
     def test_the_planner_record_itself_re_homes_instead_of_only_the_renderer(self):
         from draftwright.model.planner import plan_dimensions
 
-        model = build_drawing(Box(90, 60, 25)).model()
+        model = detect_part_model(_plain_box())
         assert model is not None
         envelope = next(
             group
@@ -299,7 +315,7 @@ class TestAnExtentMovesOrIsReported:
     def test_the_compiler_cannot_silently_replan_against_the_fixed_topology(self):
         from draftwright.model.compiled import compile_dimensions
 
-        model = build_drawing(_z_hole()).model()
+        model = detect_part_model(_z_hole())
         assert model is not None
         with pytest.raises(ViewPlanIncomplete) as caught:
             compile_dimensions(model, planned_views=("front", "side"))
@@ -352,7 +368,7 @@ class TestAnExtentMovesOrIsReported:
     def test_a_width_diagnostic_lists_both_semantically_eligible_views(self):
         from draftwright.model.planner import plan_dimensions
 
-        model = build_drawing(Box(90, 60, 25)).model()
+        model = detect_part_model(_plain_box())
         assert model is not None
         with pytest.raises(ViewPlanIncomplete) as caught:
             plan_dimensions(model, planned_views=("side",))

--- a/tests/test_issue_1058_wheel_profile.py
+++ b/tests/test_issue_1058_wheel_profile.py
@@ -48,6 +48,7 @@ from conftest import counting_calls
 from draftwright import Sheet, build_drawing
 from draftwright.annotations.from_model import callout_from_spec
 from draftwright.annotations.holes import _record_callout_drop
+from draftwright.builder import detect_part_model
 from draftwright.linting.coverage import CoverageState, lint_principal_profile_coverage
 from draftwright.linting.profiled_bore_coverage import (
     lint_profiled_bore_coverage,
@@ -564,8 +565,10 @@ def test_real_wheel_no_longer_gets_a_confident_envelope_only_result(wheel_drawin
 
 
 def test_synthetic_double_d_profile_is_recognised_without_lint_rescans():
+    detected = detect_part_model(_double_d_bore())
     with counting_calls({"orchestration": build_recognition_result}) as calls:
         drawing = build_drawing(_double_d_bore())
+        assert tuple(detected.features) == tuple(drawing.model().features)
         assert calls == {"orchestration": 1}
         for _ in range(2):
             issues = drawing.lint()
@@ -877,7 +880,7 @@ def test_a_double_d_declaration_does_not_reconcile_against_a_plain_cylinder():
 
 
 def test_profile_round_trips_through_the_sheet_emitter_line():
-    source = next(f for f in build_drawing(_double_d_bore()).model().features if f.kind == "hole")
+    source = next(f for f in detect_part_model(_double_d_bore()).features if f.kind == "hole")
     line = _hole_line(source)
     assert "sheet.double_d_bore(" in line
     assert "major_diameter=10" in line and "across_flats=7.2" in line

--- a/tests/test_issue_1143_hole_completeness.py
+++ b/tests/test_issue_1143_hole_completeness.py
@@ -109,8 +109,17 @@ def _linear_pattern():
     return part
 
 
+def _blind_linear_pattern():
+    plate = Box(100, 60, 20, align=_XYZ_MIN)
+    tools = tuple(Pos(x, 10, 12) * Cylinder(3, 8, align=_XYZ_MIN) for x in (-25, 0, 25))
+    part = plate
+    for tool in tools:
+        part -= tool
+    return part, tools
+
+
 def _declared_model(part, feature):
-    detected = build_drawing(part, auto_dims=False).model()
+    detected = detect_part_model(part)
     retained = [
         candidate
         for candidate in detected.features
@@ -201,6 +210,7 @@ def _stepped_x_shaft_with_coaxial_and_offset_bores():
 
 _MODEL_ONLY_PARTS = {
     "blind_hole": _blind_hole,
+    "blind_linear_pattern": lambda: _blind_linear_pattern()[0],
     "grid_pattern": _grid_pattern,
     "linear_pattern": _linear_pattern,
     "opposed_blind_holes": _opposed_blind_holes,
@@ -1217,11 +1227,7 @@ def test_default_linear_direction_matches_recogniser_accepted_step_noise(locatio
 
 
 def test_declared_blind_pattern_tool_centres_correspond_to_recognised_openings():
-    plate = Box(100, 60, 20, align=_XYZ_MIN)
-    tools = [Pos(x, 10, 12) * Cylinder(3, 8, align=_XYZ_MIN) for x in (-25, 0, 25)]
-    part = plate
-    for tool in tools:
-        part -= tool
+    part, tools = _blind_linear_pattern()
     member = declare_hole(tools[1], through=False, depth=8)
     feature = declare_pattern(
         member,

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -11,6 +11,7 @@ import pytest
 from build123d import Align, Box, Cylinder, Pos
 
 from draftwright import build_drawing
+from draftwright.builder import detect_part_model
 from draftwright.fits import fit_class
 from draftwright.linting.hole_coverage import hole_requirement_outcomes
 from draftwright.model.compiled import compile_dimensions
@@ -967,6 +968,9 @@ def test_automatic_table_fails_closed_against_a_retained_public_balloon(
     component_metadata, monkeypatch
 ):
     drawing = build_drawing(_dense_perimeter_plate(), page="A3", auto_dims=False)
+    if component_metadata == "valid":
+        detected = detect_part_model(_dense_perimeter_plate())
+        assert tuple(detected.features) == tuple(drawing.model().features)
     tag = "RETAINED_PUBLIC_BALLOON_WITH_A_VERY_LONG_TAG"
     retained_name = f"balloon_plan_{tag}_0"
     drawing.add_balloons("plan", [(tag, 0, drawing.recognition().holes[0])])
@@ -1150,7 +1154,7 @@ def test_real_constrained_a4_failure_keeps_valid_fallback_coverage():
     from draftwright.model.ir import RequestedDimension
 
     part = _dense_perimeter_plate()
-    detected = build_drawing(part, auto_dims=False).model()
+    detected = detect_part_model(part)
     holes = [feature for feature in detected.features if feature.kind == "hole"]
     # Keep the A4 assertion about the transaction rather than asking an already
     # crowded sheet to render 32 location ordinates. Authored omission remains
@@ -1202,7 +1206,7 @@ def test_automatic_partial_balloon_result_rolls_back_the_shared_table(monkeypatc
 
 def test_scattered_table_reports_a_balloon_landed_on_the_wrong_semantic_owner():
     part = _dense_perimeter_plate()
-    detected = build_drawing(part, auto_dims=False).model()
+    detected = detect_part_model(part)
     victim = max(
         (feature for feature in detected.features if feature.kind == "hole"),
         key=lambda feature: feature.diameter,
@@ -1265,6 +1269,8 @@ def test_grouped_pattern_marker_cannot_certify_an_undefined_hole_tag():
 
     part = _bolt_circle_plate()
     drawing = build_drawing(part, page="A4")
+    detected = detect_part_model(_bolt_circle_plate())
+    assert tuple(detected.features) == tuple(drawing.model().features)
     analysis = _analyse(
         part,
         title="",
@@ -1402,14 +1408,13 @@ def test_long_grouped_pattern_marker_fails_closed_when_its_shaft_crosses_its_tex
     from draftwright.linting.issues import LintIssue
 
     part = _bolt_circle_plate()
-    detected = build_drawing(part, page="A4")
-    pattern = next(feature for feature in detected.model().features if feature.kind == "pattern")
+    detected = detect_part_model(part)
+    pattern = next(feature for feature in detected.features if feature.kind == "pattern")
     long_pattern = replace(pattern, count=1000)
     model = replace(
-        detected.model(),
+        detected,
         features=[
-            long_pattern if feature is pattern else feature
-            for feature in detected.model().features
+            long_pattern if feature is pattern else feature for feature in detected.features
         ],
     )
     drawing = build_drawing(part, model=model, page="A4")
@@ -1464,6 +1469,8 @@ def test_fitted_callout_can_remain_while_table_resolves_its_location_drop(monkey
     with monkeypatch.context() as disabled:
         disabled.setattr(orchestrator, "_maybe_tabulate_holes", lambda *_args, **_kwargs: None)
         baseline = build_drawing(part, page="A2")
+    detected = detect_part_model(_dense_plate_with_close_x_ordinates())
+    assert tuple(detected.features) == tuple(baseline.model().features)
     placed_callout_features = set(_plan_bore_callouts(baseline))
     location_issue = next(
         issue
@@ -1769,7 +1776,7 @@ def test_retained_fit_leader_crossing_rolls_the_automatic_table_back():
     from draftwright.model.ir import RequestedDimension
 
     part = _dense_plate_with_close_x_ordinates()
-    detected = build_drawing(part, page="A3", auto_dims=False).model()
+    detected = detect_part_model(part)
     fitted = next(
         feature
         for feature in detected.features

--- a/tests/test_issue_1276_turned_leader_targets.py
+++ b/tests/test_issue_1276_turned_leader_targets.py
@@ -10,6 +10,7 @@ from build123d import chamfer as b3d_chamfer
 from build123d import fillet as b3d_fillet
 
 from draftwright import build_drawing
+from draftwright.builder import detect_part_model
 from draftwright.model import boss, chamfer, fillet, finish, groove, note
 from draftwright.sheet import Sheet
 
@@ -34,6 +35,12 @@ def _chamfered_shaft():
     shaft = Cylinder(10, 40)
     circular_edges = [edge for edge in shaft.edges() if edge.geom_type == GeomType.CIRCLE]
     return b3d_chamfer(circular_edges, 1)
+
+
+def test_direct_detection_matches_built_model_features_for_chamfered_shaft():
+    built = tuple(build_drawing(_chamfered_shaft(), number="REF").model().features)
+    detected = tuple(detect_part_model(_chamfered_shaft()).features)
+    assert detected == built
 
 
 def test_grm03_chamfers_read_in_profile_and_land_on_distinct_edge_sites():
@@ -122,8 +129,8 @@ def test_detected_parallel_shafts_rotate_about_their_own_axes_not_the_part_bbox(
 
 def test_turned_site_ignores_radially_matching_cylinder_at_a_remote_axial_station():
     primary = _chamfered_shaft()
-    reference = build_drawing(primary, number="REF")
-    feature = next(item for item in reference.model().features if item.kind == "chamfer")
+    model = detect_part_model(primary)
+    feature = next(item for item in model.features if item.kind == "chamfer")
     x, y, _z = feature.frame.origin
 
     # Its radius makes the remote cylinder an exact radial match for the chamfer site.  The
@@ -141,8 +148,8 @@ def test_turned_site_ignores_radially_matching_cylinder_at_a_remote_axial_statio
 
 def test_turned_site_ignores_partial_cylindrical_blend_that_is_not_a_shaft():
     primary = _chamfered_shaft()
-    reference = build_drawing(primary, number="REF")
-    feature = next(item for item in reference.model().features if item.kind == "chamfer")
+    model = detect_part_model(primary)
+    feature = next(item for item in model.features if item.kind == "chamfer")
 
     block = Box(4, 4, 2)
     vertical = next(edge for edge in block.edges() if edge.bounding_box().size.Z > 1.9)

--- a/tests/test_issue_885_prismatic_coverage.py
+++ b/tests/test_issue_885_prismatic_coverage.py
@@ -4,6 +4,7 @@ from b123d_recognisers import recognise_rectangular_pads
 from build123d import Align, Box, Cylinder, Plane, Pos, SlotOverall, extrude
 
 from draftwright import build_drawing
+from draftwright.builder import detect_part_model
 from draftwright.model import PadFeature, pad
 from draftwright.sheet_emit import emit_sheet_script
 
@@ -62,7 +63,7 @@ def test_pad_declaration_and_sheet_emission_round_trip_surface():
     assert isinstance(feature, PadFeature)
     assert (feature.length, feature.width) == (40.0, 18.0)
 
-    model = build_drawing(_case_study()).model()
+    model = detect_part_model(_case_study())
     source = emit_sheet_script(model, "part", "out", title="T", number="N")
     assert source.count("sheet.pad(") == 4
     compile(source, "<generated-pad-sheet>", "exec")
@@ -85,6 +86,8 @@ def test_pad_declaration_and_sheet_emission_round_trip_surface():
 
 def test_auto_drawing_defines_pad_footprints_and_pocket_locations():
     drawing = build_drawing(_case_study())
+    detected = detect_part_model(_case_study())
+    assert tuple(detected.features) == tuple(drawing.model().features)
     assert [f.kind for f in drawing.model().features].count("pad") == 4
     names = set(drawing.annotations())
     assert len({name for name in names if name.startswith("m_pad")}) == 8

--- a/tests/test_issue_917_open_channel.py
+++ b/tests/test_issue_917_open_channel.py
@@ -6,6 +6,7 @@ from b123d_recognisers import recognise_channels, recognise_pockets
 from build123d import Align, Box, Cylinder, Pos, Rot
 
 from draftwright import build_drawing
+from draftwright.builder import detect_part_model
 from draftwright.model import ChannelFeature, HoleFeature, PartModel, plan_dimensions
 
 
@@ -52,6 +53,8 @@ def test_corrected_fixture_has_one_channel_and_one_independent_wall_thickness():
     assert recognise_pockets(part) == []
 
     drawing = build_drawing(part)
+    detected = detect_part_model(_u_channel())
+    assert tuple(detected.features) == tuple(drawing.model().features)
     (channel,) = [
         feature for feature in drawing.model().features if isinstance(feature, ChannelFeature)
     ]
@@ -149,7 +152,7 @@ def test_channel_width_places_for_principal_axis_rotations_and_both_open_signs()
 
 def test_wrong_channel_identity_cannot_clear_the_physical_transition_warning():
     part = _u_channel()
-    detected = build_drawing(part, auto_dims=False).model()
+    detected = detect_part_model(part)
     features = [
         replace(feature, d_hi=feature.d_hi - 1) if isinstance(feature, ChannelFeature) else feature
         for feature in detected.features
@@ -169,7 +172,7 @@ def test_wrong_channel_identity_cannot_clear_the_physical_transition_warning():
 
 
 def test_declared_non_full_span_channel_does_not_suppress_a_wall():
-    detected = build_drawing(_u_channel(), auto_dims=False).model()
+    detected = detect_part_model(_u_channel())
     features = [
         replace(feature, lo=feature.lo + 1, hi=feature.hi - 1)
         if isinstance(feature, ChannelFeature)


### PR DESCRIPTION
Closes #1310
Part of #1307.

## What changed

The earlier five #1310 slices left a real audit tail. This finishes the AST-assisted and manual audit of all current test-suite `.model()` call sites:

- converts 19 remaining model-only full-build executions across seven modules;
- adds/retains fresh-solid exact `tuple(features)` gates for every distinct converted geometry;
- removes 15 net full builds after accounting for four new full-build equivalence cases;
- preserves public `build_drawing` recognition/lifecycle tests, foreign-Drawing ownership tests, and one-off sites whose mandatory gate would cancel the only saving.

No mutable drawing state is shared. Direct detection is used only where the discarded Drawing was consumed solely through its model/features.

## Measured evidence

Honest profiling-harness runs over all seven affected modules, serial on the same host:

| | base | head |
|---|---:|---:|
| selected tests | 310 | 314 |
| `builder.build_drawing` calls | 223 | 208 |
| `builder._build_drawing_once` calls | 241 | 226 |
| public-build time | 88.303 s | 82.045 s |
| pytest wall | 119.79 s | 113.19 s |

That is 15 fewer complete builds, 7.1% less measured public-build time, and 5.5% less wall while adding four permanent equivalence cases.

Repeated warm per-module wall was mostly flat/noise at individual-module scale; the clear individual movement was `test_issue_885_prismatic_coverage.py`, 15.66 -> 13.20 s. Cold/stalled first runs are disclosed in the issue and not used as gains.

## Gates

- affected non-slow suite: 314 passed, 2 deselected;
- private import/attribute canaries: 4 passed;
- static, typing, docs, Ruff, formatting and diff hygiene: green;
- independent pre-rebase review: ACCEPT, no findings;
- fresh exact-head review and regular CI are pending;
- slow tests were not run and will not be awaited.