### PR TITLE
Remove redundant fast-tier drawing builds

### DIFF
--- a/tests/test_issue_1215_no_approved_tolerance_is_dropped.py
+++ b/tests/test_issue_1215_no_approved_tolerance_is_dropped.py
@@ -44,6 +44,7 @@ from collections import Counter
 
 import pytest
 from build123d import Axis, Box, Cylinder, Pos, Rot
+from build123d_drafting.helpers import Draft
 
 from draftwright._core import _tol_suffix
 from draftwright.builder import build_drawing, detect_part_model
@@ -51,10 +52,9 @@ from draftwright.model.compiled import compile_dimensions
 
 _TOL = 0.05
 
-#: The draft the suffix is formatted against. `_tol_suffix` rounds to `decimal_precision`, so
-#: the expected text must come from the same draft the renderer used — a different precision
-#: would make the comparison a guess again.
-_DRAFT = build_drawing(Box(20, 20, 20), title="T", number="N").draft
+#: `_tol_suffix` reads only `decimal_precision`; pin that to the builder preset's precision
+#: without constructing an entire drawing during collection on every xdist worker.
+_DRAFT = Draft(decimal_precision=1)
 
 
 def _staircase():
@@ -315,13 +315,9 @@ def _absence_reported(drawing) -> set:
     return reported
 
 
-def _sweep(part_name, feature, param, mode):
-    """Build with exactly one decoration and return ``(drops, unreported_absences)``."""
-    model = detect_part_model(_PARTS[part_name]())
-    target = next((f for f in model.features if f.kind == feature.kind and f == feature), None)
-    if target is None:
-        return [], []
-    key = (target, param.kind, param.role) if mode == "role" else (target, param.kind)
+def _sweep(part_name, model, feature, param, mode):
+    """Build once with one decoration; the caller owns the immutable detected model."""
+    key = (feature, param.kind, param.role) if mode == "role" else (feature, param.kind)
     drawing = build_drawing(
         _PARTS[part_name](),
         model=model,
@@ -331,7 +327,7 @@ def _sweep(part_name, feature, param, mode):
     )
     approved = _approved_with_tolerance(compile_dimensions(drawing.model()))
     if not approved:
-        return [], []
+        return [], [], 0
     where = f"{part_name}/{feature.kind}.{param.role}[{mode}]"
     dropped = []
     claimed_anywhere: set = set()
@@ -362,7 +358,7 @@ def _sweep(part_name, feature, param, mode):
     unreported = (
         [f"{where}: {silent} approved, drawn by nothing, reported by nothing"] if silent else []
     )
-    return dropped, unreported
+    return dropped, unreported, len(approved)
 
 
 @pytest.mark.parametrize("mode", _KEY_MODES)
@@ -371,11 +367,18 @@ def test_no_approved_tolerance_is_dropped_by_a_renderer(part_name, mode):
     model = detect_part_model(_PARTS[part_name]())
     dropped: list[str] = []
     unreported: list[str] = []
+    approved = 0
     for feature in model.features:
         for param in feature.parameters():
-            got_dropped, got_unreported = _sweep(part_name, feature, param, mode)
+            got_dropped, got_unreported, got_approved = _sweep(
+                part_name, model, feature, param, mode
+            )
             dropped += got_dropped
             unreported += got_unreported
+            approved += got_approved
+    # This precondition belongs to the property whose coverage it guards. Keeping it here
+    # catches a vacuous fixture without rebuilding the entire role-key sweep in another test.
+    assert approved, f"{part_name}[{mode}] approves no toleranced dimension; it guards nothing"
     assert not dropped, (
         f"{dropped}\n\nThe compiler approved a tolerance on these measurements and the "
         "annotation claiming them renders no suffix, so the drawing states the requirement "
@@ -390,25 +393,6 @@ def test_no_approved_tolerance_is_dropped_by_a_renderer(part_name, mode):
     )
 
 
-def test_the_sweep_actually_decorates_something():
-    """The precondition. A sweep that approves no toleranced dimension asserts nothing, and
-    every part above must contribute — otherwise a fixture silently stops covering its site."""
-    for part_name in sorted(_PARTS):
-        model = detect_part_model(_PARTS[part_name]())
-        seen = 0
-        for feature in model.features:
-            for param in feature.parameters():
-                drawing = build_drawing(
-                    _PARTS[part_name](),
-                    model=model,
-                    decorations={(feature, param.kind, param.role): _TOL},
-                    title="T",
-                    number="N",
-                )
-                seen += len(_approved_with_tolerance(compile_dimensions(drawing.model())))
-        assert seen, f"{part_name} approves no toleranced dimension; it guards nothing"
-
-
 def test_the_deliberately_bare_names_are_reachable():
     """`_DELIBERATELY_BARE` must exclude something that OCCURS.
 
@@ -418,16 +402,16 @@ def test_the_deliberately_bare_names_are_reachable():
     asserted nowhere, and the rule could have been broken in either direction with this file
     green (#1216 review r9).
     """
-    seen: set[str] = set()
-    for part_name in ("uniform_staircase", "uniform_stepped_shaft"):
-        drawing = build_drawing(_PARTS[part_name](), title="T", number="N")
-        seen |= set(drawing.registry.names())
+    drawings = {
+        part_name: build_drawing(_PARTS[part_name](), title="T", number="N")
+        for part_name in ("uniform_staircase", "uniform_stepped_shaft")
+    }
+    seen = {name for drawing in drawings.values() for name in drawing.registry.names()}
     assert _DELIBERATELY_BARE <= seen, (
         f"{sorted(_DELIBERATELY_BARE - seen)} never occur in this corpus, so excluding them "
         "excludes nothing"
     )
-    for part_name in ("uniform_staircase", "uniform_stepped_shaft"):
-        drawing = build_drawing(_PARTS[part_name](), title="T", number="N")
+    for part_name, drawing in drawings.items():
         for name in _DELIBERATELY_BARE & set(drawing.registry.names()):
             label = str(getattr(drawing.registry.named(name), "label", ""))
             assert label.startswith(("3\u00d7", "4\u00d7")), (

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -80,7 +80,7 @@ def _state_snapshot(dwg):
 
 
 @pytest.fixture(scope="module")
-def dwg_box_60_40_20():
+def plain_box_dwg():
     """A built ``Box(60, 40, 20)`` drawing, built once and shared by the
     **read-only** tests in this module (#153 — the hot part is otherwise rebuilt
     dozens of times). A teardown guard asserts the drawing was not mutated, so a
@@ -90,7 +90,7 @@ def dwg_box_60_40_20():
     before = _state_snapshot(dwg)
     yield dwg
     assert _state_snapshot(dwg) == before, (
-        "a shared-fixture consumer mutated dwg_box_60_40_20 — give that test its "
+        "a shared-fixture consumer mutated plain_box_dwg — give that test its "
         "own build_drawing(Box(60, 40, 20)) (see #153)"
     )
 
@@ -98,12 +98,6 @@ def dwg_box_60_40_20():
 # ---------------------------------------------------------------------------
 # Pure-function unit tests (fast, no OCP projection)
 # ---------------------------------------------------------------------------
-
-
-@pytest.fixture(scope="module")
-def plain_box_dwg():
-    """One plain-box build shared by read-only critiques (#656). Mutating tests build their own."""
-    return build_drawing(Box(60, 40, 20))
 
 
 @pytest.fixture(scope="module")
@@ -8603,14 +8597,14 @@ class TestLintSuggestions:
 
         assert not any(i.code == "feature_not_dimensioned" for i in dwg.lint())
 
-    def test_clean_drawing_has_no_suggestions(self, dwg_box_60_40_20):
+    def test_clean_drawing_has_no_suggestions(self, plain_box_dwg):
         # A fully auto-dimensioned plain box should lint clean → no suggestions.
-        for i in dwg_box_60_40_20.lint():
+        for i in plain_box_dwg.lint():
             assert i.suggestion is None
 
-    def test_lint_summary_omits_none_suggestion(self, dwg_box_60_40_20):
+    def test_lint_summary_omits_none_suggestion(self, plain_box_dwg):
         # A clean box: issue dicts (if any) must not carry a suggestion key.
-        for d in dwg_box_60_40_20.lint_summary()["issues"]:
+        for d in plain_box_dwg.lint_summary()["issues"]:
             assert "suggestion" not in d
 
     def test_lint_summary_includes_present_suggestion(self):
@@ -8989,8 +8983,8 @@ class TestAnnotationsQuery:
 class TestViewBounds:
     """#28: page bounding box of a named view's projected geometry."""
 
-    def test_view_bounds_returns_page_bbox(self, dwg_box_60_40_20):
-        dwg = dwg_box_60_40_20
+    def test_view_bounds_returns_page_bbox(self, plain_box_dwg):
+        dwg = plain_box_dwg
         b = dwg.view_bounds("front")
         assert b is not None and len(b) == 4
         x0, y0, x1, y1 = b
@@ -8999,19 +8993,19 @@ class TestViewBounds:
         assert (x1 - x0) == pytest.approx(60 * dwg.scale, rel=1e-3)
         assert (y1 - y0) == pytest.approx(20 * dwg.scale, rel=1e-3)
 
-    def test_view_bounds_contains_projected_centroid(self, dwg_box_60_40_20):
+    def test_view_bounds_contains_projected_centroid(self, plain_box_dwg):
         # The part centroid (world origin for a centred Box) projects inside.
-        dwg = dwg_box_60_40_20
+        dwg = plain_box_dwg
         x0, y0, x1, y1 = dwg.view_bounds("front")
         px, py, _ = dwg.at("front", 0, 0, 0)
         assert x0 <= px <= x1
         assert y0 <= py <= y1
 
-    def test_view_bounds_unknown_view_is_none(self, dwg_box_60_40_20):
-        assert dwg_box_60_40_20.view_bounds("does_not_exist") is None
+    def test_view_bounds_unknown_view_is_none(self, plain_box_dwg):
+        assert plain_box_dwg.view_bounds("does_not_exist") is None
 
-    def test_view_bounds_for_each_standard_view(self, dwg_box_60_40_20):
-        dwg = dwg_box_60_40_20
+    def test_view_bounds_for_each_standard_view(self, plain_box_dwg):
+        dwg = plain_box_dwg
         for v in ("front", "plan", "side", "iso"):
             b = dwg.view_bounds(v)
             assert b is not None, v


### PR DESCRIPTION
Closes redundant work identified in the final fast-tier profile.

- folds the tolerance sweep precondition into the property it guards, removing 77 duplicate builds
- reuses one immutable detected model per part/mode, removing 154 repeated recognition passes
- replaces the collection-time drawing build with a lightweight Draft
- reuses the deliberately-bare drawings and consolidates identical plain-box fixtures
- preserves distinct kind and role coverage and retains the shared-fixture mutation guard

Verification:
- 50 tests passed in test_issue_1215_no_approved_tolerance_is_dropped.py
- 18 shared plain-box fixture consumers passed
- 12 import/private-boundary tests passed
- focused counter: 5 builds, 1 recognition pass
- ruff check and format check passed
- no slow tests run