### PR TITLE
Prevent same-batch annotation ink collisions

### DIFF
--- a/docs/adr/0014-collect-then-solve-annotation-placement.md
+++ b/docs/adr/0014-collect-then-solve-annotation-placement.md
@@ -276,6 +276,31 @@ compatibility boundaries remain current. The change completes the analytical tie
 described by Amendment 2 and applies Amendment 4's budget rule to the now-observed
 two-tier cost model.
 
+**Amendment 6 (2026-08-25, #1334) — same-batch dimension ink participates
+before commit.** Strip assignment prevents collisions with previously committed
+occupancy, but dimensions surviving one corridor batch were formerly invisible to
+their siblings until emission. Immediate turned-part step chains had the same gap.
+After strip positions are assigned, the annotation layer now measures the complete
+natural dimension batch and selects bounded, along-dimension-line label alternatives
+before committing it. The lint backstop and this selector share the exact-label-region,
+connected-stroke crossing measure and `MIN_CROSSING_MM`; filled terminators participate
+through their attachment tips because the helper does not expose arrow polygons.
+Pinned candidates are immutable, page bounds use the common drawable margin, and an
+immediate chain may not introduce contact with already committed annotation ink.
+
+The selector is a deterministic, strictly improving local solve. At most sixteen
+nearest derived centres plus the two association bounds per involved candidate are
+considered for at most twice the batch size in iterations. A clean batch returns the
+already-built objects unchanged. A
+conflicted batch rebuilds only cached alternatives because moving a label also moves
+the helper's line cutout: translating label boxes analytically would miss the coupled
+change in line-work that resolves the reported defect. Every trial is rescored against
+the complete batch. Semantic evidence riders are copied to a selected rebuilt object;
+its fresh placement specification is retained. If no bounded improvement exists, the
+natural result survives and `annotation_ink_overlap` reports the infeasible layout.
+This is a refinement inside **Emit**, not a second placement engine or permission for
+raw-coordinate placement.
+
 ## Context (short — the full story is 0009's)
 
 A recurring defect class (#133/#225/#305: the "invisible occupant" — one strip,
@@ -349,9 +374,12 @@ Per view, per strip: **collect → solve → emit.**
   occupancy (`strip_obstacles` — full rendered footprints, decomposed per
   stroke since #685, not label boxes), evaluates candidates on analytical or
   probe footprints (`dim_footprint`, #602 — no OCC build per probe), then
-  builds each survivor **once** and re-validates its real box (corridor
+  builds each natural survivor **once** and re-validates its real box (corridor
   blockers, the `forbid` title-block box, out-of-band obstacles) — a
-  prediction miss degrades to a later-segment retry, never a collision.
+  prediction miss degrades to a later-segment retry, never a collision. A
+  dimension batch with peer ink conflicts may exceptionally rebuild the bounded,
+  cached label alternatives defined by Amendment 6; unchanged survivors are not
+  rebuilt or revalidated.
   Feature provenance is recorded at this drain seam
   (`CorridorCandidate.feature` → `dwg.add(..., feature=)`, ADR 0010).
 

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -21,11 +21,13 @@ from build123d_drafting.helpers import DEFAULT_FONT_PATH, Dimension, Note, SafeD
 from draftwright._core import (  # noqa: F401 — _anno_box re-exported (#700)
     _anno_box,
     _decode_hole_location_fact,
+    _dim,
     _text_size,
     place_annotation,
 )
 from draftwright._geometry import (  # noqa: F401
     _boxes_overlap,
+    _segment_clip_extent,
     _segment_clips_box,
     _segment_crosses_box,
 )
@@ -38,6 +40,14 @@ from draftwright.linting.structural import (
 from draftwright.model.compiled import resolve_feature
 
 _log = logging.getLogger(__name__)
+
+
+# A line entering a label by less than this is a corner graze, not obscured text.  Keep
+# this equal to the Stage-1 ratchet's measured floor without importing that late critique
+# into the placement DAG: candidate selection owns its arithmetic and Stage 1 remains a
+# backstop, not the oracle invoked for every alternative (#1334).
+_LABEL_INK_CROSSING_MM = 0.5
+_LABEL_INK_CLEARANCE_MM = 0.25
 
 
 def _with_hole_location_coverage(annotation, coverage):
@@ -1458,6 +1468,280 @@ def box_within_page_and_clear(bb, page_box, obstacles) -> bool:
     )
 
 
+def prevent_dimension_label_ink(
+    dimensions,
+    *,
+    page=None,
+    immutable=(),
+):
+    """Choose small along-line label offsets for a just-built dimension batch.
+
+    Corridor candidates used to reserve only their stacking tier while they were being
+    solved.  Their *eventual* decomposed ink became an obstacle after commit, but siblings
+    built in the same batch could therefore put an extension line or an external-arrow tip
+    through one another's labels (#1334).  Immediate step-length chains have the identical
+    gap: they build the whole row before any member is visible to strip occupancy.
+
+    This is the shared, bounded candidate-selection seam for both producers.  It inspects
+    public ``segments``/``label_bbox`` metadata once on the already-built natural batch.
+    A clean batch returns the same objects immediately.  Only a conflicting batch explores
+    a bounded set of analytically-derived label centres, rebuilding the selected survivors
+    through their ``_dw_spec``.  No Stage-1 lint scan and no CAD boolean participates.
+
+    The label *centre* stays within half a millimetre of its measured span (rather than
+    requiring the whole label to fit inside it).  That distinction matters for short
+    dimensions: their text is wider than the measured span by construction, yet a small
+    shift can keep a shared witness out of the digits without making the label read as its
+    neighbour's.  If the bounded choices cannot improve the batch, the natural deterministic
+    placement survives and the normal ``annotation_ink_overlap`` lint remains explicit
+    evidence of the infeasible fallback.  Names in *immutable* are never shifted (pins win).
+
+    Returns ``[(name, dimension), ...]`` in input order.
+    """
+
+    original = list(dimensions)
+    if len(original) < 1:
+        return original
+    immutable = set(immutable)
+
+    def _axis_info(dim):
+        spec = getattr(dim, "_dw_spec", None)
+        label = getattr(dim, "label_bbox", None)
+        if spec is None or label is None:
+            return None
+        dx = float(spec.p2[0]) - float(spec.p1[0])
+        dy = float(spec.p2[1]) - float(spec.p1[1])
+        if min(abs(dx), abs(dy)) > 0.1 or max(abs(dx), abs(dy)) <= 1e-9:
+            return None  # rotated labels need polygonal motion, not an AABB-axis solve
+        axis = 1 if abs(dy) > abs(dx) else 0
+        other = 1 - axis
+        return axis, other, spec
+
+    infos = [_axis_info(dim) for _name, dim in original]
+    if not any(info is not None for info in infos):
+        return original
+
+    def _box(dim):
+        raw = getattr(dim, "label_bbox", None)
+        return tuple(float(value) for value in raw) if raw is not None else None
+
+    def _segments(dim):
+        try:
+            return tuple(
+                (
+                    (float(first[0]), float(first[1])),
+                    (float(second[0]), float(second[1])),
+                )
+                for first, second in (getattr(dim, "segments", ()) or ())
+            )
+        except Exception:  # noqa: BLE001 — optional metadata fails closed to lint
+            return ()
+
+    def _arrow_tips(dim, info):
+        """Dimension terminator tips from its measured endpoints and dim-line ordinate.
+
+        Helpers expose line pieces but not the filled arrow triangles.  Their tips remain
+        exactly the two measured ordinates on the label's dimension line; treating the tip
+        attachment as label-blocking catches the short-span arrow-through-digit case without
+        inflating every shaft into a coarse full-geometry box.
+        """
+        if info is None or (label := _box(dim)) is None:
+            return ()
+        axis, other, spec = info
+        line = (label[other] + label[other + 2]) / 2.0
+        result = []
+        for point in (spec.p1, spec.p2):
+            tip = [0.0, 0.0]
+            tip[axis] = float(point[axis])
+            tip[other] = line
+            result.append(tuple(tip))
+        return tuple(result)
+
+    def _line_depth(segment, label):
+        clipped = _segment_clip_extent(segment[0], segment[1], label, pad=0.0)
+        return (
+            0.0
+            if clipped is None
+            else math.hypot(clipped[2] - clipped[0], clipped[3] - clipped[1])
+        )
+
+    def _conflicts(batch):
+        """Stable conflict tokens; their count is the local solve's primary objective."""
+        labels = [_box(dim) for _name, dim in batch]
+        segs = [_segments(dim) for _name, dim in batch]
+        tips = [_arrow_tips(dim, info) for (_name, dim), info in zip(batch, infos, strict=True)]
+        found: set[tuple] = set()
+        for target, label in enumerate(labels):
+            if label is None:
+                continue
+            # Helpers expose no arrow polygons.  The foreign dimension's exact
+            # attachment tips still participate, closing the line-metadata gap without
+            # guessing the orientation of this dimension's own inside/outside arrows.
+            for source, source_tips in enumerate(tips):
+                if source == target:
+                    continue
+                info = infos[target]
+                if info is None:
+                    continue
+                axis, other, _spec = info
+                for tip_index, tip in enumerate(source_tips):
+                    if (
+                        label[axis] + _LABEL_INK_CLEARANCE_MM
+                        < tip[axis]
+                        < label[axis + 2] - _LABEL_INK_CLEARANCE_MM
+                        and label[other] - 1e-6 < tip[other] < label[other + 2] + 1e-6
+                    ):
+                        found.add(("arrow", source, tip_index, target))
+            for source, source_segments in enumerate(segs):
+                if source == target:
+                    continue  # the helper deliberately cuts its own line around its label
+                for segment_index, segment in enumerate(source_segments):
+                    if _line_depth(segment, label) >= _LABEL_INK_CROSSING_MM:
+                        found.add(("line", source, segment_index, target))
+        for left, left_box in enumerate(labels):
+            if left_box is None:
+                continue
+            for right in range(left + 1, len(labels)):
+                right_box = labels[right]
+                if right_box is not None and _boxes_overlap(left_box, right_box):
+                    found.add(("label", left, right))
+        return frozenset(found)
+
+    natural_centres = []
+    for (_name, dim), info in zip(original, infos, strict=True):
+        label = _box(dim)
+        natural_centres.append(
+            None if info is None or label is None else (label[info[0]] + label[info[0] + 2]) / 2.0
+        )
+
+    def _objective(batch):
+        conflicts = _conflicts(batch)
+        offsets = []
+        for (_name, dim), info, natural in zip(batch, infos, natural_centres, strict=True):
+            label = _box(dim)
+            offsets.append(
+                0.0
+                if info is None or natural is None or label is None
+                else abs((label[info[0]] + label[info[0] + 2]) / 2.0 - natural)
+            )
+        return (
+            len(conflicts),
+            round(sum(offsets), 9),
+            round(max(offsets, default=0.0), 9),
+            tuple(round(value, 9) for value in offsets),
+        ), conflicts
+
+    current = list(original)
+    current_objective, conflicts = _objective(current)
+    if not conflicts:
+        return current  # overwhelmingly common path: no extra Dimension construction
+
+    cache: dict[tuple[int, float], Any] = {}
+
+    def _rebuild(index, centre):
+        key = (index, round(centre, 6))
+        if key in cache:
+            return cache[key]
+        name, dim = original[index]
+        info = infos[index]
+        natural = natural_centres[index]
+        if info is None or natural is None:
+            return dim
+        axis, _other, spec = info
+        direction = 1.0 if float(spec.p2[axis]) >= float(spec.p1[axis]) else -1.0
+        kwargs = dict(spec.kwargs)
+        kwargs["label_offset_x"] = (
+            kwargs.get("label_offset_x", 0.0) + (centre - natural) * direction
+        )
+        rebuilt = _dim(spec.p1, spec.p2, spec.side, spec.distance, spec.draft, **kwargs)
+        for attr in ("_dw_scale", "_dw_label_value"):
+            if getattr(dim, attr, None) is not None:
+                setattr(rebuilt, attr, getattr(dim, attr))
+        cache[key] = rebuilt
+        return rebuilt
+
+    def _centres_for(index, batch):
+        info = infos[index]
+        target = batch[index][1]
+        label = _box(target)
+        if info is None or label is None:
+            return ()
+        axis, other, spec = info
+        current_centre = (label[axis] + label[axis + 2]) / 2.0
+        half = (label[axis + 2] - label[axis]) / 2.0
+        # The centre remains attached to its own measured span.  A half-millimetre
+        # overhang admits the minimum clear position for text wider than a short span.
+        lo, hi = sorted((float(spec.p1[axis]), float(spec.p2[axis])))
+        lo -= _LABEL_INK_CROSSING_MM
+        hi += _LABEL_INK_CROSSING_MM
+        if page is not None:
+            lo = max(lo, float(page[axis]) + half)
+            hi = min(hi, float(page[axis + 2]) - half)
+        if lo > hi:
+            return ()
+        choices = {min(max(current_centre, lo), hi), lo, hi}
+        for source, ((_name, dim), source_info) in enumerate(zip(batch, infos, strict=True)):
+            source_label = _box(dim)
+            if source != index and source_label is not None:
+                # Existing labels are obstacles too; moving out of line-work must not
+                # exchange one illegibility defect for text-on-text.
+                if (
+                    source_label[other] < label[other + 2]
+                    and source_label[other + 2] > label[other]
+                ):
+                    choices.add(source_label[axis] - half - _LABEL_INK_CLEARANCE_MM)
+                    choices.add(source_label[axis + 2] + half + _LABEL_INK_CLEARANCE_MM)
+            if source == index:
+                continue
+            for tip in _arrow_tips(dim, source_info):
+                if label[other] - 1e-6 <= tip[other] <= label[other + 2] + 1e-6:
+                    choices.add(tip[axis] - half - _LABEL_INK_CLEARANCE_MM)
+                    choices.add(tip[axis] + half + _LABEL_INK_CLEARANCE_MM)
+            # Clip each foreign segment only to this label's fixed-axis band.  The
+            # resulting projection is the exact interval its centre must clear.
+            band = [-1e9, -1e9, 1e9, 1e9]
+            band[other], band[other + 2] = label[other], label[other + 2]
+            for segment in _segments(dim):
+                clipped = _segment_clip_extent(segment[0], segment[1], tuple(band), pad=0.0)
+                if clipped is None:
+                    continue
+                choices.add(clipped[axis] - half - _LABEL_INK_CLEARANCE_MM)
+                choices.add(clipped[axis + 2] + half + _LABEL_INK_CLEARANCE_MM)
+        bounded = {min(max(value, lo), hi) for value in choices if math.isfinite(value)}
+        # Bound exceptional work.  Nearest candidates are the meaningful drafting
+        # alternatives; the two association bounds remain present explicitly.
+        nearest = sorted(bounded, key=lambda value: (abs(value - current_centre), value))[:16]
+        return tuple(dict.fromkeys([*nearest, lo, hi]))
+
+    # Deterministic steepest descent.  Every accepted move strictly improves the
+    # lexicographic objective, so it terminates even when the layout is infeasible.
+    for _iteration in range(max(1, 2 * len(current))):
+        involved: set[int] = set()
+        for conflict in conflicts:
+            if conflict[0] in {"arrow", "line"}:
+                involved.update((conflict[1], conflict[3]))  # source + crossed label
+            else:  # label/label
+                involved.update((conflict[1], conflict[2]))
+        best = None
+        for index in sorted(involved):
+            name, _dim_obj = original[index]
+            if name in immutable or infos[index] is None:
+                continue
+            for centre in _centres_for(index, current):
+                trial = list(current)
+                trial[index] = (name, _rebuild(index, centre))
+                objective, trial_conflicts = _objective(trial)
+                key = (objective, index, round(centre, 9))
+                if objective < current_objective and (best is None or key < best[0]):
+                    best = (key, trial, objective, trial_conflicts)
+        if best is None:
+            break
+        _key, current, current_objective, conflicts = best
+        if not conflicts:
+            break
+    return current
+
+
 # ── The corridor priority ladder (#894) ───────────────────────────────────────
 # `CorridorCandidate.priority` is an over-capacity survival rank, and a rank only
 # means anything RELATIVE to the other rungs. Defining the whole ladder here — beside
@@ -2210,6 +2494,7 @@ def place_strip_candidates(
             accepted.append(((name, build), pos))
         return accepted, rejected
 
+    solved = []
     for seg_lo, seg_hi in segs:
         if not todo:
             break
@@ -2258,16 +2543,45 @@ def place_strip_candidates(
             if tp is not None:
                 tp["placed"].append({"name": name, "pos": pos})
         todo = todo + rejected_total
-        for name, dim in placed:
-            # Record feature provenance (ADR 0010): the drain-time seam for corridor-placed
-            # dims — `features` maps this batch's names to their source IR feature.
-            ctx.place(
-                dim,
-                name,
-                view=view,
-                feature=(features or {}).get(name),
-                measurement=(measurements or {}).get(name),
+        solved.extend(placed)
+
+    if len(solved) > 1:
+        natural_solved = dict(solved)
+        adjusted = prevent_dimension_label_ink(
+            solved,
+            page=(
+                (0.0, 0.0, float(dwg.page_w), float(dwg.page_h))
+                if hasattr(dwg, "page_w") and hasattr(dwg, "page_h")
+                else None
+            ),
+            immutable={name for name, _dim_obj in solved if (anchored or {}).get(name, False)},
+        )
+        # A label shift normally stays inside the dimension's measured span and
+        # therefore inside its already-validated footprint.  Keep the validation
+        # contract explicit nevertheless: if an unusual helper/style grows the real
+        # box into a hard obstacle, retain the natural survivor.  Stage-1 lint then
+        # records the infeasible ink conflict instead of this prevention step trading
+        # it for a structural collision.
+        solved = []
+        for name, dim in adjusted:
+            real = _geom_box(dim)
+            fb = (forbid or {}).get(name)
+            invalid = (
+                (not force and real is not None and _box_hits(real, blockers))
+                or (fb is not None and real is not None and _box_hits(real, (fb,)))
+                or (real is not None and _box_hits(real, out_of_band))
             )
+            solved.append((name, natural_solved[name] if invalid else dim))
+    for name, dim in solved:
+        # Record feature provenance (ADR 0010): the drain-time seam for corridor-placed
+        # dims — `features` maps this batch's names to their source IR feature.
+        ctx.place(
+            dim,
+            name,
+            view=view,
+            feature=(features or {}).get(name),
+            measurement=(measurements or {}).get(name),
+        )
     if tp is not None:
         tp["unplaced"] = [n for n, _ in todo]
         trace.end_pass(tp)  # folds a standalone pass's items; no-op when corridor-nested

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -1654,9 +1654,14 @@ def prevent_dimension_label_ink(
             kwargs.get("label_offset_x", 0.0) + (centre - natural) * direction
         )
         rebuilt = _dim(spec.p1, spec.p2, spec.side, spec.distance, spec.draft, **kwargs)
-        for attr in ("_dw_scale", "_dw_label_value"):
-            if getattr(dim, attr, None) is not None:
-                setattr(rebuilt, attr, getattr(dim, attr))
+        # The producer attaches semantic evidence before the corridor commits the
+        # survivor. Rebuilding only the rendered Dimension must not erase that evidence:
+        # hole-table escalation and coverage lint read these riders from the final object.
+        # Copy semantic namespaces, never helper geometry internals; `_dw_spec` belongs to
+        # the rebuilt placement and must remain the one `_dim` just created.
+        for attr, value in vars(dim).items():
+            if attr.startswith("covers_") or (attr.startswith("_dw_") and attr != "_dw_spec"):
+                setattr(rebuilt, attr, value)
         cache[key] = rebuilt
         return rebuilt
 

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -19,6 +19,7 @@ from typing import Any
 from build123d_drafting.helpers import DEFAULT_FONT_PATH, Dimension, Note, SafeDimension
 
 from draftwright._core import (  # noqa: F401 — _anno_box re-exported (#700)
+    _MARGIN,
     _anno_box,
     _decode_hole_location_fact,
     _dim,
@@ -32,6 +33,7 @@ from draftwright._geometry import (  # noqa: F401
     _segment_crosses_box,
 )
 from draftwright.layout import StripCandidate, plan_strip
+from draftwright.linting.ink_overlap import MIN_CROSSING_MM, crossable_region, crossing_length
 from draftwright.linting.issues import LintIssue
 from draftwright.linting.structural import (
     _ann_box,
@@ -42,11 +44,6 @@ from draftwright.model.compiled import resolve_feature
 _log = logging.getLogger(__name__)
 
 
-# A line entering a label by less than this is a corner graze, not obscured text.  Keep
-# this equal to the Stage-1 ratchet's measured floor without importing that late critique
-# into the placement DAG: candidate selection owns its arithmetic and Stage 1 remains a
-# backstop, not the oracle invoked for every alternative (#1334).
-_LABEL_INK_CROSSING_MM = 0.5
 _LABEL_INK_CLEARANCE_MM = 0.25
 
 
@@ -1473,6 +1470,7 @@ def prevent_dimension_label_ink(
     *,
     page=None,
     immutable=(),
+    obstacles=(),
 ):
     """Choose small along-line label offsets for a just-built dimension batch.
 
@@ -1483,10 +1481,10 @@ def prevent_dimension_label_ink(
     gap: they build the whole row before any member is visible to strip occupancy.
 
     This is the shared, bounded candidate-selection seam for both producers.  It inspects
-    public ``segments``/``label_bbox`` metadata once on the already-built natural batch.
+    the same public ``segments``/exact-label-region arithmetic as the lint backstop.
     A clean batch returns the same objects immediately.  Only a conflicting batch explores
     a bounded set of analytically-derived label centres, rebuilding the selected survivors
-    through their ``_dw_spec``.  No Stage-1 lint scan and no CAD boolean participates.
+    through their ``_dw_spec``.  No full lint scan and no CAD boolean participates.
 
     The label *centre* stays within half a millimetre of its measured span (rather than
     requiring the whole label to fit inside it).  That distinction matters for short
@@ -1495,14 +1493,17 @@ def prevent_dimension_label_ink(
     neighbour's.  If the bounded choices cannot improve the batch, the natural deterministic
     placement survives and the normal ``annotation_ink_overlap`` lint remains explicit
     evidence of the infeasible fallback.  Names in *immutable* are never shifted (pins win).
+    Fixed *obstacles* do not make an existing contact this local batch's responsibility, but
+    no selected move may introduce a new label contact with one.
 
     Returns ``[(name, dimension), ...]`` in input order.
     """
 
     original = list(dimensions)
-    if len(original) < 1:
+    if len(original) < 2:
         return original
     immutable = set(immutable)
+    obstacles = tuple(obstacles)
 
     def _axis_info(dim):
         spec = getattr(dim, "_dw_spec", None)
@@ -1521,13 +1522,24 @@ def prevent_dimension_label_ink(
     if not any(info is not None for info in infos):
         return original
 
+    box_cache: dict[int, Any] = {}
+    segments_cache: dict[int, Any] = {}
+    tips_cache: dict[int, Any] = {}
+
     def _box(dim):
+        key = id(dim)
+        if key in box_cache:
+            return box_cache[key]
         raw = getattr(dim, "label_bbox", None)
-        return tuple(float(value) for value in raw) if raw is not None else None
+        box_cache[key] = tuple(float(value) for value in raw) if raw is not None else None
+        return box_cache[key]
 
     def _segments(dim):
+        key = id(dim)
+        if key in segments_cache:
+            return segments_cache[key]
         try:
-            return tuple(
+            segments_cache[key] = tuple(
                 (
                     (float(first[0]), float(first[1])),
                     (float(second[0]), float(second[1])),
@@ -1535,7 +1547,8 @@ def prevent_dimension_label_ink(
                 for first, second in (getattr(dim, "segments", ()) or ())
             )
         except Exception:  # noqa: BLE001 — optional metadata fails closed to lint
-            return ()
+            segments_cache[key] = ()
+        return segments_cache[key]
 
     def _arrow_tips(dim, info):
         """Dimension terminator tips from its measured endpoints and dim-line ordinate.
@@ -1545,6 +1558,9 @@ def prevent_dimension_label_ink(
         attachment as label-blocking catches the short-span arrow-through-digit case without
         inflating every shaft into a coarse full-geometry box.
         """
+        key = id(dim)
+        if key in tips_cache:
+            return tips_cache[key]
         if info is None or (label := _box(dim)) is None:
             return ()
         axis, other, spec = info
@@ -1555,24 +1571,31 @@ def prevent_dimension_label_ink(
             tip[axis] = float(point[axis])
             tip[other] = line
             result.append(tuple(tip))
-        return tuple(result)
+        tips_cache[key] = tuple(result)
+        return tips_cache[key]
 
-    def _line_depth(segment, label):
-        clipped = _segment_clip_extent(segment[0], segment[1], label, pad=0.0)
-        return (
-            0.0
-            if clipped is None
-            else math.hypot(clipped[2] - clipped[0], clipped[3] - clipped[1])
+    natural_obstacle_hits = [
+        frozenset(
+            obstacle_index
+            for obstacle_index, obstacle in enumerate(obstacles)
+            if label is not None and _boxes_overlap(label, obstacle)
         )
+        for _name, dim in original
+        for label in (_box(dim),)
+    ]
 
     def _conflicts(batch):
         """Stable conflict tokens; their count is the local solve's primary objective."""
         labels = [_box(dim) for _name, dim in batch]
         segs = [_segments(dim) for _name, dim in batch]
+        regions = [
+            crossable_region(label, item=dim, segments=segments)
+            for (_name, dim), label, segments in zip(batch, labels, segs, strict=True)
+        ]
         tips = [_arrow_tips(dim, info) for (_name, dim), info in zip(batch, infos, strict=True)]
         found: set[tuple] = set()
-        for target, label in enumerate(labels):
-            if label is None:
+        for target, (label, region) in enumerate(zip(labels, regions, strict=True)):
+            if label is None or region is None:
                 continue
             # Helpers expose no arrow polygons.  The foreign dimension's exact
             # attachment tips still participate, closing the line-metadata gap without
@@ -1595,9 +1618,13 @@ def prevent_dimension_label_ink(
             for source, source_segments in enumerate(segs):
                 if source == target:
                     continue  # the helper deliberately cuts its own line around its label
-                for segment_index, segment in enumerate(source_segments):
-                    if _line_depth(segment, label) >= _LABEL_INK_CROSSING_MM:
-                        found.add(("line", source, segment_index, target))
+                if crossing_length(source_segments, region) >= MIN_CROSSING_MM:
+                    found.add(("line", source, target))
+            for obstacle_index, obstacle in enumerate(obstacles):
+                if obstacle_index not in natural_obstacle_hits[target] and _boxes_overlap(
+                    label, obstacle
+                ):
+                    found.add(("fixed", obstacle_index, target))
         for left, left_box in enumerate(labels):
             if left_box is None:
                 continue
@@ -1616,6 +1643,7 @@ def prevent_dimension_label_ink(
 
     def _objective(batch):
         conflicts = _conflicts(batch)
+        fixed_conflicts = sum(conflict[0] == "fixed" for conflict in conflicts)
         offsets = []
         for (_name, dim), info, natural in zip(batch, infos, natural_centres, strict=True):
             label = _box(dim)
@@ -1625,6 +1653,7 @@ def prevent_dimension_label_ink(
                 else abs((label[info[0]] + label[info[0] + 2]) / 2.0 - natural)
             )
         return (
+            fixed_conflicts,
             len(conflicts),
             round(sum(offsets), 9),
             round(max(offsets, default=0.0), 9),
@@ -1677,8 +1706,8 @@ def prevent_dimension_label_ink(
         # The centre remains attached to its own measured span.  A half-millimetre
         # overhang admits the minimum clear position for text wider than a short span.
         lo, hi = sorted((float(spec.p1[axis]), float(spec.p2[axis])))
-        lo -= _LABEL_INK_CROSSING_MM
-        hi += _LABEL_INK_CROSSING_MM
+        lo -= MIN_CROSSING_MM
+        hi += MIN_CROSSING_MM
         if page is not None:
             lo = max(lo, float(page[axis]) + half)
             hi = min(hi, float(page[axis + 2]) - half)
@@ -1723,8 +1752,12 @@ def prevent_dimension_label_ink(
     for _iteration in range(max(1, 2 * len(current))):
         involved: set[int] = set()
         for conflict in conflicts:
-            if conflict[0] in {"arrow", "line"}:
+            if conflict[0] == "arrow":
                 involved.update((conflict[1], conflict[3]))  # source + crossed label
+            elif conflict[0] == "line":
+                involved.update((conflict[1], conflict[2]))  # source + crossed label
+            elif conflict[0] == "fixed":
+                involved.add(conflict[2])
             else:  # label/label
                 involved.update((conflict[1], conflict[2]))
         best = None
@@ -2415,6 +2448,19 @@ def place_strip_candidates(
         tp["free_segments"] = [list(s) for s in segs]
     todo = list(cands)
 
+    def _real_box_conflict(name, real):
+        """Return the hard-obstacle reason for a built survivor, if any."""
+        if real is None:
+            return None
+        if not force and _box_hits(real, blockers):
+            return "real_box_corridor_blocked"
+        fb = (forbid or {}).get(name)
+        if fb is not None and _box_hits(real, (fb,)):
+            return "real_box_forbid"
+        if _box_hits(real, out_of_band):
+            return "real_box_out_of_band"
+        return None
+
     def _take_for_segment(items, n):
         if len(items) <= n:
             return items, []
@@ -2521,29 +2567,11 @@ def place_strip_candidates(
         for (name, build), pos in accepted:
             dim = build(pos)
             real = _geom_box(dim)
-            if real is not None:
-                if not force and _box_hits(real, blockers):
-                    if tp is not None:
-                        tp["rejected"].append(
-                            {"name": name, "reason": "real_box_corridor_blocked"}
-                        )
-                    rejected_total.append((name, build))
-                    continue
-                fb = (forbid or {}).get(name)
-                if fb is not None and _box_hits(real, (fb,)):
-                    if tp is not None:
-                        tp["rejected"].append({"name": name, "reason": "real_box_forbid"})
-                    rejected_total.append((name, build))
-                    continue
-                # A survivor whose real geometry escaped the batch's predicted
-                # perpendicular band could overlap an obstacle the carve was never
-                # shown (review #679) — the one collision class the stacking-axis
-                # model cannot tolerate. Never fires while predictions are accurate.
-                if _box_hits(real, out_of_band):
-                    if tp is not None:
-                        tp["rejected"].append({"name": name, "reason": "real_box_out_of_band"})
-                    rejected_total.append((name, build))
-                    continue
+            if reason := _real_box_conflict(name, real):
+                if tp is not None:
+                    tp["rejected"].append({"name": name, "reason": reason})
+                rejected_total.append((name, build))
+                continue
             placed.append((name, dim))
             if tp is not None:
                 tp["placed"].append({"name": name, "pos": pos})
@@ -2551,11 +2579,19 @@ def place_strip_candidates(
         solved.extend(placed)
 
     if len(solved) > 1:
+        assert len({name for name, _dim_obj in solved}) == len(solved), (
+            "strip survivor names must be unique before label selection"
+        )
         natural_solved = dict(solved)
         adjusted = prevent_dimension_label_ink(
             solved,
             page=(
-                (0.0, 0.0, float(dwg.page_w), float(dwg.page_h))
+                (
+                    _MARGIN,
+                    _MARGIN,
+                    float(dwg.page_w) - _MARGIN,
+                    float(dwg.page_h) - _MARGIN,
+                )
                 if hasattr(dwg, "page_w") and hasattr(dwg, "page_h")
                 else None
             ),
@@ -2564,19 +2600,17 @@ def place_strip_candidates(
         # A label shift normally stays inside the dimension's measured span and
         # therefore inside its already-validated footprint.  Keep the validation
         # contract explicit nevertheless: if an unusual helper/style grows the real
-        # box into a hard obstacle, retain the natural survivor.  Stage-1 lint then
+        # box into a hard obstacle, retain the natural survivor.  The lint backstop then
         # records the infeasible ink conflict instead of this prevention step trading
         # it for a structural collision.
         solved = []
         for name, dim in adjusted:
+            natural = natural_solved[name]
+            if dim is natural:
+                solved.append((name, dim))
+                continue
             real = _geom_box(dim)
-            fb = (forbid or {}).get(name)
-            invalid = (
-                (not force and real is not None and _box_hits(real, blockers))
-                or (fb is not None and real is not None and _box_hits(real, (fb,)))
-                or (real is not None and _box_hits(real, out_of_band))
-            )
-            solved.append((name, natural_solved[name] if invalid else dim))
+            solved.append((name, natural if _real_box_conflict(name, real) else dim))
     for name, dim in solved:
         # Record feature provenance (ADR 0010): the drain-time seam for corridor-placed
         # dims — `features` maps this batch's names to their source IR feature.

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -3698,6 +3698,7 @@ def _draw_step_chain(
         for name, dim in prevent_dimension_label_ink(
             [(name, dim) for name, dim, _measurements in candidates],
             page=page,
+            obstacles=strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES),
         )
     ]
 

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -81,6 +81,7 @@ from draftwright.annotations._common import (
     full_strip_message,
     leader_callout_geometry,
     place_strip_candidates,
+    prevent_dimension_label_ink,
     register_corridor,
     strip_free_span,
     strip_obstacles,
@@ -3686,8 +3687,21 @@ def _draw_step_chain(
                 )
             )
 
-    # Room guard: if any dim would fall off the drawable page, place NONE.
     page = (_MARGIN, _MARGIN, dwg.page_w - _MARGIN, dwg.page_h - _MARGIN)
+    # The chain is one placement batch: until commit, no sibling's extension line or
+    # terminator exists in strip occupancy.  Select small along-line label offsets against
+    # the complete batch before the room guard (#1334).  Measurement provenance stays paired
+    # by name; only the rendered Dimension survivor changes.
+    measurements_by_name = {name: measurements for name, _dim_obj, measurements in candidates}
+    candidates = [
+        (name, dim, measurements_by_name[name])
+        for name, dim in prevent_dimension_label_ink(
+            [(name, dim) for name, dim, _measurements in candidates],
+            page=page,
+        )
+    ]
+
+    # Room guard: if any dim would fall off the drawable page, place NONE.
     for _, dim, _measurements in candidates:
         box = _anno_box(dim)
         if box is not None and not (

--- a/tests/test_issue_1166_cross_pass_feature_leaders.py
+++ b/tests/test_issue_1166_cross_pass_feature_leaders.py
@@ -267,8 +267,8 @@ def test_unavoidable_policy_b_crossing_is_persisted_without_opt_in_trace():
     assert all(issue.severity == "info" for issue in issues)
     assert all(issue.measurement_ids for issue in issues)
     legibility = drawing.lint_summary()["quality"]["legibility"]
-    # `annotation_ink_overlap` (#1321/#1332) scores on legibility too. Stage 3
-    # (#1334) prevents the same-batch dimension crossing; the retained Policy-B
+    # `annotation_ink_overlap` (#1321/#1332) scores on legibility too. Candidate
+    # prevention (#1334) removes the same-batch crossing; the retained Policy-B
     # cross-stage leader conflict remains visible under both codes.
     assert legibility["by_code"] == {
         "feature_leader_crossing": 1,

--- a/tests/test_issue_1166_cross_pass_feature_leaders.py
+++ b/tests/test_issue_1166_cross_pass_feature_leaders.py
@@ -267,12 +267,12 @@ def test_unavoidable_policy_b_crossing_is_persisted_without_opt_in_trace():
     assert all(issue.severity == "info" for issue in issues)
     assert all(issue.measurement_ids for issue in issues)
     legibility = drawing.lint_summary()["quality"]["legibility"]
-    # `annotation_ink_overlap` (#1321/#1332) scores on legibility too, and this
-    # sheet carries two. Measured, not rendered -- the same family as the cases
-    # that were; stage 3 (#1334) is what prevents them.
+    # `annotation_ink_overlap` (#1321/#1332) scores on legibility too. Stage 3
+    # (#1334) prevents the same-batch dimension crossing; the retained Policy-B
+    # cross-stage leader conflict remains visible under both codes.
     assert legibility["by_code"] == {
         "feature_leader_crossing": 1,
-        "annotation_ink_overlap": 2,
+        "annotation_ink_overlap": 1,
     }
     assert legibility["score"] < 1.0
 

--- a/tests/test_issue_1308_machined_leader_analytics.py
+++ b/tests/test_issue_1308_machined_leader_analytics.py
@@ -37,13 +37,12 @@ EXPECTED = {
             "m_chamfer_x1": ("Leader", (153.14, 69.829, 177.598, 76.25)),
             "title_block": ("TitleBlock", (165.925, 10.925, 286.075, 27.075)),
         },
-        # Two crossings on the step-length chain (#1321/#1332): '2' draws 2.2 mm
-        # of line-work through the label '0.5', and '0.5' 1.1 mm back through '2'.
-        # Two obscured labels, two findings. Rendered at 600 dpi and confirmed — an
-        # arrowhead is driven through the '5'. This sheet was never clean; the
-        # check that could see it did not exist. #1334 is what stops it being
-        # placed.
-        {"annotation_ink_overlap": 2},
+        # The natural step-length chain has two crossings (#1321/#1332): '2' draws
+        # 2.2 mm through '0.5', and '0.5' 1.1 mm back through '2'.  The Stage-3
+        # same-batch selector (#1334) now moves only those two labels along their
+        # dimension lines, leaving the annotation boxes above unchanged and the
+        # finished sheet clean.
+        {},
     ),
     "issue_1058_wheel_rh.step": (
         {

--- a/tests/test_issue_1334_prevent_ink.py
+++ b/tests/test_issue_1334_prevent_ink.py
@@ -1,10 +1,17 @@
-"""Stage-3 prevention: candidate line-work and terminators block peer labels (#1334)."""
+"""Candidate prevention: dimension ink blocks peer labels before commit (#1334)."""
 
 from build123d_drafting.helpers import Draft
 
 from draftwright._core import _dim
+from draftwright._geometry import _boxes_overlap
 from draftwright.annotations._common import prevent_dimension_label_ink
-from draftwright.linting.ink_overlap import crossable_region, label_crossings, segments_of
+from draftwright.linting.ink_overlap import (
+    MIN_CROSSING_MM,
+    crossable_region,
+    crossing_length,
+    label_crossings,
+    segments_of,
+)
 
 
 def _short_chain():
@@ -93,7 +100,7 @@ def test_immutable_label_keeps_deterministic_linted_fallback():
 
     assert placed[0][1] is natural[0][1]
     assert placed[1][1] is natural[1][1]
-    assert _stage1_crossings(placed), "an infeasible pin must remain visible to Stage-1 lint"
+    assert _stage1_crossings(placed), "an infeasible pin must remain visible to lint"
 
 
 def test_clean_batch_is_a_zero_construction_fast_path():
@@ -107,3 +114,45 @@ def test_clean_batch_is_a_zero_construction_fast_path():
 
     assert [dim for _name, dim in placed] == [dim for _name, dim in clean]
     assert all(placed[index][1] is clean[index][1] for index in range(len(clean)))
+
+
+def test_candidate_move_does_not_create_contact_with_committed_ink():
+    natural = _short_chain()
+    # The otherwise-preferred rightward position for ``next`` lands here.  This box
+    # represents annotation ink committed before an immediate step chain is built.
+    committed = (28.2, 9.0, 29.5, 13.0)
+    assert not _boxes_overlap(natural[1][1].label_bbox, committed)
+
+    placed = prevent_dimension_label_ink(
+        natural,
+        page=(0.0, 0.0, 100.0, 100.0),
+        obstacles=(committed,),
+    )
+
+    assert _stage1_crossings(placed) == []
+    assert not any(_boxes_overlap(dim.label_bbox, committed) for _name, dim in placed)
+
+
+def test_connected_short_segments_use_the_same_crossing_measure_as_lint():
+    draft = Draft(font_size=3.0, arrow_length=2.7, line_width=0.1)
+    source = _dim((0, 0, 0), (20, 0, 0), "above", 11, draft, label="20")
+    target = _dim((30, 0, 0), (50, 0, 0), "above", 11, draft, label="20")
+    # Each renderer piece is shorter than the lint floor, but they join inside the
+    # target label and are therefore one 0.6 mm visual stroke.
+    source._segments_local = [((39.7, 11.0), (40.0, 11.0)), ((40.0, 11.0), (40.3, 11.0))]
+    region = crossable_region(target.label_bbox, item=target, segments=target.segments)
+    assert crossing_length(source.segments, region) >= MIN_CROSSING_MM
+
+    placed = prevent_dimension_label_ink(
+        [("source", source), ("target", target)],
+        page=(0.0, 0.0, 100.0, 100.0),
+        immutable={"source"},
+    )
+
+    shifted = placed[1][1]
+    shifted_region = crossable_region(
+        shifted.label_bbox,
+        item=shifted,
+        segments=shifted.segments,
+    )
+    assert crossing_length(source.segments, shifted_region) < MIN_CROSSING_MM

--- a/tests/test_issue_1334_prevent_ink.py
+++ b/tests/test_issue_1334_prevent_ink.py
@@ -1,0 +1,106 @@
+"""Stage-3 prevention: candidate line-work and terminators block peer labels (#1334)."""
+
+from build123d_drafting.helpers import Draft
+
+from draftwright._core import _dim
+from draftwright.annotations._common import prevent_dimension_label_ink
+from draftwright.linting.ink_overlap import crossable_region, label_crossings, segments_of
+
+
+def _short_chain():
+    draft = Draft(font_size=3.0, arrow_length=2.7, line_width=0.1)
+    return [
+        (
+            "short",
+            _dim((20.0, 0.0, 0.0), (22.5, 0.0, 0.0), "above", 11.0, draft, label="0.5"),
+        ),
+        (
+            "next",
+            _dim((22.5, 0.0, 0.0), (32.5, 0.0, 0.0), "above", 11.0, draft, label="2"),
+        ),
+    ]
+
+
+def _stage1_crossings(batch):
+    found = []
+    for left_index, (_left_name, left) in enumerate(batch):
+        left_segments = segments_of(left)
+        left_label = crossable_region(
+            left.label_bbox,
+            item=left,
+            segments=left_segments,
+        )
+        for _right_name, right in batch[left_index + 1 :]:
+            right_segments = segments_of(right)
+            right_label = crossable_region(
+                right.label_bbox,
+                item=right,
+                segments=right_segments,
+            )
+            found.extend(
+                label_crossings(
+                    left_segments,
+                    right_segments,
+                    label_a=left_label,
+                    label_b=right_label,
+                )
+            )
+    return found
+
+
+def _foreign_arrow_tips_in_labels(batch):
+    found = []
+    for target_name, target in batch:
+        label = target.label_bbox
+        for source_name, source in batch:
+            if source_name == target_name:
+                continue
+            for point in (source._dw_spec.p1, source._dw_spec.p2):
+                if label[0] + 0.25 < point[0] < label[2] - 0.25:
+                    found.append((source_name, target_name))
+    return found
+
+
+def test_same_batch_dimension_ink_selects_clear_label_candidates():
+    natural = _short_chain()
+    assert len(_stage1_crossings(natural)) == 2
+    assert _foreign_arrow_tips_in_labels(natural)
+
+    placed = prevent_dimension_label_ink(natural, page=(0.0, 0.0, 100.0, 100.0))
+
+    assert _stage1_crossings(placed) == []
+    assert _foreign_arrow_tips_in_labels(placed) == []
+    assert any("label_offset_x" in dim._dw_spec.kwargs for _name, dim in placed)
+
+    # The bounded solve is deterministic, including its exact selected offsets.
+    replay = prevent_dimension_label_ink(_short_chain(), page=(0.0, 0.0, 100.0, 100.0))
+    assert [dim._dw_spec.kwargs for _name, dim in replay] == [
+        dim._dw_spec.kwargs for _name, dim in placed
+    ]
+
+
+def test_immutable_label_keeps_deterministic_linted_fallback():
+    natural = _short_chain()
+
+    placed = prevent_dimension_label_ink(
+        natural,
+        page=(0.0, 0.0, 100.0, 100.0),
+        immutable={"short", "next"},
+    )
+
+    assert placed[0][1] is natural[0][1]
+    assert placed[1][1] is natural[1][1]
+    assert _stage1_crossings(placed), "an infeasible pin must remain visible to Stage-1 lint"
+
+
+def test_clean_batch_is_a_zero_construction_fast_path():
+    draft = Draft()
+    clean = [
+        ("left", _dim((0, 0, 0), (20, 0, 0), "above", 11, draft, label="20")),
+        ("right", _dim((30, 0, 0), (50, 0, 0), "above", 11, draft, label="20")),
+    ]
+
+    placed = prevent_dimension_label_ink(clean, page=(0.0, 0.0, 100.0, 100.0))
+
+    assert [dim for _name, dim in placed] == [dim for _name, dim in clean]
+    assert all(placed[index][1] is clean[index][1] for index in range(len(clean)))

--- a/tests/test_issue_1334_prevent_ink.py
+++ b/tests/test_issue_1334_prevent_ink.py
@@ -63,6 +63,8 @@ def _foreign_arrow_tips_in_labels(batch):
 
 def test_same_batch_dimension_ink_selects_clear_label_candidates():
     natural = _short_chain()
+    semantic_evidence = ((object(), "location.location.x", (22.5, 0.0, 0.0)),)
+    natural[1][1].covers_hole_locations = semantic_evidence
     assert len(_stage1_crossings(natural)) == 2
     assert _foreign_arrow_tips_in_labels(natural)
 
@@ -70,6 +72,7 @@ def test_same_batch_dimension_ink_selects_clear_label_candidates():
 
     assert _stage1_crossings(placed) == []
     assert _foreign_arrow_tips_in_labels(placed) == []
+    assert placed[1][1].covers_hole_locations == semantic_evidence
     assert any("label_offset_x" in dim._dw_spec.kwargs for _name, dim in placed)
 
     # The bounded solve is deterministic, including its exact selected offsets.

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4011,8 +4011,8 @@ class TestPrismaticClassification:
         assert min(ymid(o) for o in loc) > ymid(env), "location must stack inside the envelope"
         # #1321/#1332: this drawing genuinely carries one crossing, named rather
         # than filtered by code so a second one would fail here. Measured, not
-        # rendered — same family as the cases that were. Stage 3 (#1334) is what
-        # stops it being placed; until then the honest assertion is that it is
+        # rendered — same family as the cases that were. Candidate prevention
+        # (#1334) stops it being placed; until then the honest assertion is that it is
         # here, not that the sheet is clean.
         rest = _ink_crossings_named(dwg, [("40", "⌀6 THRU")])
         assert [i for i in rest if i.severity != "info"] == []
@@ -4899,8 +4899,8 @@ class TestLocationDimsAndSection:
         assert len([n for n in dwg.annotations() if n.startswith("hc_side")]) == 4
         # #1321/#1332: the envelope length '80' runs through all four side-drilled
         # callouts. Named rather than filtered by code, so a fifth would fail here.
-        # Measured, not rendered — same family as the cases that were. Stage 3
-        # (#1334) is what stops them being placed.
+        # Measured, not rendered — same family as the cases that were. Candidate
+        # prevention (#1334) stops them being placed.
         rest = _ink_crossings_named(
             dwg,
             [
@@ -9627,9 +9627,9 @@ class TestTurnedDiameters:
         # The `leader_crosses_silhouette` entry is the #798 bolt-circle cut described in
         # test_issue_881_...; it appears on BOTH paths, which is what this test is
         # actually about — the replay reproduces the same critique, defects included.
-        # Stage 3 (#1334) prevents the two same-batch step-chain crossings while
-        # preserving the two crossings against ink emitted by another placement
-        # stage. Both paths report the same residual critique, which is what this
+        # Candidate prevention (#1334) removes the same-batch step-chain crossings.
+        # One crossing against ink committed by a different producer remains. Both
+        # paths report the same residual critique, which is what this
         # round-trip test is actually about -- replay reproduces the automatic
         # drawing, defects included.
         assert (
@@ -9638,7 +9638,7 @@ class TestTurnedDiameters:
             == {
                 "hole_requirement_missing": 2,
                 "leader_crosses_silhouette": 1,
-                "annotation_ink_overlap": 2,
+                "annotation_ink_overlap": 1,
             }
         )
 

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -9627,19 +9627,18 @@ class TestTurnedDiameters:
         # The `leader_crosses_silhouette` entry is the #798 bolt-circle cut described in
         # test_issue_881_...; it appears on BOTH paths, which is what this test is
         # actually about — the replay reproduces the same critique, defects included.
-        # Four `annotation_ink_overlap` (#1321/#1332): the step-length chain on this
-        # fixture is crowded enough that four dimensions draw line-work through a
-        # neighbour's label, the smallest 0.9 mm and the largest 2.2 mm. Rendered at
-        # 600 dpi and confirmed. Both paths report all four, which is what this test
-        # is actually about -- the replay reproduces the same critique, defects
-        # included. Stage 3 (#1334) is what stops them being placed.
+        # Stage 3 (#1334) prevents the two same-batch step-chain crossings while
+        # preserving the two crossings against ink emitted by another placement
+        # stage. Both paths report the same residual critique, which is what this
+        # round-trip test is actually about -- replay reproduces the automatic
+        # drawing, defects included.
         assert (
             auto.lint_summary()["by_code"]
             == replayed.lint_summary()["by_code"]
             == {
                 "hole_requirement_missing": 2,
                 "leader_crosses_silhouette": 1,
-                "annotation_ink_overlap": 4,
+                "annotation_ink_overlap": 2,
             }
         )
 


### PR DESCRIPTION
## Summary

- add a bounded same-batch dimension-label selector using public label, segment, and terminator metadata
- run it across the complete corridor survivor batch and immediate turned step-length chains
- preserve pinned candidates and retain deterministic, lint-visible fallback when no clear alternative exists
- keep already-clean batches on an object-identical zero-construction fast path

## Results

- GRM-03 step-chain ink findings: 2 -> 0
- crowded flange corpus ink findings: 4 -> 2, removing the two same-batch crossings while retaining cross-stage findings

## Validation

- `uv run pytest -q -n0 tests/test_issue_1334_prevent_ink.py`
- focused corridor placement tests: 11 passed
- analytical fixture suite: 6 passed
- smoke tier: 91 passed
- Ruff, formatting, mypy, and `git diff --check`

Slow tests and the alternate-kernel CI matrix were intentionally left to CI.

Closes #1334