### PR TITLE
Consume standalone face inspection for declared fillets

### DIFF
--- a/docs/geometry-facade-spike.md
+++ b/docs/geometry-facade-spike.md
@@ -1,22 +1,22 @@
 # Geometry facade spike: Draftwright finding
 
-Draftwright's selected F7 workflow was the existing `fillet(face)` declaration. The spike replaces
-Draftwright's direct `BRepAdaptor_Surface` read and recogniser-specific `fillet_anchor` call with
-`b123d_recognisers.experimental_geometry`.
+Draftwright's selected F7 workflow was the existing `fillet(face)` declaration. The completed
+spike replaces Draftwright's direct `BRepAdaptor_Surface` read and recogniser-specific
+`fillet_anchor` call with the graph-independent
+`b123d_recognisers.experimental_geometry.inspect_face`.
 
 The result is semantically successful: the same principal axis, radius and on-round anchor are
 produced; planar faces refuse with the existing user-facing error; existing declared/detected
 fillet and drawing tests pass; and Draftwright imports no underscore-private recogniser module.
 
-The architectural result is a deliberate **no-go on publishing the graph yet**. This workflow
-needs a closed analytic fact for one face and an anchor on that face. It does not need adjacency,
-smooth regions, blend selection or graph-owned traversal. A one-face `GeometryGraph` costs only
-about 0.2 ms, but its conceptual surface is still too large.
+The architectural result is a deliberate **no-go on publishing the graph yet**, and a **go on API
+review for face inspection**. Draftwright imports exactly `AnalyticSurface` and `inspect_face`; no
+graph, run-local reference, adjacency, smooth region or blend-selection type crosses the package
+boundary. The result contains the closed surface fact and an optional on-face anchor.
 
-The next Draftwright integration should therefore consume a smaller graph-independent
-`inspect_face(face)` projection. `GeometryGraph` should be published only after another concrete
-Draftwright workflow independently requires adjacency or selected blend provenance. Correspondence,
-snapshots, body matching, registries and recognition ownership remain out of scope.
+`GeometryGraph` should be published only after another concrete out-of-tree workflow independently
+requires adjacency or selected blend provenance. Correspondence, snapshots, body matching,
+registries and recognition ownership remain out of scope.
 
 Executable evidence lives in `tests/test_geometry_graph_spike.py`; the package-side design,
 benchmarks and complete recommendation live in `docs/f7-geometry-facade-spike.md` in the paired

--- a/docs/geometry-facade-spike.md
+++ b/docs/geometry-facade-spike.md
@@ -1,0 +1,23 @@
+# Geometry facade spike: Draftwright finding
+
+Draftwright's selected F7 workflow was the existing `fillet(face)` declaration. The spike replaces
+Draftwright's direct `BRepAdaptor_Surface` read and recogniser-specific `fillet_anchor` call with
+`b123d_recognisers.experimental_geometry`.
+
+The result is semantically successful: the same principal axis, radius and on-round anchor are
+produced; planar faces refuse with the existing user-facing error; existing declared/detected
+fillet and drawing tests pass; and Draftwright imports no underscore-private recogniser module.
+
+The architectural result is a deliberate **no-go on publishing the graph yet**. This workflow
+needs a closed analytic fact for one face and an anchor on that face. It does not need adjacency,
+smooth regions, blend selection or graph-owned traversal. A one-face `GeometryGraph` costs only
+about 0.2 ms, but its conceptual surface is still too large.
+
+The next Draftwright integration should therefore consume a smaller graph-independent
+`inspect_face(face)` projection. `GeometryGraph` should be published only after another concrete
+Draftwright workflow independently requires adjacency or selected blend provenance. Correspondence,
+snapshots, body matching, registries and recognition ownership remain out of scope.
+
+Executable evidence lives in `tests/test_geometry_graph_spike.py`; the package-side design,
+benchmarks and complete recommendation live in `docs/f7-geometry-facade-spike.md` in the paired
+`b123d-recognisers` spike checkout.

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -67,7 +67,7 @@ with no inferred gear feature added to fill the table.
 
 ## Passage compatibility boundary
 
-The installed `b123d-recognisers==0.4.0` release contains the `passages` family introduced
+The installed `b123d-recognisers==0.4.1` release contains the `passages` family introduced
 in 0.2.6. Version 0.4.0 makes `SectionPassage` the authoritative physical output and retains
 schema-v1 `Passage` as its compatibility projection. Draftwright declares all six public and nested
 record schemas exhaustively but deliberately keeps the family `unsupported`, with the drafting
@@ -84,6 +84,6 @@ The 0.4 contract is explicit:
 - rich split-junction passages can supersede a Slot claim, moving physical ownership to the
   unsupported Passage family through `SLOT_SUPERSEDED_BY_PASSAGE`.
 
-The exact 0.4.0 pin, manifest-v2 validator and explicit unsupported inventories make that limitation
+The exact 0.4.1 pin, manifest-v2 validator and explicit unsupported inventories make that limitation
 fail-visible rather than silently treating rich passages as supported. Issue #1245 still owns the
 decision about what newly Passage-owned occurrences draw and how they participate in completeness.

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -67,31 +67,23 @@ with no inferred gear feature added to fill the table.
 
 ## Passage compatibility boundary
 
-The installed `b123d-recognisers==0.3.1` release already contains the `passages` family introduced
-in 0.2.6. Draftwright declares its schema-v1 `Passage` output exhaustively but deliberately keeps
-the family `unsupported`, with the drafting decision tracked by issue #1245. This is a truthful
-consumer disposition: the geometry remains visible in the aggregate inventory, while Draftwright
-does not invent an IR feature, DSL declaration, generated code, drawing annotation, or completeness
-requirement for it.
+The installed `b123d-recognisers==0.4.0` release contains the `passages` family introduced
+in 0.2.6. Version 0.4.0 makes `SectionPassage` the authoritative physical output and retains
+schema-v1 `Passage` as its compatibility projection. Draftwright declares all six public and nested
+record schemas exhaustively but deliberately keeps the family `unsupported`, with the drafting
+decision tracked by issue #1245. This is a truthful consumer disposition: both aggregate
+inventories are visible and explicitly unscored, while Draftwright does not invent an IR feature,
+DSL declaration, generated code, drawing annotation, or completeness requirement for them.
 
-Draftwright's exact dependency pin must remain on a reviewed released version in the interval
-`>=0.2.6,<0.4.0` until the separately reviewed F4b transition is ready. The lower boundary ensures
-the installed manifest really contains `passages`; the upper boundary prevents accidental adoption
-of the planned 0.4 compatibility change.
-
-The reviewed future 0.4 model is a distinct migration, not latent behavior in this declaration:
+The 0.4 contract is explicit:
 
 - `SectionPassage` will be the authoritative physical output and aggregate census source;
 - legacy `Passage` values will be an accepted-only compatibility projection;
 - `recognise_passages(..., ledger=...)` will be a fail-loud unavailable compatibility operation;
 - the writer-free `recognise_passages` name will remain public but non-authoritative; and
-- rich split-junction passages can supersede a currently rendered Slot claim, moving ownership to
-  the Passage family through `SLOT_SUPERSEDED_BY_PASSAGE`; and
-- the capability contract must represent those API and per-output roles exhaustively before the
-  dependency pin can cross 0.4.
+- rich split-junction passages can supersede a Slot claim, moving physical ownership to the
+  unsupported Passage family through `SLOT_SUPERSEDED_BY_PASSAGE`.
 
-That migration must update the package release, Draftwright adapter and declaration model,
-validator, tests, exact pin, and lockfile together. The current validator remains unchanged and
-fail closed; there is no forward declaration or stale-manifest exception. Crossing 0.4 also
-requires #1245 to decide what those newly Passage-owned occurrences draw, or an explicit reviewed
-decision to accept the resulting loss of the existing Slot callout.
+The exact 0.4.0 pin, manifest-v2 validator and explicit unsupported inventories make that limitation
+fail-visible rather than silently treating rich passages as supported. Issue #1245 still owns the
+decision about what newly Passage-owned occurrences draw and how they participate in completeness.

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -67,7 +67,7 @@ with no inferred gear feature added to fill the table.
 
 ## Passage compatibility boundary
 
-The installed `b123d-recognisers==0.4.1` release contains the `passages` family introduced
+The installed `b123d-recognisers==0.4.2` release contains the `passages` family introduced
 in 0.2.6. Version 0.4.0 makes `SectionPassage` the authoritative physical output and retains
 schema-v1 `Passage` as its compatibility projection. Draftwright declares all six public and nested
 record schemas exhaustively but deliberately keeps the family `unsupported`, with the drafting
@@ -84,6 +84,6 @@ The 0.4 contract is explicit:
 - rich split-junction passages can supersede a Slot claim, moving physical ownership to the
   unsupported Passage family through `SLOT_SUPERSEDED_BY_PASSAGE`.
 
-The exact 0.4.1 pin, manifest-v2 validator and explicit unsupported inventories make that limitation
+The exact 0.4.2 pin, manifest-v2 validator and explicit unsupported inventories make that limitation
 fail-visible rather than silently treating rich passages as supported. Issue #1245 still owns the
 decision about what newly Passage-owned occurrences draw and how they participate in completeness.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "build123d>=0.9.0,<0.11 ; python_full_version < '3.13'",
     "build123d>=0.11,<0.12 ; python_full_version >= '3.13'",
     "build123d-drafting-helpers>=0.14.2",
-    "b123d-recognisers==0.3.1",
+    "b123d-recognisers==0.4.0",
     "numpy>=1.24",
     # PNG raster export (SVG→PDF→PNG). Both permissively licensed (Pillow HPND; pypdfium2
     # Apache-2.0 wrapping Google PDFium BSD-3) and ship pre-built wheels with NO native system

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "build123d>=0.9.0,<0.11 ; python_full_version < '3.13'",
     "build123d>=0.11,<0.12 ; python_full_version >= '3.13'",
     "build123d-drafting-helpers>=0.14.2",
-    "b123d-recognisers==0.4.0",
+    "b123d-recognisers==0.4.1",
     "numpy>=1.24",
     # PNG raster export (SVG→PDF→PNG). Both permissively licensed (Pillow HPND; pypdfium2
     # Apache-2.0 wrapping Google PDFium BSD-3) and ship pre-built wheels with NO native system

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "build123d>=0.9.0,<0.11 ; python_full_version < '3.13'",
     "build123d>=0.11,<0.12 ; python_full_version >= '3.13'",
     "build123d-drafting-helpers>=0.14.2",
-    "b123d-recognisers==0.4.1",
+    "b123d-recognisers==0.4.2",
     "numpy>=1.24",
     # PNG raster export (SVG→PDF→PNG). Both permissively licensed (Pillow HPND; pypdfium2
     # Apache-2.0 wrapping Google PDFium BSD-3) and ship pre-built wheels with NO native system

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -126,6 +126,7 @@ _NON_REQUIREMENT_INVENTORIES = frozenset(
 _UNDECIDED_INVENTORIES: dict[str, str] = {
     "angled_steps": "https://github.com/pzfreo/draftwright/issues/1247",
     "passages": "https://github.com/pzfreo/draftwright/issues/1245",
+    "section_passages": "https://github.com/pzfreo/draftwright/issues/1245",
     "prismatic_pockets": "https://github.com/pzfreo/draftwright/issues/1246",
 }
 

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -617,11 +617,10 @@ def _read_fillet_face(face) -> tuple[str, float, Point]:
     along), the radius (the cylinder radius), and a point **on the round** (mid angular/axial of
     the trimmed face — the ``R`` leader's tip). Agrees with the recogniser (recognition/fillets.py)
     in the two in-plane (placement) coordinates; the along-edge coordinate is view depth."""
-    from b123d_recognisers.experimental_geometry import AnalyticSurface, GeometryGraph
+    from b123d_recognisers.experimental_geometry import AnalyticSurface, inspect_face
 
-    geometry = GeometryGraph(face)
-    ref = geometry.ref(face)
-    surface = geometry.surface_fact(ref)
+    inspection = inspect_face(face)
+    surface = inspection.surface
     if not isinstance(surface, AnalyticSurface) or surface.kind.value != "cylinder":
         raise ValueError(
             "fillet(face=...) needs a cylindrical blend face (the round); an edge or flat "
@@ -633,9 +632,13 @@ def _read_fillet_face(face) -> tuple[str, float, Point]:
             "fillet(face=...): the round must run along one principal axis; use axis=, radius=, at="
         )
     edge_i = max(range(3), key=lambda i: comp[i])
-    # The facade owns both the analytic fact and the trimmed-surface anchor, so
-    # Draftwright no longer reopens the raw OCCT surface or depends on a recogniser helper.
-    p = geometry.surface_anchor(ref)
+    # The inspection result owns both the analytic fact and trimmed-surface anchor, so
+    # Draftwright sees neither a graph handle nor a recogniser implementation helper.
+    p = inspection.anchor
+    if p is None:
+        raise ValueError(
+            "fillet(face=...): no stable point on the round is available; use axis=, radius=, at="
+        )
     return (
         "xyz"[edge_i],
         round(surface.parameters[6], 3),

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -617,31 +617,28 @@ def _read_fillet_face(face) -> tuple[str, float, Point]:
     along), the radius (the cylinder radius), and a point **on the round** (mid angular/axial of
     the trimmed face — the ``R`` leader's tip). Agrees with the recogniser (recognition/fillets.py)
     in the two in-plane (placement) coordinates; the along-edge coordinate is view depth."""
-    from OCP.BRepAdaptor import BRepAdaptor_Surface
-    from OCP.GeomAbs import GeomAbs_Cylinder
+    from b123d_recognisers.experimental_geometry import AnalyticSurface, GeometryGraph
 
-    s = BRepAdaptor_Surface(face.wrapped)
-    if s.GetType() != GeomAbs_Cylinder:
+    geometry = GeometryGraph(face)
+    ref = geometry.ref(face)
+    surface = geometry.surface_fact(ref)
+    if not isinstance(surface, AnalyticSurface) or surface.kind.value != "cylinder":
         raise ValueError(
             "fillet(face=...) needs a cylindrical blend face (the round); an edge or flat "
             "face is not a fillet — declare with axis=, radius=, at= instead"
         )
-    d = s.Cylinder().Axis().Direction()
-    comp = (abs(d.X()), abs(d.Y()), abs(d.Z()))
+    comp = tuple(abs(value) for value in surface.parameters[3:6])
     if max(comp) <= 0.99:
         raise ValueError(
             "fillet(face=...): the round must run along one principal axis; use axis=, radius=, at="
         )
     edge_i = max(range(3), key=lambda i: comp[i])
-    # Anchor on the curved radius surface itself — the recogniser's own fillet_anchor
-    # (#622 lesson: never the bbox centre), so a declared fillet's leader tip is
-    # identical to the detected one's by construction (#704).
-    from b123d_recognisers import fillet_anchor
-
-    p = fillet_anchor(s)
+    # The facade owns both the analytic fact and the trimmed-surface anchor, so
+    # Draftwright no longer reopens the raw OCCT surface or depends on a recogniser helper.
+    p = geometry.surface_anchor(ref)
     return (
         "xyz"[edge_i],
-        round(s.Cylinder().Radius(), 3),
+        round(surface.parameters[6], 3),
         (
             round(p[0], 4),
             round(p[1], 4),

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -45,6 +45,7 @@ from b123d_recognisers import (
     RectGrid,
     RepeatingRadialProfile,
     RiserEvidence,
+    SectionPassage,
     Slot,
     SlotArray,
     SlotGrid,
@@ -719,8 +720,12 @@ _UNCONSUMED_RECORDS: dict[type, str] = {
         "chamfer; whether draftwright dimensions it is open (#1247)"
     ),
     Passage: (
-        "a prismatic through-opening — the internal counterpart to polygonal stock; whether it "
-        "is an IR kind or refines `hole`, and what it draws, is open (#1245)"
+        "the compatibility projection of a prismatic through-opening; whether it is an IR kind "
+        "or refines `hole`, and what it draws, is open (#1245)"
+    ),
+    SectionPassage: (
+        "the authoritative physical prismatic-opening evidence introduced in 0.4.0; its IR kind, "
+        "section rendering and completeness semantics remain open (#1245)"
     ),
     PrismaticPocket: (
         "a non-rectangular blind recess that OVERLAPS the supported `pockets` family — measured, "

--- a/src/draftwright/recogniser_contract.py
+++ b/src/draftwright/recogniser_contract.py
@@ -215,7 +215,14 @@ def _geometry_only_declaration() -> dict[str, Any]:
 #: these three did (#1244).
 _UNSUPPORTED: dict[str, tuple[tuple[str, ...], str, str]] = {
     "passages": (
-        ("Passage",),
+        (
+            "Passage",
+            "PassageEnds",
+            "PassageFrame",
+            "PassageSection",
+            "PassageSectionVertex",
+            "SectionPassage",
+        ),
         "https://github.com/pzfreo/draftwright/issues/1245",
         "A prismatic through-opening — the internal counterpart to polygonal stock. Whether it "
         "becomes an IR kind or refines `hole`, and what a passage draws (across-flats + THRU, or "
@@ -285,7 +292,7 @@ def consumer_capability_declaration() -> dict[str, Any]:
         "package_compatibility": {
             "distribution": _RECOGNISER_DISTRIBUTION,
             "version": f"=={distribution_version(_RECOGNISER_DISTRIBUTION)}",
-            "manifest_format": 1,
+            "manifest_format": 2,
         },
         "families": families,
         "transitions": [],
@@ -384,7 +391,7 @@ def pending_family_declarations(*, package: object | None = None) -> list[str]:
     repository, not a reason to block the package's release. See
     ``tests/test_recogniser_adoption.py``, which is what makes that job visible.
     """
-    manifest = capability_manifest(format_version=1) if package is None else package
+    manifest = capability_manifest(format_version=2) if package is None else package
     if not isinstance(manifest, dict) or not isinstance(manifest.get("families"), list):
         raise RecogniserCapabilityError("installed recogniser manifest format is unsupported")
     package_ids = {
@@ -404,7 +411,7 @@ def validate_recogniser_capabilities(
 ) -> None:
     """Fail closed when installed package truth and Draftwright policy do not exactly join."""
     current = consumer_capability_declaration() if declaration is None else declaration
-    manifest = capability_manifest(format_version=1) if package is None else package
+    manifest = capability_manifest(format_version=2) if package is None else package
     if not isinstance(current, dict) or set(current) != {
         "consumer",
         "families",
@@ -435,7 +442,7 @@ def validate_recogniser_capabilities(
     if not isinstance(compatibility, dict) or compatibility != {
         "distribution": _RECOGNISER_DISTRIBUTION,
         "version": f"=={installed_package_version}",
-        "manifest_format": 1,
+        "manifest_format": 2,
     }:
         raise RecogniserCapabilityError(
             "package compatibility does not match installed b123d-recognisers metadata"
@@ -444,7 +451,7 @@ def validate_recogniser_capabilities(
         not isinstance(manifest, dict)
         or manifest.get("format") != "b123d-recognisers-capabilities"
         or type(manifest.get("format_version")) is not int
-        or manifest.get("format_version") != 1
+        or manifest.get("format_version") != 2
     ):
         raise RecogniserCapabilityError("installed recogniser manifest format is unsupported")
     package_info = manifest.get("package")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@
 guard (#1019) counts recogniser families the same way.
 """
 
+import inspect
 import sys
 from collections.abc import Callable, Mapping
 from contextlib import contextmanager
@@ -84,6 +85,31 @@ def counting_calls(functions: Mapping[str, Callable[..., object]]):
         yield counts
     finally:
         sys.setprofile(previous)
+
+
+@contextmanager
+def recognition_family_calls(names: set[str] | frozenset[str] | None = None):
+    """Count aggregate family executions at the recogniser registry seam.
+
+    Since b123d-recognisers 0.4 the aggregate executes evidence-producing registry adapters,
+    not the public value-only compatibility wrappers. Simple adapters close over a per-family
+    callable; count that callable so families made through the shared adapter factory remain
+    distinguishable by code object.
+    """
+    from b123d_recognisers._registry import DERIVED_DEFINITIONS, PHYSICAL_DEFINITIONS
+
+    functions: dict[str, Callable[..., object]] = {}
+    for physical in PHYSICAL_DEFINITIONS:
+        discover = physical.discover
+        call = inspect.getclosurevars(discover).nonlocals.get("call", discover)
+        functions[physical.public_entrypoint] = call
+    for derived in DERIVED_DEFINITIONS:
+        if derived.public_entrypoint is not None:
+            functions[derived.public_entrypoint] = derived.derive
+    if names is not None:
+        functions = {name: functions[name] for name in names}
+    with counting_calls(functions) as counts:
+        yield counts
 
 
 # ── The `unit` tier (#656): pure-logic tests, zero OCC geometry ──────────────────────

--- a/tests/test_declared_recognition_gate.py
+++ b/tests/test_declared_recognition_gate.py
@@ -19,7 +19,6 @@ import inspect
 from contextlib import contextmanager
 from types import SimpleNamespace
 
-import b123d_recognisers as recognition
 import pytest
 from b123d_recognisers import (
     RecognitionResult,
@@ -30,7 +29,7 @@ from b123d_recognisers import (
 )
 from b123d_recognisers.result import DEFERRED, MIGRATED
 from build123d import Align, Box, Cylinder, Pos, Rot
-from conftest import counting_calls
+from conftest import counting_calls, recognition_family_calls
 
 from draftwright import Sheet, build_drawing
 from draftwright.compose import _est_right_strip_depth, _n_right_strip_boss_heights
@@ -39,9 +38,7 @@ from draftwright.linting.coverage import lint_prismatic_coverage
 
 @contextmanager
 def _counting_every_family():
-    with counting_calls(
-        {name: getattr(recognition, name) for name in MIGRATED | DEFERRED.keys()}
-    ) as counts:
+    with recognition_family_calls(MIGRATED | DEFERRED.keys()) as counts:
         yield counts
 
 

--- a/tests/test_detect_once.py
+++ b/tests/test_detect_once.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import pytest
 from build123d import Axis, Box, fillet
-from conftest import counting_calls
+from conftest import counting_calls, recognition_family_calls
 
 from draftwright import build_drawing
 
@@ -39,17 +39,16 @@ def fillet_counter():
     Same reasoning as ``cyls_counter`` below and the ADR 0017 manifest guards: a code object
     cannot be re-bound, so the count survives the next migration too.
     """
-    from b123d_recognisers import recognise_fillets
-
-    with counting_calls({"n": recognise_fillets}) as counts:
-        yield counts
+    with recognition_family_calls({"recognise_fillets"}) as family_counts:
+        yield family_counts
 
 
 def test_detectors_run_once_per_build(fillet_counter):
     dwg = build_drawing(_filleted())
 
-    assert fillet_counter.get("n") == 1, (
-        f"recognise_fillets ran {fillet_counter.get('n', 0)}× in one build — the sizing and "
+    assert fillet_counter.get("recognise_fillets") == 1, (
+        "recognise_fillets ran "
+        f"{fillet_counter.get('recognise_fillets', 0)}× in one build — the sizing and "
         f"render paths are re-detecting instead of sharing one inventory (ADR 0008: detected "
         f"once). A prismatic fixture, so the #1028 classification gate does not apply."
     )
@@ -65,8 +64,9 @@ def test_generate_script_detects_once(fillet_counter, tmp_path):
     step = str(tmp_path / "filleted.step")
     export_step(_filleted(), step)
     generate_sheet_script(step, out=str(tmp_path / "s"))
-    assert fillet_counter.get("n") == 1, (
-        f"recognise_fillets ran {fillet_counter.get('n', 0)}× in generate_sheet_script — the "
+    assert fillet_counter.get("recognise_fillets") == 1, (
+        "recognise_fillets ran "
+        f"{fillet_counter.get('recognise_fillets', 0)}× in generate_sheet_script — the "
         f"emitter must reuse one inventory, not rebuild"
     )
 
@@ -113,8 +113,9 @@ def test_declared_model_runs_no_detection(fillet_counter):
 
     part = _filleted()
     dwg = build_drawing(part, model=[declare.envelope(part)])
-    assert fillet_counter.get("n", 0) == 0, (
-        f"recognise_fillets ran {fillet_counter['n']}× on the declared-model path — "
+    assert fillet_counter.get("recognise_fillets", 0) == 0, (
+        "recognise_fillets ran "
+        f"{fillet_counter.get('recognise_fillets', 0)}× on the declared-model path — "
         f"declaration must skip detection (ADR 0011)"
     )
     assert dwg._analysis.model is None  # declared models are not stored on Analysis

--- a/tests/test_geometry_graph_spike.py
+++ b/tests/test_geometry_graph_spike.py
@@ -27,6 +27,15 @@ def test_declared_fillet_uses_the_facade_without_private_recogniser_imports() ->
 
     assert "b123d_recognisers.experimental_geometry" in recogniser_imports
     assert all(not name.startswith("b123d_recognisers._") for name in recogniser_imports)
+    imported_names = {
+        alias.name
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        and node.module == "b123d_recognisers.experimental_geometry"
+        for alias in node.names
+    }
+    assert imported_names == {"AnalyticSurface", "inspect_face"}
+    assert "GeometryGraph" not in source
 
 
 def test_real_declared_fillet_reads_radius_axis_and_on_surface_anchor() -> None:

--- a/tests/test_geometry_graph_spike.py
+++ b/tests/test_geometry_graph_spike.py
@@ -1,0 +1,45 @@
+"""Bounded Draftwright consumer evidence for the provisional F7 facade."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+from build123d import Axis, Box, GeomType, Vertex
+from build123d import fillet as bd_fillet
+
+from draftwright.model.declare import fillet
+
+ROOT = Path(__file__).parents[1]
+
+
+def test_declared_fillet_uses_the_facade_without_private_recogniser_imports() -> None:
+    source = (ROOT / "src/draftwright/model/declare.py").read_text()
+    tree = ast.parse(source)
+    recogniser_imports = {
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom)
+        and node.module is not None
+        and node.module.startswith("b123d_recognisers")
+    }
+
+    assert "b123d_recognisers.experimental_geometry" in recogniser_imports
+    assert all(not name.startswith("b123d_recognisers._") for name in recogniser_imports)
+
+
+def test_real_declared_fillet_reads_radius_axis_and_on_surface_anchor() -> None:
+    part = bd_fillet(Box(60, 40, 30).edges().filter_by(Axis.Z).sort_by(Axis.X)[-1], 5)
+    round_face = next(face for face in part.faces() if face.geom_type is GeomType.CYLINDER)
+
+    feature = fillet(round_face)
+
+    assert feature.axis == "z"
+    assert feature.radius == pytest.approx(5)
+    assert part.distance_to(Vertex(*feature.frame.origin)) < 0.05
+
+
+def test_declared_fillet_refuses_a_planar_face_as_a_closed_consumer_error() -> None:
+    with pytest.raises(ValueError, match="needs a cylindrical blend face"):
+        fillet(Box(10, 20, 30).faces()[0])

--- a/tests/test_issue_1058_wheel_profile.py
+++ b/tests/test_issue_1058_wheel_profile.py
@@ -296,7 +296,11 @@ def test_equal_profiles_on_distinct_bodies_remain_ambiguous(wheel_part, monkeypa
     monkeypatch.setattr(
         repeating_profiles,
         "_recognise_solid",
-        lambda solid, **_kwargs: [profile] if solid in bodies else [],
+        lambda solid, **_kwargs: [
+            repeating_profiles._RepeatingRadialProposal(profile, object(), object())
+        ]
+        if solid in bodies
+        else [],
     )
 
     assert repeating_profiles.recognise_repeating_radial_profiles(part) == [profile, profile]

--- a/tests/test_issue_1058_wheel_profile.py
+++ b/tests/test_issue_1058_wheel_profile.py
@@ -296,11 +296,11 @@ def test_equal_profiles_on_distinct_bodies_remain_ambiguous(wheel_part, monkeypa
     monkeypatch.setattr(
         repeating_profiles,
         "_recognise_solid",
-        lambda solid, **_kwargs: [
-            repeating_profiles._RepeatingRadialProposal(profile, object(), object())
-        ]
-        if solid in bodies
-        else [],
+        lambda solid, **_kwargs: (
+            [repeating_profiles._RepeatingRadialProposal(profile, object(), object())]
+            if solid in bodies
+            else []
+        ),
     )
 
     assert repeating_profiles.recognise_repeating_radial_profiles(part) == [profile, profile]

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -117,7 +117,7 @@ def test_installed_package_contract_validates_without_a_sibling_checkout() -> No
     assert package_path.is_relative_to(ROOT / ".venv")
 
     _validate()
-    package = recognition.capability_manifest(format_version=1)
+    package = recognition.capability_manifest(format_version=2)
     declaration = consumer_capability_declaration()
     # 25 since 0.2.6 added angled-steps, passages and prismatic-pockets (#1244). A literal,
     # not a length comparison against the package: the point is that BOTH sides changed
@@ -125,27 +125,34 @@ def test_installed_package_contract_validates_without_a_sibling_checkout() -> No
     assert len(package["families"]) == len(declaration["families"]) == 25
 
 
-def test_existing_passage_contract_is_truthfully_declared_before_f4b() -> None:
-    """Pin the current-family declaration separately from the future 0.4 migration."""
+def test_rich_passage_contract_is_truthfully_deferred_with_its_projection() -> None:
+    """Pin the 0.4 physical record and compatibility projection to one decision."""
 
-    assert INSTALLED_PACKAGE_VERSION == "0.3.1"
+    assert INSTALLED_PACKAGE_VERSION == "0.4.0"
     installed = tuple(int(component) for component in INSTALLED_PACKAGE_VERSION.split("."))
-    # b123d-recognisers#184 and Draftwright #1337/#1245 must be accepted before this
-    # upper bound moves: 0.4 changes both the capability model and rendered ownership.
-    assert (0, 2, 6) <= installed < (0, 4, 0)
+    assert (0, 4, 0) <= installed < (0, 5, 0)
     package = _families(recognition.capability_manifest())
     declaration = _families(consumer_capability_declaration())
     passage_package = package["passages"]
     passage_consumer = declaration["passages"]
 
     assert passage_package["introduced_in"] == "0.2.6"
-    assert len(passage_package["records"]) == 1
-    passage_record = passage_package["records"][0]
+    assert len(passage_package["records"]) == 6
+    passage_record = next(
+        record for record in passage_package["records"] if record["name"] == "Passage"
+    )
     assert passage_record["name"] == "Passage"
-    assert passage_record["role"] == "output"
+    assert passage_record["role"] == "projection"
     assert passage_record["schema_version"] == 1
     assert passage_record["aggregate_membership"] == ["RecognitionResult.passages"]
-    assert passage_consumer["record_schemas"] == {"Passage": [1]}
+    assert passage_consumer["record_schemas"] == {
+        "Passage": [1],
+        "PassageEnds": [1],
+        "PassageFrame": [1],
+        "PassageSection": [1],
+        "PassageSectionVertex": [1],
+        "SectionPassage": [1],
+    }
     assert passage_consumer["disposition"] == "unsupported"
     assert passage_consumer["tracking"] == "https://github.com/pzfreo/draftwright/issues/1245"
     assert {
@@ -428,7 +435,7 @@ def test_pending_declarations_reject_a_malformed_manifest() -> None:
 
 def test_schema_format_fails_closed() -> None:
     package = recognition.capability_manifest()
-    package["format_version"] = 2
+    package["format_version"] = 1
     with pytest.raises(RecogniserCapabilityError, match="manifest format"):
         _validate(package=package)
 

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -128,7 +128,7 @@ def test_installed_package_contract_validates_without_a_sibling_checkout() -> No
 def test_rich_passage_contract_is_truthfully_deferred_with_its_projection() -> None:
     """Pin the 0.4 physical record and compatibility projection to one decision."""
 
-    assert INSTALLED_PACKAGE_VERSION == "0.4.0"
+    assert INSTALLED_PACKAGE_VERSION == "0.4.1"
     installed = tuple(int(component) for component in INSTALLED_PACKAGE_VERSION.split("."))
     assert (0, 4, 0) <= installed < (0, 5, 0)
     package = _families(recognition.capability_manifest())

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -128,7 +128,7 @@ def test_installed_package_contract_validates_without_a_sibling_checkout() -> No
 def test_rich_passage_contract_is_truthfully_deferred_with_its_projection() -> None:
     """Pin the 0.4 physical record and compatibility projection to one decision."""
 
-    assert INSTALLED_PACKAGE_VERSION == "0.4.1"
+    assert INSTALLED_PACKAGE_VERSION == "0.4.2"
     installed = tuple(int(component) for component in INSTALLED_PACKAGE_VERSION.split("."))
     assert (0, 4, 0) <= installed < (0, 5, 0)
     package = _families(recognition.capability_manifest())

--- a/tests/test_recognition_manifest.py
+++ b/tests/test_recognition_manifest.py
@@ -45,6 +45,7 @@ from b123d_recognisers import (
     recognise_rectangular_pads,
     recognise_repeating_radial_profiles,
     recognise_risers,
+    recognise_section_passages,
     recognise_slot_patterns,
     recognise_slots,
     recognise_turned_steps,
@@ -67,7 +68,7 @@ from build123d import (
     extrude,
     import_step,
 )
-from conftest import counting_calls
+from conftest import recognition_family_calls
 
 import draftwright.model.detect as detect_module
 from draftwright import Sheet, build_drawing
@@ -272,9 +273,12 @@ def _public_families() -> set[str]:
     return {name for name in recognition.__all__ if name.startswith("recognise_")}
 
 
+_PROJECTED_COMPATIBILITY = frozenset({"recognise_passages"})
+
+
 def test_every_public_recogniser_is_migrated_or_deferred_with_a_reason():
     families = _public_families()
-    classified = MIGRATED | DEFERRED.keys()
+    classified = MIGRATED | DEFERRED.keys() | _PROJECTED_COMPATIBILITY
 
     unclassified = families - classified
     assert not unclassified, (
@@ -285,6 +289,9 @@ def test_every_public_recogniser_is_migrated_or_deferred_with_a_reason():
     stale = classified - families
     assert not stale, f"manifest names non-existent recogniser(s): {sorted(stale)}"
     assert not (MIGRATED & DEFERRED.keys()), "a family cannot be both migrated and deferred"
+    assert not (_PROJECTED_COMPATIBILITY & (MIGRATED | DEFERRED.keys())), (
+        "a projected compatibility API cannot also be a physical migrated/deferred family"
+    )
 
 
 def test_every_public_recogniser_reaches_the_package_surface():
@@ -428,7 +435,7 @@ def test_the_migrated_families_are_the_ones_the_orchestration_actually_runs():
     # A part carrying every migrated feature kind would be enormous; the claim under test
     # is that the ORCHESTRATION invokes each family, which holds for any solid — a family
     # that finds nothing was still asked.
-    with counting_calls({name: getattr(recognition, name) for name in MIGRATED}) as called:
+    with recognition_family_calls(MIGRATED) as called:
         result_module.build_recognition_result(Box(40, 30, 10))
 
     assert set(called) == MIGRATED, (
@@ -490,6 +497,7 @@ def _expected_inventory(part, *, rotational: bool = False) -> dict:
         # nobody converts is exactly where an empty tuple would go unnoticed (#1244).
         "angled_steps": tuple(recognise_angled_steps(part)) if not rotational else (),
         "passages": tuple(recognise_passages(part)),
+        "section_passages": tuple(recognise_section_passages(part)),
         "prismatic_pockets": tuple(recognise_prismatic_pockets(part)),
     }
 
@@ -497,8 +505,8 @@ def _expected_inventory(part, *, rotational: bool = False) -> dict:
 #: Fields where a DIRECT recogniser call is not a valid oracle for the aggregate, because the
 #: aggregate applies a cross-family reconciliation the direct call deliberately precedes:
 #:
-#:   "Calling `recognise_passages` directly returns candidates BEFORE that aggregate policy,
-#:    consistently with the other reconciled families."  — b123d-recognisers 0.2.6 notes
+#: Passage compatibility and its authoritative SectionPassage source are both observed before
+#: aggregate cross-family ownership removes occurrences that yield to a Slot.
 #:
 #: A four-wall passage yields to the more directly dimensioned `Slot`;
 #: `_reconcile.prismatic_pockets_that_are_not_pockets` keeps the `Pocket`; and
@@ -508,7 +516,9 @@ def _expected_inventory(part, *, rotational: bool = False) -> dict:
 #: For these the assertion is SUBSET, not equality: the aggregate may drop a candidate to
 #: another family, and may never invent one. Equality is still demanded everywhere else, so the
 #: "ran it and stored ()" failure this test exists for is still caught for 19 of 22 fields.
-_RECONCILED_FIELDS = frozenset({"angled_steps", "chamfers", "passages", "prismatic_pockets"})
+_RECONCILED_FIELDS = frozenset(
+    {"angled_steps", "chamfers", "passages", "prismatic_pockets", "section_passages"}
+)
 
 
 def test_the_aggregate_carries_what_its_recognisers_returned():
@@ -580,9 +590,7 @@ def _counting_every_family():
     imports, then containers). A code object cannot be re-bound, so there is genuinely
     nowhere to call these from that the count does not see.
     """
-    with counting_calls(
-        {name: getattr(recognition, name) for name in MIGRATED | DEFERRED.keys()}
-    ) as counts:
+    with recognition_family_calls(MIGRATED | DEFERRED.keys()) as counts:
         yield counts
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -85,15 +85,15 @@ wheels = [
 
 [[package]]
 name = "b123d-recognisers"
-version = "0.3.1"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/db/5f/987efc53bd8f468881b19bbbe10abd8a62fdd5a3643cc02fe83080b15cd3/b123d_recognisers-0.3.1.tar.gz", hash = "sha256:6b0dd527513654ec153655ea0e1440549451d567f7f840a3fffe4c3a69200047", size = 583119, upload-time = "2026-08-23T08:52:33.258Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/66/697bae8cab1fcded99903f8d750103743be0cb5a94973366fb0e9526fffa/b123d_recognisers-0.4.0.tar.gz", hash = "sha256:8f821412f556ccb34aed2da0501605a9df171b5c046b171cb943c9f78675dd9f", size = 1012376, upload-time = "2026-08-27T06:57:48.684Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6c/16/30706e7b76abb22d726191b31091489024ae8b7de1b482f328ee4466a906/b123d_recognisers-0.3.1-py3-none-any.whl", hash = "sha256:cfb806ec348612af7dc1c4fb51ce46b8bc654e863befd457b37a02889722bb7f", size = 221711, upload-time = "2026-08-23T08:52:31.551Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/ce/a466fadaa18b581b76de8bf116d44c334bb1872543704c5fdf6a4f01e206/b123d_recognisers-0.4.0-py3-none-any.whl", hash = "sha256:256ce529801f9a12238f002d27002ad08f3ff125d808534773afdf92fbe4b14d", size = 332876, upload-time = "2026-08-27T06:57:47.072Z" },
 ]
 
 [[package]]
@@ -746,7 +746,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "antlr4-python3-runtime", specifier = "<4.10" },
-    { name = "b123d-recognisers", specifier = "==0.3.1" },
+    { name = "b123d-recognisers", specifier = "==0.4.0" },
     { name = "build123d", marker = "python_full_version < '3.13'", specifier = ">=0.9.0,<0.11" },
     { name = "build123d", marker = "python_full_version >= '3.13'", specifier = ">=0.11,<0.12" },
     { name = "build123d-drafting-helpers", specifier = ">=0.14.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -85,15 +85,15 @@ wheels = [
 
 [[package]]
 name = "b123d-recognisers"
-version = "0.4.1"
+version = "0.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/a5/01455bbb244af3a582bf73133efa1dd1e0f3a3ad375421ae1e02e2380d9e/b123d_recognisers-0.4.1.tar.gz", hash = "sha256:4c62c88f656971a80ec82c291af24158f0b24b8f8422cf47b535bab274356fd1", size = 1012878, upload-time = "2026-08-27T07:38:32.716Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/1c/968350d87c664dfcc967066e4fa8fbcf0af077c7f63db71cfcb9b294d309/b123d_recognisers-0.4.2.tar.gz", hash = "sha256:7ca7827804fe0ae3e9767daaf571805b730dda7abf4d0b51e013ad2829c04ef3", size = 1013615, upload-time = "2026-08-27T10:03:01.431Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/e7/810799a78a8b3920ecdb6424cf6355fe546d10a3c7d394d9c54f98f40a2e/b123d_recognisers-0.4.1-py3-none-any.whl", hash = "sha256:037220b26d44393f1b6e9925c9af0db4880189a76c24bd952e8b24df49a014d4", size = 333086, upload-time = "2026-08-27T07:38:31.248Z" },
+    { url = "https://files.pythonhosted.org/packages/04/45/8d3deb343ce714a9c0f1eef76027cdd52a6e718373c71a13b7f0db494c09/b123d_recognisers-0.4.2-py3-none-any.whl", hash = "sha256:ac306d0451e23574792c4f8a6b2d9273784775a8d99aaf976684ee8eafe97401", size = 333103, upload-time = "2026-08-27T10:02:59.783Z" },
 ]
 
 [[package]]
@@ -746,7 +746,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "antlr4-python3-runtime", specifier = "<4.10" },
-    { name = "b123d-recognisers", specifier = "==0.4.1" },
+    { name = "b123d-recognisers", specifier = "==0.4.2" },
     { name = "build123d", marker = "python_full_version < '3.13'", specifier = ">=0.9.0,<0.11" },
     { name = "build123d", marker = "python_full_version >= '3.13'", specifier = ">=0.11,<0.12" },
     { name = "build123d-drafting-helpers", specifier = ">=0.14.2" },

--- a/uv.lock
+++ b/uv.lock
@@ -85,15 +85,15 @@ wheels = [
 
 [[package]]
 name = "b123d-recognisers"
-version = "0.4.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a2/66/697bae8cab1fcded99903f8d750103743be0cb5a94973366fb0e9526fffa/b123d_recognisers-0.4.0.tar.gz", hash = "sha256:8f821412f556ccb34aed2da0501605a9df171b5c046b171cb943c9f78675dd9f", size = 1012376, upload-time = "2026-08-27T06:57:48.684Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/a5/01455bbb244af3a582bf73133efa1dd1e0f3a3ad375421ae1e02e2380d9e/b123d_recognisers-0.4.1.tar.gz", hash = "sha256:4c62c88f656971a80ec82c291af24158f0b24b8f8422cf47b535bab274356fd1", size = 1012878, upload-time = "2026-08-27T07:38:32.716Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/ce/a466fadaa18b581b76de8bf116d44c334bb1872543704c5fdf6a4f01e206/b123d_recognisers-0.4.0-py3-none-any.whl", hash = "sha256:256ce529801f9a12238f002d27002ad08f3ff125d808534773afdf92fbe4b14d", size = 332876, upload-time = "2026-08-27T06:57:47.072Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e7/810799a78a8b3920ecdb6424cf6355fe546d10a3c7d394d9c54f98f40a2e/b123d_recognisers-0.4.1-py3-none-any.whl", hash = "sha256:037220b26d44393f1b6e9925c9af0db4880189a76c24bd952e8b24df49a014d4", size = 333086, upload-time = "2026-08-27T07:38:31.248Z" },
 ]
 
 [[package]]
@@ -746,7 +746,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "antlr4-python3-runtime", specifier = "<4.10" },
-    { name = "b123d-recognisers", specifier = "==0.4.0" },
+    { name = "b123d-recognisers", specifier = "==0.4.1" },
     { name = "build123d", marker = "python_full_version < '3.13'", specifier = ">=0.9.0,<0.11" },
     { name = "build123d", marker = "python_full_version >= '3.13'", specifier = ">=0.11,<0.12" },
     { name = "build123d-drafting-helpers", specifier = ">=0.14.2" },


### PR DESCRIPTION
## Symptom and evidence

- User-visible problem: `fillet(face)` reopened the raw OCCT surface and depended on a recogniser-specific anchor helper; the first F7 spike then exposed a graph to solve a one-face problem.
- Fixture/reproducer: a real build123d cylindrical blend face plus planar-face refusal in `tests/test_geometry_graph_spike.py`.
- Before/after result: axis, radius and on-round anchor are unchanged; Draftwright now imports only `AnalyticSurface` and graph-independent `inspect_face`.
- Mutation that makes the guard fail: importing or naming `GeometryGraph` in `declare.py`, or importing any underscore-private recogniser module.

## Contract and scope

- Smallest contract this change tests: one closed analytic surface fact plus an optional trimmed-surface anchor.
- Relevant ADRs: ADR 0011 declaration geometry; recognisers delivery protocol stable-package-first join.
- Explicitly deferred: publishing `GeometryGraph`, adjacency/blend APIs, root export/manifest support, and all F6 correspondence.

Draftwright is pinned and locked to the released immutable `b123d-recognisers==0.4.0` artifact.

## Validation

- [x] `scripts/pr-check --quick` (91 passed; formatting, lint, docs and smoke checks green)
- [ ] `scripts/pr-check` before final review
- [x] The named import-boundary mutation is guarded structurally
- [x] Declared and drawing paths were checked; automatic/generated recognition semantics are unchanged
- [x] Recognition/repeated-lint call counts are unaffected (one declared face inspection only)
- [x] 16 focused declared-fillet and facade-boundary tests pass against the released 0.4.0 artifact
- [x] Ruff and mypy pass

## Stop check

- [x] No two consecutive review rounds invalidated the same core association strategy
- [x] The larger graph publication is explicitly deferred; this PR integrates only the proven small contract

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/pzfreo/draftwright/blob/main/CLA.md) and agree to it. If I am contributing on behalf of an organisation, I am authorised to agree on its behalf.