### PR TITLE
Measure machined feature leaders analytically

### DIFF
--- a/docs/adr/0014-collect-then-solve-annotation-placement.md
+++ b/docs/adr/0014-collect-then-solve-annotation-placement.md
@@ -93,7 +93,7 @@ selected OCC `Leader`; the rendered survivor is checked against that geometry
 before it is committed.
 
 The inventory is bounded before candidate OCC construction by job and
-expanded-candidate caps. Fixed rendered ink is itself component-bounded while
+measured candidate-work caps. Fixed rendered ink is itself component-bounded while
 it is lowered, cached once across joint/fallback use, and then guarded by the
 candidate×fixed-obstacle probe cap. Quadratic candidate geometry has a separate
 pair cap, and the exact solve retains its existing state cap. A cap
@@ -237,6 +237,35 @@ The rule this ADR now records:
 This is a placement-layer instance of the same discipline ADR 0001 applies to solvers:
 the bound has to be explainable, and "the estimate said it might be expensive" is not an
 explanation a user can act on.
+
+**Amendment 5 (2026-08-24, #1308) — machined-feature leaders use the existing
+analytical tier, and candidate budgets buy measured work.** The shared
+`FeatureLeaderJob` seam now lowers the plain-text label box, shaft and shelf for
+chamfer, fillet, flat, pocket, groove, boss, polygonal boss/stock and Y-axis step
+diameter callouts through the same `leader_callout_geometry` contract already used
+by ordinary holes. The generic pass measures each distinct label once through the
+cached renderer-faithful `_text_size`; candidate exploration constructs no OCC
+`Leader`. Only a selected survivor is materialised, and its rendered label and ink
+must match the analytical candidate before commit. A mismatch remains a
+validation-stage failure and replays the canonical producer tail. This extends the
+one shared solve; it does not introduce another placement mechanism.
+
+The old 512-candidate cap treated every candidate as equally expensive. Measurement
+on the #1308 corpus showed an OCC candidate at about 14.8 ms and an analytical one
+at about 0.1 ms. The joint-inventory guard is therefore denominated in 0.1 ms work
+units: analytical measurement costs one, OCC measurement costs 150, and the
+per-view allowance is 76,800 units. That preserves the former worst-case allowance
+of 512 OCC probes while allowing the cheap tier to explore more alternatives for
+the same measured-work ceiling. Trace records the projected joint work by view and
+the per-view limit, so a fallback states the capability it lost. Fixed-ink inventory
+components and candidate×component tests remain directly counted work (one unit per
+component/probe) under their 100,000-unit cap; they were renamed as work rather than
+relaxed. Pair and search-state guards retain their own direct-operation units.
+
+This does not supersede ADR 0014: the collect → solve → emit decision and all prior
+compatibility boundaries remain current. The change completes the analytical tier
+described by Amendment 2 and applies Amendment 4's budget rule to the now-observed
+two-tier cost model.
 
 ## Context (short — the full story is 0009's)
 

--- a/docs/adr/0014-collect-then-solve-annotation-placement.md
+++ b/docs/adr/0014-collect-then-solve-annotation-placement.md
@@ -28,7 +28,7 @@ unification remains separate work (#1166).
 
 **Amendment 2 (2026-08-15, #1166) — compatible same-view feature leaders
 share one late inventory.** Automatic and deferred sparse ordinary side/plan
-hole callouts and the five post-drain machined-feature leader families no longer
+hole callouts and the six post-drain machined-feature leader families no longer
 commit in separate local passes. They collect semantic jobs into
 `PlacementContext.feature_leaders`; the one `"feature_leaders"` stage after the
 corridor drain and before section/detail composition lowers them through
@@ -189,7 +189,7 @@ downstream furniture and table semantics. Recorded so it is not re-derived.
 
 The material term reaches every placer that weighs routing, not only the shared
 inventory: the within-pass assignment and the legacy first-clear scope in
-`_leader_callout_pass` take the same preference through the same
+`place_machined_leader_jobs` takes the same preference through the same
 `material_penalty_units`, so boss diameters and the machined families cannot drift from
 the critique either (#1187). The pre-drain diameter and grouped pattern consumers keep
 their pure legacy selection, as Amendment 1 requires.
@@ -247,8 +247,17 @@ by ordinary holes. The generic pass measures each distinct label once through th
 cached renderer-faithful `_text_size`; candidate exploration constructs no OCC
 `Leader`. Only a selected survivor is materialised, and its rendered label and ink
 must match the analytical candidate before commit. A mismatch remains a
-validation-stage failure and replays the canonical producer tail. This extends the
-one shared solve; it does not introduce another placement mechanism.
+validation-stage failure and replays the canonical producer tail. The six
+post-drain adapters enter the canonical late exact inventory. Y-axis diameters,
+boss diameters and polygonal boss/stock callouts still emit at their pre-drain
+semantic stage because their winners feed downstream passes. A finished-sheet
+single-feature `Drawing.callout()` likewise has no pending late inventory to join.
+Those immediate consumers invoke the same `FeatureLeaderJob` measurement,
+materialisation and rendered-validation machinery through its lazy first-clear
+producer floor. Thus every listed family uses one placement implementation while
+the established compatibility boundary continues to decide whether a job
+participates in late exact assignment or its immediate producer floor. No second
+placement mechanism or new candidate lane is introduced.
 
 The old 512-candidate cap treated every candidate as equally expensive. Measurement
 on the #1308 corpus showed an OCC candidate at about 14.8 ms and an analytical one
@@ -373,7 +382,7 @@ exactly the space other principals needed.
 
 Compatible automatic/deferred feature leaders are likewise
 **collect → assign → emit** (#740/#1166). The side/plan hole renderer and the
-five `_leader_callout_pass` adapters register rich `FeatureLeaderJob`s in
+six `place_machined_leader_jobs` adapters register rich `FeatureLeaderJob`s in
 `annotations/leaders.py`; the canonical late stage lowers analytical ordinary-
 hole alternatives and bounded rendered machined-feature alternatives against
 the completed fixed inventory, derives conflicts from exact leader ink plus

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -830,6 +830,37 @@ def leader_callout_geometry(tip, elbow, draft, *, text_side="auto", callout_box=
     return label_box, segments
 
 
+def analytical_leader_lands_clear(
+    candidate,
+    obstacles,
+    silhouette,
+    page,
+    *,
+    label,
+    geom_clear=False,
+) -> bool:
+    """Apply the producer's label/full-ink clearance floor to an unbuilt leader."""
+    label_box = candidate.label_box
+    if not label or label_box is None:
+        return False
+    check_box = label_box
+    if geom_clear:
+        xs = [label_box[0], label_box[2]]
+        ys = [label_box[1], label_box[3]]
+        for polygon in candidate.ink_polygons:
+            xs.extend(point[0] for point in polygon)
+            ys.extend(point[1] for point in polygon)
+        check_box = (min(xs), min(ys), max(xs), max(ys))
+    return not (
+        _box_hits(check_box, obstacles)
+        or _box_hits(label_box, [silhouette])
+        or label_box[0] < page[0]
+        or label_box[1] < page[1]
+        or label_box[2] > page[2]
+        or label_box[3] > page[3]
+    )
+
+
 def leader_footprint(tip, elbow, draft, *, text_side="auto", callout_box=None):
     """Analytical page-mm AABB ``(x0, y0, x1, y1)`` of the :class:`Leader` that
     ``Leader(tip, elbow, label="", draft, text_side=…, callout=…)`` would build —

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -79,6 +79,7 @@ from draftwright.annotations._common import (
     carve_free_position,
     dim_footprint,
     full_strip_message,
+    leader_callout_geometry,
     place_strip_candidates,
     register_corridor,
     strip_free_span,
@@ -1898,6 +1899,37 @@ def _label_lands_clear(ldr, obstacles, silhouette, page, *, geom_clear=False) ->
     )
 
 
+def _analytical_label_lands_clear(
+    candidate,
+    obstacles,
+    silhouette,
+    page,
+    *,
+    label,
+    geom_clear=False,
+) -> bool:
+    """Analytical equivalent of :func:`_label_lands_clear` for an unbuilt leader."""
+    label_box = candidate.label_box
+    if not label or label_box is None:
+        return False
+    check_box = label_box
+    if geom_clear:
+        xs = [label_box[0], label_box[2]]
+        ys = [label_box[1], label_box[3]]
+        for polygon in candidate.ink_polygons:
+            xs.extend(point[0] for point in polygon)
+            ys.extend(point[1] for point in polygon)
+        check_box = (min(xs), min(ys), max(xs), max(ys))
+    return not (
+        _box_hits(check_box, obstacles)
+        or _box_hits(label_box, [silhouette])
+        or label_box[0] < page[0]
+        or label_box[1] < page[1]
+        or label_box[2] > page[2]
+        or label_box[3] > page[3]
+    )
+
+
 def _corner_candidates(dwg, view, vb, members, reach, *, provenances=None, cylinders=None):
     """Lead candidates for a corner-sitting feature (chamfer/fillet/flat): from each member's
     projected origin, a diagonal from the view centre out through the corner, *reach* beyond
@@ -2128,6 +2160,28 @@ def _leader_callout_pass(
                     draft=dwg.draft,
                 )
 
+            label_width, label_height = _text_size(
+                str(label),
+                float(dwg.draft.font_size),
+                getattr(dwg.draft, "font_path", DEFAULT_FONT_PATH),
+                getattr(dwg.draft, "font", "Arial"),
+            )
+            label_box = (
+                (0.0, 0.0, label_width, label_height)
+                if label_width > 0.0 and label_height > 0.0
+                else None
+            )
+
+            def _analytical_geometry(tip, elbow, _feature, *, _label_box=label_box):
+                if _label_box is None:
+                    return None
+                return leader_callout_geometry(
+                    tip,
+                    elbow,
+                    dwg.draft,
+                    callout_box=_label_box,
+                )
+
             def _fallback_accept(
                 candidate,
                 obstacles,
@@ -2135,7 +2189,17 @@ def _leader_callout_pass(
                 *,
                 _vb=vb,
                 _geom_clear=geom_clear,
+                _label=label,
             ):
+                if candidate.annotation is None:
+                    return _analytical_label_lands_clear(
+                        candidate,
+                        obstacles,
+                        _vb,
+                        page,
+                        label=_label,
+                        geom_clear=_geom_clear,
+                    )
                 return _label_lands_clear(
                     candidate.annotation,
                     obstacles,
@@ -2169,6 +2233,7 @@ def _leader_callout_pass(
                     label=label,
                     candidates=_lane_candidates(),
                     build=_build,
+                    analytical_geometry=_analytical_geometry,
                     measurement=tuple(measurement),
                     noun=noun,
                     drop_code=drop_code,

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1900,6 +1900,10 @@ def _label_lands_clear(ldr, obstacles, silhouette, page, *, geom_clear=False) ->
     )
 
 
+# Kept as the producer binding patched by the pre-drain Policy-B mutation guard.
+_analytical_label_lands_clear = analytical_leader_lands_clear
+
+
 def _corner_candidates(dwg, view, vb, members, reach, *, provenances=None, cylinders=None):
     """Lead candidates for a corner-sitting feature (chamfer/fillet/flat): from each member's
     projected origin, a diagonal from the view centre out through the corner, *reach* beyond
@@ -2162,7 +2166,7 @@ def _leader_callout_pass(
                 _label=label,
             ):
                 if candidate.annotation is None:
-                    return analytical_leader_lands_clear(
+                    return _analytical_label_lands_clear(
                         candidate,
                         obstacles,
                         _vb,

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, replace
-from itertools import chain, groupby, islice, tee
+from itertools import groupby, tee
 from typing import Any
 
 from build123d_drafting import DatumFeature, FeatureControlFrame, SurfaceFinish, TextBlock
@@ -76,7 +76,6 @@ from draftwright.annotations._common import (
     _with_hole_center_coverage,
     _with_hole_location_coverage,
     analytical_leader_lands_clear,
-    annotation_obstacle_boxes,
     carve_free_position,
     dim_footprint,
     full_strip_message,
@@ -88,18 +87,13 @@ from draftwright.annotations._common import (
     strip_occupants,
 )
 from draftwright.annotations.leaders import (
-    _GREEDY_MATERIAL_LOOKAHEAD,
     FeatureLeaderJob,
-    _assign_by_view,
     collect_feature_leader,
     material_penalty_units,
+    place_feature_leader_jobs,
     view_material,
 )
-from draftwright.layout import (
-    _LEADER_ASSIGN_MAX_JOBS,
-    StripCandidate,
-    plan_strip,
-)
+from draftwright.layout import StripCandidate, plan_strip
 
 # Re-exported: `annotations/holes.py` and the tests import the spec from here, and the
 # renderer is its natural home from a caller's point of view even though the reading
@@ -1488,7 +1482,7 @@ def _render_typed_diameter_leaders(dwg, a, indexed_buckets, *, prefix, start, ct
                 ),
             )
         )
-    return _leader_callout_pass(
+    return place_machined_leader_jobs(
         dwg,
         a,
         jobs,
@@ -1668,7 +1662,7 @@ def render_diameters(dwg, plan, a, tol: float = 0.15, *, ctx, only=None) -> int:
                 owner = next(iter(refs)) if len(refs) == 1 else None
                 # Materialise now: a generator expression would close over ``owner``
                 # and all jobs would read the final loop iteration's feature when
-                # _leader_callout_pass consumes them (#890).
+                # place_machined_leader_jobs consumes them (#890).
                 candidates = [
                     (tip, elbow, owner)
                     for tip, elbow, _feature in _radial_candidates(
@@ -1701,7 +1695,7 @@ def render_diameters(dwg, plan, a, tol: float = 0.15, *, ctx, only=None) -> int:
                 )
                 jobs.append((name, "front", vb, label, candidates, mids))
                 covered_by_name[name] = dia
-            placed += _leader_callout_pass(
+            placed += place_machined_leader_jobs(
                 dwg,
                 a,
                 jobs,
@@ -1874,36 +1868,6 @@ def _leader_callout_reach(draft) -> float:
     return float(draft.font_size + 6 * draft.pad_around_text)
 
 
-def _label_lands_clear(ldr, obstacles, silhouette, page, *, geom_clear=False) -> bool:
-    """True when a leader's LABEL box sits in clear margin: off other annotations
-    (*obstacles*), off the part *silhouette* (the leader line may cross into the view, its
-    text may not), and inside the *page* margin box. The single accept test the callout
-    passes share (was the identical six-line guard, copied five times).
-
-    With *geom_clear* the obstacle test uses the FULL ``_geom_box`` footprint (shaft +
-    arrow + label) instead of the label box — the shaft is the invisible occupant a
-    label-only box hides (#133/#305/#358), so a rim-anchored boss ø leader must clear
-    the other callouts/witnesses along its whole length (#629/#700). The silhouette/
-    page checks stay on the label box, since such a shaft legitimately starts inside
-    the view."""
-    geom = _geom_box(ldr) if geom_clear else None
-    label = getattr(ldr, "label_bbox", None) or (geom if geom_clear else _anno_box(ldr))
-    if label is None or (geom_clear and geom is None):
-        return False
-    return not (
-        _box_hits(geom if geom_clear else label, obstacles)
-        or _box_hits(label, [silhouette])
-        or label[0] < page[0]
-        or label[1] < page[1]
-        or label[2] > page[2]
-        or label[3] > page[3]
-    )
-
-
-# Kept as the producer binding patched by the pre-drain Policy-B mutation guard.
-_analytical_label_lands_clear = analytical_leader_lands_clear
-
-
 def _corner_candidates(dwg, view, vb, members, reach, *, provenances=None, cylinders=None):
     """Lead candidates for a corner-sitting feature (chamfer/fillet/flat): from each member's
     projected origin, a diagonal from the view centre out through the corner, *reach* beyond
@@ -1996,37 +1960,7 @@ def _flat_candidates(dwg, view, vb, members, reach, *, provenances):
         )
 
 
-_LEADER_ASSIGN_MAX_CANDIDATES = 256
-_LEADER_ASSIGN_MAX_PAIR_PROBES = 100_000
-
-
-@dataclass(frozen=True)
-class _LeaderPassCandidate:
-    """One measured alternative for the bounded #740 within-pass assignment."""
-
-    tip: tuple
-    elbow: tuple
-    feature: Any
-    leader: Any
-    raw_index: int
-    check_box: tuple
-    obstacle_boxes: tuple
-    cost: float
-
-
-def _leader_candidate_check_box(leader, *, geom_clear):
-    """The footprint the candidate itself must keep clear of earlier leaders.
-
-    This is the obstacle half of :func:`_label_lands_clear`, factored so the
-    joint assignment uses exactly the same rule as the former sequential pass.
-    """
-
-    geom = _geom_box(leader) if geom_clear else None
-    label = getattr(leader, "label_bbox", None) or (geom if geom_clear else _anno_box(leader))
-    return geom if geom_clear else label
-
-
-def _leader_callout_pass(
+def place_machined_leader_jobs(
     dwg,
     a,
     jobs,
@@ -2038,447 +1972,138 @@ def _leader_callout_pass(
     joint=False,
     source_ids_by_name=None,
 ) -> int:
-    """Place one machined-feature leader callout per job (#637/#740). A *job* is
-    ``(name, view, vb, label, candidates, measurement)`` where *candidates* yields ``(tip,
-    elbow, feature)`` lead positions to try in order and *measurement* is the tuple of
-    `DimensionId`s the callout's label draws — several, because these callouts are compound:
-    a pocket prints width × length × depth, a groove width × ⌀ (#1002 r3, which found the
-    whole machined-feature group recording nothing at all).
-    The six scoped post-drain adapters pass ``joint=True``. Their candidate geometry is
-    collected before anything is emitted. Fixed-obstacle eligibility and pairwise conflicts
-    use the same rendered occupancy as the old first-clear loop; the geometry-only layout
-    solver then maximises placed jobs, minimises total leader length, and uses candidate order
-    as the deterministic final tie-break. Alternative construction, pass size, pair
-    construction, and the exact search are bounded. If any budget is reached, the legacy
-    greedy result is retained, so resource pressure can never place fewer callouts than before
-    #740. Pre-drain diameter/pattern consumers leave ``joint=False`` because their winners
-    affect later semantic passes; #740 deliberately does not change that stage boundary.
+    """Lower every machined callout to the one shared ``FeatureLeaderJob`` path.
 
-    A selected Leader is attributed to that candidate's feature; every unselected job records
-    ``<noun> callout … not placed`` as ``<drop_code>`` lint (never a silent drop). Returns the
-    count placed.
+    Post-drain families join the canonical late inventory.  Pre-drain families
+    are solved immediately through that same analytical machinery with its lazy
+    producer floor, preserving both their semantic stage and first-clear order.
+    """
 
-    Traced (#736): with ``ctx.trace`` on, one ``pass_events`` record
-    (``<noun>_callouts``) carries a per-job item — name, view, label, candidates
-    tried, obstacle count, placed tip/elbow or the drop reason. Post-#734 these
-    callouts place after the drain, so without this the #733 story ("why did this
-    pocket callout land here / drop") would be invisible to the trace."""
     source_ids_by_name = source_ids_by_name or {}
-    # Keep alternatives lazy until the bounded joint tier is known to be usable.
-    # This matters for one grouped job with many members: counting jobs or
-    # cross-job pairs alone cannot protect its collect-all OCC construction.
-    jobs = [(*job[:4], iter(job[4]), job[5]) for job in jobs]
-    if not jobs:
-        return 0
+    late_inventory = joint and getattr(ctx, "feature_leaders", None) is not None
+    feature_jobs = []
+    for name, view, silhouette, label, raw_candidates, measurement in jobs:
+        joint_candidates, fallback_candidates = tee(iter(raw_candidates))
 
-    def record_drop(
-        label,
-        measurement,
-        *,
-        source_ids=(),
-        reason="no_clear_room",
-    ) -> None:
-        """Record every pass drop through one provenance-preserving producer."""
+        def _lane_candidates(_raw=joint_candidates):
+            spacing = dwg.draft.font_size + 2 * dwg.draft.pad_around_text
+            for tip, elbow, feature in _raw:
+                dx, dy = float(elbow[0]) - float(tip[0]), float(elbow[1]) - float(tip[1])
+                length = math.hypot(dx, dy)
+                if length <= 1e-12:
+                    yield (tip, elbow, feature)
+                    continue
+                ux, uy = dx / length, dy / length
+                px, py = -dy / length, dx / length
+                for outward, lane in (
+                    (0, 0),
+                    (0, 1),
+                    (0, -1),
+                    (0, 2),
+                    (0, -2),
+                    (1, 0),
+                    (2, 0),
+                    (1, 1),
+                    (1, -1),
+                ):
+                    yield (
+                        tip,
+                        (
+                            float(elbow[0]) + ux * spacing * outward + px * spacing * lane,
+                            float(elbow[1]) + uy * spacing * outward + py * spacing * lane,
+                            0,
+                        ),
+                        feature,
+                    )
 
-        validation = reason == "geometry_validation"
-        detail = "rendered geometry validation failed" if validation else "no clear room"
-        ctx.record_issue(
-            "warning",
-            drop_code,
-            f"{noun} callout {label} not placed ({detail})",
-            measurement=measurement,
-            source=tuple(source_ids),
-            outcome_stage="validation" if validation else "placement",
+        def _build(tip, elbow, _feature, *, _label=label):
+            return Leader(tip=(tip[0], tip[1], 0), elbow=elbow, label=_label, draft=dwg.draft)
+
+        label_width, label_height = _text_size(
+            str(label),
+            float(dwg.draft.font_size),
+            getattr(dwg.draft, "font_path", DEFAULT_FONT_PATH),
+            getattr(dwg.draft, "font", "Arial"),
+        )
+        label_box = (
+            (0.0, 0.0, label_width, label_height)
+            if label_width > 0.0 and label_height > 0.0
+            else None
         )
 
-    if joint and getattr(ctx, "feature_leaders", None) is not None:
-        for name, view, vb, label, raw_candidates, measurement in jobs:
-            joint_candidates, fallback_candidates = tee(raw_candidates)
+        def _analytical_geometry(tip, elbow, _feature, *, _label_box=label_box):
+            if _label_box is None:
+                return None
+            return leader_callout_geometry(tip, elbow, dwg.draft, callout_box=_label_box)
 
-            def _lane_candidates(_raw=joint_candidates):
-                spacing = dwg.draft.font_size + 2 * dwg.draft.pad_around_text
-                for tip, elbow, feature in _raw:
-                    dx, dy = float(elbow[0]) - float(tip[0]), float(elbow[1]) - float(tip[1])
-                    length = math.hypot(dx, dy)
-                    if length <= 1e-12:
-                        yield (tip, elbow, feature)
-                        continue
-                    ux, uy = dx / length, dy / length
-                    px, py = -dy / length, dx / length
-                    for outward, lane in (
-                        (0, 0),
-                        (0, 1),
-                        (0, -1),
-                        (0, 2),
-                        (0, -2),
-                        (1, 0),
-                        (2, 0),
-                        (1, 1),
-                        (1, -1),
-                    ):
-                        yield (
-                            tip,
-                            (
-                                float(elbow[0]) + ux * spacing * outward + px * spacing * lane,
-                                float(elbow[1]) + uy * spacing * outward + py * spacing * lane,
-                                0,
-                            ),
-                            feature,
-                        )
-
-            def _build(tip, elbow, _feature, *, _label=label):
-                return Leader(
-                    tip=(tip[0], tip[1], 0),
-                    elbow=elbow,
-                    label=_label,
-                    draft=dwg.draft,
-                )
-
-            label_width, label_height = _text_size(
-                str(label),
-                float(dwg.draft.font_size),
-                getattr(dwg.draft, "font_path", DEFAULT_FONT_PATH),
-                getattr(dwg.draft, "font", "Arial"),
-            )
-            label_box = (
-                (0.0, 0.0, label_width, label_height)
-                if label_width > 0.0 and label_height > 0.0
-                else None
-            )
-
-            def _analytical_geometry(tip, elbow, _feature, *, _label_box=label_box):
-                if _label_box is None:
-                    return None
-                return leader_callout_geometry(
-                    tip,
-                    elbow,
-                    dwg.draft,
-                    callout_box=_label_box,
-                )
-
-            def _fallback_accept(
+        def _fallback_accept(
+            candidate,
+            obstacles,
+            page,
+            *,
+            _silhouette=silhouette,
+            _geom_clear=geom_clear,
+            _label=label,
+        ):
+            return analytical_leader_lands_clear(
                 candidate,
                 obstacles,
+                _silhouette,
                 page,
-                *,
-                _vb=vb,
-                _geom_clear=geom_clear,
-                _label=label,
-            ):
-                if candidate.annotation is None:
-                    return _analytical_label_lands_clear(
-                        candidate,
-                        obstacles,
-                        _vb,
-                        page,
-                        label=_label,
-                        geom_clear=_geom_clear,
-                    )
-                return _label_lands_clear(
-                    candidate.annotation,
-                    obstacles,
-                    _vb,
-                    page,
-                    geom_clear=_geom_clear,
-                )
-
-            source_ids = tuple(source_ids_by_name.get(name, ()))
-
-            def _on_drop(
-                reason,
-                *,
-                _source_ids=source_ids,
-                _label=label,
-                _measurement=measurement,
-            ):
-                record_drop(
-                    _label,
-                    _measurement,
-                    source_ids=_source_ids,
-                    reason=reason,
-                )
-
-            collect_feature_leader(
-                ctx,
-                FeatureLeaderJob(
-                    name=name,
-                    view=view,
-                    silhouette=vb,
-                    label=label,
-                    candidates=_lane_candidates(),
-                    build=_build,
-                    analytical_geometry=_analytical_geometry,
-                    measurement=tuple(measurement),
-                    noun=noun,
-                    drop_code=drop_code,
-                    fallback_candidates=fallback_candidates,
-                    fallback_accept=_fallback_accept,
-                    # Fixed dimensions/witnesses are exact-ink constraints in
-                    # the shared solve.  If every relocation is worse, retain
-                    # the established semantic callout only through explicit
-                    # Policy B: the solver penalises the crossing and the
-                    # emitter records a machine-readable warning (#1166).
-                    allow_policy_b_fixed=True,
-                    on_drop=_on_drop if source_ids else None,
-                ),
+                label=_label,
+                geom_clear=_geom_clear,
             )
+
+        source_ids = tuple(source_ids_by_name.get(name, ()))
+
+        def _on_drop(
+            reason,
+            *,
+            _source_ids=source_ids,
+            _label=label,
+            _measurement=measurement,
+        ):
+            validation = reason == "geometry_validation"
+            detail = "rendered geometry validation failed" if validation else "no clear room"
+            ctx.record_issue(
+                "warning",
+                drop_code,
+                f"{noun} callout {_label} not placed ({detail})",
+                measurement=_measurement,
+                source=_source_ids,
+                outcome_stage="validation" if validation else "placement",
+            )
+
+        feature_jobs.append(
+            FeatureLeaderJob(
+                name=name,
+                view=view,
+                silhouette=silhouette,
+                label=label,
+                candidates=_lane_candidates() if late_inventory else joint_candidates,
+                build=_build,
+                analytical_geometry=_analytical_geometry,
+                measurement=tuple(measurement),
+                noun=noun,
+                drop_code=drop_code,
+                fallback_candidates=fallback_candidates,
+                fallback_accept=_fallback_accept,
+                allow_policy_b_fixed=True,
+                on_drop=_on_drop if source_ids else None,
+            )
+        )
+
+    if late_inventory:
+        for job in feature_jobs:
+            collect_feature_leader(ctx, job)
         return 0
-    trace = getattr(ctx, "trace", None)
-    ev = trace.pass_event(f"{noun}_callouts") if trace is not None else None
-    page = (a.margin, a.margin, a.PAGE_W - a.margin, a.PAGE_H - a.margin)
-
-    def trace_item(
-        name,
-        view,
-        label,
-        raw_count,
-        obstacle_count,
-        candidate=None,
-        *,
-        viable=None,
-        drop_reason="no_clear_room",
-    ):
-        if ev is None:
-            return
-        item = {
-            "name": name,
-            "view": view,
-            "label": label,
-            "candidates_tried": raw_count,
-            "obstacles": obstacle_count,
-        }
-        if viable is not None:
-            item["viable_candidates"] = viable
-        if candidate is None:
-            item.update({"outcome": "dropped", "reason": drop_reason})
-        else:
-            item.update(
-                {
-                    "outcome": "placed",
-                    "candidate": candidate.raw_index,
-                    "tip": [candidate.tip[0], candidate.tip[1]],
-                    "elbow": [candidate.elbow[0], candidate.elbow[1]],
-                }
-            )
-        ev["items"].append(item)
-
-    def place(candidate, job) -> None:
-        name, view, _vb, _label, _raw, measurement = job
-        # Compiled renderers carry opaque FeatureRefs so they cannot recover
-        # measurements from the source feature. Provenance is the one seam where
-        # the registry intentionally needs the source object itself (#1002).
-        ctx.place(
-            candidate.leader,
-            name,
-            view=view,
-            feature=resolve_feature(candidate.feature),
-            measurement=measurement,
-        )
-
-    def greedy(reason: str) -> int:
-        """The exact pre-#740 first-clear loop, retained as the bounded fallback."""
-
-        if ev is not None:
-            ev.update({"assignment": reason, "optimal": False})
-        placed_count = 0
-        for job in jobs:
-            name, view, vb, label, raw_candidates, measurement = job
-            obstacles = strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
-            field = view_material(dwg, view)
-            tried = 0
-            chosen = None
-            # Acceptable-but-cutting alternatives, held while a bounded lookahead searches
-            # for one that clears the body (#1187). Empty in the common case, where the
-            # first acceptable route already clears and this breaks exactly where the
-            # pre-#798 loop did.
-            held: list[tuple[int, int, Any]] = []
-            examined_since_accept = None
-            for raw_index, (tip, elbow, feature) in enumerate(raw_candidates):
-                tried = raw_index + 1
-                if examined_since_accept is not None:
-                    examined_since_accept += 1
-                    if examined_since_accept > _GREEDY_MATERIAL_LOOKAHEAD:
-                        break
-                leader = Leader(tip=(tip[0], tip[1], 0), elbow=elbow, label=label, draft=dwg.draft)
-                if not _label_lands_clear(leader, obstacles, vb, page, geom_clear=geom_clear):
-                    continue
-                candidate = _LeaderPassCandidate(
-                    tip,
-                    elbow,
-                    feature,
-                    leader,
-                    raw_index,
-                    _leader_candidate_check_box(leader, geom_clear=geom_clear),
-                    tuple(annotation_obstacle_boxes(dwg, leader)),
-                    math.hypot(elbow[0] - tip[0], elbow[1] - tip[1]),
-                )
-                units = material_penalty_units(tip, elbow, field)
-                if units:
-                    # Eligible, but it cuts the part. Policy B keeps a required callout at
-                    # a logged cost rather than dropping it, so this is only ever a
-                    # preference — the candidate stays available if nothing clearer is.
-                    held.append((units, raw_index, candidate))
-                    if examined_since_accept is None:
-                        examined_since_accept = 0
-                    continue
-                chosen = candidate
-                break
-            if chosen is None and held:
-                chosen = min(held, key=lambda entry: entry[:2])[2]
-            if chosen is not None:
-                place(chosen, job)
-                trace_item(name, view, label, tried, len(obstacles), chosen)
-                placed_count += 1
-            else:
-                record_drop(
-                    label,
-                    measurement,
-                    source_ids=source_ids_by_name.get(name, ()),
-                )
-                trace_item(name, view, label, tried, len(obstacles))
-        return placed_count
-
-    if not joint:
-        return greedy("greedy_legacy_scope")
-
-    # Apply the pure solver's recursion bound before constructing any OCC
-    # candidate geometry. The fallback creates at most the alternatives the old
-    # first-clear loop actually visits, so an oversized pass cannot pay the
-    # collect-all cost merely to discover that it is outside the exact tier.
-    if len(jobs) > _LEADER_ASSIGN_MAX_JOBS:
-        return greedy("greedy_job_budget")
-
-    # Materialise at most the cheap tuple alternatives allowed into the joint
-    # tier. On the first excess item, restore the consumed prefix in front of the
-    # still-lazy tail and run the old loop. The fallback therefore constructs at
-    # most as many OCC Leaders as pre-#740 did, even for one enormous grouped job.
-    candidate_count = 0
-    for job_index, job in enumerate(jobs):
-        remaining = _LEADER_ASSIGN_MAX_CANDIDATES - candidate_count
-        raw_candidates = job[4]
-        prefix = list(islice(raw_candidates, remaining + 1))
-        if len(prefix) > remaining:
-            jobs[job_index] = (*job[:4], chain(prefix, raw_candidates), job[5])
-            return greedy("greedy_candidate_budget")
-        jobs[job_index] = (*job[:4], prefix, job[5])
-        candidate_count += len(prefix)
-
-    fixed_obstacles = {
-        view: strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES)
-        for view in dict.fromkeys(job[1] for job in jobs)
-    }
-    candidates_by_job: list[list[_LeaderPassCandidate]] = []
-    for _name, view, vb, label, raw_candidates, _measurement in jobs:
-        viable = []
-        for raw_index, (tip, elbow, feature) in enumerate(raw_candidates):
-            leader = Leader(tip=(tip[0], tip[1], 0), elbow=elbow, label=label, draft=dwg.draft)
-            if not _label_lands_clear(
-                leader,
-                fixed_obstacles[view],
-                vb,
-                page,
-                geom_clear=geom_clear,
-            ):
-                continue
-            check_box = _leader_candidate_check_box(leader, geom_clear=geom_clear)
-            viable.append(
-                _LeaderPassCandidate(
-                    tip,
-                    elbow,
-                    feature,
-                    leader,
-                    raw_index,
-                    check_box,
-                    tuple(annotation_obstacle_boxes(dwg, leader)),
-                    # Leader adds the same 2 mm landing segment to every
-                    # alternative. Cardinality is the primary objective, so
-                    # only this variable tip-to-elbow length affects ranking.
-                    math.hypot(elbow[0] - tip[0], elbow[1] - tip[1]),
-                )
-            )
-        candidates_by_job.append(viable)
-
-    # Only same-view candidates can become obstacles to one another. Apply the
-    # deterministic probe budget before entering the quadratic geometry loop.
-    pair_probes = 0
-    prior_by_view: dict[str, int] = {}
-    for job, candidates in zip(jobs, candidates_by_job, strict=True):
-        view = job[1]
-        pair_probes += prior_by_view.get(view, 0) * len(candidates)
-        prior_by_view[view] = prior_by_view.get(view, 0) + len(candidates)
-        if pair_probes > _LEADER_ASSIGN_MAX_PAIR_PROBES:
-            return greedy("greedy_pair_budget")
-
-    conflicts = []
-    for later_job, later_candidates in enumerate(candidates_by_job):
-        later_view = jobs[later_job][1]
-        for earlier_job in range(later_job):
-            if jobs[earlier_job][1] != later_view:
-                continue
-            for earlier_index, earlier in enumerate(candidates_by_job[earlier_job]):
-                for later_index, later in enumerate(later_candidates):
-                    if _box_hits(later.check_box, earlier.obstacle_boxes):
-                        conflicts.append((earlier_job, earlier_index, later_job, later_index))
-
-    # Same material term and same per-view decomposition as the shared inventory
-    # (#798/#1188): a within-pass callout is no more entitled to cut the part than a
-    # shared one, and its conflicts are likewise same-view only.
-    assignment = _assign_by_view(
-        [job[1] for job in jobs],
-        [[candidate.cost for candidate in candidates] for candidates in candidates_by_job],
-        conflicts,
-        priorities=[0.0] * len(jobs),
-        penalties_by_job=[
-            [
-                material_penalty_units(candidate.tip, candidate.elbow, view_material(dwg, job[1]))
-                for candidate in candidates
-            ]
-            for job, candidates in zip(jobs, candidates_by_job, strict=True)
-        ],
+    return place_feature_leader_jobs(
+        dwg,
+        a,
+        ctx,
+        feature_jobs,
+        producer_floor=not late_inventory,
     )
-    if ev is not None:
-        ev.update(
-            {
-                "assignment": "joint" if assignment.optimal else "joint_budget_incumbent",
-                "optimal": assignment.optimal,
-                "states": assignment.states,
-                "pair_probes": pair_probes,
-            }
-        )
-
-    placed_count = 0
-    for job_index, (job, choice) in enumerate(zip(jobs, assignment.choices, strict=True)):
-        name, view, _vb, label, raw_candidates, measurement = job
-        candidates = candidates_by_job[job_index]
-        if choice is not None:
-            candidate = candidates[choice]
-            place(candidate, job)
-            trace_item(
-                name,
-                view,
-                label,
-                len(raw_candidates),
-                len(fixed_obstacles[view]),
-                candidate,
-                viable=len(candidates),
-            )
-            placed_count += 1
-            continue
-        record_drop(
-            label,
-            measurement,
-            source_ids=source_ids_by_name.get(name, ()),
-        )
-        trace_item(
-            name,
-            view,
-            label,
-            len(raw_candidates),
-            len(fixed_obstacles[view]),
-            viable=len(candidates),
-            drop_reason="assignment_conflict" if candidates else "no_clear_room",
-        )
-    return placed_count
 
 
 def render_chamfers(dwg, plan, a, *, ctx, only=None) -> int:
@@ -2571,7 +2196,7 @@ def render_chamfers(dwg, plan, a, *, ctx, only=None) -> int:
                 tuple(pd.id for _, pd in members),
             )
         )
-    return _leader_callout_pass(
+    return place_machined_leader_jobs(
         dwg,
         a,
         jobs,
@@ -2705,7 +2330,7 @@ def render_fillets(dwg, plan, a, *, ctx, only=None) -> int:
                 tuple(pd.id for _, pd in members),
             )
         )
-    return _leader_callout_pass(
+    return place_machined_leader_jobs(
         dwg,
         a,
         jobs,
@@ -2811,7 +2436,7 @@ def render_flats(dwg, plan, a, *, ctx, only=None) -> int:
                 tuple(pd.id for _, pd in ordered),  # the grouped callout draws every member
             )
         )
-    return _leader_callout_pass(
+    return place_machined_leader_jobs(
         dwg,
         a,
         jobs,
@@ -3036,7 +2661,7 @@ def render_pockets(dwg, plan, a, *, ctx, only=None) -> int:
                 (wpd.id, lpd.id, dpd.id),  # width × length × depth, one callout (#1002)
             )
         )
-    return _leader_callout_pass(
+    return place_machined_leader_jobs(
         dwg,
         a,
         jobs,
@@ -3101,7 +2726,7 @@ def render_grooves(dwg, plan, a, *, ctx, only=None) -> int:
                 (wpd.id, dpd.id),  # one callout, two measurements (#1002)
             )
         )
-    return _leader_callout_pass(
+    return place_machined_leader_jobs(
         dwg,
         a,
         jobs,
@@ -3127,7 +2752,7 @@ def render_boss_diameters(dwg, plan, a, *, ctx) -> int:
     Run BEFORE ``render_diameters`` so a placed boss ø is 'mentioned' and not re-placed. A boss
     whose ø a coincident feature already carries is skipped; an unplaceable one drops lint-visibly.
 
-    Placement rides the shared :func:`_leader_callout_pass` adapter (#700 — never a sixth copy
+    Placement rides the shared :func:`place_machined_leader_jobs` adapter (#700 — never a sixth copy
     of the ray-exit loop, #637): rim-anchored :func:`_radial_candidates`, accepted with
     ``geom_clear`` (the full shaft, not just the label, must clear other annotations)."""
     if a.is_rotational or a.prof is not None:
@@ -3176,7 +2801,7 @@ def render_boss_diameters(dwg, plan, a, *, ctx) -> int:
                 (dpd.id,),
             )
         )
-    return _leader_callout_pass(
+    return place_machined_leader_jobs(
         dwg, a, jobs, noun="boss", drop_code="boss_dia_dropped", ctx=ctx, geom_clear=True
     )
 
@@ -3253,7 +2878,7 @@ def _render_polygonal_prisms(
                 (dimension.id,),
             )
         )
-    return _leader_callout_pass(
+    return place_machined_leader_jobs(
         dwg,
         a,
         jobs,

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -75,6 +75,7 @@ from draftwright.annotations._common import (
     _same_location_ordinate,
     _with_hole_center_coverage,
     _with_hole_location_coverage,
+    analytical_leader_lands_clear,
     annotation_obstacle_boxes,
     carve_free_position,
     dim_footprint,
@@ -1899,37 +1900,6 @@ def _label_lands_clear(ldr, obstacles, silhouette, page, *, geom_clear=False) ->
     )
 
 
-def _analytical_label_lands_clear(
-    candidate,
-    obstacles,
-    silhouette,
-    page,
-    *,
-    label,
-    geom_clear=False,
-) -> bool:
-    """Analytical equivalent of :func:`_label_lands_clear` for an unbuilt leader."""
-    label_box = candidate.label_box
-    if not label or label_box is None:
-        return False
-    check_box = label_box
-    if geom_clear:
-        xs = [label_box[0], label_box[2]]
-        ys = [label_box[1], label_box[3]]
-        for polygon in candidate.ink_polygons:
-            xs.extend(point[0] for point in polygon)
-            ys.extend(point[1] for point in polygon)
-        check_box = (min(xs), min(ys), max(xs), max(ys))
-    return not (
-        _box_hits(check_box, obstacles)
-        or _box_hits(label_box, [silhouette])
-        or label_box[0] < page[0]
-        or label_box[1] < page[1]
-        or label_box[2] > page[2]
-        or label_box[3] > page[3]
-    )
-
-
 def _corner_candidates(dwg, view, vb, members, reach, *, provenances=None, cylinders=None):
     """Lead candidates for a corner-sitting feature (chamfer/fillet/flat): from each member's
     projected origin, a diagonal from the view centre out through the corner, *reach* beyond
@@ -2192,7 +2162,7 @@ def _leader_callout_pass(
                 _label=label,
             ):
                 if candidate.annotation is None:
-                    return _analytical_label_lands_clear(
+                    return analytical_leader_lands_clear(
                         candidate,
                         obstacles,
                         _vb,

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -61,7 +61,6 @@ from draftwright.annotations._common import (
 from draftwright.annotations.from_model import (
     _diameter_column_left,
     _diameter_row_below,
-    _leader_callout_pass,
     _leader_callout_reach,
     _pocket_label,
     _radial_candidates,
@@ -69,6 +68,7 @@ from draftwright.annotations.from_model import (
     _tol_suffix,
     callout_from_spec,
     hole_callout_spec,
+    place_machined_leader_jobs,
 )
 from draftwright.annotations.leaders import (
     FeatureLeaderJob,
@@ -1832,7 +1832,7 @@ def render_pocket_patterns(dwg, plan, a, *, ctx, only=None) -> int:
             )
         )
         furniture.append((i, g, view, name))
-    placed = _leader_callout_pass(
+    placed = place_machined_leader_jobs(
         dwg, a, jobs, noun="pocket pattern", drop_code="pocket_dropped", ctx=ctx
     )
     placed_names = dwg.annotations()
@@ -1943,7 +1943,7 @@ def render_slot_patterns(dwg, plan, a, *, ctx, only=None) -> int:
             )
         )
         furniture.append((i, g, view, name))
-    placed = _leader_callout_pass(
+    placed = place_machined_leader_jobs(
         dwg, a, jobs, noun="slot pattern", drop_code="slot_dropped", ctx=ctx
     )
     placed_names = dwg.annotations()

--- a/src/draftwright/annotations/leaders.py
+++ b/src/draftwright/annotations/leaders.py
@@ -1186,6 +1186,20 @@ def drain_feature_leaders(dwg, analysis, ctx) -> int:
         return 0
     jobs = list(pending)
     pending.clear()
+    return place_feature_leader_jobs(dwg, analysis, ctx, jobs)
+
+
+def place_feature_leader_jobs(dwg, analysis, ctx, jobs, *, producer_floor=False) -> int:
+    """Solve explicit jobs now through the shared analytical leader machinery.
+
+    Pre-drain semantic consumers use ``producer_floor=True`` to retain their
+    established first-clear ordering without postponing their winners to the
+    canonical late inventory.  Candidate measurement and survivor validation
+    remain the same shared path; only the assignment tier is fixed to the lazy
+    producer floor.
+    """
+
+    jobs = list(jobs)
     if not jobs:
         return 0
 
@@ -1400,6 +1414,13 @@ def drain_feature_leaders(dwg, analysis, ctx) -> int:
         therefore expose the accepted crossing through structured lint rather
         than looking clean merely because the trace recorder was disabled.
         """
+
+        if producer_floor:
+            # Immediate pre-drain consumers retain their historical diagnostic
+            # contract as well as their selection order. Their later semantic
+            # passes already diagnose the resulting drawing; this late-inventory
+            # Policy-B finding was never part of the immediate producer floor.
+            return
 
         unverified = "fixed_probe_budget" in blockers
         crossed = tuple(
@@ -1819,6 +1840,9 @@ def drain_feature_leaders(dwg, analysis, ctx) -> int:
             cost=total_cost,
         )
         return placed_count
+
+    if producer_floor:
+        return greedy("greedy_stage_boundary")
 
     if len(jobs) > _LEADER_ASSIGN_MAX_JOBS:
         return greedy("greedy_job_budget")

--- a/src/draftwright/annotations/leaders.py
+++ b/src/draftwright/annotations/leaders.py
@@ -41,8 +41,17 @@ from draftwright.layout import (
 from draftwright.model.compiled import resolve_feature
 from draftwright.projection import _MATERIAL_PAGE_TOLERANCE
 
-_FEATURE_LEADER_MAX_CANDIDATES = 512
-_FEATURE_LEADER_MAX_FIXED_PROBES = 100_000
+# One unit is the measured ~0.1 ms analytical candidate cost from #1308.  A real
+# OCC Leader probe costs ~14.8 ms on the same corpus, so it is charged 150 units.
+# The default preserves the former 512-OCC-probe ceiling while allowing the cheap
+# analytical tier to spend the same bounded wall-work budget on more alternatives.
+_FEATURE_LEADER_ANALYTICAL_MEASURE_WORK = 1
+_FEATURE_LEADER_OCC_MEASURE_WORK = 150
+_FEATURE_LEADER_MAX_MEASURE_WORK = 512 * _FEATURE_LEADER_OCC_MEASURE_WORK
+
+# Fixed-ink inventory components and candidate×component probes are already direct
+# measured operations, so one component/probe is one work unit (#1308).
+_FEATURE_LEADER_MAX_FIXED_WORK = 100_000
 _FEATURE_LEADER_MAX_PAIR_PROBES = 100_000
 _FIXED_INVENTORY_EXHAUSTED = object()
 
@@ -139,6 +148,14 @@ class _FixedInkComponent:
     kind: str = ""
     segment: tuple[tuple[float, float], tuple[float, float]] | None = None
     global_axis: bool = False
+
+
+def _candidate_measure_work(job: FeatureLeaderJob) -> int:
+    return (
+        _FEATURE_LEADER_ANALYTICAL_MEASURE_WORK
+        if job.analytical_geometry is not None
+        else _FEATURE_LEADER_OCC_MEASURE_WORK
+    )
 
 
 def collect_feature_leader(ctx, job: FeatureLeaderJob) -> bool:
@@ -1196,6 +1213,7 @@ def drain_feature_leaders(dwg, analysis, ctx) -> int:
     )
     raw_jobs = []
     fallback_jobs = []
+    measurement_work_by_view: dict[str, int] = {}
     for job in jobs:
         if job.fallback_candidates is None:
             joint, fallback = tee(job.candidates)
@@ -1235,7 +1253,7 @@ def drain_feature_leaders(dwg, analysis, ctx) -> int:
         cached = provisional_inventory if provisional else committed_inventory
         if cached is not inventory_unset:
             return cached
-        remaining = _FEATURE_LEADER_MAX_FIXED_PROBES
+        remaining = _FEATURE_LEADER_MAX_FIXED_WORK
         lowered: dict[str, tuple[_FixedInkComponent, ...]] = {}
         result = {}
         for view in views:
@@ -1445,7 +1463,13 @@ def drain_feature_leaders(dwg, analysis, ctx) -> int:
                         "states": states,
                         "fixed_probes": fixed_probes,
                         "fixed_probe_bound": fixed_probe_bound,
+                        "fixed_work_limit": _FEATURE_LEADER_MAX_FIXED_WORK,
                         "pair_probes": pair_probes,
+                        "joint_measurement_work": sum(measurement_work_by_view.values()),
+                        "joint_measurement_work_by_view": dict(measurement_work_by_view),
+                        "joint_measurement_work_limit_per_view": (
+                            _FEATURE_LEADER_MAX_MEASURE_WORK
+                        ),
                         "provisional_refinement": provisional_refinement,
                         "inventory_jobs": len(jobs),
                         "objective": {
@@ -1567,7 +1591,7 @@ def drain_feature_leaders(dwg, analysis, ctx) -> int:
                         break
                 fixed_components = fixed[job.view]
                 if fixed_verified and (
-                    actual_fixed_probes + len(fixed_components) <= _FEATURE_LEADER_MAX_FIXED_PROBES
+                    actual_fixed_probes + len(fixed_components) <= _FEATURE_LEADER_MAX_FIXED_WORK
                 ):
                     blockers = _fixed_blockers(candidate, job, page, fixed_components)
                     actual_fixed_probes += len(fixed_components)
@@ -1661,7 +1685,7 @@ def drain_feature_leaders(dwg, analysis, ctx) -> int:
                     fixed_components = fixed[job.view]
                     if fixed_verified and (
                         actual_fixed_probes + len(fixed_components)
-                        <= _FEATURE_LEADER_MAX_FIXED_PROBES
+                        <= _FEATURE_LEADER_MAX_FIXED_WORK
                     ):
                         blockers = _fixed_blockers(candidate, job, page, fixed_components)
                         actual_fixed_probes += len(fixed_components)
@@ -1742,7 +1766,7 @@ def drain_feature_leaders(dwg, analysis, ctx) -> int:
             place(job_index, selected, annotation)
             record_policy_b(job_index, selected_policy_b)
             if fixed_verified:
-                remaining_components = _FEATURE_LEADER_MAX_FIXED_PROBES - sum(
+                remaining_components = _FEATURE_LEADER_MAX_FIXED_WORK - sum(
                     len(components) for components in fixed.values()
                 )
                 if remaining_components <= 0:
@@ -1805,29 +1829,31 @@ def drain_feature_leaders(dwg, analysis, ctx) -> int:
     # inventory each view could actually handle, and every dense fixture fell back to the
     # greedy floor before the exact solve began.
     candidate_counts_by_job = []
-    candidates_by_view: dict[str, int] = {}
     for job_index, iterator in enumerate(raw_jobs):
         view = jobs[job_index].view
-        remaining = _FEATURE_LEADER_MAX_CANDIDATES - candidates_by_view.get(view, 0)
-        prefix = list(islice(iterator, remaining + 1))
-        if len(prefix) > remaining:
+        unit_work = _candidate_measure_work(jobs[job_index])
+        used_work = measurement_work_by_view.get(view, 0)
+        remaining_work = max(0, _FEATURE_LEADER_MAX_MEASURE_WORK - used_work)
+        admitted = remaining_work // unit_work
+        prefix = list(islice(iterator, admitted + 1))
+        measurement_work_by_view[view] = used_work + len(prefix) * unit_work
+        if len(prefix) > admitted:
             raw_jobs[job_index] = chain(prefix, iterator)
             return greedy("greedy_candidate_budget")
         raw_jobs[job_index] = iter(prefix)
-        candidates_by_view[view] = candidates_by_view.get(view, 0) + len(prefix)
         candidate_counts_by_job.append(len(prefix))
 
     fixed = bounded_fixed_obstacles()
     if fixed is _FIXED_INVENTORY_EXHAUSTED:
         return greedy(
             "greedy_fixed_inventory_budget",
-            fixed_probe_bound=_FEATURE_LEADER_MAX_FIXED_PROBES + 1,
+            fixed_probe_bound=_FEATURE_LEADER_MAX_FIXED_WORK + 1,
         )
     probes_by_view: dict[str, int] = {}
     for count, job in zip(candidate_counts_by_job, jobs, strict=True):
         probes_by_view[job.view] = probes_by_view.get(job.view, 0) + count * len(fixed[job.view])
     fixed_probe_bound = sum(probes_by_view.values())
-    if any(bound > _FEATURE_LEADER_MAX_FIXED_PROBES for bound in probes_by_view.values()):
+    if any(bound > _FEATURE_LEADER_MAX_FIXED_WORK for bound in probes_by_view.values()):
         return greedy(
             "greedy_fixed_probe_budget",
             fixed_probe_bound=fixed_probe_bound,
@@ -1970,7 +1996,7 @@ def drain_feature_leaders(dwg, analysis, ctx) -> int:
                 job.view, 0
             ) + len(candidates) * len(provisional[job.view])
     provisional_probe_bound = (
-        _FEATURE_LEADER_MAX_FIXED_PROBES + 1
+        _FEATURE_LEADER_MAX_FIXED_WORK + 1
         if provisional_inventory_exhausted
         else sum(provisional_probes_by_view.values())
     )
@@ -1986,7 +2012,7 @@ def drain_feature_leaders(dwg, analysis, ctx) -> int:
         and provisional_probe_bound
         and all(
             probes_by_view.get(view, 0) + provisional_probes_by_view.get(view, 0)
-            <= _FEATURE_LEADER_MAX_FIXED_PROBES
+            <= _FEATURE_LEADER_MAX_FIXED_WORK
             for view in {*probes_by_view, *provisional_probes_by_view}
         )
     ):

--- a/tests/test_issue_1166_cross_pass_feature_leaders.py
+++ b/tests/test_issue_1166_cross_pass_feature_leaders.py
@@ -961,6 +961,62 @@ def test_selected_occ_survivor_validates_arrow_shaft_and_shelf_ink():
     )
 
 
+def test_machined_leader_wrong_analytical_ink_fails_the_rendered_survivor_gate(
+    monkeypatch,
+):
+    import draftwright.annotations.leaders as leaders
+
+    drawing = build_drawing(Box(40, 30, 8), page="A4", auto_dims=False)
+    bounds = drawing.view_bounds("front")
+    assert bounds is not None
+    tip = (bounds[2], (bounds[1] + bounds[3]) / 2.0)
+    elbow = (tip[0] + 15.0, tip[1])
+
+    def build(tip, elbow, _feature):
+        return Leader(tip=(*tip, 0), elbow=(*elbow, 0), label="R1", draft=drawing.draft)
+
+    probe = build(tip, elbow, None)
+    ctx = PlacementContext(
+        registry=drawing.registry,
+        coverage=drawing.coverage,
+        items=drawing.items,
+        part_model=drawing.model(),
+        feature_leaders=[],
+    )
+    collect_feature_leader(
+        ctx,
+        FeatureLeaderJob(
+            name="m_fillet0",
+            view="front",
+            silhouette=bounds,
+            label="R1",
+            candidates=((tip, elbow, None),),
+            build=build,
+            analytical_geometry=lambda *_args: (probe.label_bbox, probe.segments),
+            measurement=(),
+            noun="fillet",
+            drop_code="fillet_dropped",
+        ),
+    )
+    # Deliberately under-predict the shaft/arrow ink while keeping label and segment
+    # metadata exact. _geometry_matches therefore passes; rendered-face validation must
+    # be the gate that rejects the selected OCC survivor.
+    monkeypatch.setattr(leaders, "_leader_ink_polygons", lambda *_args, **_kwargs: ())
+    title = drawing.get_annotation("title_block").bounding_box()
+    analysis = SimpleNamespace(
+        margin=10.0,
+        PAGE_W=drawing.page_w,
+        PAGE_H=drawing.page_h,
+        TB_W=title.size.X,
+    )
+
+    assert drain_feature_leaders(drawing, analysis, ctx) == 0
+    assert "m_fillet0" not in drawing.annotations()
+    issue = next(issue for issue in drawing.lint() if issue.code == "fillet_dropped")
+    assert issue.outcome_stage == "validation"
+    assert "rendered geometry validation failed" in issue.message
+
+
 def test_continuous_face_coverage_accepts_multi_shape_cut_results():
     """build123d 0.10 returns a ShapeList where 0.11 returns one shape."""
 
@@ -1266,7 +1322,7 @@ def test_candidate_measurement_failure_is_truthful_and_does_not_abort(
 ):
     if fixed_budget is not None:
         monkeypatch.setattr(
-            "draftwright.annotations.leaders._FEATURE_LEADER_MAX_FIXED_PROBES",
+            "draftwright.annotations.leaders._FEATURE_LEADER_MAX_FIXED_WORK",
             fixed_budget,
         )
     trace_path = tmp_path / "candidate-construction.json"
@@ -1779,7 +1835,7 @@ def test_cross_pass_candidate_budget_precedes_collect_all_geometry(monkeypatch, 
         measured += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(leaders, "_FEATURE_LEADER_MAX_CANDIDATES", 1)
+    monkeypatch.setattr(leaders, "_FEATURE_LEADER_MAX_MEASURE_WORK", 1)
     monkeypatch.setattr(leaders, "_measure", counted)
     trace_path = tmp_path / "bounded-cross-pass.json"
 
@@ -1792,6 +1848,8 @@ def test_cross_pass_candidate_budget_precedes_collect_all_geometry(monkeypatch, 
 
     assert event["assignment"] == "greedy_candidate_budget"
     assert event["optimal"] is False
+    assert event["joint_measurement_work"] > 1
+    assert event["joint_measurement_work_limit_per_view"] == 1
     assert measured < 50  # an uncapped collect-all measures 78 alternatives here
     assert set(_feature_leader_names(drawing)) == {
         "hc_side0",
@@ -1823,7 +1881,7 @@ def test_fixed_obstacle_probe_budget_precedes_joint_geometry(monkeypatch, tmp_pa
         lowerings += 1
         return original_lower(*args, **kwargs)
 
-    monkeypatch.setattr(leaders, "_FEATURE_LEADER_MAX_FIXED_PROBES", 0)
+    monkeypatch.setattr(leaders, "_FEATURE_LEADER_MAX_FIXED_WORK", 0)
     monkeypatch.setattr(leaders, "_candidate_hits_component", counted)
     monkeypatch.setattr(leaders, "_annotation_fixed_ink", counted_lower)
     trace_path = tmp_path / "bounded-fixed-probes.json"
@@ -1839,6 +1897,7 @@ def test_fixed_obstacle_probe_budget_precedes_joint_geometry(monkeypatch, tmp_pa
     assert event["optimal"] is False
     assert event["fixed_probes"] == 0
     assert event["fixed_probe_bound"] > 0
+    assert event["fixed_work_limit"] == 0
     assert probes == 0
     assert lowerings == 0
     assert set(_feature_leader_names(drawing)) == {
@@ -1861,7 +1920,7 @@ def test_fixed_probe_product_budget_replays_the_exact_producer_floor(monkeypatch
 
     part, model = _narrow_cross_pass_part()
     monkeypatch.setattr(
-        "draftwright.annotations.leaders._FEATURE_LEADER_MAX_FIXED_PROBES",
+        "draftwright.annotations.leaders._FEATURE_LEADER_MAX_FIXED_WORK",
         75,
     )
     trace_path = tmp_path / "bounded-fixed-probe-product.json"
@@ -1876,6 +1935,7 @@ def test_fixed_probe_product_budget_replays_the_exact_producer_floor(monkeypatch
     assert event["assignment"] == "greedy_fixed_probe_budget"
     assert event["optimal"] is False
     assert event["fixed_probe_bound"] > 75 >= event["fixed_probes"]
+    assert event["fixed_work_limit"] == 75
     assert event["pair_probes"] == 0
     assert event["objective"]["placed"] == 4
     assert set(_feature_leader_names(drawing)) == {
@@ -1897,7 +1957,7 @@ def test_fixed_probe_product_budget_replays_the_exact_producer_floor(monkeypatch
 @pytest.mark.parametrize("hard_boundary", ("page", "silhouette", "title"))
 def test_resource_fallback_never_bypasses_hard_boundaries(monkeypatch, tmp_path, hard_boundary):
     monkeypatch.setattr(
-        "draftwright.annotations.leaders._FEATURE_LEADER_MAX_FIXED_PROBES",
+        "draftwright.annotations.leaders._FEATURE_LEADER_MAX_FIXED_WORK",
         0,
     )
     trace_path = tmp_path / f"hard-{hard_boundary}.json"
@@ -1989,7 +2049,7 @@ def test_candidate_budget_preserves_the_exact_pre_joint_hole_floor(monkeypatch):
     assert not [issue for issue in joint.registry.issues if issue.code == "callout_dropped"]
 
     monkeypatch.setattr(
-        "draftwright.annotations.leaders._FEATURE_LEADER_MAX_CANDIDATES",
+        "draftwright.annotations.leaders._FEATURE_LEADER_MAX_MEASURE_WORK",
         1,
     )
     with pytest.warns(ScaleCompletenessWarning):
@@ -2036,7 +2096,7 @@ def test_future_section_cannot_veto_a_required_leader_but_title_is_hard(monkeypa
     # Exercise the producer fallback, not only the normal joint solve: optional
     # future furniture must not become a veto when a resource guard fires.
     monkeypatch.setattr(
-        "draftwright.annotations.leaders._FEATURE_LEADER_MAX_CANDIDATES",
+        "draftwright.annotations.leaders._FEATURE_LEADER_MAX_MEASURE_WORK",
         0,
     )
 
@@ -2104,7 +2164,7 @@ def test_future_section_cannot_veto_a_required_leader_but_title_is_hard(monkeypa
         ),
     )
     monkeypatch.setattr(
-        "draftwright.annotations.leaders._FEATURE_LEADER_MAX_CANDIDATES",
+        "draftwright.annotations.leaders._FEATURE_LEADER_MAX_MEASURE_WORK",
         0,
     )
     assert drain_feature_leaders(drawing, analysis, ctx) == 0

--- a/tests/test_issue_1176_quality_fidelity.py
+++ b/tests/test_issue_1176_quality_fidelity.py
@@ -499,7 +499,11 @@ _PRODUCERS = {"LintIssue": 3, "record_issue": 1, "_record_build_issue": 1}
 #: producer calls alone. Only the two entry points are listed: the forwarding layers
 #: (`_render_polygonal_prisms` among them) are DISCOVERED by resolving to a fixed point, so a
 #: new one is followed rather than needing to be remembered here.
-_STAGED_RECORDERS = {"_leader_callout_pass", "FeatureLeaderJob"}
+_STAGED_RECORDERS = {
+    "_leader_callout_pass",  # historical mutation probes below
+    "place_machined_leader_jobs",
+    "FeatureLeaderJob",
+}
 
 
 def _is_forwarded_parameter(expr, tree, node) -> bool:

--- a/tests/test_issue_1308_machined_leader_analytics.py
+++ b/tests/test_issue_1308_machined_leader_analytics.py
@@ -107,9 +107,7 @@ def test_analytical_producer_floor_matches_label_and_full_geometry_clearance():
     silhouette = (20.0, 20.0, 30.0, 30.0)
     shaft_obstacle = ((5.5, 5.5, 6.5, 6.5),)
 
-    assert analytical_leader_lands_clear(
-        candidate, shaft_obstacle, silhouette, page, label="R1"
-    )
+    assert analytical_leader_lands_clear(candidate, shaft_obstacle, silhouette, page, label="R1")
     assert not analytical_leader_lands_clear(
         candidate,
         shaft_obstacle,

--- a/tests/test_issue_1308_machined_leader_analytics.py
+++ b/tests/test_issue_1308_machined_leader_analytics.py
@@ -6,7 +6,7 @@ from types import SimpleNamespace
 import pytest
 
 from draftwright import build_drawing
-from draftwright.annotations.from_model import _analytical_label_lands_clear
+from draftwright.annotations._common import analytical_leader_lands_clear
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -107,8 +107,10 @@ def test_analytical_producer_floor_matches_label_and_full_geometry_clearance():
     silhouette = (20.0, 20.0, 30.0, 30.0)
     shaft_obstacle = ((5.5, 5.5, 6.5, 6.5),)
 
-    assert _analytical_label_lands_clear(candidate, shaft_obstacle, silhouette, page, label="R1")
-    assert not _analytical_label_lands_clear(
+    assert analytical_leader_lands_clear(
+        candidate, shaft_obstacle, silhouette, page, label="R1"
+    )
+    assert not analytical_leader_lands_clear(
         candidate,
         shaft_obstacle,
         silhouette,
@@ -116,8 +118,8 @@ def test_analytical_producer_floor_matches_label_and_full_geometry_clearance():
         label="R1",
         geom_clear=True,
     )
-    assert not _analytical_label_lands_clear(candidate, (), silhouette, page, label="")
-    assert not _analytical_label_lands_clear(
+    assert not analytical_leader_lands_clear(candidate, (), silhouette, page, label="")
+    assert not analytical_leader_lands_clear(
         SimpleNamespace(label_box=None, ink_polygons=()),
         (),
         silhouette,

--- a/tests/test_issue_1308_machined_leader_analytics.py
+++ b/tests/test_issue_1308_machined_leader_analytics.py
@@ -1,0 +1,142 @@
+"""Output contract for analytical machined-feature leaders (#1308)."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from draftwright import build_drawing
+from draftwright.annotations.from_model import _analytical_label_lands_clear
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+# Recorded from the OCC-measured path immediately before #1308.  This is intentionally
+# semantic rather than SVG-byte exact: every annotation, its rendered type, its 3-decimal
+# ink box, and the lint-code inventory must remain identical.
+EXPECTED = {
+    "grm03_thumbwheel_drive_screw.step": (
+        {
+            "centerline_front": ("Centerline", (31.89, 69.925, 159.39, 70.075)),
+            "centerline_plan": ("Centerline", (31.89, 139.925, 159.39, 140.075)),
+            "m_cm0": ("CenterMark", (201.28, 65.0, 211.28, 75.0)),
+            "m_dia_x1": ("Leader", (44.39, 32.875, 55.618, 45.0)),
+            "m_dia_x2": ("Leader", (56.074, 32.893, 62.876, 57.5)),
+            "m_dia_x3": ("Leader", (108.49, 32.875, 114.603, 62.5)),
+            "m_dia_x0": ("Leader", (24.623, 53.893, 38.14, 56.107)),
+            "m_steplen0": ("Dimension", (31.49, 97.0, 44.79, 107.083)),
+            "m_steplen1": ("Dimension", (39.34, 97.0, 49.44, 108.0)),
+            "m_steplen2": ("Dimension", (49.34, 97.0, 64.44, 108.0)),
+            "m_steplen3": ("Dimension", (64.34, 97.0, 154.44, 108.0)),
+            "dim_height": ("Dimension", (158.39, 44.95, 166.39, 95.05)),
+            "hc_side0": ("Leader", (210.28, 68.665, 253.305, 71.335)),
+            "m_chamfer_x0": ("Leader", (12.236, 94.25, 40.14, 101.339)),
+            "m_chamfer_x1": ("Leader", (153.14, 69.829, 177.598, 76.25)),
+            "title_block": ("TitleBlock", (165.925, 10.925, 286.075, 27.075)),
+        },
+        {},
+    ),
+    "issue_1058_wheel_rh.step": (
+        {
+            "m_cm0": ("CenterMark", (73.245, 124.5, 92.745, 144.0)),
+            "hc_plan0": ("Leader", (14.865, 132.903, 76.745, 135.597)),
+            "m_locx0": ("Dimension", (63.945, 136.25, 83.045, 165.25)),
+            "m_locy0": ("Dimension", (155.807, 97.25, 174.907, 107.25)),
+            "dim_height": ("Dimension", (105.862, 56.7, 113.862, 95.3)),
+            "m_env_width": ("Dimension", (63.945, 103.25, 101.912, 111.25)),
+            "m_env_depth": ("Dimension", (155.807, 44.75, 193.907, 52.75)),
+            "title_block": ("TitleBlock", (165.925, 10.925, 286.075, 27.075)),
+            "note_iso_nts": ("Note", (155.693, 115.549, 180.026, 118.243)),
+        },
+        {"gear_semantics_missing": 1, "unrecognised_defining_geometry": 1},
+    ),
+    "nist_ctc_01_asme1_ap242.stp": (
+        {
+            "m_cm0": ("CenterMark", (82.275, 240.5, 89.275, 247.5)),
+            "m_cm1": ("CenterMark", (146.275, 240.5, 153.275, 247.5)),
+            "m_cm2": ("CenterMark", (82.275, 222.5, 89.275, 229.5)),
+            "m_cm3": ("CenterMark", (146.275, 222.5, 153.275, 229.5)),
+            "m_cm4": ("CenterMark", (178.275, 265.5, 187.275, 274.5)),
+            "m_cm5": ("CenterMark", (48.275, 265.5, 57.275, 274.5)),
+            "m_cm6": ("CenterMark", (178.275, 195.5, 187.275, 204.5)),
+            "m_cm7": ("CenterMark", (48.275, 195.5, 57.275, 204.5)),
+            "m_cm8": ("CenterMark", (120.775, 152.0, 126.775, 158.0)),
+            "m_cm9": ("CenterMark", (108.775, 152.0, 114.775, 158.0)),
+            "hc_front0": ("Leader", (122.875, 128.665, 146.85, 153.0)),
+            "m_polygonal_boss_z0": ("Leader", (62.943, 175.663, 112.775, 226.34)),
+            "m_slot0_width": ("Dimension", (25.775, 225.6, 46.775, 244.4)),
+            "m_slot1_width": ("Dimension", (184.775, 229.95, 209.775, 240.05)),
+            "m_slot0_length": ("Dimension", (48.725, 241.0, 72.825, 292.0)),
+            "m_slot1_length": ("Dimension", (166.725, 242.0, 182.825, 301.5)),
+            "m_slot0_pos": ("Dimension", (37.725, 241.0, 48.825, 311.0)),
+            "m_locx0": ("Dimension", (37.725, 272.0, 52.825, 320.5)),
+            "m_locx1": ("Dimension", (37.725, 246.0, 85.825, 330.0)),
+            "m_locx2": ("Dimension", (37.725, 246.0, 149.825, 339.5)),
+            "m_slot1_pos": ("Dimension", (37.725, 242.0, 166.825, 349.0)),
+            "m_locx3": ("Dimension", (37.725, 272.0, 182.825, 358.5)),
+            "m_locy0": ("Dimension", (250.725, 172.0, 260.825, 182.0)),
+            "m_locy1": ("Dimension", (250.725, 172.0, 286.825, 191.5)),
+            "m_locy2": ("Dimension", (250.725, 172.0, 304.825, 201.0)),
+            "m_locy3": ("Dimension", (250.725, 172.0, 330.825, 210.5)),
+            "dim_step_0": ("Dimension", (201.775, 139.95, 209.775, 160.05)),
+            "m_bossheight_z0": ("Dimension", (119.775, 159.95, 219.275, 170.05)),
+            "dim_loc_front_z7500": ("Dimension", (199.775, 139.95, 228.775, 155.05)),
+            "dim_height": ("Dimension", (209.775, 139.95, 238.275, 170.05)),
+            "m_env_depth": ("Dimension", (250.725, 128.0, 340.825, 136.0)),
+            "dim_loc_front_x37000": ("Dimension", (37.725, 117.15, 111.825, 136.0)),
+            "dim_loc_front_x43000": ("Dimension", (37.725, 104.3, 123.825, 136.0)),
+            "m_env_width": ("Dimension", (37.725, 284.0, 197.825, 372.35)),
+            "hc_plan0": ("Leader", (151.436, 188.665, 220.148, 242.131)),
+            "hc_plan1": ("Leader", (186.275, 268.665, 220.199, 271.335)),
+            "m_chamfer_y0": ("Leader", (89.433, 169.491, 108.266, 183.115)),
+            "m_chamfer_z1": ("Leader", (192.775, 275.0, 213.032, 283.142)),
+            "m_fillet_z0": ("Leader", (15.101, 184.659, 40.704, 192.929)),
+            "title_block": ("TitleBlock", (432.925, 10.925, 583.075, 27.075)),
+            "note_iso_nts": ("Note", (460.221, 103.057, 484.554, 105.751)),
+        },
+        {"pmi_present_but_ignored": 1, "step_dim_withheld": 1},
+    ),
+}
+
+
+def test_analytical_producer_floor_matches_label_and_full_geometry_clearance():
+    candidate = SimpleNamespace(
+        label_box=(10.0, 10.0, 12.0, 12.0),
+        ink_polygons=(((5.0, 5.0), (7.0, 5.0), (7.0, 7.0), (5.0, 7.0)),),
+    )
+    page = (0.0, 0.0, 100.0, 100.0)
+    silhouette = (20.0, 20.0, 30.0, 30.0)
+    shaft_obstacle = ((5.5, 5.5, 6.5, 6.5),)
+
+    assert _analytical_label_lands_clear(candidate, shaft_obstacle, silhouette, page, label="R1")
+    assert not _analytical_label_lands_clear(
+        candidate,
+        shaft_obstacle,
+        silhouette,
+        page,
+        label="R1",
+        geom_clear=True,
+    )
+    assert not _analytical_label_lands_clear(candidate, (), silhouette, page, label="")
+    assert not _analytical_label_lands_clear(
+        SimpleNamespace(label_box=None, ink_polygons=()),
+        (),
+        silhouette,
+        page,
+        label="R1",
+    )
+
+
+@pytest.mark.parametrize("fixture", tuple(EXPECTED))
+def test_analytical_machined_leaders_preserve_the_occ_measured_drawing(fixture):
+    drawing = build_drawing(FIXTURES / fixture)
+    actual = {}
+    for name, annotation in drawing.iter_annotations():
+        box = annotation.bounding_box()
+        actual[name] = (
+            type(annotation).__name__,
+            tuple(round(value, 3) for value in (box.min.X, box.min.Y, box.max.X, box.max.Y)),
+        )
+
+    expected_annotations, expected_lint = EXPECTED[fixture]
+    assert actual == expected_annotations
+    assert drawing.lint_summary()["by_code"] == expected_lint

--- a/tests/test_issue_1308_machined_leader_analytics.py
+++ b/tests/test_issue_1308_machined_leader_analytics.py
@@ -1,11 +1,15 @@
 """Output contract for analytical machined-feature leaders (#1308)."""
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from build123d import Box, Cylinder, Pos
+from build123d_drafting.helpers import Draft
 
 from draftwright import build_drawing
+from draftwright.annotations import from_model
 from draftwright.annotations._common import analytical_leader_lands_clear
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -126,8 +130,79 @@ def test_analytical_producer_floor_matches_label_and_full_geometry_clearance():
     )
 
 
+def test_shared_machined_adapter_fails_closed_with_provenance(monkeypatch):
+    issues = []
+    ctx = SimpleNamespace(
+        feature_leaders=[],
+        record_issue=lambda *args, **kwargs: issues.append((args, kwargs)),
+    )
+    drawing = SimpleNamespace(draft=Draft())
+    feature = object()
+    monkeypatch.setattr(
+        "draftwright.annotations.from_model._text_size",
+        lambda *_args, **_kwargs: (0.0, 0.0),
+    )
+
+    placed = from_model.place_machined_leader_jobs(
+        drawing,
+        None,
+        [("probe", "plan", (0.0, 0.0, 1.0, 1.0), "R1", [((2, 2), (2, 2), feature)], ())],
+        noun="probe",
+        drop_code="probe_dropped",
+        ctx=ctx,
+        joint=True,
+        source_ids_by_name={"probe": ("feature:1",)},
+    )
+
+    assert placed == 0
+    (job,) = ctx.feature_leaders
+    assert list(job.candidates) == [((2, 2), (2, 2), feature)]
+    assert job.analytical_geometry((2, 2), (2, 2), feature) is None
+    assert job.on_drop is not None
+    job.on_drop("geometry_validation")
+    job.on_drop("no_clear_room")
+    assert [args[:3] for args, _kwargs in issues] == [
+        (
+            "warning",
+            "probe_dropped",
+            "probe callout R1 not placed (rendered geometry validation failed)",
+        ),
+        ("warning", "probe_dropped", "probe callout R1 not placed (no clear room)"),
+    ]
+    assert [kwargs["source"] for _args, kwargs in issues] == [
+        ("feature:1",),
+        ("feature:1",),
+    ]
+
+
 @pytest.mark.parametrize("fixture", tuple(EXPECTED))
-def test_analytical_machined_leaders_preserve_the_occ_measured_drawing(fixture):
+def test_analytical_machined_leaders_preserve_the_occ_measured_drawing(fixture, monkeypatch):
+    immediate_jobs = []
+    constructed_polygonal = []
+    place_feature_leader_jobs = from_model.place_feature_leader_jobs
+    real_leader = from_model.Leader
+
+    def capture_immediate(drawing, analysis, ctx, jobs, *, producer_floor=False):
+        jobs = list(jobs)
+        if producer_floor:
+            immediate_jobs.extend(jobs)
+        return place_feature_leader_jobs(
+            drawing,
+            analysis,
+            ctx,
+            jobs,
+            producer_floor=producer_floor,
+        )
+
+    monkeypatch.setattr(from_model, "place_feature_leader_jobs", capture_immediate)
+
+    def counted_leader(*args, **kwargs):
+        leader = real_leader(*args, **kwargs)
+        if str(leader.label).startswith("HEX "):
+            constructed_polygonal.append(leader)
+        return leader
+
+    monkeypatch.setattr(from_model, "Leader", counted_leader)
     drawing = build_drawing(FIXTURES / fixture)
     actual = {}
     for name, annotation in drawing.iter_annotations():
@@ -140,3 +215,33 @@ def test_analytical_machined_leaders_preserve_the_occ_measured_drawing(fixture):
     expected_annotations, expected_lint = EXPECTED[fixture]
     assert actual == expected_annotations
     assert drawing.lint_summary()["by_code"] == expected_lint
+    if fixture == "nist_ctc_01_asme1_ap242.stp":
+        polygonal_jobs = [job for job in immediate_jobs if job.name == "m_polygonal_boss_z0"]
+        assert polygonal_jobs
+        assert all(job.analytical_geometry is not None for job in polygonal_jobs)
+        assert len(constructed_polygonal) == len(polygonal_jobs), (
+            "each page-layout assembly builds only its selected polygonal survivor"
+        )
+        assert constructed_polygonal[-1] is drawing.get_annotation("m_polygonal_boss_z0")
+
+
+def test_pre_drain_boss_diameter_builds_only_its_analytical_survivor(monkeypatch, tmp_path):
+    part = Box(90, 64, 38) + Pos(0, 0, 24) * Cylinder(14, 10)
+    real_leader = from_model.Leader
+    constructed = []
+
+    def counted_leader(*args, **kwargs):
+        leader = real_leader(*args, **kwargs)
+        if str(leader.label) == "ø28":
+            constructed.append(leader)
+        return leader
+
+    monkeypatch.setattr(from_model, "Leader", counted_leader)
+    trace_path = tmp_path / "boss.json"
+    drawing = build_drawing(part, trace=trace_path)
+
+    boss = drawing.get_annotation("m_bossdia_z0")
+    assert constructed == [boss], "only the selected analytical survivor builds OCC"
+    trace = json.loads(trace_path.read_text(encoding="utf-8"))
+    event = next(item for item in trace["pass_events"] if item["label"] == "boss_callouts")
+    assert event["assignment"] == "greedy_stage_boundary"

--- a/tests/test_issue_740_leader_assignment.py
+++ b/tests/test_issue_740_leader_assignment.py
@@ -19,7 +19,7 @@ from draftwright.layout import _assign_leader_candidates
 from draftwright.model import FilletFeature, Frame, GrooveFeature, PartModel, pocket
 
 
-def test_joint_assignment_is_scoped_to_the_six_post_drain_adapters():
+def test_late_joint_assignment_stays_scoped_to_the_six_post_drain_adapters():
     root = Path(__file__).parents[1] / "src" / "draftwright" / "annotations"
 
     def call_sites(filename):
@@ -27,7 +27,10 @@ def test_joint_assignment_is_scoped_to_the_six_post_drain_adapters():
         sites = set()
         for function in (node for node in tree.body if isinstance(node, ast.FunctionDef)):
             for call in (node for node in ast.walk(function) if isinstance(node, ast.Call)):
-                if not isinstance(call.func, ast.Name) or call.func.id != "_leader_callout_pass":
+                if (
+                    not isinstance(call.func, ast.Name)
+                    or call.func.id != "place_machined_leader_jobs"
+                ):
                     continue
                 keyword = next((kw.value for kw in call.keywords if kw.arg == "joint"), None)
                 sites.add(
@@ -61,7 +64,7 @@ def test_pre_drain_pattern_keeps_legacy_greedy_semantics(monkeypatch):
     # The joint solve is reached through the per-view decomposition since #1188; that
     # wrapper is the one call site, so it is what a pre-drain pattern must never enter.
     monkeypatch.setattr(
-        "draftwright.annotations.from_model._assign_by_view",
+        "draftwright.annotations.leaders._assign_by_view",
         forbidden_joint_solve,
     )
     member = pocket(
@@ -85,13 +88,10 @@ def test_pre_drain_pattern_keeps_legacy_greedy_semantics(monkeypatch):
     assert [name for name in drawing.annotations() if name.startswith("dim_pocketpat_pitch")]
 
 
-def test_pre_drain_y_diameter_keeps_the_policy_b_fallback_tail(monkeypatch):
-    """A clear ray blocked by fixed ink must not erase later obstructed fallbacks.
+def test_pre_drain_y_diameter_uses_the_shared_analytical_producer_floor(monkeypatch, tmp_path):
+    """The pre-drain semantic stage shares measurement but still emits immediately."""
+    from draftwright.annotations import from_model
 
-    #890 ranks projected-hole-clear rays first, but its pre-drain greedy pass keeps the
-    obstructed Policy-B tail. Filtering that tail for #740's joint tier made this real
-    diameter disappear before it could populate structured/downstream coverage.
-    """
     locations = ((18, 0), (-18, 0), (0, 18), (0, -18))
     part = Cylinder(21, 4)
     for x, y in locations:
@@ -108,55 +108,38 @@ def test_pre_drain_y_diameter_keeps_the_policy_b_fallback_tail(monkeypatch):
         part -= Pos(x, y, 0) * Cylinder(2, 10)
     part = part.rotate(Axis.X, 90)
 
-    def is_diagonal(tip, elbow):
-        return (
-            abs(float(elbow[0]) - float(tip[0])) > 1e-6
-            and abs(float(elbow[1]) - float(tip[1])) > 1e-6
-        )
+    constructed = []
+    real_leader = from_model.Leader
 
-    def controlled_clearance(candidate, _circles):
-        return 1.0 if is_diagonal(candidate[0], candidate[1]) else -1.0
-
-    def analytical_clear_ray_is_occupied(
-        candidate, obstacles, silhouette, page, *, label, geom_clear=False
-    ):
-        if label == "ø25":
-            # Model fixed inventory that blocks every preferred clear ray while one
-            # hole-obstructed Policy-B ray remains usable.
-            return not is_diagonal(candidate.tip, candidate.elbow)
-        return True
-
-    def clear_ray_is_occupied(leader, obstacles, silhouette, page, *, geom_clear=False):
+    def counted_leader(*args, **kwargs):
+        leader = real_leader(*args, **kwargs)
         if str(leader.label) == "ø25":
-            return not is_diagonal(leader.tip, leader.elbow)
-        return True
+            constructed.append(leader)
+        return leader
 
-    monkeypatch.setattr(
-        "draftwright.annotations.from_model._leader_hole_clearance",
-        controlled_clearance,
+    monkeypatch.setattr(from_model, "Leader", counted_leader)
+    trace_path = tmp_path / "y-diameter.json"
+    drawing = build_drawing(
+        part,
+        page="A4",
+        scale=1.0,
+        scale_policy="permissive",
+        trace=trace_path,
     )
-    monkeypatch.setattr(
-        "draftwright.annotations.from_model._analytical_label_lands_clear",
-        analytical_clear_ray_is_occupied,
-    )
-    monkeypatch.setattr(
-        "draftwright.annotations.from_model._label_lands_clear",
-        clear_ray_is_occupied,
-    )
-    # Force the measured-work guard's producer floor; the expanded analytical
-    # allowance otherwise admits this small inventory to the exact solve.
-    monkeypatch.setattr(
-        "draftwright.annotations.leaders._FEATURE_LEADER_MAX_MEASURE_WORK",
-        0,
-    )
-
-    drawing = build_drawing(part, page="A4", scale=1.0, scale_policy="permissive")
 
     diameter = drawing.get_annotation("m_dia_y0")
     assert diameter.label == "ø25"
-    assert not is_diagonal(diameter.tip, diameter.elbow)
+    assert constructed == [diameter], "only the selected analytical survivor builds OCC"
     assert diameter.covers_diameters == (25.0,)
     assert drawing.measurement_keys("m_dia_y0")
+    trace = json.loads(trace_path.read_text(encoding="utf-8"))
+    event = next(
+        item for item in trace["pass_events"] if item["label"] == "Y-axis step diameter_callouts"
+    )
+    assert event["assignment"] == "greedy_stage_boundary"
+    assert any(
+        item["name"] == "m_dia_y0" and item["outcome"] == "placed" for item in event["items"]
+    )
     assert not [
         issue
         for issue in drawing.lint()

--- a/tests/test_issue_740_leader_assignment.py
+++ b/tests/test_issue_740_leader_assignment.py
@@ -117,10 +117,17 @@ def test_pre_drain_y_diameter_keeps_the_policy_b_fallback_tail(monkeypatch):
     def controlled_clearance(candidate, _circles):
         return 1.0 if is_diagonal(candidate[0], candidate[1]) else -1.0
 
-    def clear_ray_is_occupied(leader, obstacles, silhouette, page, *, geom_clear=False):
-        if str(leader.label) == "ø25":
+    def analytical_clear_ray_is_occupied(
+        candidate, obstacles, silhouette, page, *, label, geom_clear=False
+    ):
+        if label == "ø25":
             # Model fixed inventory that blocks every preferred clear ray while one
             # hole-obstructed Policy-B ray remains usable.
+            return not is_diagonal(candidate.tip, candidate.elbow)
+        return True
+
+    def clear_ray_is_occupied(leader, obstacles, silhouette, page, *, geom_clear=False):
+        if str(leader.label) == "ø25":
             return not is_diagonal(leader.tip, leader.elbow)
         return True
 
@@ -129,8 +136,18 @@ def test_pre_drain_y_diameter_keeps_the_policy_b_fallback_tail(monkeypatch):
         controlled_clearance,
     )
     monkeypatch.setattr(
+        "draftwright.annotations.from_model._analytical_label_lands_clear",
+        analytical_clear_ray_is_occupied,
+    )
+    monkeypatch.setattr(
         "draftwright.annotations.from_model._label_lands_clear",
         clear_ray_is_occupied,
+    )
+    # Force the measured-work guard's producer floor; the expanded analytical
+    # allowance otherwise admits this small inventory to the exact solve.
+    monkeypatch.setattr(
+        "draftwright.annotations.leaders._FEATURE_LEADER_MAX_MEASURE_WORK",
+        0,
     )
 
     drawing = build_drawing(part, page="A4", scale=1.0, scale_policy="permissive")
@@ -437,6 +454,7 @@ def test_grouped_job_candidate_budget_precedes_occ_construction(monkeypatch, tmp
         return Leader(*args, **kwargs)
 
     monkeypatch.setattr("draftwright.annotations.from_model.Leader", counted_leader)
+    monkeypatch.setattr("draftwright.annotations.leaders._FEATURE_LEADER_MAX_MEASURE_WORK", 512)
     trace_path = tmp_path / "candidate-budget.json"
     drawing = build_drawing(
         shaft,
@@ -454,6 +472,8 @@ def test_grouped_job_candidate_budget_precedes_occ_construction(monkeypatch, tmp
     assert len(drawing.measurement_keys("m_fillet_z0")) == 257
     assert event["assignment"] == "greedy_candidate_budget"
     assert event["optimal"] is False
+    assert event["joint_measurement_work"] > 512
+    assert event["joint_measurement_work_limit_per_view"] == 512
 
 
 def test_grouped_job_at_candidate_budget_still_uses_joint_assignment(monkeypatch, tmp_path):
@@ -466,7 +486,7 @@ def test_grouped_job_at_candidate_budget_still_uses_joint_assignment(monkeypatch
         created += 1
         return Leader(*args, **kwargs)
 
-    monkeypatch.setattr("draftwright.annotations.leaders._FEATURE_LEADER_MAX_CANDIDATES", 54)
+    monkeypatch.setattr("draftwright.annotations.leaders._FEATURE_LEADER_MAX_MEASURE_WORK", 54)
     monkeypatch.setattr("draftwright.annotations.from_model.Leader", counted_leader)
     trace_path = tmp_path / "candidate-budget-boundary.json"
     drawing = build_drawing(
@@ -479,15 +499,19 @@ def test_grouped_job_at_candidate_budget_still_uses_joint_assignment(monkeypatch
     trace = json.loads(trace_path.read_text(encoding="utf-8"))
     event = next(item for item in trace["pass_events"] if item["label"] == "fillet_callouts")
 
-    assert created == 54
+    # All 54 analytical alternatives are measured, but OCC is materialised only for
+    # the selected survivor.
+    assert created == 1
     assert drawing.get_annotation("m_fillet_z0").label == "2× R1"
     assert event["assignment"] == "joint"
     assert event["optimal"] is True
+    assert event["joint_measurement_work"] == 54
+    assert event["joint_measurement_work_limit_per_view"] == 54
 
 
 def test_candidate_budget_is_global_across_jobs(monkeypatch, tmp_path):
     part, model = _crowded_declared_grooves()
-    monkeypatch.setattr("draftwright.annotations.leaders._FEATURE_LEADER_MAX_CANDIDATES", 16)
+    monkeypatch.setattr("draftwright.annotations.leaders._FEATURE_LEADER_MAX_MEASURE_WORK", 16)
     trace_path = tmp_path / "global-candidate-budget.json"
 
     drawing = build_drawing(
@@ -504,6 +528,7 @@ def test_candidate_budget_is_global_across_jobs(monkeypatch, tmp_path):
 
     assert event["assignment"] == "greedy_candidate_budget"
     assert event["optimal"] is False
+    assert event["joint_measurement_work"] > 16
     assert [item["candidates_tried"] for item in event["items"]] == [1, 4, 1]
     assert len([name for name in drawing.annotations() if name.startswith("m_groove")]) == 3
 
@@ -514,7 +539,7 @@ def test_candidate_budget_fallback_restores_consumed_prefix_and_lazy_tail(monkey
         FilletFeature(Frame(origin, "z"), "z", 1.0)
         for origin in ((-1000.0, 0.0, 10.0), (-900.0, 0.0, 10.0), (10.0, 0.0, 10.0))
     ]
-    monkeypatch.setattr("draftwright.annotations.leaders._FEATURE_LEADER_MAX_CANDIDATES", 2)
+    monkeypatch.setattr("draftwright.annotations.leaders._FEATURE_LEADER_MAX_MEASURE_WORK", 2)
     trace_path = tmp_path / "candidate-budget-tail.json"
 
     drawing = build_drawing(
@@ -531,6 +556,7 @@ def test_candidate_budget_fallback_restores_consumed_prefix_and_lazy_tail(monkey
     (item,) = event["items"]
 
     assert event["assignment"] == "greedy_candidate_budget"
+    assert event["joint_measurement_work"] > 2
     assert item["candidates_tried"] == 3
     assert item["candidate"] == 2  # the untouched generator tail, after two invalid members
     assert drawing.get_annotation("m_fillet_z0").label == "3× R1"

--- a/tests/test_issue_798_silhouette_lint.py
+++ b/tests/test_issue_798_silhouette_lint.py
@@ -274,7 +274,7 @@ class TestCardinalityIsNotTradedForCleanliness:
 
         from draftwright.annotations import leaders
 
-        source = inspect.getsource(leaders.drain_feature_leaders)
+        source = inspect.getsource(leaders.place_feature_leader_jobs)
         accept = source.index("accepted = not hard_blockers")
         units = source.index("units = _material_units(candidate, field)")
         assert accept < units, "material must not participate in the acceptance decision"


### PR DESCRIPTION
Closes #1308

This moves every compatible machined-feature leader family onto the existing shared FeatureLeaderJob analytical solve. Candidate exploration lowers label, shaft, shelf, and rendered ink arithmetically; OCC Leader geometry is materialised only for selected survivor attempts and each rendered survivor is checked against its analytical contract before commit. Six late adapters join the canonical inventory, while required immediate consumers use the same producer floor. There is no second placement mechanism.

Budgets are re-derived as measured work: analytical and OCC candidate costs have explicit work units; fixed inventory/component/probe, pair, job, provisional, and state bounds preserve deterministic fallback floors. The existing guard families were updated to the measured-work contract, not weakened or deleted. ADR 0014 records the analytical tier, six adapters, survivor validation, and budget semantics.

Exact current-main warm-build medians (import solid once, warm once, median of three):
- CTC-01 AP242: 7.091135 -> 3.735585 s (-47.3%)
- GRM-03: 2.434761 -> 1.125315 s (-53.8%)
- hole-only wheel control: 4.026990 -> 4.068073 s (+1.0%, flat/noise)

Output/safety gates:
- full annotation name and rendered-type inventories, every per-annotation ink box to 3 decimals, and lint-code summaries are identical on CTC, GRM, and wheel
- named Y, boss, polygonal, and generic paths prove only selected analytical survivors construct OCC
- deliberately wrong machined analytical ink fails the retained rendered-survivor gate
- measured-work and fixed/pair/state fallback guards remain load-bearing with provenance
- focused current-head run: 38 passed, 3 slow tests deselected; repository static/docs/types clean
- independent exact-SHA review of 5ba3de64e74ff651e133b97c654ff35fe4a3bedb on 3d9edb80b1fc323ffe691f11d7cb1c971d17ac0d: ACCEPT, no findings; reviewer separately ran 89 focused, 7 lint/material, and 16 architecture/private checks

Slow tests were not run.