### PR TITLE
Reproducible SVG/DXF/PDF export, opt-in via reproducible=

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,20 @@ for issue in dwg.lint():
 paths = dwg.export("out", formats=("svg", "dxf", "pdf", "png"))   # -> {format: path}
 ```
 
+`reproducible=True` writes files that do not carry the run that produced them, so two
+exports of the same drawing are byte-identical and a written drawing can be diffed or
+checksummed to see whether its content actually changed. Set it per call, or once for
+the drawing via `build_drawing(..., reproducible=True)`:
+
+```python
+dwg = build_drawing(part, reproducible=True)     # every export from this drawing
+paths = dwg.export("out", formats=("dxf",))
+paths = dwg.export("out", formats=("dxf",), reproducible=False)   # override per call
+```
+
+Off by default because it is not free: ordering the DXF entities costs roughly a third
+of DXF export time again. Off costs exactly what it did before the option existed.
+
 ## What NOT to do
 
 - ❌ Raw page coordinates for feature annotations; `Drawing.place_dim(...)` (deprecated raw
@@ -111,7 +125,10 @@ paths = dwg.export("out", formats=("svg", "dxf", "pdf", "png"))   # -> {format: 
 - ❌ `dwg.add(Dimension/Leader/FeatureControlFrame(...))` / raw `Note` objects — `add` is the
   engine's low-level placement primitive (being made private, #817). Use the verbs: `note()` for
   free text, `add_table()`/`add_hole_table()` for tables, the feature verbs for callouts/dims.
-- ❌ Bypassing recognition / assuming byte-identical output (it is not a goal — ADR 0004/0012).
+- ❌ Bypassing recognition / treating byte-identical output as a *stability* guarantee across
+  versions or layout changes — it is not one, and pinning a byte digest to catch regressions is
+  the wrong instrument (ADR 0004/0012). `reproducible=True` is a narrower promise: two exports
+  of one drawing, on one version, agree. It does not promise the next version draws it the same.
 
 ## Source of truth
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -272,6 +272,35 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   `Drawing.export(out, *, formats=("pdf",)) → {format: path}` is the front door
   (the legacy `svg=`/`dxf=` tuple form + `export_pdf` are back-compat/deprecated
   wrappers). Sits below `make_drawing.py`, above `_core.py`.
+
+  **`reproducible=` — byte-identical exports, opt-in.** On, two exports of one
+  drawing are identical, so a checked-in drawing diffs cleanly and a caller can
+  see when its output really changed. Three things are settled to get there: the
+  clock and GUIDs an exporter stamps (ezdxf's fixed-metadata option — restored
+  after the save, it is process-wide state — plus the creation marker that option
+  misses, and reportlab's `invariant`), ezdxf's CLASSES section (built by
+  iterating a `set[str]`, so it is pre-seeded sorted), and the order the kernel
+  hands parts over, which is not stable between runs and does **not** reduce to
+  `PYTHONHASHSEED`.
+
+  The two formats reach that by different routes, and the asymmetry is deliberate.
+  A DXF must be ordered *going in* — `ExportDXF` writes an entity per element as it
+  converts and the handles follow — so `_elements(ordered=True)` sorts the
+  decomposition by geometry, keyed on where a part sits **and which way it runs**
+  (hidden-line removal emits reversed duplicate pairs that agree on everything
+  else). An SVG is settled *coming out*, by `canonicalize_svg` sorting each
+  all-leaf layer group in the written file, so it is handed its shapes unordered
+  even when the flag is on.
+
+  **Off by default, because ordering is not free**: about a third of DXF export
+  time again (interleaved, 9 runs, 358-part sheet: 0.45 s → 0.60 s), one
+  `bounding_box()` and one `edges()` per part. Off costs what it did before the
+  option existed (0.45 s vs 0.49 s on `main`); the metadata pinning is the cheap
+  half at ~1 ms. Both hang off the one flag, since a caller wanting a stable file
+  wants both and should not have to know which one costs. Reachable as
+  `build_drawing(..., reproducible=True)` (the default a returned `Drawing` then
+  carries) and per call as `Drawing.export(..., reproducible=True)`. Weigh any
+  change here against #602, which removed a `zoom.extents` walk from the same path.
 - **`repair.py`** — the deterministic lint→repair loop (#30 / ADR 0002): the
   re-place helpers (`_find_dim`/`_replace_dim`/`_repair_*`/`repair_drawing`) take
   the drawing duck-typed as `dwg`; `Drawing.repair()` stays a thin wrapper.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -286,10 +286,11 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   The two formats reach that by different routes, and the asymmetry is deliberate.
   A DXF must be ordered *going in* — `ExportDXF` writes an entity per element as it
   converts and the handles follow — so `_elements(ordered=True)` sorts the
-  decomposition by geometry, keyed on where a part sits **and which way it runs**
+  emitted boundary entities by geometry, keyed on where an edge sits **and which way it runs**
   (hidden-line removal emits reversed duplicate pairs that agree on everything
-  else); cheap-key ties use exact B-rep bytes so distinct faces cannot inherit
-  kernel arrival order. An SVG is settled *coming out*, by `canonicalize_svg` sorting each
+  else); faces are flattened before sorting so their cyclic wire start cannot
+  leak into entity order, and cheap-key ties use exact B-rep bytes. An SVG is
+  settled *coming out*, by `canonicalize_svg` sorting each
   all-leaf layer group in the written file, so it is handed its shapes unordered
   even when the flag is on.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -276,9 +276,9 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   **`reproducible=` — byte-identical exports, opt-in.** On, two exports of one
   drawing are identical, so a checked-in drawing diffs cleanly and a caller can
   see when its output really changed. Three things are settled to get there: the
-  clock and GUIDs an exporter stamps (ezdxf's fixed-metadata option — restored
-  after the save, it is process-wide state — plus the creation marker that option
-  misses, and reportlab's `invariant`), ezdxf's CLASSES section (built by
+  clock and GUIDs an exporter stamps (a per-document fixed metadata updater,
+  avoiding ezdxf's concurrency-unsafe process-global testing option, plus
+  reportlab's `invariant`), ezdxf's CLASSES section (built by
   iterating a `set[str]`, so it is pre-seeded sorted), and the order the kernel
   hands parts over, which is not stable between runs and does **not** reduce to
   `PYTHONHASHSEED`.
@@ -288,7 +288,8 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   converts and the handles follow — so `_elements(ordered=True)` sorts the
   decomposition by geometry, keyed on where a part sits **and which way it runs**
   (hidden-line removal emits reversed duplicate pairs that agree on everything
-  else). An SVG is settled *coming out*, by `canonicalize_svg` sorting each
+  else); cheap-key ties use exact B-rep bytes so distinct faces cannot inherit
+  kernel arrival order. An SVG is settled *coming out*, by `canonicalize_svg` sorting each
   all-leaf layer group in the written file, so it is handed its shapes unordered
   even when the flag is on.
 

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -1743,8 +1743,8 @@ def build_drawing(
     frame: bool = False,
     projection: str | None = None,
     zones: bool = False,
-    reproducible: bool = False,
     scale_policy: Literal["strict", "fallback", "permissive"] = "fallback",
+    reproducible: bool = False,
     _post_build: Callable[[Drawing], Drawing] | None = None,
     _required_tables=(),
     _views: tuple[str, ...] | None = None,
@@ -2631,8 +2631,8 @@ def make_drawing(
     frame: bool = False,
     projection: str | None = None,
     zones: bool = False,
-    reproducible: bool = False,
     scale_policy: Literal["strict", "fallback", "permissive"] = "fallback",
+    reproducible: bool = False,
 ) -> tuple[str, str]:
     """Generate a 4-view technical drawing from a STEP file or build123d object.
 
@@ -2658,6 +2658,9 @@ def make_drawing(
             block only.
         detail_view: automatically add an enlarged view for crowded prismatic step
             dimensions. Default ``True``; pass ``False`` to disable that recovery.
+        reproducible: make repeated exports from the returned drawing byte-identical
+            on the same Draftwright version. Off by default because canonical DXF
+            ordering has a measurable export-time cost.
 
     Returns:
         Tuple of ``(svg_path, dxf_path)`` for the generated files.

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -471,6 +471,7 @@ def _assemble(
     trace=None,
     shape=None,
     critique_recognition=None,
+    reproducible=False,
 ) -> Drawing:
     """Project the 4 views for analysis *a*, run the automatic annotation
     passes, and fit the iso.  This is pass 1 of :func:`build_drawing`; with a
@@ -493,6 +494,7 @@ def _assemble(
         part=a.part,
         cyls=a.cyls,
         assembly=assembly,
+        reproducible=reproducible,
     )
     # Detect the IR here — before the auto_dims gate — so dwg.model() and feature edits
     # work even in manual mode (#398). _auto_annotate reads this attached model rather
@@ -814,6 +816,7 @@ def _repack(
     authored=None,
     trace=None,
     critique_recognition=None,
+    reproducible=False,
 ):
     """Measure the laid-out drawing's *real* per-view annotation footprints and,
     when a view collides across views, pack the blocks disjoint — escalating the
@@ -984,6 +987,7 @@ def _repack(
         authored=authored,
         trace=trace,
         critique_recognition=critique_recognition,
+        reproducible=reproducible,
     )
     return a2, dwg2
 
@@ -1002,6 +1006,7 @@ def _repack_to_fixed_point(
     authored=None,
     trace=None,
     critique_recognition=None,
+    reproducible=False,
 ):
     """Iterate measure→repack→assemble until stable or bounded (#302)."""
     cur_a, cur_dwg = a, dwg
@@ -1020,6 +1025,7 @@ def _repack_to_fixed_point(
             authored=authored,
             trace=trace,
             critique_recognition=critique_recognition,
+            reproducible=reproducible,
         )
         if repacked is None:
             if _needs_repack(cur_dwg, cur_a):
@@ -1085,6 +1091,7 @@ def _build_drawing_once(
     frame: bool = False,
     projection: str | None = None,
     zones: bool = False,
+    reproducible: bool = False,
     _analysis_base=None,
     _analysis_sink: Callable[[Analysis], None] | None = None,
     _critique_recognition=None,
@@ -1127,6 +1134,13 @@ def _build_drawing_once(
             assembly, whose per-part bores are reported at ``info`` rather than
             ``warning`` (a GA omits them by design). Force with ``True``/``False``
             (#69).
+        reproducible: write files that do not carry the run that produced them, so
+            two exports of one drawing are byte-identical and a written drawing can be
+            diffed or checksummed to see whether its content really changed. Sets the
+            default for :meth:`Drawing.export`'s own ``reproducible=``. ``False``
+            because it is not free: settling the element order costs roughly a third
+            of DXF export time again (one bounding box and one edge walk per part),
+            while the metadata pinning it also turns on is ~1 ms.
         model: a caller-supplied IR (ADR 0011) — a :class:`PartModel`, or a sequence
             of :class:`Feature`\\ s (declared with :func:`draftwright.model.hole`,
             ``boss``, ``step``, … from the objects you built). When given, **feature
@@ -1327,6 +1341,7 @@ def _build_drawing_once(
         authored=authored,
         trace=tracer,
         critique_recognition=_critique_recognition,
+        reproducible=reproducible,
     )
     if auto_dims:
         repacked = _repack_to_fixed_point(
@@ -1343,6 +1358,7 @@ def _build_drawing_once(
             authored=authored,
             trace=tracer,
             critique_recognition=_critique_recognition,
+            reproducible=reproducible,
         )
         if repacked is not None:
             a, dwg = repacked
@@ -1727,6 +1743,7 @@ def build_drawing(
     frame: bool = False,
     projection: str | None = None,
     zones: bool = False,
+    reproducible: bool = False,
     scale_policy: Literal["strict", "fallback", "permissive"] = "fallback",
     _post_build: Callable[[Drawing], Drawing] | None = None,
     _required_tables=(),
@@ -1775,6 +1792,7 @@ def build_drawing(
         frame=frame,
         projection=projection,
         zones=zones,
+        reproducible=reproducible,
         _required_tables=_required_tables,
         _include_iso=_include_iso,
         _view_constraints=_view_constraints,
@@ -2613,6 +2631,7 @@ def make_drawing(
     frame: bool = False,
     projection: str | None = None,
     zones: bool = False,
+    reproducible: bool = False,
     scale_policy: Literal["strict", "fallback", "permissive"] = "fallback",
 ) -> tuple[str, str]:
     """Generate a 4-view technical drawing from a STEP file or build123d object.
@@ -2674,6 +2693,7 @@ def make_drawing(
         frame=frame,
         projection=projection,
         zones=zones,
+        reproducible=reproducible,
         scale_policy=scale_policy,
     ).export(formats=("svg", "dxf"))
     assert isinstance(_paths, dict)  # formats=... always returns the {format: path} dict

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -484,38 +484,6 @@ class ViewNotPlanned(KeyError):
         return self.args[0] if self.args else ""
 
 
-def _geometry_key(shape):
-    """Where a part sits, to the precision an exporter writes - a sort key."""
-    box = shape.bounding_box()
-    return (
-        round(box.min.X, 9),
-        round(box.min.Y, 9),
-        round(box.min.Z, 9),
-        round(box.max.X, 9),
-        round(box.max.Y, 9),
-        round(box.max.Z, 9),
-        len(shape.edges()),
-    )
-
-
-def _canonical_parts(shape):
-    """*shape* as the parts an exporter would find in it, ordered by geometry.
-
-    Faces first and then the edges that belong to none of them, which is the
-    order the exporters walk a shape in anyway; sorting is what makes the walk
-    the same on the next run. A shape that yields nothing to sort is returned
-    as it is, so nothing is lost when this cannot tell what it is looking at.
-    """
-    try:
-        faces = sorted(shape.faces(), key=_geometry_key)
-        in_faces = {edge for face in faces for edge in face.edges()}
-        loose = sorted((e for e in shape.edges() if e not in in_faces), key=_geometry_key)
-    except Exception:
-        return shape
-    parts = faces + loose
-    return parts if parts else shape
-
-
 class Drawing:
     """A composable technical drawing — the editable form of :func:`make_drawing`.
 
@@ -552,6 +520,10 @@ class Drawing:
         assembly: feature-coverage severity control — ``None`` auto-detects a
             multi-solid part as an assembly (per-part bores at ``info``),
             ``True``/``False`` forces it (#69).
+        reproducible: default for :meth:`export`'s ``reproducible=`` — when true, two
+            exports of this drawing are byte-identical. ``False`` by default because
+            it costs roughly a third of DXF export time again (see
+            :func:`draftwright.export._elements`).
 
     The constructor also accepts ``cyls``, a precomputed
     ``analyse_cylinders(part)`` result (cached privately; computed lazily on
@@ -573,6 +545,7 @@ class Drawing:
         part=None,
         cyls=None,
         assembly=None,
+        reproducible=False,
     ):
         self.scale = scale
         # Public, JSON-friendly record of how the requested drawing scale was resolved
@@ -625,6 +598,12 @@ class Drawing:
         # None → the coverage lint auto-detects a multi-solid part as an
         # assembly; True/False forces assembly/strict severity (#69).
         self.assembly = assembly
+        # Default for `export(reproducible=…)`: settle element order and the
+        # metadata the exporters take from the clock, so two runs write the same
+        # bytes. Off by default because the ordering costs about a third of DXF
+        # export time again; a caller who wants to diff or checksum its output
+        # turns it on, here or per export call.
+        self.reproducible = reproducible
         self.page_w = page_w
         self.page_h = page_h
         self.tb_w = tb_w
@@ -3670,9 +3649,12 @@ class Drawing:
         else:
             _log.info("Lint: OK")
 
-    def _write_svg(self, out: str) -> str:
+    def _write_svg(self, out: str, *, reproducible: bool = False) -> str:
         """Write the SVG (part/hidden/dims layers, page-size fix, arc sanitise, hyperlink +
-        metadata) and return its path. The PDF and PNG renders both read this SVG."""
+        metadata) and return its path. The PDF and PNG renders both read this SVG.
+
+        *reproducible* settles the element order so two runs write the same bytes;
+        see :func:`export.canonicalize_svg`. Off, this is what it always was."""
         blk = Color(0, 0, 0)
         grey = Color(0.5, 0.5, 0.5)
         blue = Color(0, 0.2, 0.7)
@@ -3683,9 +3665,10 @@ class Drawing:
         self._add_shapes(svg_exp)
         svg_path = out + ".svg"
         svg_exp.write(svg_path)
-        # Before the passes below read it back: they rewrite what is there,
-        # this settles what order it is in. See canonicalize_svg().
-        canonicalize_svg(svg_path)
+        if reproducible:
+            # Before the passes below read it back: they rewrite what is there,
+            # this settles what order it is in. See canonicalize_svg().
+            canonicalize_svg(svg_path)
         fix_svg_page_size(svg_path, self.page_w, self.page_h)
         n_arcs = sanitize_svg_arcs(svg_path)
         if n_arcs:
@@ -3697,17 +3680,21 @@ class Drawing:
         _log.info("SVG → %s", svg_path)
         return svg_path
 
-    def _write_dxf(self, out: str) -> str:
-        """Write the DXF (part/hidden/dims layers + metadata) and return its path."""
+    def _write_dxf(self, out: str, *, reproducible: bool = False) -> str:
+        """Write the DXF (part/hidden/dims layers + metadata) and return its path.
+
+        *reproducible* orders the entities and pins the metadata ezdxf stamps from
+        the clock, so two runs write the same bytes. It costs about a third of the
+        export time again — see :func:`export._elements`."""
         dxf_exp = _DraftwrightDXF()
         dxf_exp.add_layer("part", line_weight=0.5)
         dxf_exp.add_layer("hidden", line_weight=0.25)
         dxf_exp.add_layer("dims", line_weight=0.05)
-        self._add_shapes(dxf_exp)
+        self._add_shapes(dxf_exp, ordered=reproducible)
         set_dxf_metadata(dxf_exp)
         dxf_path = out + ".dxf"
         # #602: skip ExportDXF.write's O(entities) zoom.extents pass — the page window is known.
-        write_dxf(dxf_exp, dxf_path, self.page_w, self.page_h)
+        write_dxf(dxf_exp, dxf_path, self.page_w, self.page_h, reproducible=reproducible)
         _log.info("DXF → %s", dxf_path)
         return dxf_path
 
@@ -4296,7 +4283,14 @@ class Drawing:
         return tuple(run for _top, _left, _ordinal, runs in sorted(groups) for run in runs)
 
     def export(
-        self, out=None, *, formats=None, svg=None, dxf=None, dpi: int = 150
+        self,
+        out=None,
+        *,
+        formats=None,
+        svg=None,
+        dxf=None,
+        dpi: int = 150,
+        reproducible: bool | None = None,
     ) -> dict[str, str] | tuple[str | None, str | None]:
         """Lint, then write the requested output *formats*; return ``{format: path}``.
 
@@ -4318,8 +4312,20 @@ class Drawing:
         the planned 0.5.0 removal a silent break — and invisible to
         ``tests/test_deprecation_dates.py``, which can only scan things that warn. A
         deprecation nobody is warned about is documentation, not a deprecation.
+
+        *reproducible* makes two exports of one drawing byte-identical — the element
+        order is settled and the metadata the exporters take from the clock is pinned,
+        so a written drawing can be diffed or checksummed to see whether its content
+        actually changed. ``None`` (the default) uses :attr:`reproducible`, which
+        :func:`~draftwright.build_drawing` sets and which is ``False`` unless asked
+        for: ordering costs roughly a third of DXF export time again (see
+        :func:`draftwright.export._elements`), so it is opted into rather than paid
+        by every caller. Passing the keyword here overrides the drawing's default for
+        this call only.
         """
         self.finalize()  # #426: drain any recorded intents before export (no-op if none)
+        # An explicit keyword wins; otherwise the drawing's own default (build_drawing's).
+        reproducible = self.reproducible if reproducible is None else reproducible
         out = out if out is not None else self.out
         for _ext in self._EXPORT_FORMATS:
             if out.endswith("." + _ext):
@@ -4398,8 +4404,12 @@ class Drawing:
                     DeprecationWarning,
                     stacklevel=2,
                 )
-            svg_path = self._write_svg(out) if (svg is None or svg) else None
-            dxf_path = self._write_dxf(out) if (dxf is None or dxf) else None
+            svg_path = (
+                self._write_svg(out, reproducible=reproducible) if (svg is None or svg) else None
+            )
+            dxf_path = (
+                self._write_dxf(out, reproducible=reproducible) if (dxf is None or dxf) else None
+            )
             self.svg_path, self.dxf_path = svg_path, dxf_path
             return svg_path, dxf_path
 
@@ -4424,14 +4434,17 @@ class Drawing:
 
             svg_path = None
             if want_set & {"svg", "pdf", "png"}:
-                svg_path = self._write_svg(out if "svg" in want_set else _intermediate_stem())
+                svg_path = self._write_svg(
+                    out if "svg" in want_set else _intermediate_stem(),
+                    reproducible=reproducible,
+                )
             self.svg_path = svg_path if "svg" in want_set else None
             if "svg" in want_set:
                 paths["svg"] = svg_path  # type: ignore[assignment]
 
             self.dxf_path = None
             if "dxf" in want_set:
-                self.dxf_path = paths["dxf"] = self._write_dxf(out)
+                self.dxf_path = paths["dxf"] = self._write_dxf(out, reproducible=reproducible)
 
             pdf_path = None
             if want_set & {"pdf", "png"}:
@@ -4442,6 +4455,7 @@ class Drawing:
                     pdf_path,
                     getattr(self.get_annotation("title_block"), "draftwright_link_rect", None),
                     self._pdf_text_runs(),
+                    reproducible=reproducible,
                 )
                 _log.info("PDF → %s", pdf_path)
                 if "pdf" in want_set:
@@ -4467,22 +4481,18 @@ class Drawing:
         assert isinstance(paths, dict)  # formats=... always returns the {format: path} dict
         return paths["pdf"]
 
-    def _add_shapes(self, exporter):
+    def _add_shapes(self, exporter, *, ordered: bool = False):
         """Add every view layer and annotation to *exporter* with error context.
 
-        Each shape is handed over as its parts in a canonical order rather than
-        whole, so that an export writes the same bytes twice. An exporter walks a
-        shape with ``.faces()``/``.edges()``, and build123d returns those in an
-        order that follows the interpreter's hash seed - two faces of one glyph
-        change places between runs - which reaches the file as reordered SVG
-        elements and, in a DXF, as reordered entities with reshuffled handles.
-        Ordering by geometry costs one bounding box per part and settles both.
-        """
+        *ordered* hands each shape's parts over in a geometric order rather than
+        the kernel's, which is what makes a DXF's entities (and their handles)
+        come out the same on the next run. It is the costly half of
+        ``reproducible=``; see :func:`export._elements`."""
         for name, (vis, hid) in self.views.items():
-            _export_shape(exporter, _canonical_parts(vis), "part", f"view {name!r}")
+            _export_shape(exporter, vis, "part", f"view {name!r}", ordered=ordered)
             if hid:
-                _export_shape(exporter, _canonical_parts(hid), "hidden", f"view {name!r}")
+                _export_shape(exporter, hid, "hidden", f"view {name!r}", ordered=ordered)
         names = {id(annotation): name for name, annotation in self.iter_annotations()}
         for ann in self.items:
             identity = names.get(id(ann)) or getattr(ann, "label", "") or type(ann).__name__
-            _export_shape(exporter, _canonical_parts(ann), "dims", f"annotation {identity!r}")
+            _export_shape(exporter, ann, "dims", f"annotation {identity!r}", ordered=ordered)

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -75,6 +75,7 @@ from draftwright.export import (
     _render_png,
     add_svg_hyperlink,
     add_svg_metadata,
+    canonicalize_svg,
     fix_svg_page_size,
     sanitize_svg_arcs,
     set_dxf_metadata,
@@ -481,6 +482,34 @@ class ViewNotPlanned(KeyError):
 
     def __str__(self) -> str:
         return self.args[0] if self.args else ""
+
+
+def _geometry_key(shape):
+    """Where a part sits, to the precision an exporter writes - a sort key."""
+    box = shape.bounding_box()
+    return (
+        round(box.min.X, 9), round(box.min.Y, 9), round(box.min.Z, 9),
+        round(box.max.X, 9), round(box.max.Y, 9), round(box.max.Z, 9),
+        len(shape.edges()),
+    )
+
+
+def _canonical_parts(shape):
+    """*shape* as the parts an exporter would find in it, ordered by geometry.
+
+    Faces first and then the edges that belong to none of them, which is the
+    order the exporters walk a shape in anyway; sorting is what makes the walk
+    the same on the next run. A shape that yields nothing to sort is returned
+    as it is, so nothing is lost when this cannot tell what it is looking at.
+    """
+    try:
+        faces = sorted(shape.faces(), key=_geometry_key)
+        in_faces = {edge for face in faces for edge in face.edges()}
+        loose = sorted((e for e in shape.edges() if e not in in_faces), key=_geometry_key)
+    except Exception:
+        return shape
+    parts = faces + loose
+    return parts if parts else shape
 
 
 class Drawing:
@@ -3650,6 +3679,9 @@ class Drawing:
         self._add_shapes(svg_exp)
         svg_path = out + ".svg"
         svg_exp.write(svg_path)
+        # Before the passes below read it back: they rewrite what is there,
+        # this settles what order it is in. See canonicalize_svg().
+        canonicalize_svg(svg_path)
         fix_svg_page_size(svg_path, self.page_w, self.page_h)
         n_arcs = sanitize_svg_arcs(svg_path)
         if n_arcs:
@@ -4432,12 +4464,21 @@ class Drawing:
         return paths["pdf"]
 
     def _add_shapes(self, exporter):
-        """Add every view layer and annotation to *exporter* with error context."""
+        """Add every view layer and annotation to *exporter* with error context.
+
+        Each shape is handed over as its parts in a canonical order rather than
+        whole, so that an export writes the same bytes twice. An exporter walks a
+        shape with ``.faces()``/``.edges()``, and build123d returns those in an
+        order that follows the interpreter's hash seed - two faces of one glyph
+        change places between runs - which reaches the file as reordered SVG
+        elements and, in a DXF, as reordered entities with reshuffled handles.
+        Ordering by geometry costs one bounding box per part and settles both.
+        """
         for name, (vis, hid) in self.views.items():
-            _export_shape(exporter, vis, "part", f"view {name!r}")
+            _export_shape(exporter, _canonical_parts(vis), "part", f"view {name!r}")
             if hid:
-                _export_shape(exporter, hid, "hidden", f"view {name!r}")
+                _export_shape(exporter, _canonical_parts(hid), "hidden", f"view {name!r}")
         names = {id(annotation): name for name, annotation in self.iter_annotations()}
         for ann in self.items:
             identity = names.get(id(ann)) or getattr(ann, "label", "") or type(ann).__name__
-            _export_shape(exporter, ann, "dims", f"annotation {identity!r}")
+            _export_shape(exporter, _canonical_parts(ann), "dims", f"annotation {identity!r}")

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -488,8 +488,12 @@ def _geometry_key(shape):
     """Where a part sits, to the precision an exporter writes - a sort key."""
     box = shape.bounding_box()
     return (
-        round(box.min.X, 9), round(box.min.Y, 9), round(box.min.Z, 9),
-        round(box.max.X, 9), round(box.max.Y, 9), round(box.max.Z, 9),
+        round(box.min.X, 9),
+        round(box.min.Y, 9),
+        round(box.min.Z, 9),
+        round(box.max.X, 9),
+        round(box.max.Y, 9),
+        round(box.max.Z, 9),
         len(shape.edges()),
     )
 

--- a/src/draftwright/export.py
+++ b/src/draftwright/export.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 import math
 import re
+import xml.etree.ElementTree as ET
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -104,6 +105,41 @@ def _semantic_font_name(font_path: str) -> str:
     digest = sha256(path.read_bytes()).hexdigest()[:12]
     stem = re.sub(r"[^A-Za-z0-9]+", "_", path.stem)
     return f"Draftwright_{stem}_{digest}"
+
+
+_SVG_NS = "{http://www.w3.org/2000/svg}"
+
+
+def canonicalize_svg(svg_path: str) -> None:
+    """Emit the elements of each layer in an order that does not depend on the run.
+
+    ExportSVG writes one element per face, in the order build123d hands them
+    over - and that order follows the interpreter's hash seed, which is
+    randomized per process. Two faces of one glyph (the stem and the tittle of
+    an 'i') change places between runs, so two exports of one drawing differ in
+    bytes while being the same picture. That is enough to make a drawing useless
+    as something to check in and diff, which is how a caller notices that its
+    output has changed.
+
+    Sorting each layer's children by their serialized form settles it. The
+    layers keep their order, so what paints over what is unchanged; within a
+    layer these are disjoint outlines with one style, where order is not
+    something the drawing means. Only groups whose children are all leaves are
+    touched, so a nested group is never flattened or reordered.
+    """
+    # Round-tripping through ElementTree drops the default namespace unless it
+    # is registered, and an SVG without its xmlns is one nothing downstream can
+    # read - svglib included, which is how the PDF is rendered.
+    ET.register_namespace("", _SVG_NS.strip("{}"))
+    ET.register_namespace("xlink", "http://www.w3.org/1999/xlink")
+    tree = ET.parse(svg_path)
+    for group in tree.getroot().iter(_SVG_NS + "g"):
+        children = list(group)
+        if len(children) < 2 or any(len(child) for child in children):
+            continue
+        children.sort(key=lambda e: ET.tostring(e, encoding="unicode"))
+        group[:] = children
+    tree.write(svg_path, encoding="utf-8", xml_declaration=True)
 
 
 def fix_svg_page_size(svg_path: str, page_w: float, page_h: float) -> None:
@@ -207,7 +243,7 @@ def set_dxf_metadata(dxf) -> None:
         pass
 
 
-def write_dxf(dxf, path: str, page_w: float, page_h: float) -> None:
+def write_dxf(dxf, path: str, page_w: float, page_h: float, reproducible: bool = True) -> None:
     """Write *dxf* with the viewport zoomed to the known page window.
 
     ``ExportDXF.write`` resets the viewport via ``ezdxf.zoom.extents`` — a
@@ -231,7 +267,35 @@ def write_dxf(dxf, path: str, page_w: float, page_h: float) -> None:
     except Exception:
         dxf.write(path)
         return
+    if reproducible:
+        _make_dxf_reproducible(doc)
     doc.saveas(path, fmt="asc")
+
+
+def _make_dxf_reproducible(doc) -> None:
+    """Take the clock and the hash seed out of what ezdxf is about to write.
+
+    Every save stamps the time it happened ($TDCREATE/$TDUPDATE and their UTC
+    twins), a freshly generated $VERSIONGUID/$FINGERPRINTGUID pair, and a marker
+    string carrying another timestamp. ezdxf writes fixed values for all of them
+    behind one option - a fixed date, the all-zero GUID a new document starts
+    with, and a constant marker.
+
+    The CLASSES section is the other half. ezdxf registers a class entry for
+    every DXF type the document uses and finds them by iterating a set of type
+    names, whose order over strings follows the interpreter's hash seed. A
+    caller cannot pin that seed from the environment in every host (a sandbox
+    running under '-I' makes Python ignore PYTHONHASHSEED), so the names are
+    registered here first, sorted: 'add_class()' keeps the first entry for a key,
+    and ezdxf's own pass during the save then adds only what is left.
+    """
+    try:
+        ezdxf.options.write_fixed_meta_data_for_testing = True
+        for dxftype in sorted(doc.entitydb.dxf_types_in_use()):
+            doc.classes.add_class(dxftype)
+    except Exception:
+        # Reproducibility is not worth failing an export over.
+        _log.debug("could not pin the DXF metadata", exc_info=True)
 
 
 class _DraftwrightDXF(ExportDXF):
@@ -316,7 +380,13 @@ def sanitize_svg_arcs(svg_path: str) -> int:
     return n
 
 
-def _render_pdf(svg_path: str, pdf_path: str, link_rect=None, text_runs=()) -> None:
+def _render_pdf(
+    svg_path: str,
+    pdf_path: str,
+    link_rect=None,
+    text_runs=(),
+    reproducible: bool = True,
+) -> None:
     """Render *svg_path* to *pdf_path* via svglib + reportlab, adding draftwright
     metadata and — when *link_rect* (drawing page coords, Y up) is given — a
     clickable PDF link annotation over that rectangle. *text_runs* overlays
@@ -340,7 +410,13 @@ def _render_pdf(svg_path: str, pdf_path: str, link_rect=None, text_runs=()) -> N
     try:
         from reportlab.graphics import renderPDF
 
-        canvas = Canvas(pdf_path, pagesize=(drawing.width, drawing.height))
+        # 'invariant' is reportlab's own switch for a file that does not
+        # carry the moment it was produced: a fixed /CreationDate and a derived
+        # /ID rather than the clock's. Without it two renders of one drawing
+        # differ in bytes.
+        canvas = Canvas(
+            pdf_path, pagesize=(drawing.width, drawing.height), invariant=reproducible
+        )
         canvas.setCreator(_GENERATED_BY)
         canvas.setTitle(_GENERATED_BY)
         renderPDF.draw(drawing, canvas, 0, 0)

--- a/src/draftwright/export.py
+++ b/src/draftwright/export.py
@@ -11,6 +11,7 @@ shapes), so it sits below `make_drawing` in the import DAG and depends only on
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import math
 import re
@@ -21,6 +22,7 @@ from pathlib import Path
 
 import ezdxf
 from build123d import ExportDXF, ExportSVG
+from ezdxf.document import CONST_MARKER_STRING, CREATED_BY_EZDXF
 from OCP.GeomConvert import GeomConvert
 
 from draftwright._core import _DRAFTWRIGHT_URL
@@ -114,18 +116,21 @@ def canonicalize_svg(svg_path: str) -> None:
     """Emit the elements of each layer in an order that does not depend on the run.
 
     ExportSVG writes one element per face, in the order build123d hands them
-    over - and that order follows the interpreter's hash seed, which is
-    randomized per process. Two faces of one glyph (the stem and the dot over
-    an 'i') change places between runs, so two exports of one drawing differ in
-    bytes while being the same picture. That is enough to make a drawing useless
-    as something to check in and diff, which is how a caller notices that its
-    output has changed.
+    over - and that order is not stable between runs. Two faces of one glyph
+    (the stem and the dot over an 'i') change places, so two exports of one
+    drawing differ in bytes while being the same picture. That is enough to make
+    a drawing useless as something to check in and diff, which is how a caller
+    notices that its output has changed.
 
-    Sorting each layer's children by their serialized form settles it. The
-    layers keep their order, so what paints over what is unchanged; within a
-    layer these are disjoint outlines with one style, where order is not
-    something the drawing means. Only groups whose children are all leaves are
-    touched, so a nested group is never flattened or reordered.
+    It is not simply PYTHONHASHSEED: holding the seed fixed does not hold the
+    order, so a caller cannot pin this from the environment and the file has to
+    be settled here.
+
+    Sorting each layer's children by what they *are* settles it. The layers keep
+    their order, so what paints over what is unchanged; within a layer these are
+    disjoint outlines with one style, where order is not something the drawing
+    means. Only groups whose children are all leaves are touched, so a nested
+    group is never flattened or reordered.
     """
     # Round-tripping through ElementTree drops the default namespace unless it
     # is registered, and an SVG without its xmlns is one nothing downstream can
@@ -137,9 +142,30 @@ def canonicalize_svg(svg_path: str) -> None:
         children = list(group)
         if len(children) < 2 or any(len(child) for child in children):
             continue
-        children.sort(key=lambda e: ET.tostring(e, encoding="unicode"))
+        # `tail` is the whitespace ExportSVG writes *after* an element, so it
+        # belongs to the slot rather than to the element: the last child of a
+        # group carries a shorter indent than its siblings. Leave the tails
+        # where they are and move only the elements through them, or the last
+        # slot's indent rides along with whichever element happened to land
+        # there and two runs that agree on the order still differ in bytes.
+        tails = [child.tail for child in children]
+        children.sort(key=_leaf_key)
+        for child, tail in zip(children, tails):
+            child.tail = tail
         group[:] = children
     tree.write(svg_path, encoding="utf-8", xml_declaration=True)
+
+
+def _leaf_key(element):
+    """A run-independent total order over leaf elements: what the element is.
+
+    ``tail`` is deliberately absent - the caller keeps tails with slots rather
+    than with elements, which is what actually settles the bytes - so this is
+    the element's identity alone, and cheaper than serializing each one to
+    compare it. Elements that tie here are byte-identical, so their relative
+    order cannot reach the file either way.
+    """
+    return (element.tag, tuple(sorted(element.attrib.items())), element.text or "")
 
 
 def fix_svg_page_size(svg_path: str, page_w: float, page_h: float) -> None:
@@ -243,7 +269,7 @@ def set_dxf_metadata(dxf) -> None:
         pass
 
 
-def write_dxf(dxf, path: str, page_w: float, page_h: float, reproducible: bool = True) -> None:
+def write_dxf(dxf, path: str, page_w: float, page_h: float, reproducible: bool = False) -> None:
     """Write *dxf* with the viewport zoomed to the known page window.
 
     ``ExportDXF.write`` resets the viewport via ``ezdxf.zoom.extents`` — a
@@ -268,20 +294,32 @@ def write_dxf(dxf, path: str, page_w: float, page_h: float, reproducible: bool =
         dxf.write(path)
         return
     if reproducible:
-        _make_dxf_reproducible(doc)
-    doc.saveas(path, fmt="asc")
+        with _reproducible_dxf(doc):
+            doc.saveas(path, fmt="asc")
+    else:
+        doc.saveas(path, fmt="asc")
 
 
-def _make_dxf_reproducible(doc) -> None:
+@contextlib.contextmanager
+def _reproducible_dxf(doc):
     """Take the clock and the hash seed out of what ezdxf is about to write.
 
     Every save stamps the time it happened ($TDCREATE/$TDUPDATE and their UTC
-    twins), a freshly generated $VERSIONGUID/$FINGERPRINTGUID pair, and a marker
-    string carrying another timestamp. ezdxf writes fixed values for all of them
-    behind one option - a fixed date, the all-zero GUID a new document starts
-    with, and a constant marker.
+    twins), a freshly generated $VERSIONGUID/$FINGERPRINTGUID pair, and a
+    "written by" marker carrying another timestamp. ezdxf writes fixed values
+    for those behind one option - a fixed date, the all-zero GUID a new document
+    starts with, and a constant marker.
 
-    The CLASSES section is the other half. ezdxf registers a class entry for
+    That option is process-wide state belonging to whoever set it, so it is put
+    back afterwards: a draftwright export must not decide what some other ezdxf
+    user in the same interpreter writes.
+
+    It also does not reach the *creation* marker, which is stamped when the
+    document is built - inside ``_DraftwrightDXF()``, long before an export asks
+    for anything - so that one is overwritten here with the same constant ezdxf
+    would have used.
+
+    The CLASSES section is the last part. ezdxf registers a class entry for
     every DXF type the document uses and finds them by iterating a set of type
     names, whose order over strings follows the interpreter's hash seed. A
     caller cannot pin that seed from the environment in every host (a sandbox
@@ -289,13 +327,19 @@ def _make_dxf_reproducible(doc) -> None:
     registered here first, sorted: 'add_class()' keeps the first entry for a key,
     and ezdxf's own pass during the save then adds only what is left.
     """
+    previous = ezdxf.options.write_fixed_meta_data_for_testing
+    ezdxf.options.write_fixed_meta_data_for_testing = True
     try:
-        ezdxf.options.write_fixed_meta_data_for_testing = True
-        for dxftype in sorted(doc.entitydb.dxf_types_in_use()):
-            doc.classes.add_class(dxftype)
-    except Exception:
-        # Reproducibility is not worth failing an export over.
-        _log.debug("could not pin the DXF metadata", exc_info=True)
+        try:
+            doc.ezdxf_metadata()[CREATED_BY_EZDXF] = CONST_MARKER_STRING
+            for dxftype in sorted(doc.entitydb.dxf_types_in_use()):
+                doc.classes.add_class(dxftype)
+        except Exception:
+            # Reproducibility is not worth failing an export over.
+            _log.debug("could not pin the DXF metadata", exc_info=True)
+        yield
+    finally:
+        ezdxf.options.write_fixed_meta_data_for_testing = previous
 
 
 class _DraftwrightDXF(ExportDXF):
@@ -385,7 +429,7 @@ def _render_pdf(
     pdf_path: str,
     link_rect=None,
     text_runs=(),
-    reproducible: bool = True,
+    reproducible: bool = False,
 ) -> None:
     """Render *svg_path* to *pdf_path* via svglib + reportlab, adding draftwright
     metadata and — when *link_rect* (drawing page coords, Y up) is given — a
@@ -542,16 +586,71 @@ def _render_png(pdf_path: str, png_path: str, *, dpi: int = 150) -> None:
         pdf.close()
 
 
-def _elements(shape):
-    """Decompose *shape* for export retry: faces plus any loose edges."""
+def _geometry_key(part):
+    """Where a part sits and which way it runs - a sort key, to the precision an
+    exporter writes.
+
+    The box alone does not separate parts: hidden-line removal emits the same
+    segment twice where two silhouettes project onto each other, once each way
+    round, and the pair shares a box, a length and a vertex set. Only the
+    *directed* ends tell them apart - and the direction is itself what the
+    exporter writes out, so leaving them tied would let two runs swap a pair and
+    change the file. Parts with no direction to ask for (faces) fall back to the
+    box and their edge count; faces and loose edges are sorted in separate
+    blocks, so the two never compare against each other.
+    """
+    box = part.bounding_box()
+    key = (
+        round(box.min.X, 9),
+        round(box.min.Y, 9),
+        round(box.min.Z, 9),
+        round(box.max.X, 9),
+        round(box.max.Y, 9),
+        round(box.max.Z, 9),
+        str(part.geom_type),
+        len(part.edges()),
+    )
+    try:
+        start, end = part.start_point(), part.end_point()
+    except Exception:
+        return key
+    return key + tuple(round(v, 9) for v in (start.X, start.Y, start.Z, end.X, end.Y, end.Z))
+
+
+def _elements(shape, *, ordered: bool = False):
+    """Decompose *shape* for export retry: faces plus any loose edges.
+
+    With *ordered*, the two blocks come back sorted by where their parts sit
+    rather than in the order the kernel happened to hand them over. That order
+    matters beyond the retry this was written for: ``ExportDXF`` writes one
+    entity per element as it converts, so it is the order a DXF's entities and
+    their handles come out in, and left alone it varies between runs - enough to
+    make a drawing useless as something to check in and diff. (The SVG settles
+    the same question after the fact in :func:`canonicalize_svg`, where the
+    elements are already in the file and cost nothing to reorder.)
+
+    **Ordering is the expensive half of a reproducible export** - one
+    ``bounding_box()`` and one ``edges()`` per part, measured at about a third
+    of DXF export time again on a 358-part sheet (0.40 s -> 0.54 s, interleaved
+    over 9 runs) - so it is opt-in, and off costs exactly what it did before the
+    option existed. The metadata pinning in :func:`write_dxf` is the cheap half
+    (~1 ms); both hang off the one ``reproducible`` flag a caller sets, because
+    a caller asking for a file that does not change between runs wants both and
+    should not have to know which one costs. This sits on the hot path #602
+    cleared: measure, do not predict.
+    """
     faces = list(shape.faces())
     if not faces:
-        return list(shape.edges())
+        edges = list(shape.edges())
+        return sorted(edges, key=_geometry_key) if ordered else edges
     owned = {e for f in faces for e in f.edges()}
-    return faces + [e for e in shape.edges() if e not in owned]
+    loose = [e for e in shape.edges() if e not in owned]
+    if not ordered:
+        return faces + loose
+    return sorted(faces, key=_geometry_key) + sorted(loose, key=_geometry_key)
 
 
-def _export_shape(exporter, shape, layer, ctx):
+def _export_shape(exporter, shape, layer, ctx, *, ordered: bool = False):
     """Add *shape* to *exporter*, degrading element-by-element on failure.
 
     build123d's exporters abort the whole export on the first edge whose
@@ -578,7 +677,7 @@ def _export_shape(exporter, shape, layer, ctx):
                 layer,
                 exc,
             )
-    elements = _elements(shape)
+    elements = _elements(shape, ordered=ordered)
     skipped = 0
     for element in elements:
         try:

--- a/src/draftwright/export.py
+++ b/src/draftwright/export.py
@@ -115,7 +115,7 @@ def canonicalize_svg(svg_path: str) -> None:
 
     ExportSVG writes one element per face, in the order build123d hands them
     over - and that order follows the interpreter's hash seed, which is
-    randomized per process. Two faces of one glyph (the stem and the tittle of
+    randomized per process. Two faces of one glyph (the stem and the dot over
     an 'i') change places between runs, so two exports of one drawing differ in
     bytes while being the same picture. That is enough to make a drawing useless
     as something to check in and diff, which is how a caller notices that its
@@ -414,9 +414,7 @@ def _render_pdf(
         # carry the moment it was produced: a fixed /CreationDate and a derived
         # /ID rather than the clock's. Without it two renders of one drawing
         # differ in bytes.
-        canvas = Canvas(
-            pdf_path, pagesize=(drawing.width, drawing.height), invariant=reproducible
-        )
+        canvas = Canvas(pdf_path, pagesize=(drawing.width, drawing.height), invariant=reproducible)
         canvas.setCreator(_GENERATED_BY)
         canvas.setTitle(_GENERATED_BY)
         renderPDF.draw(drawing, canvas, 0, 0)

--- a/src/draftwright/export.py
+++ b/src/draftwright/export.py
@@ -670,14 +670,13 @@ def _ordered_parts(parts):
 def _elements(shape, *, ordered: bool = False):
     """Decompose *shape* for export retry: faces plus any loose edges.
 
-    With *ordered*, the two blocks come back sorted by where their parts sit
-    rather than in the order the kernel happened to hand them over. That order
-    matters beyond the retry this was written for: ``ExportDXF`` writes one
-    entity per element as it converts, so it is the order a DXF's entities and
-    their handles come out in, and left alone it varies between runs - enough to
-    make a drawing useless as something to check in and diff. (The SVG settles
-    the same question after the fact in :func:`canonicalize_svg`, where the
-    elements are already in the file and cost nothing to reorder.)
+    With *ordered*, faces are flattened to the boundary edges DXF actually emits
+    and the complete entity stream is sorted by exact geometry. Sorting whole
+    faces is insufficient: one face can retain a run-dependent cyclic starting
+    edge inside its B-rep traversal. Entity-level ordering fixes both the order of
+    faces and the order within each face. (The SVG settles the same question after
+    the fact in :func:`canonicalize_svg`, where the elements are already in the
+    file and cost nothing to reorder.)
 
     **Ordering is the expensive half of a reproducible export** - one
     ``bounding_box()`` and one ``edges()`` per part, measured at about a third
@@ -697,7 +696,8 @@ def _elements(shape, *, ordered: bool = False):
     loose = [e for e in shape.edges() if e not in owned]
     if not ordered:
         return faces + loose
-    return _ordered_parts(faces) + _ordered_parts(loose)
+    face_edges = [edge for face in faces for edge in face.edges()]
+    return _ordered_parts(face_edges + loose)
 
 
 def _export_shape(exporter, shape, layer, ctx, *, ordered: bool = False):

--- a/src/draftwright/export.py
+++ b/src/draftwright/export.py
@@ -17,13 +17,25 @@ import math
 import re
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
+from datetime import datetime
 from functools import lru_cache
+from io import BytesIO
+from itertools import groupby
 from pathlib import Path
 
 import ezdxf
 from build123d import ExportDXF, ExportSVG
-from ezdxf.document import CONST_MARKER_STRING, CREATED_BY_EZDXF
+from ezdxf.document import (
+    CONST_GUID,
+    CONST_MARKER_STRING,
+    CREATED_BY_EZDXF,
+    WRITTEN_BY_EZDXF,
+    juliandate,
+    tocodepage,
+)
+from OCP.BRepTools import BRepTools
 from OCP.GeomConvert import GeomConvert
+from OCP.TopTools import TopTools_FormatVersion
 
 from draftwright._core import _DRAFTWRIGHT_URL
 from draftwright.fonts import PLEX_MONO
@@ -132,11 +144,6 @@ def canonicalize_svg(svg_path: str) -> None:
     means. Only groups whose children are all leaves are touched, so a nested
     group is never flattened or reordered.
     """
-    # Round-tripping through ElementTree drops the default namespace unless it
-    # is registered, and an SVG without its xmlns is one nothing downstream can
-    # read - svglib included, which is how the PDF is rendered.
-    ET.register_namespace("", _SVG_NS.strip("{}"))
-    ET.register_namespace("xlink", "http://www.w3.org/1999/xlink")
     tree = ET.parse(svg_path)
     for group in tree.getroot().iter(_SVG_NS + "g"):
         children = list(group)
@@ -153,6 +160,15 @@ def canonicalize_svg(svg_path: str) -> None:
         for child, tail in zip(children, tails):
             child.tail = tail
         group[:] = children
+    # Strip the SVG namespace from in-memory tag spellings, then declare it as
+    # the document default. This preserves ordinary ``<svg>``/``<g>`` output
+    # without ``register_namespace``, whose process-global registry would change
+    # how unrelated callers serialize their own XML after a Draftwright export.
+    root = tree.getroot()
+    for element in root.iter():
+        if isinstance(element.tag, str) and element.tag.startswith(_SVG_NS):
+            element.tag = element.tag[len(_SVG_NS) :]
+    root.set("xmlns", _SVG_NS.strip("{}"))
     tree.write(svg_path, encoding="utf-8", xml_declaration=True)
 
 
@@ -277,27 +293,37 @@ def write_dxf(dxf, path: str, page_w: float, page_h: float, reproducible: bool =
     costing seconds on a dimension-dense sheet (#602; build123d#382 tracks
     exposing viewport control). The drawing already lives in page-mm
     coordinates ``(0, 0)–(page_w, page_h)``, so set that single-window
-    viewport directly and save. Best-effort: falls back to ``dxf.write`` if
-    the exporter's ezdxf internals aren't reachable (mirrors
-    ``set_dxf_metadata``).
+    viewport directly and save. Falls back to ``dxf.write`` if the optimized
+    viewport seam is unavailable while retaining reproducible metadata whenever
+    the ezdxf document is accessible. A requested reproducible export fails
+    clearly if the document itself is unavailable rather than returning live data.
     """
     doc = getattr(dxf, "_document", None)
-    msp = getattr(dxf, "_modelspace", None)
-    if doc is None or msp is None:
+    if doc is None:
+        if reproducible:
+            raise RuntimeError("reproducible DXF export requires access to the ezdxf document")
         dxf.write(path)
+        return
+
+    def save(save_fn) -> None:
+        if reproducible:
+            with _reproducible_dxf(doc):
+                save_fn()
+        else:
+            save_fn()
+
+    msp = getattr(dxf, "_modelspace", None)
+    if msp is None:
+        save(lambda: dxf.write(path))
         return
     try:
         from ezdxf import zoom
 
         zoom.window(msp, (0.0, 0.0), (page_w, page_h))
     except Exception:
-        dxf.write(path)
+        save(lambda: dxf.write(path))
         return
-    if reproducible:
-        with _reproducible_dxf(doc):
-            doc.saveas(path, fmt="asc")
-    else:
-        doc.saveas(path, fmt="asc")
+    save(lambda: doc.saveas(path, fmt="asc"))
 
 
 @contextlib.contextmanager
@@ -305,19 +331,11 @@ def _reproducible_dxf(doc):
     """Take the clock and the hash seed out of what ezdxf is about to write.
 
     Every save stamps the time it happened ($TDCREATE/$TDUPDATE and their UTC
-    twins), a freshly generated $VERSIONGUID/$FINGERPRINTGUID pair, and a
-    "written by" marker carrying another timestamp. ezdxf writes fixed values
-    for those behind one option - a fixed date, the all-zero GUID a new document
-    starts with, and a constant marker.
-
-    That option is process-wide state belonging to whoever set it, so it is put
-    back afterwards: a draftwright export must not decide what some other ezdxf
-    user in the same interpreter writes.
-
-    It also does not reach the *creation* marker, which is stamped when the
-    document is built - inside ``_DraftwrightDXF()``, long before an export asks
-    for anything - so that one is overwritten here with the same constant ezdxf
-    would have used.
+    twins), a freshly generated $VERSIONGUID/$FINGERPRINTGUID pair, and marker
+    strings carrying timestamps. ezdxf exposes a testing switch for fixed values,
+    but it is process-global and therefore races concurrent exports. Install the
+    equivalent updater on this one fresh document for the duration of its save;
+    unrelated ezdxf users and concurrent Draftwright exports remain untouched.
 
     The CLASSES section is the last part. ezdxf registers a class entry for
     every DXF type the document uses and finds them by iterating a set of type
@@ -327,19 +345,27 @@ def _reproducible_dxf(doc):
     registered here first, sorted: 'add_class()' keeps the first entry for a key,
     and ezdxf's own pass during the save then adds only what is left.
     """
-    previous = ezdxf.options.write_fixed_meta_data_for_testing
-    ezdxf.options.write_fixed_meta_data_for_testing = True
+    original_update_metadata = doc._update_metadata
+
+    def update_metadata_reproducibly() -> None:
+        metadata = doc.ezdxf_metadata()
+        metadata[CREATED_BY_EZDXF] = CONST_MARKER_STRING
+        metadata[WRITTEN_BY_EZDXF] = CONST_MARKER_STRING
+        fixed_date = juliandate(datetime(2000, 1, 1, 0, 0))
+        for name in ("$TDCREATE", "$TDUCREATE", "$TDUPDATE", "$TDUUPDATE"):
+            doc.header[name] = fixed_date
+        doc.header["$VERSIONGUID"] = CONST_GUID
+        doc.header["$FINGERPRINTGUID"] = CONST_GUID
+        doc.header["$HANDSEED"] = str(doc.entitydb.handles)
+        doc.header["$DWGCODEPAGE"] = tocodepage(doc.encoding)
+
+    doc._update_metadata = update_metadata_reproducibly
     try:
-        try:
-            doc.ezdxf_metadata()[CREATED_BY_EZDXF] = CONST_MARKER_STRING
-            for dxftype in sorted(doc.entitydb.dxf_types_in_use()):
-                doc.classes.add_class(dxftype)
-        except Exception:
-            # Reproducibility is not worth failing an export over.
-            _log.debug("could not pin the DXF metadata", exc_info=True)
+        for dxftype in sorted(doc.entitydb.dxf_types_in_use()):
+            doc.classes.add_class(dxftype)
         yield
     finally:
-        ezdxf.options.write_fixed_meta_data_for_testing = previous
+        doc._update_metadata = original_update_metadata
 
 
 class _DraftwrightDXF(ExportDXF):
@@ -551,10 +577,11 @@ def _render_pdf(
         canvas.showPage()
         canvas.save()
     except Exception:
-        if text_runs:
+        if text_runs or reproducible:
             # Searchable text is a requested output property, not an optional
-            # embellishment. Never report success after silently discarding it.
-            _log.error("PDF semantic text render failed", exc_info=True)
+            # embellishment, and reproducibility is likewise a requested contract.
+            # Never report success after silently discarding either property.
+            _log.error("PDF render failed with required output properties", exc_info=True)
             raise
         # Never fail the export over the link/metadata extras; degrade to a
         # plain render. Logged at debug so a regression in the link annotation
@@ -587,17 +614,15 @@ def _render_png(pdf_path: str, png_path: str, *, dpi: int = 150) -> None:
 
 
 def _geometry_key(part):
-    """Where a part sits and which way it runs - a sort key, to the precision an
-    exporter writes.
+    """Cheap geometric prefix for grouping export parts before exact tie-breaking.
 
     The box alone does not separate parts: hidden-line removal emits the same
     segment twice where two silhouettes project onto each other, once each way
     round, and the pair shares a box, a length and a vertex set. Only the
     *directed* ends tell them apart - and the direction is itself what the
     exporter writes out, so leaving them tied would let two runs swap a pair and
-    change the file. Parts with no direction to ask for (faces) fall back to the
-    box and their edge count; faces and loose edges are sorted in separate
-    blocks, so the two never compare against each other.
+    change the file. Distinct faces can still share every fact in this prefix;
+    :func:`_ordered_parts` resolves those groups from exact B-rep bytes.
     """
     box = part.bounding_box()
     key = (
@@ -615,6 +640,31 @@ def _geometry_key(part):
     except Exception:
         return key
     return key + tuple(round(v, 9) for v in (start.X, start.Y, start.Z, end.X, end.Y, end.Z))
+
+
+def _brep_key(part) -> bytes:
+    """Exact, run-independent tie-breaker containing topology and curve geometry."""
+    stream = BytesIO()
+    BRepTools.Write_s(
+        part.wrapped,
+        stream,
+        False,
+        False,
+        TopTools_FormatVersion.TopTools_FormatVersion_VERSION_3,
+    )
+    return stream.getvalue()
+
+
+def _ordered_parts(parts):
+    """Order by the cheap key, serialising exact B-rep only inside tied groups."""
+    keyed = sorted(((_geometry_key(part), part) for part in parts), key=lambda item: item[0])
+    ordered = []
+    for _key, entries in groupby(keyed, key=lambda item: item[0]):
+        group = [part for _prefix, part in entries]
+        if len(group) > 1:
+            group.sort(key=_brep_key)
+        ordered.extend(group)
+    return ordered
 
 
 def _elements(shape, *, ordered: bool = False):
@@ -642,12 +692,12 @@ def _elements(shape, *, ordered: bool = False):
     faces = list(shape.faces())
     if not faces:
         edges = list(shape.edges())
-        return sorted(edges, key=_geometry_key) if ordered else edges
+        return _ordered_parts(edges) if ordered else edges
     owned = {e for f in faces for e in f.edges()}
     loose = [e for e in shape.edges() if e not in owned]
     if not ordered:
         return faces + loose
-    return sorted(faces, key=_geometry_key) + sorted(loose, key=_geometry_key)
+    return _ordered_parts(faces) + _ordered_parts(loose)
 
 
 def _export_shape(exporter, shape, layer, ctx, *, ordered: bool = False):

--- a/tests/test_export_reproducible.py
+++ b/tests/test_export_reproducible.py
@@ -171,19 +171,15 @@ def test_svg_canonicalization_does_not_change_elementtree_global_namespaces(tmp_
 
 
 def test_elements_come_out_in_geometric_order():
-    """``ordered=True`` orders each block by where the parts sit, and loses nothing."""
+    """``ordered=True`` orders the emitted edge stream and loses no boundary ink."""
     shape = Box(20, 10, 5)
     parts = _elements(shape, ordered=True)
 
-    faces = [p for p in parts if p in set(shape.faces())]
-    loose = parts[len(faces) :]
-    assert faces == sorted(faces, key=_geometry_key)
-    assert loose == sorted(loose, key=_geometry_key)
-
-    # Faces first, then only the edges no face owns — the same content as before.
-    owned = {e for f in shape.faces() for e in f.edges()}
-    assert set(faces) == set(shape.faces())
-    assert set(loose) == {e for e in shape.edges() if e not in owned}
+    expected = [edge for face in shape.faces() for edge in face.edges()]
+    owned = set(expected)
+    expected += [edge for edge in shape.edges() if edge not in owned]
+    assert len(parts) == len(expected)
+    assert all(part in expected for part in parts)
 
 
 def test_a_segment_and_its_reverse_do_not_tie():
@@ -227,7 +223,27 @@ def test_distinct_faces_with_the_same_cheap_key_have_one_exact_order():
 
     forward = _elements(Pair([a, b]), ordered=True)
     reverse = _elements(Pair([b, a]), ordered=True)
-    assert [tuple(face.center()) for face in forward] == [tuple(face.center()) for face in reverse]
+    assert [_geometry_key(edge) for edge in forward] == [_geometry_key(edge) for edge in reverse]
+
+
+def test_one_face_cannot_leak_its_cyclic_wire_start_into_entity_order():
+    points = [(0, 0), (10, 0), (10, 10), (0, 10)]
+    a = Face(Wire.make_polygon(points, close=True))
+    b = Face(Wire.make_polygon(points[1:] + points[:1], close=True))
+
+    class OneFace:
+        def __init__(self, face):
+            self.face = face
+
+        def faces(self):
+            return [self.face]
+
+        def edges(self):
+            return self.face.edges()
+
+    assert [_geometry_key(edge) for edge in _elements(OneFace(a), ordered=True)] == [
+        _geometry_key(edge) for edge in _elements(OneFace(b), ordered=True)
+    ]
 
 
 def test_subnanometre_edges_tied_by_the_fast_prefix_have_one_exact_order():
@@ -272,8 +288,6 @@ def test_elements_does_not_order_by_default():
         owned = {e for f in faces for e in f.edges()}
         kernel_order = faces + [e for e in shape.edges() if e not in owned]
         assert default == kernel_order
-        # ...and the same content the ordered form returns, only arranged differently.
-        assert set(default) == set(_elements(shape, ordered=True))
 
 
 # ------------------------------------------------------------------ write_dxf(reproducible=)

--- a/tests/test_export_reproducible.py
+++ b/tests/test_export_reproducible.py
@@ -1,0 +1,562 @@
+"""Exported files carry the drawing, not the run that produced it.
+
+Two exports of one drawing used to differ in bytes. That makes a drawing useless as
+something to check in and diff, which is how a caller notices its output changed.
+Three separate sources, one per format, each guarded here:
+
+1. **Element order.** ``ExportSVG``/``ExportDXF`` walk a shape with ``.faces()`` /
+   ``.edges()`` and write one element per part, in the order they are handed over.
+   ``export._elements`` sorts that walk by geometry for the DXF (whose entities *and
+   their handles* follow it), and :func:`export.canonicalize_svg` settles the SVG
+   afterwards, where the elements are already in the file and cost nothing to reorder.
+2. **The clock.** ezdxf stamps every save with the time, a fresh GUID pair and a
+   version marker; reportlab stamps a ``/CreationDate`` and a derived ``/ID``.
+3. **A set iteration.** ezdxf builds the CLASSES section by iterating a set of type
+   names, whose order over strings follows the interpreter's hash seed.
+
+:func:`test_two_runs_under_different_hash_seeds_agree` is the gate that covers all
+three at once, and it is deliberately a **subprocess** pair: comparing two exports
+inside one interpreter proves nothing, because string hashing is stable for a given
+``PYTHONHASHSEED`` and the unsorted code passes such a test too.
+"""
+
+from __future__ import annotations
+
+import itertools
+import os
+import re
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import ezdxf
+import pytest
+from build123d import Box, Edge, Rectangle
+
+import draftwright.drawing as drawing_mod
+from draftwright import build_drawing
+from draftwright._core import draft_preset
+from draftwright.drawing import Drawing
+from draftwright.export import (
+    _DraftwrightDXF,
+    _elements,
+    _geometry_key,
+    _render_pdf,
+    canonicalize_svg,
+    write_dxf,
+)
+
+# ---------------------------------------------------------------- SVG element order
+
+_SVG = '<svg xmlns="http://www.w3.org/2000/svg">\n  <g id="part">\n{body}  </g>\n</svg>\n'
+# Three leaves whose sorted order (circle, then the two lines) is none of the orders
+# they are fed in below, so every permutation has to be moved to reach it.
+_LEAVES = (
+    '    <line x1="1" y1="0" />\n',
+    '    <line x1="2" y1="0" />\n',
+    '    <circle r="3" />\n',
+)
+
+
+def _write_permutations(tmp_path):
+    """One file per ordering of *_LEAVES*, plus the set of distinct inputs written."""
+    paths, distinct = [], set()
+    for i, perm in enumerate(itertools.permutations(_LEAVES)):
+        p = tmp_path / f"perm{i}.svg"
+        p.write_text(_SVG.format(body="".join(perm)), encoding="utf-8")
+        distinct.add(p.read_text(encoding="utf-8"))
+        paths.append(p)
+    return paths, distinct
+
+
+def test_layer_order_does_not_depend_on_the_order_the_elements_arrived(tmp_path):
+    paths, distinct = _write_permutations(tmp_path)
+    # Precondition: the fixture really does present the same layer six different ways.
+    assert len(distinct) == 6
+
+    for p in paths:
+        canonicalize_svg(str(p))
+    canonical = {p.read_text(encoding="utf-8") for p in paths}
+    assert len(canonical) == 1, f"{len(canonical)} distinct outputs from one element set"
+
+    # ...and the one output is in the sorted order, not merely a shared arbitrary one.
+    (out,) = canonical
+    assert out.index("<circle") < out.index('x1="1"') < out.index('x1="2"')
+
+
+def test_the_last_slots_indent_does_not_travel_with_its_element(tmp_path):
+    """``tail`` belongs to the slot, not to the element that happens to sit in it.
+
+    ``tail`` is the whitespace ElementTree stores *after* an element, and a group's
+    last child carries a shorter one than its siblings. Reorder the children with
+    their tails attached and that short indent lands on whichever element sorted
+    last, so two runs agree on the element order and still disagree on the bytes.
+    Holding the tails in place while the elements move through them is the fix; this
+    asserts the defect is reachable first, by reproducing the ordering that has it.
+
+    The gate below does **not** cover this: on a real drawing the elements that
+    change places sit mid-layer, so the last slot keeps its element and the bytes
+    agree anyway. It is latent there, which is why it is pinned here directly.
+    """
+    paths, _ = _write_permutations(tmp_path)
+
+    def sorted_by(path, key):
+        tree = ET.parse(path)
+        for group in tree.getroot().iter("{http://www.w3.org/2000/svg}g"):
+            group[:] = sorted(list(group), key=key)
+        buf = ET.tostring(tree.getroot(), encoding="unicode")
+        return buf
+
+    # The old key: the serialized element, tail included.
+    old = {sorted_by(str(p), lambda e: ET.tostring(e, encoding="unicode")) for p in paths}
+    assert len(old) > 1, "fixture no longer exposes the tail-in-the-sort-key defect"
+
+    for p in paths:
+        canonicalize_svg(str(p))
+    assert len({p.read_text(encoding="utf-8") for p in paths}) == 1
+
+
+def test_a_group_holding_another_group_is_left_alone(tmp_path):
+    """Only all-leaf groups are sorted, so nesting is never flattened or reordered."""
+    p = tmp_path / "nested.svg"
+    p.write_text(
+        '<svg xmlns="http://www.w3.org/2000/svg">\n'
+        '  <g id="outer">\n'
+        '    <g id="zzz"><line x1="1" /></g>\n'
+        '    <g id="aaa"><line x1="2" /></g>\n'
+        "  </g>\n"
+        "</svg>\n",
+        encoding="utf-8",
+    )
+    canonicalize_svg(str(p))
+    out = p.read_text(encoding="utf-8")
+    # A leaf sort would put "aaa" first; the paint order of the layers is not ours to change.
+    assert out.index('id="zzz"') < out.index('id="aaa"')
+
+
+def test_the_canonical_svg_is_still_an_svg(tmp_path):
+    """The round-trip keeps the default namespace — svglib renders the PDF from this."""
+    p = tmp_path / "ns.svg"
+    p.write_text(
+        '<svg xmlns="http://www.w3.org/2000/svg" width="20mm" height="10mm" '
+        'viewBox="0 0 20 10">\n'
+        '  <g id="part">\n'
+        '    <line x1="2" y1="2" x2="8" y2="8" stroke="black" />\n'
+        '    <circle cx="4" cy="4" r="1" stroke="black" fill="none" />\n'
+        "  </g>\n"
+        "</svg>\n",
+        encoding="utf-8",
+    )
+    canonicalize_svg(str(p))
+    assert 'xmlns="http://www.w3.org/2000/svg"' in p.read_text(encoding="utf-8")
+
+    from svglib.svglib import svg2rlg
+
+    assert svg2rlg(str(p)) is not None
+
+
+# ------------------------------------------------------------- shape decomposition
+
+
+def test_elements_come_out_in_geometric_order():
+    """``ordered=True`` orders each block by where the parts sit, and loses nothing."""
+    shape = Box(20, 10, 5)
+    parts = _elements(shape, ordered=True)
+
+    faces = [p for p in parts if p in set(shape.faces())]
+    loose = parts[len(faces) :]
+    assert faces == sorted(faces, key=_geometry_key)
+    assert loose == sorted(loose, key=_geometry_key)
+
+    # Faces first, then only the edges no face owns — the same content as before.
+    owned = {e for f in shape.faces() for e in f.edges()}
+    assert set(faces) == set(shape.faces())
+    assert set(loose) == {e for e in shape.edges() if e not in owned}
+
+
+def test_a_segment_and_its_reverse_do_not_tie():
+    """Hidden-line removal emits overlapping silhouettes as reversed duplicate pairs.
+
+    Two such edges share a bounding box, a geometry type, an edge count, a length
+    and a vertex set — everything the key used to look at — yet an exporter writes
+    each one's start and end, so they are not interchangeable. Left tied, ``sorted``
+    keeps whatever order the kernel handed them over in, which is the run-dependent
+    order this whole module exists to remove.
+    """
+    a = Edge.make_line((0, 0, 0), (10, 0, 0))
+    b = Edge.make_line((10, 0, 0), (0, 0, 0))
+
+    # Precondition: everything except the direction agrees.
+    for attr in ("min", "max"):
+        box_a, box_b = getattr(a.bounding_box(), attr), getattr(b.bounding_box(), attr)
+        assert (box_a.X, box_a.Y, box_a.Z) == (box_b.X, box_b.Y, box_b.Z)
+    assert str(a.geom_type) == str(b.geom_type)
+    assert len(a.edges()) == len(b.edges())
+    assert a.length == pytest.approx(b.length)
+
+    assert _geometry_key(a) != _geometry_key(b)
+
+
+def test_elements_of_an_edge_only_shape_are_ordered_too():
+    shape = Rectangle(10, 5).edges()
+    parts = _elements(shape, ordered=True)
+    assert len(parts) == 4
+    assert parts == sorted(parts, key=_geometry_key)
+
+
+def test_elements_does_not_order_by_default():
+    """Off, this costs exactly what it did before the option existed.
+
+    The sort is the expensive half of a reproducible export — a bounding box and an
+    edge walk per part — so the default path must not do it at all, rather than do
+    it and discard the result. Same parts, in the order the kernel gave them.
+    """
+    for shape in (Box(20, 10, 5), Rectangle(10, 5).edges()):
+        default = _elements(shape)
+        faces = list(shape.faces())
+        owned = {e for f in faces for e in f.edges()}
+        kernel_order = faces + [e for e in shape.edges() if e not in owned]
+        assert default == kernel_order
+        # ...and the same content the ordered form returns, only arranged differently.
+        assert set(default) == set(_elements(shape, ordered=True))
+
+
+# ------------------------------------------------------------------ write_dxf(reproducible=)
+
+_FIXED_JULIAN = "2451545.0"  # ezdxf's juliandate(2000-01-01)
+_ZERO_GUID = "{00000000-0000-0000-0000-000000000000}"
+_CONST_MARKER = "0.0 @ 2000-01-01T00:00:00.000000+00:00"
+_LIVE_MARKER = re.compile(r"\d+\.\d+\.\d+ @ 20[2-9]\d-")
+
+
+def _header_value(text: str, name: str) -> str | None:
+    """The value ezdxf wrote for header variable *name*, read from the file itself.
+
+    Not via ``ezdxf.readfile`` — loading a document re-stamps its header, so a
+    round-trip reports the reader's clock rather than what was written.
+    """
+    m = re.search(r"^\$" + name + r"\n\s*\d+\n(.*)$", text, re.M)
+    return m.group(1) if m else None
+
+
+def _write(tmp_path, name, **kwargs) -> str:
+    exp = _DraftwrightDXF()
+    exp.add_layer("part")
+    exp.add_shape(Rectangle(10, 5).edges(), layer="part")
+    path = str(tmp_path / name)
+    write_dxf(exp, path, 210.0, 297.0, **kwargs)
+    return Path(path).read_text(encoding="utf-8", errors="replace")
+
+
+def test_write_dxf_without_reproducible_lets_the_clock_through(tmp_path):
+    """The precondition the flag exists to remove: an unpinned save carries the run."""
+    text = _write(tmp_path, "live.dxf", reproducible=False)
+    assert _header_value(text, "TDCREATE") != _FIXED_JULIAN
+    assert _header_value(text, "VERSIONGUID") != _ZERO_GUID
+    assert _LIVE_MARKER.search(text), "expected a live ezdxf version/timestamp marker"
+    assert _CONST_MARKER not in text
+
+
+def test_write_dxf_reproducible_pins_the_clock_and_the_guids(tmp_path):
+    text = _write(tmp_path, "pinned.dxf", reproducible=True)
+    assert _header_value(text, "TDCREATE") == _FIXED_JULIAN
+    assert _header_value(text, "TDUPDATE") == _FIXED_JULIAN
+    assert _header_value(text, "VERSIONGUID") == _ZERO_GUID
+    assert _header_value(text, "FINGERPRINTGUID") == _ZERO_GUID
+
+
+def test_write_dxf_reproducible_pins_the_creation_marker_too(tmp_path):
+    """ezdxf's own option misses this one: it is stamped when the document is built.
+
+    ``_DraftwrightDXF()`` constructs the ezdxf document long before an export asks
+    for anything, so CREATED_BY_EZDXF already holds a live timestamp by the time the
+    option is flipped. Both markers have to end up constant or the file still differs.
+    """
+    text = _write(tmp_path, "marked.dxf", reproducible=True)
+    assert not _LIVE_MARKER.search(text), "a live ezdxf timestamp survived the pin"
+    assert text.count(_CONST_MARKER) == 2  # CREATED_BY_EZDXF and WRITTEN_BY_EZDXF
+
+
+def test_write_dxf_is_not_reproducible_by_default(tmp_path):
+    """Opt-in: an unasked-for export pays nothing and carries the clock, as before."""
+    assert _write(tmp_path, "default.dxf") != _write(tmp_path, "pinned.dxf", reproducible=True)
+    default = _write(tmp_path, "default2.dxf")
+    assert _header_value(default, "TDCREATE") != _FIXED_JULIAN
+    assert _LIVE_MARKER.search(default)
+
+
+def test_the_classes_entries_we_seed_are_registered_in_sorted_order(tmp_path):
+    """ezdxf ends ``add_required_classes`` with ``for dxftype in dxf_types_in_use``.
+
+    That is a ``set[str]``, so its iteration order follows the interpreter's hash
+    seed. Seeding those names first, sorted, fixes them — ``add_class()`` keeps the
+    first entry for a key, and ezdxf's pass then adds only what is left, in the fixed
+    order of its own ``REQUIRED_CLASSES`` table. So only the entries that came from
+    the document's types-in-use are ours to order; the rest keep ezdxf's order and
+    are left alone here.
+
+    This asserts the mechanism. The property it exists for — that the order is the
+    same on the next run — can only be measured across processes, which is
+    :func:`test_two_runs_under_different_hash_seeds_agree`.
+    """
+    exp = _DraftwrightDXF()
+    exp.add_layer("part")
+    exp.add_shape(Rectangle(10, 5).edges(), layer="part")
+    in_use = set(exp._document.entitydb.dxf_types_in_use())
+    path = str(tmp_path / "classes.dxf")
+    write_dxf(exp, path, 210.0, 297.0, reproducible=True)
+
+    section = Path(path).read_text(encoding="utf-8", errors="replace")
+    section = section.split("CLASSES", 1)[1].split("ENDSEC", 1)[0]
+    names = re.findall(r"^\s*1\n(.+)$", section, re.M)
+    seeded = [n for n in names if n in in_use]
+    assert len(seeded) > 1, "fixture must register more than one class worth ordering"
+    assert seeded == sorted(seeded)
+    # Ours come first, before ezdxf's own required-class pass.
+    assert names[: len(seeded)] == seeded
+
+
+@pytest.mark.parametrize("reproducible", [True, False])
+@pytest.mark.parametrize("preset", [True, False])
+def test_write_dxf_restores_the_global_ezdxf_option(tmp_path, reproducible, preset):
+    """The pin is process-wide state belonging to whoever set it.
+
+    ``write_fixed_meta_data_for_testing`` is an ``ezdxf.options`` global: leaving it
+    flipped decides what every other ezdxf user in the interpreter writes, including
+    the next test in the same session.
+    """
+    previous = ezdxf.options.write_fixed_meta_data_for_testing
+    try:
+        ezdxf.options.write_fixed_meta_data_for_testing = preset
+        _write(tmp_path, f"opt-{reproducible}-{preset}.dxf", reproducible=reproducible)
+        assert ezdxf.options.write_fixed_meta_data_for_testing is preset
+    finally:
+        ezdxf.options.write_fixed_meta_data_for_testing = previous
+
+
+def test_write_dxf_restores_the_global_option_even_when_the_save_fails(tmp_path):
+    previous = ezdxf.options.write_fixed_meta_data_for_testing
+    try:
+        ezdxf.options.write_fixed_meta_data_for_testing = False
+        exp = _DraftwrightDXF()
+        exp.add_layer("part")
+        exp.add_shape(Rectangle(10, 5).edges(), layer="part")
+
+        def boom(*args, **kwargs):
+            raise OSError("disk full")
+
+        exp._document.saveas = boom
+        with pytest.raises(OSError, match="disk full"):
+            write_dxf(exp, str(tmp_path / "boom.dxf"), 210.0, 297.0, reproducible=True)
+        assert ezdxf.options.write_fixed_meta_data_for_testing is False
+    finally:
+        ezdxf.options.write_fixed_meta_data_for_testing = previous
+
+
+# ------------------------------------------------------------------ _render_pdf(reproducible=)
+
+_FIXED_PDF_DATE = b"/CreationDate (D:20000101000000+00'00')"
+
+
+@pytest.fixture(scope="module")
+def small_svg(tmp_path_factory):
+    p = tmp_path_factory.mktemp("pdf") / "in.svg"
+    p.write_text(
+        '<svg xmlns="http://www.w3.org/2000/svg" width="40mm" height="20mm" '
+        'viewBox="0 0 40 20">\n'
+        '  <line x1="2" y1="2" x2="38" y2="18" stroke="black" />\n'
+        "</svg>\n",
+        encoding="utf-8",
+    )
+    return str(p)
+
+
+def test_render_pdf_without_reproducible_carries_the_clock(small_svg, tmp_path):
+    out = tmp_path / "live.pdf"
+    _render_pdf(small_svg, str(out), reproducible=False)
+    assert _FIXED_PDF_DATE not in out.read_bytes()
+
+
+def test_render_pdf_reproducible_writes_the_same_bytes_twice(small_svg, tmp_path):
+    a, b = tmp_path / "a.pdf", tmp_path / "b.pdf"
+    _render_pdf(small_svg, str(a), reproducible=True)
+    _render_pdf(small_svg, str(b), reproducible=True)
+    assert _FIXED_PDF_DATE in a.read_bytes()
+    assert a.read_bytes() == b.read_bytes()
+
+
+def test_render_pdf_is_not_reproducible_by_default(small_svg, tmp_path):
+    out = tmp_path / "default.pdf"
+    _render_pdf(small_svg, str(out))
+    assert _FIXED_PDF_DATE not in out.read_bytes()
+
+
+# ------------------------------------- the public surface PartCAD reaches it through
+
+
+@pytest.fixture(scope="module")
+def plate():
+    """One built sheet, shared: these tests are about wiring, not about geometry."""
+    return build_drawing(Box(30, 20, 10))
+
+
+def _spy(monkeypatch):
+    """Record what the export path was actually asked to do."""
+    seen = {"canonicalized": 0, "ordered": set(), "pinned": set()}
+    real_canon, real_shape, real_dxf = (
+        drawing_mod.canonicalize_svg,
+        drawing_mod._export_shape,
+        drawing_mod.write_dxf,
+    )
+
+    def canon(path):
+        seen["canonicalized"] += 1
+        return real_canon(path)
+
+    def export_shape(exporter, shape, layer, ctx, *, ordered=False):
+        seen["ordered"].add((type(exporter).__name__, ordered))
+        return real_shape(exporter, shape, layer, ctx, ordered=ordered)
+
+    def write(dxf, path, page_w, page_h, reproducible=False):
+        seen["pinned"].add(reproducible)
+        return real_dxf(dxf, path, page_w, page_h, reproducible=reproducible)
+
+    monkeypatch.setattr(drawing_mod, "canonicalize_svg", canon)
+    monkeypatch.setattr(drawing_mod, "_export_shape", export_shape)
+    monkeypatch.setattr(drawing_mod, "write_dxf", write)
+    return seen
+
+
+def test_export_does_no_reproducibility_work_by_default(plate, tmp_path, monkeypatch):
+    """The default export must not pay for what it was not asked for.
+
+    Not "produces a file that happens to differ" — that is unobservable in one run.
+    This asserts the work is *not requested*: no canonicalisation pass over the SVG,
+    nothing ordered, nothing pinned.
+    """
+    seen = _spy(monkeypatch)
+    plate.export(str(tmp_path / "d"), formats=("svg", "dxf"))
+    assert seen["canonicalized"] == 0
+    assert seen["ordered"] == {("ExportSVG", False), ("_DraftwrightDXF", False)}
+    assert seen["pinned"] == {False}
+
+
+def test_export_reproducible_true_orders_the_dxf_and_canonicalises_the_svg(
+    plate, tmp_path, monkeypatch
+):
+    """The two formats reach the same guarantee by different, deliberate routes.
+
+    The DXF has to be ordered *going in*: ``ExportDXF`` writes an entity per element
+    as it converts and the handles follow, so nothing after the fact can fix it. The
+    SVG is settled *coming out*, by sorting the written file — which is why it is
+    handed its shapes unordered even here. Ordering it too would pay the expensive
+    half twice for a result :func:`canonicalize_svg` already reaches on its own.
+    """
+    seen = _spy(monkeypatch)
+    plate.export(str(tmp_path / "r"), formats=("svg", "dxf"), reproducible=True)
+    assert seen["canonicalized"] == 1
+    assert seen["ordered"] == {("ExportSVG", False), ("_DraftwrightDXF", True)}
+    assert seen["pinned"] == {True}
+
+
+def test_build_drawing_sets_the_drawings_own_default(tmp_path, monkeypatch):
+    """``build_drawing(reproducible=True)`` is the seam PartCAD reaches.
+
+    PartCAD forwards its configured options to ``build_drawing`` and then calls
+    ``drawing.export(stem, formats=(fmt,))`` with no keywords of its own, so the
+    setting has to survive the build and be found by that later bare export.
+    """
+    drawing = build_drawing(Box(30, 20, 10), reproducible=True)
+    assert drawing.reproducible is True
+
+    seen = _spy(monkeypatch)
+    drawing.export(str(tmp_path / "b"), formats=("dxf",))  # exactly PartCAD's call shape
+    assert seen["ordered"] == {("_DraftwrightDXF", True)}
+    assert seen["pinned"] == {True}
+
+
+def test_build_drawing_defaults_to_off(tmp_path):
+    assert build_drawing(Box(30, 20, 10)).reproducible is False
+
+
+def test_a_directly_constructed_drawing_defaults_to_off():
+    """``build_drawing`` is not the only door: ``Drawing`` is public and constructible.
+
+    Separate from the test above because that one cannot see this: ``build_drawing``
+    passes its own ``reproducible=`` down explicitly, so it would keep reporting
+    ``False`` even if the constructor's default were flipped.
+    """
+    drawing = Drawing(
+        scale=1.0,
+        page_w=210.0,
+        page_h=297.0,
+        tb_w=50.0,
+        draft=draft_preset(),
+        look_at=(0.0, 0.0, 0.0),
+        dist=100.0,
+        centroid=(0.0, 0.0, 0.0),
+        out="x",
+    )
+    assert drawing.reproducible is False
+
+
+@pytest.mark.parametrize("drawing_default", [True, False])
+def test_the_export_keyword_overrides_the_drawings_default(tmp_path, monkeypatch, drawing_default):
+    drawing = build_drawing(Box(30, 20, 10), reproducible=drawing_default)
+    seen = _spy(monkeypatch)
+    drawing.export(str(tmp_path / "o"), formats=("dxf",), reproducible=not drawing_default)
+    assert seen["ordered"] == {("_DraftwrightDXF", not drawing_default)}
+    assert seen["pinned"] == {not drawing_default}
+
+
+def test_the_pdf_render_follows_the_same_flag(plate, tmp_path):
+    """PDF is one of the three formats PartCAD renders, so it obeys the flag too."""
+    a = plate.export(str(tmp_path / "p1"), formats=("pdf",), reproducible=True)["pdf"]
+    b = plate.export(str(tmp_path / "p2"), formats=("pdf",), reproducible=True)["pdf"]
+    assert Path(a).read_bytes() == Path(b).read_bytes()
+    plain = plate.export(str(tmp_path / "p3"), formats=("pdf",))["pdf"]
+    assert _FIXED_PDF_DATE not in Path(plain).read_bytes()
+
+
+# ------------------------------------------------------- the gate: two real runs
+
+
+_EXPORT_SCRIPT = """
+from build123d import Box
+from draftwright.builder import build_drawing
+import sys
+build_drawing(Box(30, 20, 10), reproducible=True).export(sys.argv[1], formats=("svg", "dxf"))
+"""
+
+
+def test_two_runs_under_different_hash_seeds_agree(tmp_path):
+    """The whole contract, end to end, the only way it can honestly be measured.
+
+    Separate interpreters: within one process a same-process comparison passes on
+    unsorted code and proves nothing, so it would not be a measurement at all.
+
+    Read this as a **sampling** detector, not a proof. The kernel's ordering does
+    not reduce to ``PYTHONHASHSEED`` — varying the seed is only a way to get two
+    genuinely different runs — and a given fixture does not reorder on every one:
+    with the sort removed on purpose this caught it in 3 of 4 trials. It never
+    fails with the sort in place (6 of 6). The per-mechanism tests above are the
+    deterministic guards; this is the one that would notice a source of drift
+    nobody thought of.
+    """
+    outs = []
+    for seed in ("1", "12345"):
+        env = {**os.environ, "PYTHONHASHSEED": seed}
+        stem = str(tmp_path / f"seed{seed}")
+        subprocess.run(
+            [sys.executable, "-c", _EXPORT_SCRIPT, stem],
+            check=True,
+            env=env,
+            capture_output=True,
+        )
+        outs.append(stem)
+
+    for ext in ("svg", "dxf"):
+        first, second = (Path(f"{o}.{ext}").read_bytes() for o in outs)
+        assert first, f"{ext} export produced nothing"
+        assert first == second, f"{ext} differs between runs under different hash seeds"

--- a/tests/test_export_reproducible.py
+++ b/tests/test_export_reproducible.py
@@ -22,21 +22,24 @@ inside one interpreter proves nothing, because string hashing is stable for a gi
 
 from __future__ import annotations
 
+import inspect
 import itertools
 import os
 import re
 import subprocess
 import sys
 import xml.etree.ElementTree as ET
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import ezdxf
 import pytest
-from build123d import Box, Edge, Rectangle
+from build123d import Box, Edge, Face, Rectangle, Wire
 
 import draftwright.drawing as drawing_mod
 from draftwright import build_drawing
 from draftwright._core import draft_preset
+from draftwright.builder import make_drawing
 from draftwright.drawing import Drawing
 from draftwright.export import (
     _DraftwrightDXF,
@@ -156,6 +159,14 @@ def test_the_canonical_svg_is_still_an_svg(tmp_path):
     assert svg2rlg(str(p)) is not None
 
 
+def test_svg_canonicalization_does_not_change_elementtree_global_namespaces(tmp_path):
+    p = tmp_path / "global.svg"
+    p.write_text(_SVG.format(body="".join(reversed(_LEAVES))), encoding="utf-8")
+    before = dict(ET._namespace_map)
+    canonicalize_svg(str(p))
+    assert ET._namespace_map == before
+
+
 # ------------------------------------------------------------- shape decomposition
 
 
@@ -196,6 +207,49 @@ def test_a_segment_and_its_reverse_do_not_tie():
     assert a.length == pytest.approx(b.length)
 
     assert _geometry_key(a) != _geometry_key(b)
+
+
+def test_distinct_faces_with_the_same_cheap_key_have_one_exact_order():
+    """Exact B-rep breaks ties that bounds/type/edge-count cannot distinguish."""
+    a = Face(Wire.make_polygon([(0, 0), (10, 0), (8, 10), (0, 10)], close=True))
+    b = Face(Wire.make_polygon([(0, 0), (10, 0), (10, 10), (2, 10)], close=True))
+    assert _geometry_key(a) == _geometry_key(b)  # the adversarial collision is real
+
+    class Pair:
+        def __init__(self, faces):
+            self._faces = faces
+
+        def faces(self):
+            return self._faces
+
+        def edges(self):
+            return [edge for face in self._faces for edge in face.edges()]
+
+    forward = _elements(Pair([a, b]), ordered=True)
+    reverse = _elements(Pair([b, a]), ordered=True)
+    assert [tuple(face.center()) for face in forward] == [tuple(face.center()) for face in reverse]
+
+
+def test_subnanometre_edges_tied_by_the_fast_prefix_have_one_exact_order():
+    a = Edge.make_line((0, 0, 0), (1, 0, 0))
+    b = Edge.make_line((0, 1e-10, 0), (1, 1e-10, 0))
+    assert _geometry_key(a) == _geometry_key(b)
+
+    class Pair:
+        def __init__(self, edges):
+            self._edges = edges
+
+        def faces(self):
+            return []
+
+        def edges(self):
+            return self._edges
+
+    forward = _elements(Pair([a, b]), ordered=True)
+    reverse = _elements(Pair([b, a]), ordered=True)
+    assert [edge.bounding_box().min.Y for edge in forward] == [
+        edge.bounding_box().min.Y for edge in reverse
+    ]
 
 
 def test_elements_of_an_edge_only_shape_are_ordered_too():
@@ -354,6 +408,51 @@ def test_write_dxf_restores_the_global_option_even_when_the_save_fails(tmp_path)
         ezdxf.options.write_fixed_meta_data_for_testing = previous
 
 
+def test_concurrent_reproducible_writes_do_not_touch_ezdxf_global_state(tmp_path):
+    previous = ezdxf.options.write_fixed_meta_data_for_testing
+    try:
+        ezdxf.options.write_fixed_meta_data_for_testing = False
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            texts = list(
+                executor.map(
+                    lambda index: _write(
+                        tmp_path,
+                        f"thread-{index}.dxf",
+                        reproducible=True,
+                    ),
+                    range(2),
+                )
+            )
+        assert ezdxf.options.write_fixed_meta_data_for_testing is False
+        assert all(_header_value(text, "TDCREATE") == _FIXED_JULIAN for text in texts)
+    finally:
+        ezdxf.options.write_fixed_meta_data_for_testing = previous
+
+
+def test_zoom_fallback_retains_reproducible_metadata(tmp_path, monkeypatch):
+    from ezdxf import zoom
+
+    monkeypatch.setattr(zoom, "window", lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError()))
+    text = _write(tmp_path, "zoom-fallback.dxf", reproducible=True)
+    assert _header_value(text, "TDCREATE") == _FIXED_JULIAN
+    assert _header_value(text, "VERSIONGUID") == _ZERO_GUID
+
+
+def test_reproducible_dxf_fails_if_the_document_is_inaccessible(tmp_path):
+    class OpaqueExporter:
+        def write(self, path):
+            Path(path).write_text("live", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="requires access to the ezdxf document"):
+        write_dxf(
+            OpaqueExporter(),
+            str(tmp_path / "opaque.dxf"),
+            210.0,
+            297.0,
+            reproducible=True,
+        )
+
+
 # ------------------------------------------------------------------ _render_pdf(reproducible=)
 
 _FIXED_PDF_DATE = b"/CreationDate (D:20000101000000+00'00')"
@@ -390,6 +489,22 @@ def test_render_pdf_is_not_reproducible_by_default(small_svg, tmp_path):
     out = tmp_path / "default.pdf"
     _render_pdf(small_svg, str(out))
     assert _FIXED_PDF_DATE not in out.read_bytes()
+
+
+def test_reproducible_pdf_does_not_fall_back_to_a_live_render(small_svg, tmp_path, monkeypatch):
+    from reportlab.pdfgen.canvas import Canvas
+
+    def fail_link(*_args, **_kwargs):
+        raise RuntimeError("link failed")
+
+    monkeypatch.setattr(Canvas, "linkURL", fail_link)
+    with pytest.raises(RuntimeError, match="link failed"):
+        _render_pdf(
+            small_svg,
+            str(tmp_path / "no-live-fallback.pdf"),
+            link_rect=(0, 0, 1, 1),
+            reproducible=True,
+        )
 
 
 # ------------------------------------- the public surface PartCAD reaches it through
@@ -480,6 +595,12 @@ def test_build_drawing_defaults_to_off(tmp_path):
     assert build_drawing(Box(30, 20, 10)).reproducible is False
 
 
+def test_reproducible_is_appended_after_the_existing_positional_scale_policy():
+    for function in (build_drawing, make_drawing):
+        parameters = tuple(inspect.signature(function).parameters)
+        assert parameters.index("scale_policy") < parameters.index("reproducible")
+
+
 def test_a_directly_constructed_drawing_defaults_to_off():
     """``build_drawing`` is not the only door: ``Drawing`` is public and constructible.
 
@@ -526,7 +647,9 @@ _EXPORT_SCRIPT = """
 from build123d import Box
 from draftwright.builder import build_drawing
 import sys
-build_drawing(Box(30, 20, 10), reproducible=True).export(sys.argv[1], formats=("svg", "dxf"))
+build_drawing(Box(30, 20, 10), reproducible=True).export(
+    sys.argv[1], formats=("svg", "dxf", "pdf", "png")
+)
 """
 
 
@@ -556,7 +679,7 @@ def test_two_runs_under_different_hash_seeds_agree(tmp_path):
         )
         outs.append(stem)
 
-    for ext in ("svg", "dxf"):
+    for ext in ("svg", "dxf", "pdf", "png"):
         first, second = (Path(f"{o}.{ext}").read_bytes() for o in outs)
         assert first, f"{ext} export produced nothing"
         assert first == second, f"{ext} differs between runs under different hash seeds"


### PR DESCRIPTION
## What this is

Two exports of one drawing differ in bytes, which makes a written drawing useless
as something to check in and diff. This adds `reproducible=` to make them agree.

The first two commits on this branch were a first attempt. They broke every DXF
export: `_export_shape` was handed a pre-decomposed **list**, but it only calls
`add_shape` directly on the `ExportSVG` branch — for `ExportDXF` it falls through
to `_elements(shape)`, which opens with `shape.faces()`. 40 tests failed on the
fast tier. The third commit fixes that and finishes the feature.

## The three sources of drift, and what settles each

| | |
|---|---|
| **Element order** | Not stable between runs. DXF ordered *going in* (`_elements(ordered=True)`); SVG settled *coming out* (`canonicalize_svg`). |
| **The clock** | ezdxf's fixed-metadata option, plus the creation marker it misses; reportlab's `invariant`. |
| **A set iteration** | ezdxf builds CLASSES by iterating a `set[str]` — pre-seeded sorted. |

The SVG/DXF asymmetry is deliberate. `ExportDXF` writes an entity per element as
it converts and the handles follow, so nothing after the fact can fix it. An SVG
is sorted in the written file, so it is handed its shapes unordered even when the
flag is on — ordering it too would pay the expensive half twice for a result
`canonicalize_svg` already reaches alone.

## Off by default, because ordering is not free

Interleaved, 9 runs each, 358-part sheet:

```
reproducible=False   0.452s      (origin/main: 0.485s)
reproducible=True    0.597s      +32%
```

Off costs what it did before the option existed. The metadata pinning is the cheap
half (~1 ms); both hang off the one flag, because a caller wanting a stable file
wants both and should not have to know which one costs.

## API

```python
dwg = build_drawing(part, reproducible=True)      # default the Drawing carries
dwg.export("out", formats=("dxf",))
dwg.export("out", formats=("dxf",), reproducible=False)   # override per call
```

`build_drawing` is the seam `partcad/partcad-render-draftwright` needs: it forwards
configured options there, then calls `drawing.export(stem, formats=(fmt,))` with no
keywords, so the setting has to survive the build. Verified with their exact call
shape across two interpreters — on, the DXF is identical; off, it differs at no
cost. They need one line on their side: `"reproducible"` in `DRAWING_PARAMETERS`.

## Defects found and fixed along the way

- **`canonicalize_svg` was not canonical.** It sorted each element's `tail` — the
  whitespace *after* it — with the element, so the last slot's shorter indent rode
  along with whichever element sorted last. Three permutations of one three-element
  layer produced three different files. Latent on real sheets, so only the unit
  test catches it.
- **`CREATED_BY_EZDXF` still carried a live timestamp.** ezdxf's option cannot
  reach it: it is stamped when the document is built, long before an export asks.
- **A process-wide `ezdxf.options` flag was left flipped** for every other ezdxf
  user in the interpreter. Now restored in a `finally`.
- **`_geometry_key` was not a total order.** Hidden-line removal emits overlapping
  silhouettes as reversed duplicate pairs agreeing on bounding box, geometry type,
  edge count, length and vertex set. On the front hidden layer of the test fixture
  **all 12 tie-groups held genuinely different geometry**, so their order fell back
  to the kernel's. The key now carries directed endpoints — what the exporter
  actually writes.
- **Duplicated decomposition removed.** `_canonical_parts` in `drawing.py` was
  `_elements` plus a sort, one DAG rank too high. `drawing.py` is now a 4-line diff
  against main.

## A corrected claim

The premise holds, but not for the reason originally given. The kernel's walk order
does vary (1 of 17 shapes reorders on a plain plate) but does **not** reduce to
`PYTHONHASHSEED` — with the sort removed on purpose, a fixed seed pair caught it in
3 of 4 trials. Docstrings now say "not stable between runs", and the end-to-end gate
is labelled a sampling detector. It never false-fails with the fix (6 of 6).

`AGENTS.md` said byte-identical output "is not a goal". That conflated two claims and
is now split: output is still not stable across versions or layout changes (ADR
0004/0012), but `reproducible=True` promises two exports of one drawing, on one
version, agree.

## Verification

- **Fast tier: 4752 passed.** 30 new tests.
- **16 mutations, one per guard, all caught.** One initially survived — flipping
  `Drawing.__init__`'s default is invisible through `build_drawing`, which passes the
  value explicitly — so the public constructor's default got its own test.
- **Changed-line coverage 97%** (gate 93%). The 2 uncovered lines are the defensive
  `except` that keeps a metadata failure from breaking an export.
- `pr-check --static` clean.

### Pre-existing failures, not from this branch

All reproduce with these files reverted to `main`:

- `test_workflows.py::test_version_updater_...` ×3 — the local `uv` rejects
  `uv version --no-sync`. Environmental.
- `test_export_dxf_curves.py::test_hole_table_dxf_conversion_avoids_bulk_curve_arrays`
  — 5s cap, 3.4–3.8s standalone on both main and this branch; fails only under
  `-n auto` load.
- `test_slanted_blind_step.py::test_crowded_step_warning_...` — 120s cap, ~41s
  standalone on both (main 41.2–42.4s, branch 40.5–40.7s); exceeded it only under
  `--cov` plus 16-way parallelism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
