### PR TITLE
Reject disjoint convex AABBs before SAT

### DIFF
--- a/src/draftwright/_geometry.py
+++ b/src/draftwright/_geometry.py
@@ -456,6 +456,15 @@ def _convex_polygons_overlap(left, right) -> bool:
 
     if len(left) < 3 or len(right) < 3:
         return False
+    left_x, left_y = zip(*left, strict=True)
+    right_x, right_y = zip(*right, strict=True)
+    if (
+        max(left_x) <= min(right_x)
+        or max(right_x) <= min(left_x)
+        or max(left_y) <= min(right_y)
+        or max(right_y) <= min(left_y)
+    ):
+        return False
     axes: list[tuple[float, float]] = []
     for points in (left, right):
         axes.extend(

--- a/tests/test_issue_1312_engine_costs.py
+++ b/tests/test_issue_1312_engine_costs.py
@@ -1,0 +1,25 @@
+"""Measured small engine costs from #1312."""
+
+from draftwright._geometry import _convex_polygons_overlap
+
+
+class _AabbOnlyNumber(float):
+    """Fail if a touching-box rejection leaks through to the expensive SAT."""
+
+    def __sub__(self, other):
+        raise AssertionError("touching AABBs must return before building SAT axes")
+
+
+def test_convex_overlap_broad_phase_rejects_touching_aabbs_before_the_sat():
+    number = _AabbOnlyNumber
+    left = ((number(0), number(0)), (number(1), number(0)), (number(0), number(1)))
+    right = ((number(1), number(0)), (number(2), number(0)), (number(1), number(1)))
+
+    assert not _convex_polygons_overlap(left, right)
+
+
+def test_convex_overlap_broad_phase_keeps_real_overlap_for_the_sat():
+    left = ((0.0, 0.0), (2.0, 0.0), (0.0, 2.0))
+    right = ((0.5, 0.5), (2.5, 0.5), (0.5, 2.5))
+
+    assert _convex_polygons_overlap(left, right)


### PR DESCRIPTION
Closes #1312

Adds the measured strict-disjoint AABB broad phase before convex SAT. All four comparisons use `<=`, preserving the existing positive-area-overlap contract where touching edges and vertices are clear.

The named boundary test uses numbers whose subtraction raises, proving touching pairs return before SAT-axis construction; a genuine-overlap control proves real intersections still reach and pass SAT.

Post-#1308 same-host medians (import once, warm once, median 3):
- CTC-01 AP242: 3.630616s -> 3.368317s (-7.2%)
- GRM-03: 1.102130s -> 1.064957s (-3.4%)
- all-hole wheel control: 3.952388s -> 3.995277s (+1.1%, flat/noise)

The text-cache half is deliberately dropped: after analytical leader lowering its residual ~2.6% gain does not justify shared mutable dependency objects plus a deepcopy on every hit.

Validation (slow tests not run):
- 197 relevant overlap/leader/material tests pass
- all three #1308 annotation/type/3-decimal bbox/lint goldens pass
- 100% changed-line coverage
- ruff, format, mypy, codespell, strict docs pass
- deliberate `<=` -> `<` mutation fails the named boundary test
- exact-head independent review ACCEPT with no findings

Exact reviewed head: `22d9c0ad68554256a0766b38a9d7911531c9605f`
Exact base: `ba4db4f86db510b7210e1e97b7575580341c4661`