### PR TITLE
Record CLA agreement in the PR template; update contact address

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,3 +25,7 @@ Use `N/A` with a reason for items that do not apply, such as fixture evidence on
 
 - [ ] No two consecutive review rounds invalidated the same core association strategy
 - [ ] New prerequisites were split or the work was explicitly reclassified as discovery
+
+## Contributor License Agreement
+
+- [ ] I have read the [CLA](https://github.com/pzfreo/draftwright/blob/main/CLA.md) and agree to it for this Contribution. If I am contributing on behalf of an organisation, I am authorised to agree on its behalf.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,4 +28,4 @@ Use `N/A` with a reason for items that do not apply, such as fixture evidence on
 
 ## Contributor License Agreement
 
-- [ ] I have read the [CLA](https://github.com/pzfreo/draftwright/blob/main/CLA.md) and agree to it for this Contribution. If I am contributing on behalf of an organisation, I am authorised to agree on its behalf.
+- [ ] I have read the [CLA](https://github.com/pzfreo/draftwright/blob/main/CLA.md) and agree to it. If I am contributing on behalf of an organisation, I am authorised to agree on its behalf.

--- a/CLA.md
+++ b/CLA.md
@@ -15,7 +15,7 @@ your Contributions** — you are granting a licence, not assigning ownership.
 
 In this Agreement:
 
-- **"Project Owner"** means Paul Fremantle (pzfreo@gmail.com), the copyright
+- **"Project Owner"** means Paul Fremantle (paul@fremantle.org), the copyright
   holder and maintainer of draftwright.
 - **"You"** / **"Your"** means the individual or legal entity agreeing to this
   Agreement.
@@ -116,7 +116,7 @@ submission.
 
 If You are contributing on behalf of an organisation that wishes to record its
 agreement explicitly, or if You need an entity-level CLA covering employees,
-contact the Project Owner at pzfreo@gmail.com.
+contact the Project Owner at paul@fremantle.org.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,4 +256,4 @@ failure read as a pass.
 ## License
 
 AGPL-3.0. Anyone running draftwright as a network service must provide their
-application's source code. Contact pzfreo@gmail.com for a commercial licence.
+application's source code. Contact paul@fremantle.org for a commercial licence.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,4 +100,4 @@ the installed package. Never commit a path or Git override.
 - Use the PR template to record the slice and its stop condition.
 - Run `scripts/pr-check --quick` while iterating and `scripts/pr-check` before the final push.
 
-Questions or commercial-licensing enquiries: pzfreo@gmail.com.
+Questions or commercial-licensing enquiries: paul@fremantle.org.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.4.16.dev0"
 description = "Automated technical-drawing generation for build123d"
 readme = "README.md"
 license = { file = "LICENSE" }
-authors = [{ name = "Paul Fremantle", email = "pzfreo@gmail.com" }]
+authors = [{ name = "Paul Fremantle", email = "paul@fremantle.org" }]
 requires-python = ">=3.10,<3.15"
 dependencies = [
     # build123d ≤0.10 pulls cadquery-ocp (VTK), whose VTK caps at Python 3.12; 0.11 switched to


### PR DESCRIPTION
## Symptom and evidence

- **User-visible problem:** #1345 is the project's first third-party contribution (`git log --format='%an' | sort -u` returns only Paul Fremantle and github-actions[bot]). It arrived with no CLA acknowledgement anywhere — 0 issue comments, 0 review comments, nothing in the body — and there is no mechanism that would have produced one: no CLA bot in `.github/workflows/` (only `ci.yml`, `docs.yml`, `publish.yml`), no signatures file, and no item in the PR template. Establishing agreement required an ad-hoc comment.
- **Before/after:** before, the template's four sections never mention the CLA; after, a contributor ticks one box.

## Contract and scope

- **Smallest contract:** the PR template records CLA acceptance, including the on-behalf-of-an-organisation case.
- This does **not** change what the CLA says or how it is accepted. `CLA.md` and `CONTRIBUTING.md` already make opening a PR the act of agreement; the checkbox makes that acceptance visible rather than inferred, which matters for a dual-licensed project whose commercial offering rests on CLA §2.
- **Explicitly deferred:** `CLA.md`, `CLAUDE.md` and `pyproject.toml` still carry `pzfreo@gmail.com`. The CLA's Project Owner definition and the published PyPI package metadata are separate decisions, not a docs tidy-up.

## Validation

- `scripts/pr-check --static` exits 0 (ruff check, ruff format, mypy, codespell, mkdocs build).
- Remaining items `N/A` — docs/template-only change, no source or test behaviour touched.

## Stop check

- [x] No two consecutive review rounds invalidated the same core association strategy
- [x] New prerequisites were split or the work was explicitly reclassified as discovery
