### PR TITLE
Preserve authored dimension display precision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- Referential Sheet dimensions can preserve an explicit number of decimal places with
+  `sheet.dimension(feature, "parameter.id").format(decimals=n)`. The policy changes only
+  printed display text: numeric reconciliation, tolerances, suppression and dimension
+  provenance continue to use the feature parameter, and generated Sheet scripts round-trip the
+  policy (#1349).
 - New lint code `annotation_ink_overlap`: reports another annotation's line-work —
   a dimension line, an extension line or a leader shaft — drawn through a label's
   text, which `annotation_overlap` cannot see because it compares label boxes to

--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -46,6 +46,23 @@ resolved result.
     options:
       filters: public
 
+## Dimension intent handle
+
+`dimension(feature, parameter_id)` and `add_dimension(feature, parameter_id)` return a
+referential `DimensionIntent`. The handle never carries a replacement nominal and never chooses
+page coordinates. Use `format(decimals=n)` to preserve between 0 and 15 decimal places in the
+printed nominal while reconciliation, tolerance, suppression and provenance continue to read the
+numeric parameter from the feature. Trailing zeroes are intentional manufacturing display text:
+
+```python
+sheet.authored_dimensions()
+sheet.dimension(envelope, "width.length").format(decimals=2)  # 13.5 prints as 13.50
+```
+
+::: draftwright.sheet.DimensionIntent
+    options:
+      filters: public
+
 ## Hole handle
 
 ::: draftwright.sheet._Hole

--- a/src/draftwright/_geometry.py
+++ b/src/draftwright/_geometry.py
@@ -337,11 +337,18 @@ def _axis_direction_is_aligned(axis: str, direction, *, tol: float = 1e-3) -> bo
     )
 
 
-def _fmt(v: float) -> str:
+def _fmt(v: float, decimals: int | None = None) -> str:
     """Format a float as integer string if whole, otherwise 1 dp. The one number
     formatter the IR (:mod:`draftwright.model.ir`) and the drawing layers
     (:mod:`draftwright._core`) share (#700 — the two copies had already begun to
-    drift on ``-0``)."""
+    drift on ``-0``).
+
+    ``decimals`` is an explicit referential-dimension display policy (#1349). It preserves
+    trailing zeroes by design; ``None`` retains the established automatic formatting.
+    """
+    if decimals is not None:
+        normalized = 0.0 if round(float(v), decimals) == 0 else float(v)
+        return f"{normalized:.{decimals}f}"
     r = round(v)
     return str(r) if abs(v - r) < 1e-6 else f"{v:.1f}"
 

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -3965,63 +3965,13 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
                     for i, seg in enumerate(_rows)
                 ]
                 dpairs.sort(key=lambda item: (item[0].pa[0] + item[0].pb[0]) / 2)
-                dsegs: list[_StepChainSegment] = []
-                detail_widths: list[float] = []
-                j = 0
-                while j < len(dpairs):
-                    seg0, _width0 = dpairs[j]
-                    run = [dpairs[j]]
-                    k = j + 1
-                    while k < len(dpairs):
-                        prev, _prev_width = run[-1]
-                        cur, _cur_width = dpairs[k]
-                        contiguous = (
-                            abs(max(prev.pa[0], prev.pb[0]) - min(cur.pa[0], cur.pb[0])) <= 1e-4
-                        )
-                        # A repeated-pitch claim must be true at the drawing's
-                        # displayed precision, not merely "within 10%".
-                        equal = (
-                            _step_value_text(cur) == _step_value_text(seg0)
-                            if cur.display_decimals is not None
-                            or seg0.display_decimals is not None
-                            else _fmt(cur.value) == _fmt(seg0.value)
-                        )
-                        untoleranced = prev.tolerance is None and cur.tolerance is None
-                        if not (contiguous and equal and untoleranced):
-                            break
-                        run.append(dpairs[k])
-                        k += 1
-                    if len(run) >= 3:
-                        run_segs = [seg for seg, _width in run]
-                        xs = [p[0] for seg in run_segs for p in (seg.pa, seg.pb)]
-                        y = run_segs[0].pa[1]
-                        repeated_text = (
-                            _step_value_text(run_segs[0])
-                            if any(seg.display_decimals is not None for seg in run_segs)
-                            else _fmt(sum(seg.value for seg in run_segs) / len(run_segs))
-                        )
-                        label = f"{len(run_segs)}× {repeated_text}"
-                        dsegs.append(
-                            _StepChainSegment(
-                                (min(xs), y, 0.0),
-                                (max(xs), y, 0.0),
-                                sum(seg.value for seg in run_segs),
-                                measurements=_step_measurements(run_segs),
-                                label=label,
-                            )
-                        )
-                        detail_widths.append(
-                            _text_size(
-                                label,
-                                draft.font_size,
-                                font=getattr(draft, "font", "Arial"),
-                            )[0]
-                        )
-                    else:
-                        for seg, width in run:
-                            dsegs.append(seg)
-                            detail_widths.append(width)
-                    j = k
+                # The principal-view pass immediately above already collapses every
+                # contiguous repeated run of three or more and returns before queuing this
+                # callback.  Detail projection is affine, so it cannot turn a non-contiguous
+                # run into a contiguous one.  Repeating that collapse here was unreachable
+                # and risked letting the two copies drift (#1349).
+                dsegs = [seg for seg, _width in dpairs]
+                detail_widths = [width for _seg, width in dpairs]
                 # Never recreate the ambiguous stagger inside a detail. Validate
                 # both text clearance and full inside-arrow capacity at the actual
                 # fitted scale; returning zero transactionally drops the detail.

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -135,29 +135,29 @@ def callout_from_spec(spec, draft, count) -> HoleCallout | None:
     if spec is None:
         return None
 
-    def f(v):  # see the #261 note above — every value crosses as a formatted string
-        return _fmt(v) if v is not None else None
+    def f(v, decimals=None):  # see #261 above — every value crosses as formatted text
+        return _fmt(v, decimals) if v is not None else None
 
-    dia = f(spec["diameter"])
+    dia = f(spec["diameter"], spec.get("diameter_decimals"))
     if dia is not None:
         # P2a: bake the ± tolerance into the bore string (helpers' HoleCallout accepts a
         # diameter carrying tolerance/fit text, "8 ±0.05"); no tolerance → empty suffix.
         dia += _tol_suffix(spec.get("tolerance"), draft)
 
-    def ft(value, key):
+    def ft(value, key, decimals_key):
         """A formatted term with its own authored tolerance baked in.
 
         Every term of a compound callout can be toleranced, not just the bore. `.get()`
         because hand-built specs in tests omit the keys (#1234 review r7).
         """
-        text = f(value)
+        text = f(value, spec.get(decimals_key))
         return None if text is None else text + _tol_suffix(spec.get(key), draft)
 
-    depth = ft(spec["depth"], "depth_tol")
-    cbore_dia = ft(spec["cbore_dia"], "cbore_dia_tol")
-    cbore_depth = ft(spec["cbore_depth"], "cbore_depth_tol")
-    csink_dia = ft(spec.get("csink_dia"), "csink_dia_tol")
-    csink_angle = ft(spec.get("csink_angle"), "csink_angle_tol")
+    depth = ft(spec["depth"], "depth_tol", "depth_decimals")
+    cbore_dia = ft(spec["cbore_dia"], "cbore_dia_tol", "cbore_dia_decimals")
+    cbore_depth = ft(spec["cbore_depth"], "cbore_depth_tol", "cbore_depth_decimals")
+    csink_dia = ft(spec.get("csink_dia"), "csink_dia_tol", "csink_dia_decimals")
+    csink_angle = ft(spec.get("csink_angle"), "csink_angle_tol", "csink_angle_decimals")
     suffix = spec["suffix"]
     callout = HoleCallout(
         dia,
@@ -1104,7 +1104,7 @@ def _place_what_fits(specs, axis: int, min_gap: float, lo: float, hi: float):
 
 def _diameter_row_below(dwg, items, start: int = 0, trace=None, *, ctx) -> int:
     """ø-callout row BELOW the front view for X-turned step/boss diameters (#77).
-    *items* is ``[(anchor, dia, feature, tolerance, thread, mids), ...]``. The row is dropped clear of anything
+    *items* is ``[(anchor, dia, value_text, feature, tolerance, thread, mids), ...]``. The row is dropped clear of anything
     already below the profile; labels spread along page-x by the ADR-0003 strip
     solve. Skips (returns 0) if there is no room — the diameters then surface as
     ``feature_not_dimensioned``. *trace* (#736): one ``pass_events`` record with a
@@ -1136,15 +1136,15 @@ def _diameter_row_below(dwg, items, start: int = 0, trace=None, *, ctx) -> int:
     if label_y < _MARGIN + draft.font_size:
         if ev is not None:
             ev["items"].extend(
-                {"label": f"ø{_fmt(d)}", "outcome": "dropped", "reason": "no_room_below"}
-                for _, d, _, _, _, _ in items
+                {"label": f"ø{text}", "outcome": "dropped", "reason": "no_room_below"}
+                for _, _d, text, _, _, _, _ in items
             )
         return 0
     specs = []  # (tip_page, dia, label, feature, mids), tip on the step's bottom silhouette,
-    for anchor, dia, feat, dtol, thr, mids in items:  # centred along the feature's length
+    for anchor, dia, value_text, feat, dtol, thr, mids in items:
         ax, ay, az = anchor
         tip = dwg.at("front", ax, ay, az - dia / 2)
-        label = f"ø{_fmt(dia)}{_tol_suffix(dtol, draft)}" + (f" {thr}" if thr else "")  # #859
+        label = f"ø{value_text}{_tol_suffix(dtol, draft)}" + (f" {thr}" if thr else "")
         specs.append((tip, dia, label, feat, mids))
     # Real measured width, not the per-char estimate: helpers >=0.14 label boxes are
     # honest about the rendered string, so an underestimated min_gap here surfaces as a
@@ -1248,12 +1248,12 @@ def _diameter_column_left(dwg, items, start: int = 0, trace=None, *, ctx) -> int
     # (annotation_out_of_bounds). Measure the completed label like the row-below path does.
     label_w = max(
         _text_size(
-            f"ø{_fmt(dia)}{_tol_suffix(dtol, draft)}" + (f" {thr}" if thr else ""),
+            f"ø{value_text}{_tol_suffix(dtol, draft)}" + (f" {thr}" if thr else ""),
             draft.font_size,
             getattr(draft, "font_path", DEFAULT_FONT_PATH),
             getattr(draft, "font", "Arial"),
         )[0]
-        for _, dia, _, dtol, thr, _ in items
+        for _, _dia, value_text, _, dtol, thr, _ in items
     )
     elbow_x = fx0 - (draft.font_size + 2 * draft.pad_around_text)
     # A left-directed leader hangs its label a shelf-length PAST the elbow, so the label's left
@@ -1263,15 +1263,15 @@ def _diameter_column_left(dwg, items, start: int = 0, trace=None, *, ctx) -> int
     if elbow_x - draft.pad_around_text - label_w < _MARGIN:
         if ev is not None:
             ev["items"].extend(
-                {"label": f"ø{_fmt(d)}", "outcome": "dropped", "reason": "no_room_left"}
-                for _, d, _, _, _, _ in items
+                {"label": f"ø{text}", "outcome": "dropped", "reason": "no_room_left"}
+                for _, _d, text, _, _, _, _ in items
             )
         return 0
     specs = []  # (tip_page, dia, label, feature, mids), tip on the step's left silhouette,
-    for anchor, dia, feat, dtol, thr, mids in items:  # centred along the feature's length
+    for anchor, dia, value_text, feat, dtol, thr, mids in items:
         ax, ay, az = anchor
         tip = dwg.at("front", ax - dia / 2, ay, az)
-        label = f"ø{_fmt(dia)}{_tol_suffix(dtol, draft)}" + (f" {thr}" if thr else "")  # #859
+        label = f"ø{value_text}{_tol_suffix(dtol, draft)}" + (f" {thr}" if thr else "")
         specs.append((tip, dia, label, feat, mids))
     half_h = draft.font_size / 2 + draft.pad_around_text
     min_gap = 2 * half_h
@@ -1510,13 +1510,13 @@ def render_diameters(dwg, plan, a, tol: float = 0.15, *, ctx, only=None) -> int:
     ``None`` (the auto-pass) places every diameter with the historical 0-based
     ``m_dia_{x,z}`` naming; Y-axis leaders use ``m_dia_y``."""
     mentioned = _mentioned_diameters(dwg)
-    # One distinct callout per (axis, diameter). Accumulate EVERY feature that shares a
-    # diameter (insertion-ordered), so provenance (#412) can tag the callout with its
-    # single owner — or leave it unowned when two distinct features share the diameter
-    # (the #398c/#406 shared-value rule, so drop can't over-strip a sibling).
+    # One distinct callout per (axis, diameter, approved text, manufacturing suffix/owner).
+    # Accumulate EVERY feature that shares that complete printed claim (insertion-ordered),
+    # so provenance (#412) can tag the callout with its single owner — or leave it unowned
+    # when two distinct features genuinely share the same claim.
     # Keep the compiler-approved text beside the numeric diameter.  Layout still needs the
     # number for truthful rim geometry; only ``value_text`` may cross into a printed label.
-    row_buckets: dict = {}  # round(dia,2) -> [anchor, dia, text, {features}, tolerance, ...]
+    row_buckets: dict = {}  # semantic print key -> [anchor, dia, text, {features}, tol, ...]
     col_buckets: dict = {}  # Z-turned
     end_buckets: dict = {}  # Y-turned: radial leaders in the end-on front view
     for g in plan.of_kind("step", "boss"):
@@ -1536,7 +1536,11 @@ def render_diameters(dwg, plan, a, tol: float = 0.15, *, ctx, only=None) -> int:
         )
         # A coincident plain ⌀ already drawn (a bore, another step) dedups only an UNTHREADED ⌀;
         # a threaded ⌀ is a distinct callout, so a bare ⌀8 mention must not suppress ø8 M8x1.25.
-        if thr is None and any(abs(dia - m) <= tol for m in mentioned):
+        if (
+            thr is None
+            and dpd.display_decimals is None
+            and any(abs(dia - m) <= tol for m in mentioned)
+        ):
             continue
         bucket = {"x": row_buckets, "y": end_buckets, "z": col_buckets}.get(g.facts.frame.axis)
         if bucket is None:
@@ -1552,7 +1556,7 @@ def render_diameters(dwg, plan, a, tol: float = 0.15, *, ctx, only=None) -> int:
         # owned by one canonical feature and may share identical wording with another
         # source-owned feature; include the opaque compiler owner so neither provenance
         # nor public ``drop(feature)`` is collapsed into an unowned shared mark.
-        dkey = (round(dia, 2), thr, typed_owner)
+        dkey = (round(dia, 2), dpd.value_text, thr, typed_owner)
         entry = bucket.setdefault(dkey, [g.anchor, dia, dpd.value_text, set(), dtol, thr, []])
         entry[3].add(g.ref)
         entry[6].append(g)
@@ -1565,10 +1569,11 @@ def render_diameters(dwg, plan, a, tol: float = 0.15, *, ctx, only=None) -> int:
         # same derivation the m_dia_y branch below already made; the row/column placers
         # threaded nothing, so every X- and Z-turned ø callout reached the sheet unclaimed
         # and no verifier could see it (#1227).
-        a, d, _value_text, refs, t, thr, gs = entry
+        a, d, value_text, refs, t, thr, gs = entry
         return (
             _diameter_step_anchor(a, gs),
             d,
+            value_text,
             next(iter(refs)) if len(refs) == 1 else None,
             t,
             thr,
@@ -1656,7 +1661,7 @@ def render_diameters(dwg, plan, a, tol: float = 0.15, *, ctx, only=None) -> int:
                     hole_circles.append((px, py, diameter / 2 * a.SCALE))
             jobs = []
             covered_by_name = {}
-            for i, (_anchor, dia, _value_text, refs, dtol, thr, feature_groups) in enumerate(
+            for i, (_anchor, dia, value_text, refs, dtol, thr, feature_groups) in enumerate(
                 end_buckets.values()
             ):
                 representative = feature_groups[0].facts
@@ -1684,7 +1689,7 @@ def render_diameters(dwg, plan, a, tol: float = 0.15, *, ctx, only=None) -> int:
                     key=lambda candidate: _leader_hole_clearance(candidate, hole_circles),
                     reverse=True,
                 )
-                label = f"ø{_fmt(dia)}{_tol_suffix(dtol, dwg.draft)}"
+                label = f"ø{value_text}{_tol_suffix(dtol, dwg.draft)}"
                 if thr:
                     label += f" {thr}"
                 name = f"m_dia_y{start_y + i}"
@@ -2781,7 +2786,11 @@ def render_boss_diameters(dwg, plan, a, *, ctx) -> int:
         )
         # A coincident plain ⌀ dedups only an UNTHREADED boss; a threaded ⌀ is a distinct callout,
         # so a bare ⌀8 mention (a bore, a step) must not suppress ø8 M8x1.25 (#859).
-        if thr is None and any(abs(dia - m) <= 0.15 for m in mentioned):
+        if (
+            thr is None
+            and dpd.display_decimals is None
+            and any(abs(dia - m) <= 0.15 for m in mentioned)
+        ):
             continue
         view = view_of.get(b.frame.axis)
         if view is None:
@@ -2794,7 +2803,7 @@ def render_boss_diameters(dwg, plan, a, *, ctx) -> int:
                 f"m_bossdia_{b.frame.axis}{bi}",
                 view,
                 vb,
-                f"ø{_fmt(dia)}{_tol_suffix(dtol, draft)}" + (f" {thr}" if thr else ""),
+                f"ø{dpd.value_text}{_tol_suffix(dtol, draft)}" + (f" {thr}" if thr else ""),
                 # arrowhead on the boss circle's rim, not its centre
                 _radial_candidates(
                     dwg, view, vb, b, reach, rim=dia / 2 * a.SCALE, provenance=g.ref
@@ -3524,6 +3533,13 @@ class _StepChainSegment:
     tolerance: Any = None
     measurements: tuple[Any, ...] = ()
     label: str | None = None
+    value_text: str | None = None
+    display_decimals: int | None = None
+
+
+def _step_value_text(segment: _StepChainSegment) -> str:
+    """Compiler-owned nominal text, with a fallback for synthetic block segments."""
+    return segment.value_text if segment.value_text is not None else _fmt(segment.value)
 
 
 def _step_measurements(segs: list[_StepChainSegment]) -> tuple[Any, ...]:
@@ -3585,23 +3601,31 @@ def _draw_step_chain(
     # fixed for the envelope, ninety lines away, with three tests reading the discarded kwarg
     # (two asserting a value, one asserting its absence).
     # The file already contradicted itself: `label_widths` below sizes the staggering decision
-    # with `_fmt(seg.value) + _tol_suffix(...)`, i.e. it measured a string this line refused to
+    # with the compiler-owned value text + `_tol_suffix(...)`, i.e. it measured a string this line refused to
     # draw (#1234 review round 2).
     labels = [
-        seg.label if seg.label is not None else _fmt(seg.value) + _tol_suffix(seg.tolerance, draft)
+        seg.label
+        if seg.label is not None
+        else _step_value_text(seg) + _tol_suffix(seg.tolerance, draft)
         for seg in segs
     ]
     mean_v = sum(vals) / len(vals)
+    explicit_display = any(seg.display_decimals is not None for seg in segs)
     tier_step = draft.font_size + 2 * draft.pad_around_text
     if (
         allow_collapse
         and all(seg.label is None for seg in segs)
         and len(segs) >= 3
         and (max(vals) - min(vals)) <= 0.10 * mean_v
+        and (
+            not explicit_display
+            or all(_step_value_text(seg) == _step_value_text(segs[0]) for seg in segs)
+        )
     ):
         # A uniform run collapses to one "N× v" dim; a per-step ± would be a false claim on
         # N equal steps, so the collapse carries NO tolerance (#28 / P2a).
-        label = f"{len(segs)}× {_fmt(mean_v)}"
+        repeated_text = _step_value_text(segs[0]) if explicit_display else _fmt(mean_v)
+        label = f"{len(segs)}× {repeated_text}"
         xs = [p[0] for seg in segs for p in (seg.pa, seg.pb)]
         ys = [p[1] for seg in segs for p in (seg.pa, seg.pb)]
         if horizontal:
@@ -3781,6 +3805,8 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
                     length.value,
                     length.tolerance,
                     (length.id,) if length.id is not None else (),
+                    value_text=length.value_text,
+                    display_decimals=length.display_decimals,
                 ),
             )
         )
@@ -3810,7 +3836,7 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
     if horizontal and turn_axis == "y" and len(fsegs) >= 2:
         label_widths = [
             _text_size(
-                _fmt(seg.value) + _tol_suffix(seg.tolerance, draft),
+                _step_value_text(seg) + _tol_suffix(seg.tolerance, draft),
                 draft.font_size,
                 font=getattr(draft, "font", "Arial"),
             )[0]
@@ -3841,7 +3867,12 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
                 contiguous = abs(max(prev.pa[0], prev.pb[0]) - min(cur.pa[0], cur.pb[0])) <= 1e-4
                 if not (
                     contiguous
-                    and _fmt(cur.value) == _fmt(repeat_run[0].value)
+                    and (
+                        _step_value_text(cur) == _step_value_text(repeat_run[0])
+                        if cur.display_decimals is not None
+                        or repeat_run[0].display_decimals is not None
+                        else _fmt(cur.value) == _fmt(repeat_run[0].value)
+                    )
                     and prev.tolerance is None
                     and cur.tolerance is None
                 ):
@@ -3851,14 +3882,20 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
             if len(repeat_run) >= 3:
                 xs = [p[0] for seg in repeat_run for p in (seg.pa, seg.pb)]
                 y = repeat_run[0].pa[1]
-                pitch = sum(seg.value for seg in repeat_run) / len(repeat_run)
                 compact.append(
                     _StepChainSegment(
                         (min(xs), y, 0.0),
                         (max(xs), y, 0.0),
                         sum(seg.value for seg in repeat_run),
                         measurements=_step_measurements(repeat_run),
-                        label=f"{len(repeat_run)}× {_fmt(pitch)}",
+                        label=(
+                            f"{len(repeat_run)}× "
+                            + (
+                                _step_value_text(repeat_run[0])
+                                if any(seg.display_decimals is not None for seg in repeat_run)
+                                else _fmt(sum(seg.value for seg in repeat_run) / len(repeat_run))
+                            )
+                        ),
                     )
                 )
                 collapsed = True
@@ -3943,7 +3980,12 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
                         )
                         # A repeated-pitch claim must be true at the drawing's
                         # displayed precision, not merely "within 10%".
-                        equal = _fmt(cur.value) == _fmt(seg0.value)
+                        equal = (
+                            _step_value_text(cur) == _step_value_text(seg0)
+                            if cur.display_decimals is not None
+                            or seg0.display_decimals is not None
+                            else _fmt(cur.value) == _fmt(seg0.value)
+                        )
                         untoleranced = prev.tolerance is None and cur.tolerance is None
                         if not (contiguous and equal and untoleranced):
                             break
@@ -3953,8 +3995,12 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
                         run_segs = [seg for seg, _width in run]
                         xs = [p[0] for seg in run_segs for p in (seg.pa, seg.pb)]
                         y = run_segs[0].pa[1]
-                        pitch = sum(seg.value for seg in run_segs) / len(run_segs)
-                        label = f"{len(run_segs)}× {_fmt(pitch)}"
+                        repeated_text = (
+                            _step_value_text(run_segs[0])
+                            if any(seg.display_decimals is not None for seg in run_segs)
+                            else _fmt(sum(seg.value for seg in run_segs) / len(run_segs))
+                        )
+                        label = f"{len(run_segs)}× {repeated_text}"
                         dsegs.append(
                             _StepChainSegment(
                                 (min(xs), y, 0.0),

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -533,12 +533,21 @@ def add_feature_diameter(dwg, feature, model, *, ctx) -> str:
             f"callout(): a {axis!r}-turned step/boss diameter is not placeable "
             "(only X- and Z-turned parts)"
         )
-    # 6-tuple (anchor, dia, feature, tolerance, thread, mids): a manual callout honours a
-    # declared ± tolerance (P2a, #28) and an external thread aspect (#859) too, like the
-    # auto-pass — and carries the same ADR 0010 claim, so a hand-placed ø callout is verifiable
-    # on exactly the terms an auto-placed one is (#1227).
+    # 7-tuple (anchor, dia, value_text, feature, tolerance, thread, mids): a manual callout
+    # honours the compiler-approved display text, a declared ± tolerance (P2a, #28), and an
+    # external thread aspect (#859), like the auto-pass — and carries the same ADR 0010 claim,
+    # so a hand-placed ø callout is verifiable on exactly the terms an auto-placed one is
+    # (#1227).
     items = [
-        (group.anchor, dia, feature, dpd.tolerance, getattr(feature, "thread", None), (dpd.id,))
+        (
+            group.anchor,
+            dia,
+            dpd.value_text,
+            feature,
+            dpd.tolerance,
+            getattr(feature, "thread", None),
+            (dpd.id,),
+        )
     ]
     # The row/column placers name leaders m_dia_{x,z}{start+i} — pass the first FREE
     # index so a second callout() (or a call on an already-annotated turned part) never

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -278,7 +278,11 @@ def _est_planned_bore_callout_width(
             token_w.append(_text_width(f"{spec['count']}×", font_size))
         token_w.append(sym_w)  # ⌀ symbol
         token_w.append(
-            _text_width(f"{_fmt(bore)}{_tol_suffix(spec['tolerance'], draft)}", font_size)
+            _text_width(
+                f"{_fmt(bore, spec.get('diameter_decimals'))}"
+                f"{_tol_suffix(spec['tolerance'], draft)}",
+                font_size,
+            )
         )
 
         # Every term's tolerance, not just the bore's. The estimator has to measure the string
@@ -286,31 +290,35 @@ def _est_planned_bore_callout_width(
         # placement check reject a callout the reservation said would fit, and the whole
         # annotation was dropped with `callout_dropped: no room beside the view` — a wrong
         # drawing produced from a right one (#1234 review r7).
-        def _term(value, tol_key):
-            return _text_width(f"{_fmt(value)}{_tol_suffix(spec.get(tol_key), draft)}", font_size)
+        def _term(value, tol_key, decimals_key):
+            return _text_width(
+                f"{_fmt(value, spec.get(decimals_key))}{_tol_suffix(spec.get(tol_key), draft)}",
+                font_size,
+            )
 
         if spec["through"]:
             token_w.append(_text_width("THRU", font_size))
         elif depth is not None:
             token_w.append(sym_w)  # depth symbol
-            token_w.append(_term(depth, "depth_tol"))
+            token_w.append(_term(depth, "depth_tol", "depth_decimals"))
         if cbore_dia is not None:
             token_w.append(sym_w)  # counterbore/spotface symbol
             token_w.append(sym_w)  # ⌀
-            token_w.append(_term(cbore_dia, "cbore_dia_tol"))
+            token_w.append(_term(cbore_dia, "cbore_dia_tol", "cbore_dia_decimals"))
             if cbore_depth is not None:
                 token_w.append(sym_w)  # depth symbol
-                token_w.append(_term(cbore_depth, "cbore_depth_tol"))
+                token_w.append(_term(cbore_depth, "cbore_depth_tol", "cbore_depth_decimals"))
         csink_dia = spec["csink_dia"]
         if csink_dia is not None:
             token_w.append(sym_w)  # countersink symbol
             token_w.append(sym_w)  # ⌀
-            token_w.append(_term(csink_dia, "csink_dia_tol"))
+            token_w.append(_term(csink_dia, "csink_dia_tol", "csink_dia_decimals"))
             csink_angle = spec["csink_angle"]
             if csink_angle is not None:
                 token_w.append(
                     _text_width(
-                        f"× {_fmt(csink_angle)}{_tol_suffix(spec.get('csink_angle_tol'), draft)}°",
+                        f"× {_fmt(csink_angle, spec.get('csink_angle_decimals'))}"
+                        f"{_tol_suffix(spec.get('csink_angle_tol'), draft)}°",
                         font_size,
                     )
                 )

--- a/src/draftwright/model/callout.py
+++ b/src/draftwright/model/callout.py
@@ -55,6 +55,16 @@ def _first(group: DimensionGroup, kind: str, *roles: str) -> float | None:
     return None
 
 
+def _display_decimals(group: DimensionGroup, kind: str, *roles: str) -> int | None:
+    """Display policy for the same surviving term :func:`_first` selects (#1349)."""
+    for role in roles:
+        planned = _planned(group, kind, role)
+        if planned is not None and not planned.suppressed:
+            decimals = planned.display_decimals
+            return int(decimals) if decimals is not None else None
+    return None
+
+
 #: The compound callout's segments: ``(name, head, dependents)``.
 #:
 #: Each segment has a HEAD term — always its ⌀ — and terms that only mean something beside it.
@@ -112,7 +122,11 @@ def _pattern_suffix(group: DimensionGroup) -> str | None:
         return None
     if feat.pattern == "bolt_circle":
         bcd = _first(group, "diameter", "bolt_circle")
-        return None if bcd is None else f"EQ SP ON ø{_fmt(bcd)} BC"
+        return (
+            None
+            if bcd is None
+            else f"EQ SP ON ø{_fmt(bcd, _display_decimals(group, 'diameter', 'bolt_circle'))} BC"
+        )
     if feat.pattern == "grid" and feat.rows and feat.cols:
         return f"({feat.rows}×{feat.cols})"
     return None
@@ -376,21 +390,31 @@ def hole_callout_spec(group: DimensionGroup) -> dict | None:
     across = None
     if getattr(hole, "profile", None) == "double_d":
         across = _first(group, "length", "profile_across_flats")
-        profile_suffix = "DOUBLE-D" + (f" {_fmt(across)} A/F" if across is not None else "")
+        profile_suffix = "DOUBLE-D" + (
+            f" {_fmt(across, _display_decimals(group, 'length', 'profile_across_flats'))} A/F"
+            if across is not None
+            else ""
+        )
     suffix = " ".join(p for p in (profile_suffix, thread, suffix) if p) or None
     return {
         "diameter": bore,
+        "diameter_decimals": _display_decimals(group, "diameter", "bore"),
         "count": count if count and count > 1 else None,
         "through": hole.through,  # the feature's fact, not the param list's shape (#868)
         "depth": depth,
+        "depth_decimals": _display_decimals(group, "depth", "bore"),
         # counterbore precedence, spotface fallback — the engine's mapping
         # ONE role, both terms. Reading ⌀ and depth through independent fallbacks let a
         # drawing pair the counterbore's ⌀32 with the spotface's 0.5 depth — a recess that
         # exists on neither feature (#920 review). The chain picks a segment, not a value.
         "cbore_dia": cbore_dia,
         "cbore_depth": cbore_depth,
+        "cbore_dia_decimals": getattr(recess_dia_pd, "display_decimals", None),
+        "cbore_depth_decimals": getattr(recess_depth_pd, "display_decimals", None),
         "csink_dia": _first(group, "diameter", "countersink"),
         "csink_angle": _first(group, "angle", "countersink"),
+        "csink_dia_decimals": getattr(csink_dia_pd, "display_decimals", None),
+        "csink_angle_decimals": getattr(csink_angle_pd, "display_decimals", None),
         "suffix": suffix,
         "tolerance": bore_tol,  # P2a: ± on the bore ⌀, baked into the callout string below
         # ...and one per remaining term, baked in the same way (#1234 review r7).

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -170,6 +170,9 @@ class ApprovedDimension:
     role: str = ""
     discriminator: str | None = None
     tolerance: object | None = None
+    #: ``None`` preserves automatic formatting; an integer records an explicit referential
+    #: display policy so compound renderers can retain their default grouping behavior.
+    display_decimals: int | None = None
     #: Structural direction needed when a span cannot encode it. In particular, a
     #: shoulder rung retains X/Y explicitly rather than asking a renderer to infer semantic
     #: direction from projected coordinates.
@@ -732,6 +735,35 @@ def _dim_id(feature, parameter_id: str) -> DimensionId | None:
     return DimensionId(feature, parameter_id)
 
 
+def _value_text(model: PartModel, feature, parameter_id: str, value: float) -> str:
+    """Format one approved nominal, applying only its referential intent's policy.
+
+    The request still carries no number.  Matching by feature identity plus parameter id
+    keeps formatting on the same semantic address used for selection; the numeric
+    :class:`ApprovedDimension.value` remains untouched for reconciliation and lint (#1349).
+    """
+    requests = (
+        model.authored_dimensions
+        if model.authored_dimensions is not None
+        else model.requested_dimensions
+    )
+    for request in requests:
+        if request.feature is not feature or request.display_decimals is None:
+            continue
+        if "." in request.role:
+            matches = request.role == parameter_id
+        else:
+            matches = parameter_id.startswith(f"{request.role}.")
+        if not matches:
+            continue
+        if request.discriminator is not None and not parameter_id.endswith(
+            f".{request.discriminator}"
+        ):
+            continue
+        return _fmt(value, request.display_decimals)
+    return _fmt(value)
+
+
 def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder], list[Omission]]:
     """The prismatic height rungs and shoulder chain, approved as whole sets."""
     step = next((f for f in model.features if isinstance(f, StepLevelFeature)), None)
@@ -775,12 +807,12 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
         heights.append(
             ApprovedDimension(
                 id=_dim_id(step, "step_height.length"),
-                value_text=_fmt(z - step.base),
+                value_text=_value_text(model, step, "step_height.length", z - step.base),
                 value=z - step.base,
                 tolerance=step_tol,
                 span=span,
                 ref=step_ref,
-                rendered_label=_fmt(z - step.base),
+                rendered_label=_value_text(model, step, "step_height.length", z - step.base),
                 support_bounds=support_bounds,
             )
         )
@@ -798,11 +830,13 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
             heights = [
                 ApprovedDimension(
                     id=_dim_id(step, "step_height.length"),
-                    value_text=_fmt(rise),
+                    value_text=_value_text(model, step, "step_height.length", rise),
                     value=rise,
                     span=span,
                     ref=step_ref,
-                    rendered_label=f"{n}× {_fmt(rise)}",
+                    rendered_label=(
+                        f"{n}× {_value_text(model, step, 'step_height.length', rise)}"
+                    ),
                     support_bounds=support_bounds,
                 )
             ]
@@ -857,13 +891,13 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
         shoulders.append(
             ApprovedDimension(
                 id=_dim_id(step, "step_position.length"),
-                value_text=_fmt(value),
+                value_text=_value_text(model, step, "step_position.length", value),
                 value=value,
                 span=_shoulder_span(axis, pos),
                 ref=step_ref,
                 axis=axis,
                 tolerance=shoulder_tol,
-                rendered_label=_fmt(value),
+                rendered_label=_value_text(model, step, "step_position.length", value),
             )
         )
     pos_marks = [
@@ -1009,7 +1043,7 @@ def _compile_overall_height(
         (
             ApprovedDimension(
                 id=_dim_id(identity, "height.length"),
-                value_text=_fmt(value),
+                value_text=_value_text(model, env, "height.length", value),
                 value=value,
                 span=((x, y, float(bb.min.Z)), (x, y, float(bb.max.Z))),
                 ref=env_ref,
@@ -1022,7 +1056,7 @@ def _compile_overall_height(
                 # one consumer (`render_height_ladder`), which does compose it; a second
                 # consumer trusting the docstring would silently drop the tolerance
                 # (#1234 review, F8/finding 6).
-                rendered_label=_fmt(value),
+                rendered_label=_value_text(model, env, "height.length", value),
             ),
         ),
         ref=env_ref,
@@ -1349,7 +1383,7 @@ def _compile_groups(planned) -> tuple[list[ApprovedGroup], list[Omission]]:
                 id=DimensionId(g.feature, pd.param.parameter_id),
                 # DimParameter.value is a required float. Keep that invariant explicit at
                 # the boundary instead of implying a nullable state renderers cannot handle.
-                value_text=_fmt(pd.param.value),
+                value_text=_fmt(pd.param.value, pd.display_decimals),
                 value=float(pd.param.value),
                 span=pd.param.span,
                 ref=FeatureRef(g.feature),
@@ -1357,6 +1391,7 @@ def _compile_groups(planned) -> tuple[list[ApprovedGroup], list[Omission]]:
                 role=pd.param.role,
                 discriminator=pd.param.discriminator,
                 tolerance=pd.param.tolerance,
+                display_decimals=pd.display_decimals,
             )
             for pd in g.dims
             if not pd.suppressed

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -1855,7 +1855,8 @@ class RequestedDimension:
     through ``render_locations(pinned=…)`` for location dims only. Adding a third,
     pre-build spelling would scatter one concept across three layers, the same way the
     corridor priority scale was scattered before #894 consolidated it. The convergence
-    is tracked separately; this type stays pure *selection*.
+    is tracked separately; this type stays free of placement state. It carries selection plus
+    optional display policy, while the measurement itself remains referential.
     """
 
     feature: Feature
@@ -1864,6 +1865,22 @@ class RequestedDimension:
     #: pattern's two pitches (``"row"`` / ``"col"``). ``None`` where the role identifies
     #: the measurement on its own.
     discriminator: str | None = None
+    #: Explicit display precision for this referential dimension.  The numeric value and
+    #: identity still come from ``feature``; this controls only the compiler-owned text at
+    #: the rendering boundary (#1349).  ``None`` preserves the existing automatic formatting.
+    display_decimals: int | None = None
+
+    def __post_init__(self) -> None:
+        decimals = self.display_decimals
+        if decimals is None:
+            return
+        if isinstance(decimals, bool) or not isinstance(decimals, int) or not 0 <= decimals <= 15:
+            raise ValueError("display_decimals must be an integer from 0 to 15")
+        if self.role == "location":
+            raise ValueError(
+                "display precision is unavailable for location intent: one location may "
+                "compile into multiple directional values"
+            )
 
 
 @dataclass

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -142,6 +142,9 @@ class PlannedDimension:
     # the geometry states a fact, and the two must critique alike (#964 parity). ``None``
     # wherever nothing takes the fact over.
     conveyed_by: DimensionId | None = None
+    # Per-intent display policy (#1349). The authoritative numeric value remains on ``param``;
+    # legacy callout consumers use this field until they migrate to ``ApprovedDimension``.
+    display_decimals: int | None = None
 
 
 # Correlated sets (ADR 0016 identity, tier 3): exact ``(feature kind, role)`` pairs
@@ -963,6 +966,36 @@ def _authored_for(model, feature, param):
     return None
 
 
+def _check_display_policy_conflicts(model: PartModel) -> None:
+    """A semantic dimension cannot have two competing display authorities (#1349)."""
+    requests = (
+        model.authored_dimensions
+        if model.authored_dimensions is not None
+        else model.requested_dimensions
+    )
+    seen: dict[tuple[int, str], int | None] = {}
+    for request in requests:
+        targets: tuple[str, ...]
+        if request.role == LOCATION_ROLE:
+            targets = (LOCATION_ROLE,)
+        else:
+            targets = tuple(
+                parameter.parameter_id
+                for parameter in request.feature.parameters()
+                if _authored_addresses(request, request.feature, parameter)
+            )
+        for parameter_id in targets:
+            key = (id(request.feature), parameter_id)
+            previous = seen.get(key, request.display_decimals)
+            if key in seen and previous != request.display_decimals:
+                raise ValueError(
+                    f"conflicting display precision for {parameter_id}: "
+                    f"{previous!r} and {request.display_decimals!r}; repeat intent is "
+                    "idempotent only when its display policy agrees"
+                )
+            seen[key] = request.display_decimals
+
+
 def authored_location_omitted(model, feature) -> bool:
     """Did an AUTHORED set leave *feature*'s position out?
 
@@ -1246,6 +1279,7 @@ def plan_dimensions(model: PartModel, *, planned_views=None) -> list[DimensionGr
     """Plan each feature's parameters into one `DimensionGroup` (anchor + single
     view + planned dims, each carrying its render intent — convention, model-level
     suppression, datum). No cross- or within-feature value de-duplication."""
+    _check_display_policy_conflicts(model)
     if model.authored_dimensions is not None:
         _check_authored_targets(model)
     groups: list[DimensionGroup] = []
@@ -1271,6 +1305,7 @@ def plan_dimensions(model: PartModel, *, planned_views=None) -> list[DimensionGr
             # planner already emits is a deliberate no-op (idempotence gate): a script
             # must be able to ask without first knowing the rule set's mind.
             request = _request_for(model, feature, p)
+            display_intent = request
             if request is not None:
                 suppressed, reason, conveyed_by = False, None, None
             if model.authored_dimensions is not None:
@@ -1279,7 +1314,9 @@ def plan_dimensions(model: PartModel, *, planned_views=None) -> list[DimensionGr
                 # Marked, not filtered (#875) — the value survives on the group so the
                 # omission stays inspectable, and the compound-callout dependency rules
                 # still refuse to orphan half a term.
-                if _authored_for(model, feature, p) is None:
+                authored = _authored_for(model, feature, p)
+                display_intent = authored
+                if authored is None:
                     # `conveyed_by` deliberately SURVIVES an authored omission: the author
                     # chose which dimensions are drawn, but not where the geometry states
                     # this fact. Nulling it made a script that lists the overall extent and
@@ -1296,6 +1333,9 @@ def plan_dimensions(model: PartModel, *, planned_views=None) -> list[DimensionGr
                     reason=reason,
                     conveyed_by=conveyed_by,
                     datum=_datum_for(model, p),
+                    display_decimals=(
+                        display_intent.display_decimals if display_intent is not None else None
+                    ),
                 )
             )
         if dims:

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -597,6 +597,24 @@ class DimensionIntent:
         self._sheet = sheet
         self._entry = entry
 
+    def format(self, *, decimals: int) -> DimensionIntent:
+        """Preserve *decimals* places in this dimension's printed nominal (#1349).
+
+        This is display policy on a referential intent, not a restated label: reconciliation,
+        tolerance, suppression and provenance continue to use the feature parameter's numeric
+        value and semantic identity.  Automatic dimensions keep their existing formatting
+        unless their explicit ``add_dimension`` intent opts in.
+        """
+        if isinstance(decimals, bool) or not isinstance(decimals, int) or not 0 <= decimals <= 15:
+            raise ValueError("format(decimals=...) requires an integer from 0 to 15")
+        if self._entry["role"] == _LOCATION_ROLE:
+            raise ValueError(
+                "format() is unavailable for location intent: one location may compile "
+                "into multiple directional values"
+            )
+        self._entry["display_decimals"] = decimals
+        return self
+
     def __getattr__(self, name):  # declare-then-chain: forward to the sheet
         return getattr(self._sheet, name)
 
@@ -2352,6 +2370,7 @@ class Sheet:
                 feature=self._features[self._index_of_token(e["token"])],
                 role=e["role"],
                 discriminator=e["discriminator"],
+                display_decimals=e.get("display_decimals"),
             )
             for e in self._added_dimensions
         )
@@ -2377,6 +2396,7 @@ class Sheet:
                 feature=self._features[self._index_of_token(e["token"])],
                 role=e["role"],
                 discriminator=e["discriminator"],
+                display_decimals=e.get("display_decimals"),
             )
             for e in self._authored
         )

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -33,7 +33,7 @@ import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, fields, is_dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Literal, cast
 
 from build123d import Shape
 
@@ -1239,6 +1239,24 @@ def _mirrored_requests(declared, declared_envelope=None):
     return out
 
 
+def _requested_display_decimals(model, feature, role, discriminator) -> int | None:
+    """Precision attached to an augmenting intent mirrored as an authored line (#1349)."""
+    for request in model.requested_dimensions:
+        if request.feature is not feature:
+            continue
+        matches = (
+            request.role == role if "." in request.role else role.startswith(f"{request.role}.")
+        )
+        if not matches:
+            continue
+        if request.discriminator is not None and not (
+            request.discriminator == discriminator or role.endswith(f".{request.discriminator}")
+        ):
+            continue
+        return cast(int | None, request.display_decimals)
+    return None
+
+
 def _dimension_block(model, names: dict[int, str], synthesised_envelope=None) -> list[str]:
     """The authored set as `sheet.dimension(...)` declarations, or the `auto_dimensions()` line.
 
@@ -1283,7 +1301,10 @@ def _dimension_block(model, names: dict[int, str], synthesised_envelope=None) ->
             "sheet.auto_dimensions()",
         ]
     requests = (
-        [(a.feature, a.role, a.discriminator) for a in model.authored_dimensions]
+        [
+            (a.feature, a.role, a.discriminator, a.display_decimals)
+            for a in model.authored_dimensions
+        ]
         if model.authored_dimensions is not None
         # A detected model has no authored set, so the script MIRRORS the planner's choice as
         # explicit lines instead of `auto_dimensions()` (#938). That is what makes an
@@ -1291,7 +1312,13 @@ def _dimension_block(model, names: dict[int, str], synthesised_envelope=None) ->
         # drop it" held for features and not for dimensions, so the only way to drop one
         # dimension was to drop its whole feature — losing the callout, the centre marks and
         # the location with it.
-        else _mirrored_requests(model, synthesised_envelope)
+        else [
+            (
+                *request,
+                _requested_display_decimals(model, *request),
+            )
+            for request in _mirrored_requests(model, synthesised_envelope)
+        ]
     )
     out = [
         "# ── Dimensions ────────────────────────────────────────────────────────────────",
@@ -1310,7 +1337,7 @@ def _dimension_block(model, names: dict[int, str], synthesised_envelope=None) ->
         # automatic one does, rather than in prose a reader has to trust.
         "sheet.authored_dimensions()",
     ]
-    for feature, role, discriminator in requests:
+    for feature, role, discriminator, display_decimals in requests:
         name = names.get(id(feature))
         if name is None:
             # Reachable for a kind with no declarative verb (its line is a comment, so it
@@ -1333,7 +1360,10 @@ def _dimension_block(model, names: dict[int, str], synthesised_envelope=None) ->
             if discriminator and "." not in role[role.find(".") + 1 :]
             else ""
         )
-        out.append(f'sheet.dimension({name}, "{role}"{axis})')
+        line = f'sheet.dimension({name}, "{role}"{axis})'
+        if display_decimals is not None:
+            line += f".format(decimals={display_decimals})"
+        out.append(line)
     return out
 
 

--- a/tests/test_issue_1349_precision_display.py
+++ b/tests/test_issue_1349_precision_display.py
@@ -14,11 +14,11 @@ from draftwright.annotations.from_model import callout_from_spec
 from draftwright.compose import _est_planned_bore_callout_width
 from draftwright.model import PartModel, double_d_bore, hole, pattern
 from draftwright.model.callout import hole_callout_spec
-from draftwright.model.compiled import compile_dimensions
+from draftwright.model.compiled import _value_text, compile_dimensions
 from draftwright.model.declare import envelope as declare_envelope
 from draftwright.model.ir import RequestedDimension
 from draftwright.model.planner import plan_dimensions
-from draftwright.sheet_emit import emit_sheet_script
+from draftwright.sheet_emit import _requested_display_decimals, emit_sheet_script
 
 
 def _width_plan(value: float, decimals: int | None):
@@ -342,6 +342,46 @@ def test_generated_mirror_preserves_precision_on_an_augmenting_intent():
     assert compile_dimensions(regenerated).groups[0].dim(role="width").value_text == "13.55"
 
 
+def test_generated_mirror_preserves_each_discriminated_grid_pitch_policy():
+    part = Box(50, 50, 5)
+    sheet = Sheet(part, title="Precision", number="1349")
+    envelope = sheet.envelope()
+    member = hole(diameter=4, at=(0, 0, 0), axis="z")
+    grid = sheet.pattern(
+        member,
+        kind="grid",
+        count=4,
+        grid=(13.55, 20.125),
+        rows=2,
+        cols=2,
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        sheet.auto_dimensions()
+        # A foreign-feature request first exercises the identity gate while the two
+        # legitimate variants prove discriminator matching through the public surface.
+        sheet.add_dimension(envelope, "width.length").format(decimals=1)
+        sheet.add_dimension(grid, "grid_pitch", axis="row").format(decimals=2)
+        sheet.add_dimension(grid, "grid_pitch", axis="col").format(decimals=3)
+
+    source = emit_sheet_script(
+        sheet.model(), "part", "precision-grid", title="Precision", number="1349"
+    )
+    assert '"grid_pitch.length.row").format(decimals=2)' in source
+    assert '"grid_pitch.length.col").format(decimals=3)' in source
+
+    namespace = {"part": part}
+    body = source.replace("\npart\n", "\n", 1)
+    body = body[: body.index("drawing = sheet.build()")]
+    exec(compile(body, "<grid-precision-round-trip>", "exec"), namespace)  # noqa: S102
+    requests = {
+        request.role: request.display_decimals
+        for request in namespace["sheet"].model().authored_dimensions
+        if request.role.startswith("grid_pitch")
+    }
+    assert requests == {"grid_pitch.length.row": 2, "grid_pitch.length.col": 3}
+
+
 def test_direct_part_model_input_preserves_precision_without_restatement():
     part = Box(13.55, 10, 5)
     envelope = declare_envelope(part)
@@ -364,6 +404,55 @@ def test_direct_part_model_input_preserves_precision_without_restatement():
     )
     requested = compile_dimensions(requested_model).groups[0].dim(role="width")
     assert requested.value_text == "13.55"
+
+
+def test_policy_matching_uses_semantic_role_and_discriminator_without_leaking():
+    part = Box(13.55, 10, 5)
+    envelope = declare_envelope(part)
+    other = declare_envelope(Box(20, 10, 5))
+    mismatched = RequestedDimension(
+        envelope,
+        "width",
+        discriminator="not-length",
+        display_decimals=3,
+    )
+    matching = RequestedDimension(envelope, "width", display_decimals=2)
+    model = PartModel(
+        bbox=part.bounding_box(),
+        orientation=None,
+        features=[envelope],
+        requested_dimensions=(
+            RequestedDimension(other, "width", display_decimals=4),
+            mismatched,
+            matching,
+        ),
+    )
+
+    assert _value_text(model, envelope, "width.length", 13.55) == "13.55"
+    assert _requested_display_decimals(model, envelope, "width.length", None) == 2
+
+
+def test_y_turned_repeated_chain_collapses_before_requesting_a_detail():
+    shaft = Cylinder(30, 10, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    for index, radius in enumerate((25, 20, 15), start=1):
+        shaft += Pos(0, 0, 10 * index) * Cylinder(
+            radius, 10, align=(Align.CENTER, Align.CENTER, Align.MIN)
+        )
+    part = Rot(90, 0, 0) * shaft
+    sheet = Sheet(part, title="Precision", number="1349").authored_dimensions()
+    for index, diameter in enumerate((60, 50, 40, 30)):
+        step = sheet.step(diameter=diameter, length=10, at=(0, -5 - 10 * index, 0), axis="y")
+        sheet.dimension(step, "step.length").format(decimals=2)
+
+    drawing = sheet.build()
+    labels = {
+        name: item.label
+        for name, item in drawing.iter_annotations()
+        if name.startswith("m_steplen")
+    }
+    assert set(labels.values()) == {"4× 10.00"}
+    assert len(labels) == 1
+    assert "detail_a" not in drawing.views
 
 
 def test_conflicting_precision_for_one_semantic_dimension_fails_closed():
@@ -412,3 +501,6 @@ def test_a_compound_location_intent_refuses_one_misleading_precision_policy():
     hole = sheet.hole(diameter=4, at=(0, 0, 0), axis="z")
     with pytest.raises(ValueError, match="multiple directional values"):
         sheet.dimension(hole, "location").format(decimals=2)
+
+    with pytest.raises(ValueError, match="multiple directional values"):
+        RequestedDimension(sheet.features[0], "location", display_decimals=2)

--- a/tests/test_issue_1349_precision_display.py
+++ b/tests/test_issue_1349_precision_display.py
@@ -1,0 +1,414 @@
+"""#1349 — precision is display policy on a referential dimension intent."""
+
+from __future__ import annotations
+
+import warnings
+
+import pytest
+from build123d import Align, Box, Cylinder, Pos, Rot
+from build123d_drafting.helpers import Draft
+
+from draftwright import Sheet, build_drawing
+from draftwright._geometry import _fmt
+from draftwright.annotations.from_model import callout_from_spec
+from draftwright.compose import _est_planned_bore_callout_width
+from draftwright.model import PartModel, double_d_bore, hole, pattern
+from draftwright.model.callout import hole_callout_spec
+from draftwright.model.compiled import compile_dimensions
+from draftwright.model.declare import envelope as declare_envelope
+from draftwright.model.ir import RequestedDimension
+from draftwright.model.planner import plan_dimensions
+from draftwright.sheet_emit import emit_sheet_script
+
+
+def _width_plan(value: float, decimals: int | None):
+    part = Box(value, 10, 5)
+    sheet = Sheet(part, title="Precision", number="1349").authored_dimensions()
+    envelope = sheet.envelope()
+    intent = sheet.dimension(envelope, "width.length")
+    if decimals is not None:
+        intent.format(decimals=decimals)
+    model = sheet.model()
+    plan = compile_dimensions(model)
+    group = next(group for group in plan.groups if group.feature_kind == "envelope")
+    return part, sheet, model, group.dim(role="width")
+
+
+@pytest.mark.parametrize(
+    ("nominal", "decimals", "printed"),
+    [
+        (13.55, 2, "13.55"),
+        (6.25, 2, "6.25"),
+        (4.75, 2, "4.75"),
+        (0.85, 2, "0.85"),
+        (1.875, 3, "1.875"),
+    ],
+)
+def test_feature_linked_nominals_preserve_requested_precision(nominal, decimals, printed):
+    _part, _sheet, _model, approved = _width_plan(nominal, decimals)
+
+    assert approved.value_text == printed
+    assert approved.value == pytest.approx(nominal), "display policy must not replace the value"
+    assert approved.id.parameter == "width.length", "the referential identity must survive"
+
+
+def test_automatic_default_formatting_is_unchanged_without_an_explicit_policy():
+    _part, _sheet, _model, approved = _width_plan(13.55, None)
+    assert approved.value_text == "13.6"
+    automatic = build_drawing(Box(13.55, 10, 5))
+    assert automatic.get_annotation("m_env_width").label == "13.6"
+
+
+def test_requested_precision_reaches_the_rendered_dimension_without_false_lint():
+    _part, sheet, _model, _approved = _width_plan(13.55, 2)
+    drawing = sheet.build()
+
+    assert drawing.get_annotation("m_env_width").label == "13.55"
+    assert not [issue for issue in drawing.lint() if issue.code == "label_vs_measured"]
+
+
+def test_requested_precision_reaches_compound_hole_callouts_too():
+    part = Box(20, 20, 5) - Cylinder(3.125, 10)
+    sheet = Sheet(part, title="Precision", number="1349").authored_dimensions()
+    hole = sheet.hole(diameter=6.25, at=(0, 0, 0), axis="z")
+    sheet.dimension(hole, "bore.diameter").format(decimals=2)
+
+    drawing = sheet.build()
+    assert drawing.get_annotation("hc_plan0").label == "⌀6.25 THRU"
+    assert not [issue for issue in drawing.lint() if issue.code == "label_vs_measured"]
+
+    estimate = _est_planned_bore_callout_width(plan_dimensions(drawing.model()), drawing.draft)
+    group = next(
+        group for group in plan_dimensions(drawing.model()) if group.feature.kind == "hole"
+    )
+    rendered = callout_from_spec(hole_callout_spec(group), drawing.draft, None)
+    assert rendered is not None
+    assert estimate >= rendered.callout_width
+
+
+def _compound_callout_model():
+    sheet = Sheet(Box(40, 40, 10)).authored_dimensions()
+    compound = (
+        sheet.hole(diameter=6.25, at=(0, 0, 0), axis="z")
+        .depth(4.75)
+        .cbore(diameter=8.75, depth=1.875)
+        .countersink(major=10.25, angle=82.5)
+    )
+    for role, decimals in (
+        ("bore.diameter", 2),
+        ("bore.depth", 2),
+        ("counterbore.diameter", 2),
+        ("counterbore.depth", 3),
+        ("countersink.diameter", 2),
+        ("countersink.angle", 2),
+    ):
+        sheet.dimension(compound, role).format(decimals=decimals)
+    return sheet.model()
+
+
+def _bolt_circle_callout_model():
+    member = hole(diameter=6.25, at=(0, 0, 0), axis="z")
+    feature = pattern(member, kind="bolt_circle", count=4, bcd=13.55)
+    requests = tuple(
+        RequestedDimension(feature, role, display_decimals=2)
+        for role in ("bore.diameter", "bolt_circle.diameter")
+    )
+    return PartModel(
+        bbox=Box(40, 40, 10).bounding_box(),
+        orientation=None,
+        features=[feature],
+        authored_dimensions=requests,
+    )
+
+
+def _double_d_callout_model():
+    feature = double_d_bore(
+        major_diameter=10.25,
+        across_flats=6.25,
+        at=(0, 0, 0),
+        axis="z",
+    )
+    requests = tuple(
+        RequestedDimension(feature, role, display_decimals=2)
+        for role in ("bore.diameter", "profile_across_flats.length")
+    )
+    return PartModel(
+        bbox=Box(40, 40, 10).bounding_box(),
+        orientation=None,
+        features=[feature],
+        authored_dimensions=requests,
+    )
+
+
+@pytest.mark.parametrize(
+    ("model_factory", "expected"),
+    [
+        (
+            _compound_callout_model,
+            "⌀6.25 ↧ 4.75 ⌴ ⌀8.75 ↧ 1.875 ⌵ ⌀10.25 × 82.50°",
+        ),
+        (_bolt_circle_callout_model, "4× ⌀6.25 THRU EQ SP ON ø13.55 BC"),
+        (_double_d_callout_model, "⌀10.25 THRU DOUBLE-D 6.25 A/F"),
+    ],
+    ids=["all compound terms", "bolt-circle suffix", "double-D across flats"],
+)
+def test_every_compound_and_suffix_term_uses_the_policy_and_fits_its_reservation(
+    model_factory, expected
+):
+    model = model_factory()
+    plan = plan_dimensions(model)
+    spec = next(spec for group in plan if (spec := hole_callout_spec(group)) is not None)
+    draft = Draft(font_size=3.0)
+    callout = callout_from_spec(spec, draft, spec["count"])
+
+    assert callout is not None
+    assert callout.label == expected
+    assert _est_planned_bore_callout_width(plan, draft) >= callout.callout_width
+
+
+@pytest.mark.parametrize(
+    ("axis", "part"),
+    [
+        ("x", Rot(0, 90, 0) * Cylinder(3.125, 6.25)),
+        ("y", Rot(90, 0, 0) * Cylinder(3.125, 6.25)),
+        ("z", Cylinder(3.125, 6.25)),
+    ],
+)
+def test_precision_reaches_every_turned_diameter_and_step_chain(axis, part):
+    centre = part.bounding_box().center()
+    sheet = Sheet(part, title="Precision", number="1349").authored_dimensions()
+    step = sheet.step(
+        diameter=6.25,
+        length=6.25,
+        at=(centre.X, centre.Y, centre.Z),
+        axis=axis,
+    )
+    sheet.dimension(step, "step.diameter").format(decimals=2)
+    sheet.dimension(step, "step.length").format(decimals=2)
+
+    labels = {
+        name: item.label
+        for name, item in sheet.build().iter_annotations()
+        if name.startswith(("m_dia", "m_steplen"))
+    }
+    assert labels == {f"m_dia_{axis}0": "ø6.25", "m_steplen0": "6.25"}
+
+
+def test_precision_reaches_a_prismatic_boss_diameter():
+    part = Box(20, 20, 5) + Pos(0, 0, 5) * Cylinder(3.125, 5)
+    sheet = Sheet(part, title="Precision", number="1349").authored_dimensions()
+    boss = sheet.boss(diameter=6.25, height=5, at=(0, 0, 7.5), axis="z")
+    sheet.dimension(boss, "boss.diameter").format(decimals=2)
+    assert sheet.build().get_annotation("m_bossdia_z0").label == "ø6.25"
+
+
+def test_live_turned_callout_uses_the_compiler_approved_text_after_drop():
+    part = Rot(0, 90, 0) * Cylinder(3.125, 6.25)
+    centre = part.bounding_box().center()
+    sheet = Sheet(part, title="Precision", number="1349").authored_dimensions()
+    step = sheet.step(diameter=6.25, length=6.25, at=tuple(centre), axis="x")
+    sheet.dimension(step, "step.diameter").format(decimals=3)
+    drawing = sheet.build()
+    feature = next(feature for feature in drawing.model().features if feature.kind == "step")
+
+    drawing.drop(feature)
+    name = drawing.callout(feature)
+
+    assert drawing.get_annotation(name).label == "ø6.250"
+
+
+def test_repeated_step_chain_keeps_its_compact_form_with_explicit_precision():
+    shaft = Cylinder(30, 10, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    for index, radius in enumerate((25, 20, 15), start=1):
+        shaft += Pos(0, 0, 10 * index) * Cylinder(
+            radius, 10, align=(Align.CENTER, Align.CENTER, Align.MIN)
+        )
+    sheet = Sheet(shaft, title="Precision", number="1349").authored_dimensions()
+    for index, diameter in enumerate((60, 50, 40, 30)):
+        step = sheet.step(diameter=diameter, length=10, at=(0, 0, 5 + 10 * index), axis="z")
+        sheet.dimension(step, "step.length").format(decimals=2)
+
+    drawing = sheet.build()
+    assert drawing.get_annotation("m_steplen_typ").label == "4× 10.00"
+
+
+def test_near_uniform_automatic_chain_keeps_its_existing_default_collapse():
+    shaft = Cylinder(30, 10, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    shaft += Pos(0, 0, 10) * Cylinder(25, 10.5, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    shaft += Pos(0, 0, 20.5) * Cylinder(20, 9.5, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    drawing = build_drawing(shaft)
+    labels = {
+        name: item.label
+        for name, item in drawing.iter_annotations()
+        if name.startswith("m_steplen")
+    }
+    assert labels == {"m_steplen_typ": "3× 10"}
+
+
+def test_close_diameters_with_distinct_authoritative_text_do_not_deduplicate():
+    shaft = Cylinder(3.1205, 30, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    shaft += Pos(0, 0, 30) * Cylinder(3.122, 30, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    part = Rot(0, 90, 0) * shaft
+    sheet = Sheet(part, title="Precision", number="1349", page="A3").authored_dimensions()
+    for position, diameter in ((15, 6.241), (45, 6.244)):
+        step = sheet.step(diameter=diameter, length=30, at=(position, 0, 0), axis="x")
+        sheet.dimension(step, "step.diameter").format(decimals=3)
+
+    labels = {
+        name: item.label
+        for name, item in sheet.build().iter_annotations()
+        if name.startswith("m_dia")
+    }
+    assert labels == {"m_dia_x0": "ø6.241", "m_dia_x1": "ø6.244"}
+
+
+def test_special_ladders_consume_the_same_display_policy():
+    part = Box(20, 20, 13.55)
+    sheet = Sheet(part, title="Precision", number="1349").authored_dimensions()
+    envelope = sheet.envelope()
+    level = sheet.step_level(base=0, levels=(13.55,), shoulders=(), datum=(0, 0, 0))
+    sheet.dimension(envelope, "height.length").format(decimals=2)
+    sheet.dimension(level, "step_height.length").format(decimals=2)
+
+    plan = compile_dimensions(sheet.model())
+    labels = {
+        ladder.kind: {rung.value_text for rung in ladder.rungs}
+        for ladder in plan.ladders
+        if ladder.kind in {"overall_height", "step_height"}
+    }
+    assert labels == {"overall_height": {"13.55"}, "step_height": {"13.55"}}
+
+
+def test_display_policy_keeps_tolerance_and_numeric_provenance_separate():
+    part = Box(13.55, 10, 5)
+    sheet = Sheet(part, title="Precision", number="1349").authored_dimensions()
+    envelope = sheet.envelope().tolerance(0.05, on="width")
+    sheet.dimension(envelope, "width.length").format(decimals=2)
+
+    plan = compile_dimensions(sheet.model())
+    approved = next(group for group in plan.groups if group.feature_kind == "envelope").dim(
+        role="width"
+    )
+    assert approved.value_text == "13.55"
+    assert approved.value == pytest.approx(13.55)
+    assert approved.tolerance == pytest.approx(0.05)
+
+
+def test_generated_sheet_code_round_trips_the_display_policy():
+    part, _sheet, model, _approved = _width_plan(1.875, 3)
+    source = emit_sheet_script(
+        model,
+        "part",
+        "precision",
+        title="Precision",
+        number="1349",
+    )
+    assert 'sheet.dimension(envelope1, "width.length").format(decimals=3)' in source
+
+    namespace = {"part": part}
+    body = source.replace("\npart\n", "\n", 1)
+    body = body[: body.index("drawing = sheet.build()")]
+    exec(compile(body, "<precision-round-trip>", "exec"), namespace)  # noqa: S102
+
+    (request,) = namespace["sheet"].model().authored_dimensions
+    assert request.display_decimals == 3
+    regenerated = compile_dimensions(namespace["sheet"].model())
+    approved = next(group for group in regenerated.groups if group.feature_kind == "envelope").dim(
+        role="width"
+    )
+    assert approved.value_text == "1.875"
+
+
+def test_generated_mirror_preserves_precision_on_an_augmenting_intent():
+    part = Box(13.55, 10, 5)
+    sheet = Sheet(part, title="Precision", number="1349")
+    envelope = sheet.envelope()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        sheet.auto_dimensions()
+        sheet.add_dimension(envelope, "width.length").format(decimals=2)
+
+    source = emit_sheet_script(
+        sheet.model(), "part", "precision", title="Precision", number="1349"
+    )
+    assert 'sheet.dimension(envelope1, "width.length").format(decimals=2)' in source
+
+    namespace = {"part": part}
+    body = source.replace("\npart\n", "\n", 1)
+    body = body[: body.index("drawing = sheet.build()")]
+    exec(compile(body, "<augmenting-precision-round-trip>", "exec"), namespace)  # noqa: S102
+    regenerated = namespace["sheet"].model()
+    assert regenerated.authored_dimensions[0].display_decimals == 2
+    assert compile_dimensions(regenerated).groups[0].dim(role="width").value_text == "13.55"
+
+
+def test_direct_part_model_input_preserves_precision_without_restatement():
+    part = Box(13.55, 10, 5)
+    envelope = declare_envelope(part)
+    request = RequestedDimension(envelope, "width.length", display_decimals=2)
+    model = PartModel(
+        bbox=part.bounding_box(),
+        orientation=None,
+        features=[envelope],
+        authored_dimensions=(request,),
+    )
+    approved = compile_dimensions(model).groups[0].dim(role="width")
+    assert approved.value_text == "13.55"
+    assert approved.value == pytest.approx(13.55)
+
+    requested_model = PartModel(
+        bbox=part.bounding_box(),
+        orientation=None,
+        features=[envelope],
+        requested_dimensions=(request,),
+    )
+    requested = compile_dimensions(requested_model).groups[0].dim(role="width")
+    assert requested.value_text == "13.55"
+
+
+def test_conflicting_precision_for_one_semantic_dimension_fails_closed():
+    part = Box(13.55, 10, 5)
+    envelope = declare_envelope(part)
+    model = PartModel(
+        bbox=part.bounding_box(),
+        orientation=None,
+        features=[envelope],
+        authored_dimensions=(
+            RequestedDimension(envelope, "width.length", display_decimals=2),
+            RequestedDimension(envelope, "width.length", display_decimals=3),
+        ),
+    )
+    with pytest.raises(ValueError, match="conflicting display precision"):
+        compile_dimensions(model)
+
+
+@pytest.mark.parametrize("bad", [-1, 16, 1.5, True])
+def test_invalid_precision_is_refused_at_both_public_inputs(bad):
+    part = Box(10, 10, 5)
+    sheet = Sheet(part).authored_dimensions()
+    envelope = sheet.envelope()
+    with pytest.raises(ValueError, match="integer from 0 to 15"):
+        sheet.dimension(envelope, "width.length").format(decimals=bad)
+
+    feature = sheet.features[0]
+    with pytest.raises(ValueError, match="integer from 0 to 15"):
+        RequestedDimension(feature, "width.length", display_decimals=bad)
+
+
+def test_precision_boundaries_and_negative_zero_are_stable():
+    assert _fmt(1.25, 0) == "1"
+    assert _fmt(1.0, 15) == "1.000000000000000"
+    assert _fmt(-0.0001, 2) == "0.00"
+
+    part = Box(10, 10, 5)
+    envelope = declare_envelope(part)
+    assert RequestedDimension(envelope, "width.length", display_decimals=0).display_decimals == 0
+    assert RequestedDimension(envelope, "width.length", display_decimals=15).display_decimals == 15
+
+
+def test_a_compound_location_intent_refuses_one_misleading_precision_policy():
+    part = Box(20, 20, 5)
+    sheet = Sheet(part).authored_dimensions()
+    hole = sheet.hole(diameter=4, at=(0, 0, 0), axis="z")
+    with pytest.raises(ValueError, match="multiple directional values"):
+        sheet.dimension(hole, "location").format(decimals=2)

--- a/tests/test_label_provenance.py
+++ b/tests/test_label_provenance.py
@@ -56,7 +56,6 @@ _FMT_BUDGET: dict[str, tuple[int, str]] = {
     # --- The turned step chain composes its labels while collapsing repeat runs, so the
     # text is decided by the collapse rather than per approved entry.
     "from_model.render_step_lengths": (3, "labels decided during the repeat-run collapse"),
-    "from_model.render_step_lengths._redraw_y": (3, "the same collapse, detail redraw"),
     "from_model._draw_step_chain": (1, "default repeat collapse preserves legacy mean text"),
     "from_model._step_value_text": (1, "synthetic block segments have no approved entry"),
     # --- `hole_callout_spec` hands the callout builder floats, and the #261 invariant

--- a/tests/test_label_provenance.py
+++ b/tests/test_label_provenance.py
@@ -57,20 +57,8 @@ _FMT_BUDGET: dict[str, tuple[int, str]] = {
     # text is decided by the collapse rather than per approved entry.
     "from_model.render_step_lengths": (3, "labels decided during the repeat-run collapse"),
     "from_model.render_step_lengths._redraw_y": (3, "the same collapse, detail redraw"),
-    "from_model._draw_step_chain": (2, "the same collapse, drawing half"),
-    # --- The ø-leader placers take `(anchor, dia, feature, tol, thread, mids)` items, where
-    # `dia` is a float BOTH printed and used for geometry (`az - dia / 2`). Carrying the
-    # approved text alongside it is a five-call-site change to the item tuple; named here
-    # rather than rushed, because the budget's job is to make it visible.
-    #
-    # #1225 widened that tuple to carry the compiled measurement IDS and did not take the
-    # opportunity to carry the approved text as well — deliberately: the ids close a
-    # verification gap that had every turned ø callout unclaimed, while the text is a label
-    # -provenance concern with its own budget line. Same tuple, two changes, kept separate.
-    "from_model._diameter_row_below": (2, "item tuple carries a float for tip geometry"),
-    "from_model._diameter_column_left": (2, "item tuple carries a float for tip geometry"),
-    "from_model.render_diameters": (1, "builds those items from approved entries"),
-    "from_model.render_boss_diameters": (1, "builds those items from approved entries"),
+    "from_model._draw_step_chain": (1, "default repeat collapse preserves legacy mean text"),
+    "from_model._step_value_text": (1, "synthetic block segments have no approved entry"),
     # --- `hole_callout_spec` hands the callout builder floats, and the #261 invariant
     # ("every value crosses as a _fmt string") is enforced there. Fixing it means the spec
     # carrying approved text — the hole-callout migration ADR 0016 still names as pending.

--- a/tests/test_render_seam.py
+++ b/tests/test_render_seam.py
@@ -221,6 +221,8 @@ class TestStepChainDrop:
                 tolerance=None,
                 measurements=("step-a",),
                 label=None,
+                value_text="5",
+                display_decimals=None,
             ),
             SimpleNamespace(
                 pa=(80.0, 10.1, 0),
@@ -229,6 +231,8 @@ class TestStepChainDrop:
                 tolerance=None,
                 measurements=("step-b",),
                 label=None,
+                value_text="8",
+                display_decimals=None,
             ),
         ]
         placed = _draw_step_chain(dwg, "front", segs, "m_steplen", ctx=ctx)
@@ -280,11 +284,12 @@ class TestDiameterColumnOccupancy:
 
         return _Dwg()
 
-    # (anchor, dia, feature, tolerance, thread, mids) — feature=None (unit test of placement; #412
-    # added the tag); tolerance=None (untoleranced — a P2a ± field, #28); thread=None (#859)
+    # (anchor, dia, value_text, feature, tolerance, thread, mids) — feature=None (unit test of
+    # placement; #412 added the tag); tolerance=None (untoleranced — a P2a ± field, #28);
+    # thread=None (#859)
     _ITEMS = [
-        ((10.0, 0.0, 8.0), 12.0, None, None, None, ()),
-        ((10.0, 0.0, 24.0), 8.0, None, None, None, ()),
+        ((10.0, 0.0, 8.0), 12.0, "12", None, None, None, ()),
+        ((10.0, 0.0, 24.0), 8.0, "8", None, None, None, ()),
     ]  # two Z-turned ø steps; empty mids — this seam test is about occupancy, not provenance
 
     def _ctx(self):

--- a/tests/test_sheet_identity_invariant.py
+++ b/tests/test_sheet_identity_invariant.py
@@ -174,17 +174,17 @@ def _scn_dimension(s):
 
 
 def _scn_add_dimension(s):
-    """The verb runs in the DRIVER, not in setup — so the matrix exercises the resolver on an
-    already-reordered sheet, which is a different claim from "a recorded intent survives a
-    reorder" and the one an earlier draft silently skipped.
+    """Retain a `DimensionIntent`, reorder, then apply its display policy.
 
-    `DimensionIntent` itself exposes no verb that consumes its stored reference (ADR 0012's
-    `.pin()`/`.priority()` were removed from #905 pending #906), so there is nothing further to
-    drive on the returned object. `test_dimension_intent_still_has_no_verbs` fails the moment
-    there is."""
+    This covers both halves of the identity claim: `add_dimension()` records the target by
+    token, and the retained handle's `format()` must update that same intent after neighbouring
+    features move. The closed verb-roster test below forces any future handle verb into this
+    driver too.
+    """
     a = s.hole(diameter=10, at=(-25, 0, 20), axis="z").depth(12)
     s.hole(diameter=6, at=(25, 0, 20), axis="z").depth(8)
-    return a, lambda a: s.add_dimension(a, "bore.diameter")
+    intent = s.add_dimension(a, "bore.diameter")
+    return intent, lambda intent: intent.format(decimals=2)
 
 
 def _scn_view(s):
@@ -754,10 +754,8 @@ def test_every_reference_carrying_state_field_is_exercised():
     )
 
 
-def test_dimension_intent_still_has_no_verbs():
-    """`_scn_add_dimension`'s driver is a no-op, which is honest only while `DimensionIntent`
-    has nothing to drive. #906 will restore `.pin()`/`.priority()`; this fails then, so the
-    scenario gets a real driver rather than staying quietly vacuous."""
+def test_dimension_intent_verb_roster_is_closed():
+    """Every retained-intent verb must be exercised after the feature-order mutation."""
     tree = ast.parse(_SRC.read_text())
     (intent,) = [
         n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "DimensionIntent"
@@ -767,9 +765,9 @@ def test_dimension_intent_still_has_no_verbs():
         for f in intent.body
         if isinstance(f, ast.FunctionDef) and not f.name.startswith("_")
     }
-    assert verbs == set(), (
-        f"DimensionIntent gained {sorted(verbs)} — give _scn_add_dimension a driver that calls "
-        "it after the mutation, or the retained-object matrix does not cover this class"
+    assert verbs == {"format"}, (
+        f"DimensionIntent verbs changed to {sorted(verbs)} — make _scn_add_dimension's driver "
+        "call every verb after the mutation, or the retained-object matrix does not cover them"
     )
 
 


### PR DESCRIPTION
## Symptom and evidence

- User-visible problem: feature-linked authored dimensions rounded manufacturing nominals such as `13.55` to `13.6`, even though the underlying numeric parameter remained exact.
- Fixture/reproducer: `tests/test_issue_1349_precision_display.py` covers `13.55`, `6.25`, `4.75`, `0.85`, and `1.875`, plus compound hole callouts, turned dimensions, ladders, live edits, and generated scripts.
- Before/after result: `sheet.dimension(feature, "parameter.id").format(decimals=n)` now preserves requested trailing places while `ApprovedDimension.value` and `DimensionId` remain authoritative.
- Mutation that makes the guard fail: removing the precision policy at the intent, planner/compiler, renderer, reservation, or script-emission boundary makes the corresponding end-to-end regression fail; the public acceptance regression fails on `main` because `DimensionIntent.format()` is absent.

## Contract and scope

- Smallest contract this change tests: a referential dimension may control printed decimal places without restating its nominal or changing placement.
- Relevant ADRs: 0011 (declared IR), 0014 (collect then solve), 0015 (compiler pipeline), and 0016 (declared dimensioning intent and compiler-owned label text).
- Explicitly deferred: arbitrary display strings and precision policy for compound `location` intent; automatic/detected formatting remains unchanged.

## Validation

- [x] `scripts/pr-check --quick`
- [x] `scripts/pr-check` before final review (`4916 passed, 5 skipped, 2 xfailed`; 95.13% total coverage; 94% diff coverage)
- [x] The named mutation was observed failing before the implementation passed it
- [x] Automatic, declared, and generated-script paths were checked where affected
- [x] Recognition and repeated-lint call counts were checked where affected (N/A for recognition: no recognizer code or behavior changed; repeated lint remains covered by the full suite)

## Stop check

- [x] No two consecutive review rounds invalidated the same core association strategy
- [x] New prerequisites were split or the work was explicitly reclassified as discovery (N/A: no new prerequisite or discovery work)

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/pzfreo/draftwright/blob/main/CLA.md) and agree to it. If I am contributing on behalf of an organisation, I am authorised to agree on its behalf.

Closes #1349