### PR TITLE
Make PDF notes and tables selectable

### DIFF
--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -3622,7 +3622,7 @@ class Drawing:
         """Return semantic text overlaid on path-rendered PDF glyphs.
 
         Scope is deliberately limited to text whose authoritative source and
-        final page geometry are both retained: free notes and generic tables.
+        final page geometry are both retained: unrotated free notes and generic tables.
         Other annotations remain path-only until their renderers expose the
         same information without reverse-engineering exported geometry.
         """
@@ -3651,7 +3651,11 @@ class Drawing:
                             )
             else:
                 value = getattr(annotation, "pdf_text", None)
-                if value:
+                rotation = getattr(annotation, "pdf_text_rotation", 0.0)
+                # An axis-aligned bounding box cannot recover a rotated note's
+                # original text origin. Leave those path-only until the note
+                # renderer retains its anchor/alignment transform explicitly.
+                if value and not rotation:
                     lines = str(value).splitlines() or [str(value)]
                     for index, line in enumerate(lines):
                         if line:
@@ -3661,7 +3665,6 @@ class Drawing:
                                     box.min.X,
                                     box.max.Y - (index + 1) * fs,
                                     fs,
-                                    getattr(annotation, "pdf_text_rotation", 0.0),
                                 )
                             )
             if runs:

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -46,6 +46,7 @@ from draftwright._core import (
     _fmt,
     _font_safe_text,
     _log,
+    _table_metrics,
     _tag_sequence,
     _tol_suffix,
     place_annotation,
@@ -62,6 +63,7 @@ from draftwright.annotations.leaders import drain_feature_leaders
 from draftwright.export import (
     _DraftwrightDXF,
     _export_shape,
+    _PDFTextRun,
     _render_pdf,
     _render_png,
     add_svg_hyperlink,
@@ -2821,6 +2823,10 @@ class Drawing:
             rotation=rotation,
             align=align if align is not None else (Align.CENTER, Align.CENTER),
         )
+        # Keep the exact string shown by the drafting font for the PDF semantic
+        # overlay (notably its established ⌀ -> ø compatibility substitution).
+        n.pdf_text = _font_safe_text(text)
+        n.pdf_text_rotation = float(rotation)
         if name is None:
             i = 0
             while (name := f"note{i}") in self._registry:
@@ -2853,6 +2859,7 @@ class Drawing:
         # claims it carries are exactly the ones coverage relies on when the engine withdraws
         # the individual callouts. Mirrors `gear_requirement_rows`.
         table.table_rows = tuple(tuple(str(cell) for cell in row) for row in rows)
+        table.table_block_cols = block_cols
         w, h = table.table_size
         a = self._analysis
         margin = a.margin if a is not None else 10.0
@@ -3611,6 +3618,56 @@ class Drawing:
         _log.info("DXF → %s", dxf_path)
         return dxf_path
 
+    def _pdf_text_runs(self):
+        """Return semantic text overlaid on path-rendered PDF glyphs.
+
+        Scope is deliberately limited to text whose authoritative source and
+        final page geometry are both retained: free notes and generic tables.
+        Other annotations remain path-only until their renderers expose the
+        same information without reverse-engineering exported geometry.
+        """
+        groups = []
+        fs = self.draft.font_size
+        pad = self.draft.pad_around_text
+        for _name, annotation in self._registry.iter_named():
+            box = annotation.bounding_box()
+            rows = getattr(annotation, "table_rows", None)
+            runs = []
+            if rows:
+                lefts, _rights, _width, total_h, row_h, _bc = _table_metrics(
+                    rows, fs, pad, getattr(annotation, "table_block_cols", None)
+                )
+                for ri, row in enumerate(rows):
+                    baseline = box.min.Y + total_h - (ri + 0.5) * row_h - fs * 0.35
+                    for ci, cell in enumerate(row):
+                        if cell:
+                            runs.append(
+                                _PDFTextRun(
+                                    _font_safe_text(cell),
+                                    box.min.X + lefts[ci] + pad,
+                                    baseline,
+                                    fs,
+                                )
+                            )
+            else:
+                value = getattr(annotation, "pdf_text", None)
+                if value:
+                    lines = str(value).splitlines() or [str(value)]
+                    for index, line in enumerate(lines):
+                        if line:
+                            runs.append(
+                                _PDFTextRun(
+                                    line,
+                                    box.min.X,
+                                    box.max.Y - (index + 1) * fs,
+                                    fs,
+                                    getattr(annotation, "pdf_text_rotation", 0.0),
+                                )
+                            )
+            if runs:
+                groups.append((-box.max.Y, box.min.X, runs))
+        return tuple(run for _top, _left, runs in sorted(groups) for run in runs)
+
     def export(
         self, out=None, *, formats=None, svg=None, dxf=None, dpi: int = 150
     ) -> dict[str, str] | tuple[str | None, str | None]:
@@ -3757,6 +3814,7 @@ class Drawing:
                     svg_path,
                     pdf_path,
                     getattr(self.get_annotation("title_block"), "draftwright_link_rect", None),
+                    self._pdf_text_runs(),
                 )
                 _log.info("PDF → %s", pdf_path)
                 if "pdf" in want_set:

--- a/src/draftwright/export.py
+++ b/src/draftwright/export.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 import re
+from dataclasses import dataclass
 from pathlib import Path
 
 import ezdxf
@@ -20,8 +21,20 @@ from build123d import ExportDXF, ExportSVG
 from OCP.GeomConvert import GeomConvert
 
 from draftwright._core import _DRAFTWRIGHT_URL
+from draftwright.fonts import PLEX_MONO
 
 _log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class _PDFTextRun:
+    """One searchable, invisible text run in drawing page coordinates (mm)."""
+
+    text: str
+    x: float
+    y: float
+    font_size: float
+    rotation: float = 0.0
 
 
 def fix_svg_page_size(svg_path: str, page_w: float, page_h: float) -> None:
@@ -234,10 +247,12 @@ def sanitize_svg_arcs(svg_path: str) -> int:
     return n
 
 
-def _render_pdf(svg_path: str, pdf_path: str, link_rect=None) -> None:
+def _render_pdf(svg_path: str, pdf_path: str, link_rect=None, text_runs=()) -> None:
     """Render *svg_path* to *pdf_path* via svglib + reportlab, adding draftwright
     metadata and — when *link_rect* (drawing page coords, Y up) is given — a
-    clickable PDF link annotation over that rectangle.
+    clickable PDF link annotation over that rectangle. *text_runs* overlays
+    invisible Unicode text on the path-rendered glyphs, preserving the visual
+    output while making notes and table cells searchable and selectable.
 
     svglib does not translate the SVG ``<a>`` element into a PDF link, so the
     link is added with reportlab's ``Canvas.linkURL``. The drawing page maps to
@@ -260,6 +275,34 @@ def _render_pdf(svg_path: str, pdf_path: str, link_rect=None) -> None:
         canvas.setCreator(_GENERATED_BY)
         canvas.setTitle(_GENERATED_BY)
         renderPDF.draw(drawing, canvas, 0, 0)
+        if text_runs:
+            from reportlab.pdfbase import pdfmetrics
+            from reportlab.pdfbase.ttfonts import TTFont
+
+            font_name = "DraftwrightSemanticText"
+            if font_name not in pdfmetrics.getRegisteredFontNames():
+                pdfmetrics.registerFont(TTFont(font_name, PLEX_MONO))
+            k = 72.0 / 25.4
+            for run in text_runs:
+                text = canvas.beginText()
+                text.setTextRenderMode(3)  # invisible, but retained for search/copy
+                text.setFont(font_name, run.font_size * k)
+                if run.rotation:
+                    import math
+
+                    angle = math.radians(run.rotation)
+                    text.setTextTransform(
+                        math.cos(angle),
+                        math.sin(angle),
+                        -math.sin(angle),
+                        math.cos(angle),
+                        run.x * k,
+                        run.y * k,
+                    )
+                else:
+                    text.setTextOrigin(run.x * k, run.y * k)
+                text.textOut(run.text)
+                canvas.drawText(text)
         if link_rect is not None:
             k = 72.0 / 25.4
             x0, y0, x1, y1 = link_rect

--- a/src/draftwright/export.py
+++ b/src/draftwright/export.py
@@ -279,7 +279,7 @@ def _render_pdf(svg_path: str, pdf_path: str, link_rect=None, text_runs=()) -> N
             from reportlab.pdfbase import pdfmetrics
             from reportlab.pdfbase.ttfonts import TTFont
 
-            font_name = "DraftwrightSemanticText"
+            font_name = "Draftwright_IBMPlexMono_Semantic_v1"
             if font_name not in pdfmetrics.getRegisteredFontNames():
                 pdfmetrics.registerFont(TTFont(font_name, PLEX_MONO))
             k = 72.0 / 25.4
@@ -312,6 +312,11 @@ def _render_pdf(svg_path: str, pdf_path: str, link_rect=None, text_runs=()) -> N
         canvas.showPage()
         canvas.save()
     except Exception:
+        if text_runs:
+            # Searchable text is a requested output property, not an optional
+            # embellishment. Never report success after silently discarding it.
+            _log.error("PDF semantic text render failed", exc_info=True)
+            raise
         # Never fail the export over the link/metadata extras; degrade to a
         # plain render. Logged at debug so a regression in the link annotation
         # is diagnosable (in normal use only the dedicated test would catch it).

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -11567,6 +11567,39 @@ class TestDraftwrightAttribution:
                 found = True
         assert found, "PDF must embed a clickable draftwright URI link annotation"
 
+    def test_export_pdf_notes_and_tables_are_searchable_unicode_text(self, tmp_path):
+        import pypdfium2 as pdfium
+
+        dwg = build_drawing(Box(60, 40, 20), auto_dims=False)
+        dwg.note("INSPECT SURFACE ±0.1", (65, 55), name="inspection_note")
+        dwg.add_table(
+            [("NOTES", "SIZE"), ("DEBURR", "⌀5 ±0.1")],
+            name="notes_table",
+        )
+
+        pdf_path = dwg.export(str(tmp_path / "searchable"), formats=("pdf",))["pdf"]
+        pdf = pdfium.PdfDocument(pdf_path)
+        try:
+            page = pdf[0]
+            text_page = page.get_textpage()
+            extracted = text_page.get_text_range()
+            first_char_box = text_page.get_charbox(extracted.index("INSPECT SURFACE"))
+        finally:
+            pdf.close()
+
+        assert "INSPECT SURFACE ±0.1" in extracted
+        assert "NOTES" in extracted and "DEBURR" in extracted
+        # The visible drafting font's longstanding CAD compatibility glyph is
+        # ø for source ⌀; copied text must match what the engineer sees.
+        assert "ø5 ±0.1" in extracted
+        # It is not merely an off-page search index: the selectable character
+        # geometry lies over the visible note on the drawing.
+        note_box = dwg.get_annotation("inspection_note").bounding_box()
+        k = 72.0 / 25.4
+        left, bottom, right, top = first_char_box
+        assert left < note_box.max.X * k and right > note_box.min.X * k
+        assert bottom < note_box.max.Y * k and top > note_box.min.Y * k
+
 
 class TestExportFormats:
     """The unified export(formats=...) → {format: path} API + PNG raster export

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -11572,6 +11572,7 @@ class TestDraftwrightAttribution:
 
         dwg = build_drawing(Box(60, 40, 20), auto_dims=False)
         dwg.note("INSPECT SURFACE ±0.1", (65, 55), name="inspection_note")
+        dwg.note("ROTATED PATH ONLY", (100, 55), rotation=45, name="rotated_note")
         dwg.add_table(
             [("NOTES", "SIZE"), ("DEBURR", "⌀5 ±0.1")],
             name="notes_table",
@@ -11588,6 +11589,7 @@ class TestDraftwrightAttribution:
             pdf.close()
 
         assert "INSPECT SURFACE ±0.1" in extracted
+        assert "ROTATED PATH ONLY" not in extracted
         assert "NOTES" in extracted and "DEBURR" in extracted
         # The visible drafting font's longstanding CAD compatibility glyph is
         # ø for source ⌀; copied text must match what the engineer sees.
@@ -11599,6 +11601,19 @@ class TestDraftwrightAttribution:
         left, bottom, right, top = first_char_box
         assert left < note_box.max.X * k and right > note_box.min.X * k
         assert bottom < note_box.max.Y * k and top > note_box.min.Y * k
+
+    def test_export_pdf_does_not_silently_discard_semantic_text(self, tmp_path, monkeypatch):
+        from reportlab.pdfgen.canvas import Canvas
+
+        dwg = build_drawing(Box(30, 20, 10), auto_dims=False)
+        dwg.note("MUST BE SEARCHABLE", (50, 50))
+
+        def fail_semantic_text(_self, _text):
+            raise RuntimeError("semantic text failure")
+
+        monkeypatch.setattr(Canvas, "drawText", fail_semantic_text)
+        with pytest.raises(RuntimeError, match="semantic text failure"):
+            dwg.export(str(tmp_path / "broken"), formats=("pdf",))
 
 
 class TestExportFormats:

--- a/tests/test_private_test_attr_reads.py
+++ b/tests/test_private_test_attr_reads.py
@@ -81,6 +81,7 @@ _DRAWING_PRIVATES: frozenset[str] = frozenset(
         "_lint",
         "_lint_and_log",
         "_part_model",
+        "_pdf_text_runs",
         "_place_dim",
         "_queue_dimension_intent",
         "_record_build_issue",


### PR DESCRIPTION
## Summary
- retain path-rendered PDF glyphs so drawing appearance remains unchanged
- overlay invisible semantic text for free notes and generic table cells
- preserve spatial selection geometry and visible CAD glyph substitutions

## Verification
- `scripts/pr-check --static`
- focused note/table/export suite: 36 passed
- full fast suite: 4,886 passed, 5 skipped, 2 xfailed; one private-helper inventory failure identified and fixed
- post-fix private inventory + PDF tests: 5 passed