### PR TITLE
Add detected baseline takeover workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- `Sheet.from_part(...).take_over(...)` now adopts detected features in place while choosing
+  authored or automatic dimension, principal-view, and derived-view sources explicitly. This
+  preserves detected handles, supports automatic principal views with authored requirements,
+  replaces or suppresses inferred sections without duplicates, and round-trips the adopted view
+  request through generated Sheet code (#1350).
 - Referential Sheet dimensions can preserve an explicit number of decimal places with
   `sheet.dimension(feature, "parameter.id").format(decimals=n)`. The policy changes only
   printed display text: numeric reconciliation, tolerances, suppression and dimension

--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -40,6 +40,30 @@ refused at declaration and constraints are never silently relaxed. The immutable
 snapshot is available as `sheet.view_constraints`, while `drawing.view_plan` is the distinct
 resolved result.
 
+### Taking over a detected baseline
+
+`Sheet.from_part(part)` retains the detector's feature set and starts with implicit automatic
+dimensions. Use `take_over(...)` to adopt that same Sheet as an explicit editable request without
+copying features into a second Sheet:
+
+```python
+s = Sheet.from_part(part).take_over(
+    dimensions="authored",
+    principal_views="automatic",
+    derived_views="authored",
+)
+s.dimension(hole, "bore.diameter")
+s.section_view("A", through=hole)
+```
+
+The three sources are chosen atomically. In this example the principal planner keeps the
+automatic front/plan/side/isometric baseline, while the authored derived set replaces inferred
+sections. Leaving that authored set empty suppresses inferred derived views; selecting
+`derived_views="automatic"` accepts them. Matching declarations may appear before or after
+`take_over(...)` with the same result. Explicit source contradictions fail without partially
+changing the Sheet, and automatic dimensions remain incompatible with authored views under ADR
+0018.
+
 ## View handle
 
 ::: draftwright.sheet._View

--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -64,6 +64,23 @@ sections. Leaving that authored set empty suppresses inferred derived views; sel
 changing the Sheet, and automatic dimensions remain incompatible with authored views under ADR
 0018.
 
+To emit editable Python from an adopted Sheet, pass both request halves to the script emitter;
+the model carries the feature/dimension semantics and `view_constraints` carries the independent
+view sources and semantic targets:
+
+```python
+from draftwright.sheet_emit import emit_sheet_script
+
+source = emit_sheet_script(
+    s.model(),
+    "part = make_part()",
+    "drawing",
+    title="BRACKET",
+    number="DWG-001",
+    view_constraints=s.view_constraints,
+)
+```
+
 ## View handle
 
 ::: draftwright.sheet._View

--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -47,7 +47,9 @@ dimensions. Use `take_over(...)` to adopt that same Sheet as an explicit editabl
 copying features into a second Sheet:
 
 ```python
-s = Sheet.from_part(part).take_over(
+s = Sheet.from_part(part)
+hole = s.of(next(feature for feature in s.features if feature.kind == "hole"))
+s.take_over(
     dimensions="authored",
     principal_views="automatic",
     derived_views="authored",

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -1672,6 +1672,18 @@ class Sheet:
                 "take_over(dimensions='authored') conflicts with an explicit "
                 "auto_dimensions() source"
             )
+        if dimensions == "authored" and self._added_dimensions:
+            raise ValueError(
+                "take_over(dimensions='authored') conflicts with add_dimension() automatic-set "
+                "additions"
+            )
+        if derived_views == "authored" and (
+            self._section is not None or self._opts.get("detail_view") is True
+        ):
+            raise ValueError(
+                "take_over(derived_views='authored') conflicts with a legacy section()/detail() "
+                "automatic-set augmentation; migrate it to section_view()/detail_view()"
+            )
 
         source_requests = (
             (
@@ -1756,9 +1768,9 @@ class Sheet:
                 "view() defines the complete authored set and cannot follow auto_views(); "
                 "use add_view() to augment the automatic set"
             )
+        name, kind = self._principal_view_name(name)
         self._principal_view_source = "authored"
         self._principal_view_source_at = self._principal_view_source_at or _constraint_source()
-        name, kind = self._principal_view_name(name)
         return self._append_view_record(
             "_principal_views", name=name, kind=kind, source=_constraint_source()
         )
@@ -1795,13 +1807,15 @@ class Sheet:
                 "section_view() defines the authored derived set and cannot follow auto_views(); "
                 "use add_section_view() to augment automatic derived views"
             )
+        name = self._derived_view_name("section", label)
+        target = self._derived_target("section_view()", feature=through, at=at)
         self._derived_view_source = "authored"
         self._derived_view_source_at = self._derived_view_source_at or _constraint_source()
         return self._append_view_record(
             "_derived_views",
-            name=self._derived_view_name("section", label),
+            name=name,
             kind="section",
-            target=self._derived_target("section_view()", feature=through, at=at),
+            target=target,
             source=_constraint_source(),
         )
 
@@ -1827,13 +1841,15 @@ class Sheet:
                 "detail_view() defines the authored derived set and cannot follow auto_views(); "
                 "use add_detail_view() to augment automatic derived views"
             )
+        name = self._derived_view_name("detail", label)
+        target = self._derived_target("detail_view()", feature=around, at=None)
         self._derived_view_source = "authored"
         self._derived_view_source_at = self._derived_view_source_at or _constraint_source()
         return self._append_view_record(
             "_derived_views",
-            name=self._derived_view_name("detail", label),
+            name=name,
             kind="detail",
-            target=self._derived_target("detail_view()", feature=around, at=None),
+            target=target,
             source=_constraint_source(),
         )
 
@@ -1869,6 +1885,11 @@ class Sheet:
             DeprecationWarning,
             stacklevel=2,
         )
+        if self._derived_view_source == "authored":
+            raise ValueError(
+                "section() augments automatic derived views and cannot follow an authored "
+                "derived-view source; use section_view()"
+            )
         if at is not None:
             if not math.isfinite(at):
                 raise ValueError(f"section(at=…) needs a finite Y, got {at!r}")
@@ -1899,6 +1920,11 @@ class Sheet:
             DeprecationWarning,
             stacklevel=2,
         )
+        if self._derived_view_source == "authored":
+            raise ValueError(
+                "detail() augments automatic derived views and cannot follow an authored "
+                "derived-view source; use detail_view()"
+            )
         self._opts["detail_view"] = True
         return self
 

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -55,7 +55,7 @@ import math
 import warnings
 from collections.abc import MutableSequence
 from dataclasses import replace
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 from draftwright._geometry import _solids_body
 from draftwright._warnings import SoftDeprecationWarning
@@ -111,6 +111,8 @@ from draftwright.view_plan import (
     ViewRelation,
     ViewSpec,
 )
+
+_SOURCE_CHOICES = ("automatic", "authored")
 
 #: "Not supplied" for `Sheet.dimension`'s positional parameters. They cannot simply be
 #: required: a keyword-only legacy call has to reach the removal message rather than die on
@@ -1614,13 +1616,100 @@ class Sheet:
         return _View(self, bucket, len(records) - 1)
 
     def _reject_authored_view_auto_dimensions(self, verb: str) -> None:
-        if self._auto_dimensions is not None:
+        if self._auto_dimensions == "explicit":
             raise ValueError(
                 f"{verb} authors the view set, but this sheet already called "
                 "auto_dimensions(). ADR 0018 makes requirements determine views, not the "
                 "reverse: use authored_dimensions() with explicit dimension(...) lines, or "
                 "keep auto_views() and use add_view()/add_section_view()/add_detail_view()."
             )
+
+    def take_over(
+        self,
+        *,
+        dimensions: Literal["automatic", "authored"],
+        principal_views: Literal["automatic", "authored"],
+        derived_views: Literal["automatic", "authored"],
+    ) -> Sheet:
+        """Adopt a detected baseline with explicit, independently chosen sources.
+
+        This is the public transition from :meth:`from_part`'s detected features and implicit
+        automatic dimensions to an editable Sheet request.  Principal and derived views are
+        separate sources (ADR 0018): keeping automatic principal planning while authoring the
+        complete derived set replaces an inferred section instead of augmenting it; an empty
+        authored derived set explicitly suppresses every inferred section/detail.
+
+        The declaration is atomic and order-independent.  Matching declarations made before
+        this call are accepted, while an explicit contradictory source raises without changing
+        any source.  The incoherent ADR 0018 combination -- authored views with automatic
+        dimensions -- is always refused.
+        """
+        choices = {
+            "dimensions": dimensions,
+            "principal_views": principal_views,
+            "derived_views": derived_views,
+        }
+        invalid = {name: value for name, value in choices.items() if value not in _SOURCE_CHOICES}
+        if invalid:
+            name, value = next(iter(invalid.items()))
+            raise ValueError(f"{name} must be 'automatic' or 'authored', got {value!r}")
+        if dimensions == "automatic" and (
+            principal_views == "authored" or derived_views == "authored"
+        ):
+            raise ValueError(
+                "take_over() cannot combine automatic dimensions with authored views. "
+                "ADR 0018 makes requirements determine views, not views determine requirements"
+            )
+
+        authored_dimensions = bool(self._authored) or self._authored_source
+        if dimensions == "automatic" and authored_dimensions:
+            raise ValueError(
+                "take_over(dimensions='automatic') conflicts with this sheet's authored "
+                "dimension source"
+            )
+        if dimensions == "authored" and self._auto_dimensions == "explicit":
+            raise ValueError(
+                "take_over(dimensions='authored') conflicts with an explicit "
+                "auto_dimensions() source"
+            )
+
+        source_requests = (
+            (
+                "principal_views",
+                principal_views,
+                self._principal_view_source,
+                self._added_principal_views,
+            ),
+            (
+                "derived_views",
+                derived_views,
+                self._derived_view_source,
+                self._added_derived_views,
+            ),
+        )
+        for name, requested, current, added_records in source_requests:
+            if current is not None and current != requested:
+                raise ValueError(
+                    f"take_over({name}={requested!r}) conflicts with the existing "
+                    f"{current!r} {name} source"
+                )
+            if requested == "authored" and added_records:
+                raise ValueError(
+                    f"take_over({name}='authored') conflicts with automatic-set additions"
+                )
+
+        # All checks precede mutation: a failed takeover never leaves a partly changed Sheet.
+        source = _constraint_source()
+        if dimensions == "authored":
+            self._authored_source = True
+            self._auto_dimensions = None
+        else:
+            self._auto_dimensions = "explicit"
+        self._principal_view_source = principal_views
+        self._derived_view_source = derived_views
+        self._principal_view_source_at = self._principal_view_source_at or source
+        self._derived_view_source_at = self._derived_view_source_at or source
+        return self
 
     def authored_views(self) -> Sheet:
         """Declare that subsequent :meth:`view` lines are the complete principal set.
@@ -2211,6 +2300,14 @@ class Sheet:
             # authored set is the script overriding that choice, not contradicting itself.
             # (An explicit `auto_dimensions()` line already raised above.)
             self._auto_dimensions = None
+        if self._auto_dimensions and (
+            self._principal_view_source == "authored" or self._derived_view_source == "authored"
+        ):
+            raise ValueError(
+                "authored views require authored dimensions. Sheet.from_part() starts with an "
+                "implicit automatic dimension source; call authored_dimensions() or "
+                "take_over(dimensions='authored', ...) before build()"
+            )
         if self._added_dimensions and not self._auto_dimensions:
             raise ValueError(
                 "add_dimension() augments the planner's automatic dimension set, so the sheet "

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -1538,6 +1538,22 @@ def _adopted_view_block(constraints: ViewConstraints, names: Mapping[int, str]) 
     """Emit a semantic Sheet request for an adopted view-source state (#1350)."""
     principal_source = constraints.principal_source or "automatic"
     derived_source = constraints.derived_source or "automatic"
+    for records, actual_source, expected_source, label in (
+        (constraints.principals, constraints.principal_source, "authored", "principal"),
+        (
+            constraints.added_principals,
+            constraints.principal_source,
+            "automatic",
+            "added principal",
+        ),
+        (constraints.derived, constraints.derived_source, "authored", "derived"),
+        (constraints.added_derived, constraints.derived_source, "automatic", "added derived"),
+    ):
+        if records and actual_source != expected_source:
+            raise ValueError(
+                f"cannot emit {label} views with source {actual_source!r}; "
+                f"expected {expected_source!r}"
+            )
     lines = [
         "# Adopt the detected baseline with independent dimension/principal/derived sources.",
         "sheet.take_over(",
@@ -1548,8 +1564,24 @@ def _adopted_view_block(constraints: ViewConstraints, names: Mapping[int, str]) 
     ]
     handles: dict[str, str] = {}
 
+    def reject_unexpressed_spec_fields(spec) -> None:
+        unsupported = [
+            field for field in ("camera", "up", "page_axes") if getattr(spec, field) is not None
+        ]
+        if unsupported:
+            raise ValueError(
+                f"cannot emit {spec.name!r}: Sheet view verbs do not express "
+                f"{', '.join(unsupported)}"
+            )
+
     def emit_principal(item, verb: str) -> None:
         spec = item.spec
+        reject_unexpressed_spec_fields(spec)
+        expected_kind = "pictorial" if spec.name == "iso" else "principal"
+        if spec.name not in {"front", "plan", "side", "iso"} or spec.kind != expected_kind:
+            raise ValueError(f"cannot emit principal view {spec.name!r} with kind {spec.kind!r}")
+        if spec.target is not None:
+            raise ValueError(f"cannot emit principal view {spec.name!r} with a target")
         handle = f"{spec.name}_view"
         handles[spec.name] = handle
         suffix = "" if spec.scale_factor is None else f".scale({spec.scale_factor!r})"
@@ -1557,6 +1589,9 @@ def _adopted_view_block(constraints: ViewConstraints, names: Mapping[int, str]) 
 
     def emit_derived(item, verb: str) -> None:
         spec = item.spec
+        reject_unexpressed_spec_fields(spec)
+        if spec.kind not in {"section", "detail"}:
+            raise ValueError(f"cannot emit derived view {spec.name!r} with kind {spec.kind!r}")
         label = _derived_label(spec.name, spec.kind)
         target = spec.target
         if not isinstance(target, tuple) or len(target) != 2:
@@ -1589,14 +1624,36 @@ def _adopted_view_block(constraints: ViewConstraints, names: Mapping[int, str]) 
         emit_derived(item, f"add_{item.spec.kind}_view")
 
     for relation in constraints.relations:
-        handle = handles.get(relation.subject)
-        if handle is None:
-            raise ValueError(
-                f"cannot emit relation for automatic view {relation.subject!r}; "
-                "declare or add the subject view to obtain its public handle"
-            )
         gap = "" if relation.gap is None else f", gap={relation.gap!r}"
-        lines.append(f'{handle}.{relation.relation}("{relation.reference}"{gap})')
+        handle = handles.get(relation.subject)
+        if handle is not None:
+            if relation.relation in {"align_x", "align_y"} and relation.gap is not None:
+                raise ValueError(
+                    f"cannot emit {relation.relation} relation with gap={relation.gap!r}; "
+                    "the public alignment verbs do not accept a gap"
+                )
+            lines.append(f'{handle}.{relation.relation}("{relation.reference}"{gap})')
+            continue
+        if relation.relation in {"left_of", "right_of"}:
+            left, right = (
+                (relation.subject, relation.reference)
+                if relation.relation == "left_of"
+                else (relation.reference, relation.subject)
+            )
+            lines.append(f'sheet.row("{left}", "{right}"{gap})')
+            continue
+        if relation.relation in {"above", "below"}:
+            below, above = (
+                (relation.reference, relation.subject)
+                if relation.relation == "above"
+                else (relation.subject, relation.reference)
+            )
+            lines.append(f'sheet.column("{below}", "{above}"{gap})')
+            continue
+        raise ValueError(
+            f"cannot emit {relation.relation} relation for automatic view "
+            f"{relation.subject!r}; declare or add the subject view to obtain its public handle"
+        )
     for pin in constraints.pins:
         handle = handles.get(pin.view)
         if handle is None:

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -29,9 +29,11 @@ fixtures (#472).
 
 from __future__ import annotations
 
+import math
 import re
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, fields, is_dataclass
+from numbers import Real
 from pathlib import Path
 from typing import Literal, cast
 
@@ -1606,6 +1608,14 @@ def _adopted_view_block(constraints: ViewConstraints, names: Mapping[int, str]) 
             keyword = "through" if spec.kind == "section" else "around"
             args = f'"{label}", {keyword}={feature_name}'
         elif target_kind == "at" and spec.kind == "section":
+            if (
+                isinstance(target_value, bool)
+                or not isinstance(target_value, Real)
+                or not math.isfinite(float(target_value))
+            ):
+                raise ValueError(
+                    f"cannot emit {spec.name!r}: an at= target must be a finite numeric value"
+                )
             args = f'"{label}", at={float(target_value)!r}'
         else:
             raise ValueError(f"cannot emit {spec.name!r}: unsupported target {target!r}")

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -44,6 +44,7 @@ from draftwright.model.ir import (
     ThreadRequirement,
     ToleranceDecoration,
 )
+from draftwright.view_plan import ViewConstraints
 
 
 @dataclass(frozen=True)
@@ -1524,6 +1525,89 @@ def _validate_scale_policy(scale, scale_policy) -> None:
         raise ValueError("scale_policy applies only when an explicit scale is supplied")
 
 
+def _derived_label(name: str, kind: str) -> str:
+    """Recover the public one-character label from a canonical derived-view name."""
+    if kind == "section" and re.fullmatch(r"section_([a-z0-9])\1", name):
+        return name[-1].upper()
+    if kind == "detail" and re.fullmatch(r"detail_[a-z0-9]", name):
+        return name[-1].upper()
+    raise ValueError(f"cannot emit {kind} view with non-canonical name {name!r}")
+
+
+def _adopted_view_block(constraints: ViewConstraints, names: Mapping[int, str]) -> list[str]:
+    """Emit a semantic Sheet request for an adopted view-source state (#1350)."""
+    principal_source = constraints.principal_source or "automatic"
+    derived_source = constraints.derived_source or "automatic"
+    lines = [
+        "# Adopt the detected baseline with independent dimension/principal/derived sources.",
+        "sheet.take_over(",
+        '    dimensions="authored",',
+        f'    principal_views="{principal_source}",',
+        f'    derived_views="{derived_source}",',
+        ")",
+    ]
+    handles: dict[str, str] = {}
+
+    def emit_principal(item, verb: str) -> None:
+        spec = item.spec
+        handle = f"{spec.name}_view"
+        handles[spec.name] = handle
+        suffix = "" if spec.scale_factor is None else f".scale({spec.scale_factor!r})"
+        lines.append(f'{handle} = sheet.{verb}("{spec.name}"){suffix}')
+
+    def emit_derived(item, verb: str) -> None:
+        spec = item.spec
+        label = _derived_label(spec.name, spec.kind)
+        target = spec.target
+        if not isinstance(target, tuple) or len(target) != 2:
+            raise ValueError(f"cannot emit {spec.name!r}: it has no semantic target")
+        target_kind, target_value = target
+        if target_kind == "feature":
+            feature_name = names.get(id(target_value))
+            if feature_name is None:
+                raise ValueError(
+                    f"cannot emit {spec.name!r}: its target feature has no script binding"
+                )
+            keyword = "through" if spec.kind == "section" else "around"
+            args = f'"{label}", {keyword}={feature_name}'
+        elif target_kind == "at" and spec.kind == "section":
+            args = f'"{label}", at={float(target_value)!r}'
+        else:
+            raise ValueError(f"cannot emit {spec.name!r}: unsupported target {target!r}")
+        handle = f"{spec.name}_view"
+        handles[spec.name] = handle
+        suffix = "" if spec.scale_factor is None else f".scale({spec.scale_factor!r})"
+        lines.append(f"{handle} = sheet.{verb}({args}){suffix}")
+
+    for item in constraints.principals:
+        emit_principal(item, "view")
+    for item in constraints.added_principals:
+        emit_principal(item, "add_view")
+    for item in constraints.derived:
+        emit_derived(item, f"{item.spec.kind}_view")
+    for item in constraints.added_derived:
+        emit_derived(item, f"add_{item.spec.kind}_view")
+
+    for relation in constraints.relations:
+        handle = handles.get(relation.subject)
+        if handle is None:
+            raise ValueError(
+                f"cannot emit relation for automatic view {relation.subject!r}; "
+                "declare or add the subject view to obtain its public handle"
+            )
+        gap = "" if relation.gap is None else f", gap={relation.gap!r}"
+        lines.append(f'{handle}.{relation.relation}("{relation.reference}"{gap})')
+    for pin in constraints.pins:
+        handle = handles.get(pin.view)
+        if handle is None:
+            raise ValueError(
+                f"cannot emit pin for automatic view {pin.view!r}; "
+                "declare or add the view to obtain its public handle"
+            )
+        lines.append(f"{handle}.pin({pin.at!r})")
+    return lines
+
+
 def emit_sheet_script(
     model,
     part_expr: str,
@@ -1548,6 +1632,7 @@ def emit_sheet_script(
     source_part: Shape | None = None,
     formats: Sequence[str] = ("pdf",),
     settled_layout: Mapping | None = None,
+    view_constraints: ViewConstraints | None = None,
 ) -> str:
     """The generated declarative ``Sheet`` script text for a detected *model*.
 
@@ -1577,7 +1662,10 @@ def emit_sheet_script(
     semantic correction changed the initially composed scale or view set. The generated
     script mirrors dimensions as an authored set, so that correction is deliberately gated
     off on re-run; spelling the already-resolved scale/page/views preserves round-trip parity
-    without pretending an edited authored set is still automatic."""
+    without pretending an edited authored set is still automatic. ``view_constraints`` lets a
+    caller emitting an adopted :class:`~draftwright.Sheet` preserve its independent principal
+    and derived source choices plus semantic view declarations; targets remain stable feature
+    bindings rather than raw page coordinates."""
     _validate_scale_policy(scale, scale_policy)
     # The script declares this model — `model` plus an envelope when the overall height would
     # otherwise be unnameable under the mirrored (authored) set. BEFORE the import scan, since
@@ -1733,7 +1821,9 @@ def emit_sheet_script(
         for name in (() if settled_layout is None else settled_layout["views"])
         if name in {"front", "plan", "side", "iso"}
     )
-    if principal_views and principal_views != ("front", "plan", "side", "iso"):
+    if view_constraints is not None:
+        lines += _adopted_view_block(view_constraints, _names)
+    elif principal_views and principal_views != ("front", "plan", "side", "iso"):
         lines += [
             "# The automatic build settled on this complete view set; it is declared so",
             "# the editable authored-dimension mirror reproduces that resolved layout.",
@@ -1742,7 +1832,7 @@ def emit_sheet_script(
         ]
     else:
         lines.append("# front / plan / side / iso are produced automatically.")
-    if _needs_section(model):
+    if view_constraints is None and _needs_section(model):
         lines.append("# Section A–A auto-triggers from the counterbore/blind bore above.")
     # Build and export as two statements, so the finalized Drawing has a name (#968). That is
     # the lifecycle the architecture already has — Sheet declares intent, `build()` compiles and

--- a/tests/test_issue_1260_view_constraints.py
+++ b/tests/test_issue_1260_view_constraints.py
@@ -116,10 +116,11 @@ class TestSourceCoherence:
         with pytest.raises(ValueError, match="authors the view set"):
             sheet.view("front")
 
-    def test_from_part_implicit_automatic_dimensions_also_refuse_authored_views(self):
+    def test_from_part_implicit_automatic_dimensions_refuse_authored_views_at_build(self):
         sheet = Sheet.from_part(Box(30, 20, 10))
-        with pytest.raises(ValueError, match="authors the view set"):
-            sheet.view("front")
+        sheet.view("front")
+        with pytest.raises(ValueError, match="authored views require authored dimensions"):
+            sheet.build()
 
     def test_add_forms_require_auto_views_at_build(self):
         sheet = _sheet()

--- a/tests/test_issue_1350_detected_takeover.py
+++ b/tests/test_issue_1350_detected_takeover.py
@@ -468,6 +468,13 @@ def test_emitter_round_trips_directional_relations_between_automatic_views():
         ),
         (
             ViewConstraints(
+                principal_source="authored",
+                principals=(ViewConstraint(ViewSpec("front", "pictorial")),),
+            ),
+            "principal view 'front' with kind 'pictorial'",
+        ),
+        (
+            ViewConstraints(
                 derived_source="authored",
                 derived=(ViewConstraint(ViewSpec("front", "principal", target=("at", 0.0))),),
             ),
@@ -502,6 +509,22 @@ def test_emitter_round_trips_directional_relations_between_automatic_views():
                 derived=(ViewConstraint(ViewSpec("detail_b", "detail", target=("at", 0.0))),),
             ),
             "unsupported target",
+        ),
+        (
+            ViewConstraints(
+                derived_source="authored",
+                derived=(
+                    ViewConstraint(ViewSpec("section_aa", "section", target=("at", float("inf")))),
+                ),
+            ),
+            "at= target must be a finite numeric value",
+        ),
+        (
+            ViewConstraints(
+                derived_source="authored",
+                derived=(ViewConstraint(ViewSpec("section_aa", "section", target=("at", True))),),
+            ),
+            "at= target must be a finite numeric value",
         ),
         (
             ViewConstraints(relations=(ViewRelation("front", "align_x", "plan"),)),

--- a/tests/test_issue_1350_detected_takeover.py
+++ b/tests/test_issue_1350_detected_takeover.py
@@ -1,0 +1,368 @@
+"""Detected-baseline takeover is one public, order-independent Sheet workflow (#1350)."""
+
+from __future__ import annotations
+
+from typing import Literal, cast
+
+import pytest
+from build123d import Box, Cylinder, Pos
+
+from draftwright import Sheet, SoftDeprecationWarning
+from draftwright.model import DimensionParameterId
+from draftwright.sheet_emit import emit_sheet_script
+from draftwright.view_plan import (
+    ViewConstraint,
+    ViewConstraints,
+    ViewPin,
+    ViewRelation,
+    ViewSpec,
+)
+
+
+def _counterbored_blind_part():
+    """A prismatic part with both a counterbored through-hole and a separate blind bore."""
+    return (
+        Box(60, 40, 20)
+        - Cylinder(4, 40)
+        - Pos(0, 0, 6) * Cylinder(7, 8)
+        - Pos(18, 0, 8) * Cylinder(3, 20)
+    )
+
+
+def _counterbore(sheet: Sheet):
+    feature = next(f for f in sheet.features if f.kind == "hole" and f.cbore is not None)
+    return sheet.of(feature)
+
+
+def _author_complete_dimensions(sheet: Sheet) -> None:
+    """State the complete useful manufacturing set for this fixture through public handles."""
+    for feature in sheet.features:
+        if feature.kind == "hole":
+            handle = sheet.of(feature)
+            for parameter_id in handle.dimension_ids():
+                sheet.dimension(handle, cast(DimensionParameterId, parameter_id))
+        elif feature.kind == "envelope":
+            for parameter in feature.parameters():
+                sheet.dimension(feature, parameter.parameter_id)
+
+
+def _adopted_sheet(*, derived_views: Literal["automatic", "authored"] = "authored") -> Sheet:
+    sheet = Sheet.from_part(_counterbored_blind_part(), page="A3")
+    sheet.take_over(
+        dimensions="authored",
+        principal_views="automatic",
+        derived_views=derived_views,
+    )
+    _author_complete_dimensions(sheet)
+    return sheet
+
+
+def _blocking_lint(drawing):
+    return [issue for issue in drawing.lint() if issue.severity != "info"]
+
+
+def test_takeover_retains_detected_handles_and_replaces_the_inferred_section():
+    sheet = Sheet.from_part(_counterbored_blind_part(), page="A3")
+    detected_features = tuple(sheet.features)
+    bore = _counterbore(sheet)  # acquired before takeover
+
+    returned = sheet.take_over(
+        dimensions="authored",
+        principal_views="automatic",
+        derived_views="authored",
+    )
+    assert returned is sheet
+    assert tuple(sheet.features) == detected_features
+
+    _author_complete_dimensions(sheet)
+    sheet.section_view("A", through=bore)  # the pre-takeover handle remains usable
+    drawing = sheet.build()
+
+    assert set(drawing.views) == {"front", "plan", "side", "iso", "section_aa"}
+    assert [spec.name for spec in drawing.view_plan.of_kind("section")] == ["section_aa"]
+    assert len([name for name in drawing.annotations() if name == "section_caption"]) == 1
+    assert not _blocking_lint(drawing)
+
+
+def test_derived_source_can_accept_suppress_or_replace_the_inferred_section():
+    accepted = _adopted_sheet(derived_views="automatic").build()
+    assert "section_aa" in accepted.views
+    assert accepted.section_decision["status"] == "placed"
+
+    suppressed = _adopted_sheet(derived_views="authored").build()
+    assert suppressed.view_plan.of_kind("section") == ()
+
+    replaced_sheet = _adopted_sheet(derived_views="authored")
+    replaced_sheet.section_view("B", through=_counterbore(replaced_sheet))
+    replaced = replaced_sheet.build()
+    assert [spec.name for spec in replaced.view_plan.of_kind("section")] == ["section_bb"]
+    assert "section_aa" not in replaced.views
+    assert not _blocking_lint(replaced)
+
+
+def test_matching_declarations_mean_the_same_before_or_after_takeover():
+    first = Sheet.from_part(_counterbored_blind_part(), page="A3")
+    first.take_over(
+        dimensions="authored",
+        principal_views="automatic",
+        derived_views="authored",
+    )
+    _author_complete_dimensions(first)
+    first.section_view("A", through=_counterbore(first))
+
+    last = Sheet.from_part(_counterbored_blind_part(), page="A3")
+    last.authored_dimensions()
+    _author_complete_dimensions(last)
+    last.section_view("A", through=_counterbore(last))
+    last.take_over(
+        dimensions="authored",
+        principal_views="automatic",
+        derived_views="authored",
+    )
+
+    assert first.view_constraints.principal_source == last.view_constraints.principal_source
+    assert first.view_constraints.derived_source == last.view_constraints.derived_source
+    assert [item.spec.name for item in first.view_constraints.derived] == [
+        item.spec.name for item in last.view_constraints.derived
+    ]
+    first_drawing, last_drawing = first.build(), last.build()
+    assert set(first_drawing.views) == set(last_drawing.views)
+    assert _blocking_lint(first_drawing) == _blocking_lint(last_drawing) == []
+
+
+def test_takeover_rejects_contradictory_sources_atomically():
+    sheet = Sheet.from_part(_counterbored_blind_part())
+    before = sheet.view_constraints
+
+    with pytest.raises(ValueError, match="automatic dimensions with authored views"):
+        sheet.take_over(
+            dimensions="automatic",
+            principal_views="automatic",
+            derived_views="authored",
+        )
+    assert sheet.view_constraints == before
+
+    with pytest.raises(ValueError, match="dimensions must be"):
+        sheet.take_over(
+            dimensions="planner",  # type: ignore[arg-type]
+            principal_views="automatic",
+            derived_views="automatic",
+        )
+    assert sheet.view_constraints == before
+
+
+def test_takeover_rejects_prior_explicit_sources_and_accepts_all_automatic():
+    authored = Sheet.from_part(_counterbored_blind_part()).authored_dimensions()
+    with pytest.raises(ValueError, match="authored dimension source"):
+        authored.take_over(
+            dimensions="automatic",
+            principal_views="automatic",
+            derived_views="automatic",
+        )
+
+    automatic = Sheet.from_part(_counterbored_blind_part())
+    with pytest.warns(SoftDeprecationWarning):
+        automatic.auto_dimensions()
+    with pytest.raises(ValueError, match=r"explicit auto_dimensions\(\) source"):
+        automatic.take_over(
+            dimensions="authored",
+            principal_views="automatic",
+            derived_views="automatic",
+        )
+
+    prior_views = Sheet.from_part(_counterbored_blind_part())
+    prior_views.take_over(
+        dimensions="authored",
+        principal_views="automatic",
+        derived_views="automatic",
+    )
+    with pytest.raises(ValueError, match="existing 'automatic' derived_views source"):
+        prior_views.take_over(
+            dimensions="authored",
+            principal_views="automatic",
+            derived_views="authored",
+        )
+
+    pending_addition = Sheet.from_part(_counterbored_blind_part()).authored_dimensions()
+    pending_addition.add_view("side")
+    with pytest.raises(ValueError, match="conflicts with automatic-set additions"):
+        pending_addition.take_over(
+            dimensions="authored",
+            principal_views="authored",
+            derived_views="authored",
+        )
+
+    all_automatic = Sheet.from_part(_counterbored_blind_part()).take_over(
+        dimensions="automatic",
+        principal_views="automatic",
+        derived_views="automatic",
+    )
+    assert all_automatic.view_constraints.principal_source == "automatic"
+    assert all_automatic.view_constraints.derived_source == "automatic"
+    assert set(all_automatic.build().views) == {"front", "plan", "side", "iso", "section_aa"}
+
+
+def _dimension_signature(sheet: Sheet):
+    model = sheet.model()
+    feature_indexes = {id(feature): index for index, feature in enumerate(model.features)}
+    return tuple(
+        (
+            feature_indexes[id(request.feature)],
+            request.role,
+            request.discriminator,
+            request.display_decimals,
+        )
+        for request in model.authored_dimensions
+    )
+
+
+def test_emitter_round_trips_the_adopted_sources_dimensions_and_feature_target():
+    sheet = _adopted_sheet()
+    sheet.section_view("A", through=_counterbore(sheet))
+    direct = sheet.build()
+
+    source = emit_sheet_script(
+        sheet.model(),
+        "part",
+        "adopted",
+        title="T",
+        number="N",
+        view_constraints=sheet.view_constraints,
+    )
+    namespace = {"part": _counterbored_blind_part()}
+    body = source.replace("\npart\n", "\n", 1)
+    exec(  # noqa: S102 - the generated public script is the behavior under test
+        compile(body[: body.index("drawing = sheet.build()")], "<adopted-emit>", "exec"),
+        namespace,
+    )
+    regenerated = namespace["sheet"]
+
+    assert regenerated.view_constraints.principal_source == "automatic"
+    assert regenerated.view_constraints.derived_source == "authored"
+    assert [item.spec.name for item in regenerated.view_constraints.derived] == ["section_aa"]
+    target = regenerated.view_constraints.derived[0].spec.target
+    assert target[0] == "feature" and target[1].kind == "hole" and target[1].cbore is not None
+    assert _dimension_signature(regenerated) == _dimension_signature(sheet)
+    rebuilt = regenerated.build()
+    assert set(rebuilt.views) == set(direct.views)
+    assert [spec.name for spec in rebuilt.view_plan.of_kind("section")] == ["section_aa"]
+    assert [(issue.code, issue.severity) for issue in rebuilt.lint()] == [
+        (issue.code, issue.severity) for issue in direct.lint()
+    ]
+
+
+def test_emitter_preserves_authored_added_and_whole_view_constraints():
+    sheet = _adopted_sheet()
+    model = sheet.model()
+    hole = next(feature for feature in model.features if feature.kind == "hole")
+    constraints = ViewConstraints(
+        principal_source="authored",
+        principals=(
+            ViewConstraint(ViewSpec("front", "principal")),
+            ViewConstraint(ViewSpec("iso", "pictorial", scale_factor=0.75)),
+        ),
+        derived_source="authored",
+        derived=(
+            ViewConstraint(ViewSpec("section_aa", "section", target=("at", 0.0))),
+            ViewConstraint(
+                ViewSpec("detail_b", "detail", target=("feature", hole), scale_factor=2.0)
+            ),
+        ),
+        relations=(
+            ViewRelation("front", "left_of", "iso"),
+            ViewRelation("front", "below", "iso", gap=3.0),
+        ),
+        pins=(ViewPin("front", (40.0, 50.0)),),
+    )
+
+    source = emit_sheet_script(
+        model,
+        "part",
+        "views",
+        title="T",
+        number="N",
+        view_constraints=constraints,
+    )
+
+    assert 'front_view = sheet.view("front")' in source
+    assert 'iso_view = sheet.view("iso").scale(0.75)' in source
+    assert 'section_aa_view = sheet.section_view("A", at=0.0)' in source
+    assert 'detail_b_view = sheet.detail_view("B", around=hole1).scale(2.0)' in source
+    assert 'front_view.left_of("iso")' in source
+    assert 'front_view.below("iso", gap=3.0)' in source
+    assert "front_view.pin((40.0, 50.0))" in source
+
+    augmenting = ViewConstraints(
+        principal_source="automatic",
+        added_principals=(ViewConstraint(ViewSpec("side", "principal")),),
+        derived_source="automatic",
+        added_derived=(ViewConstraint(ViewSpec("detail_c", "detail", target=("feature", hole))),),
+    )
+    augmenting_source = emit_sheet_script(
+        model,
+        "part",
+        "views",
+        title="T",
+        number="N",
+        view_constraints=augmenting,
+    )
+    assert 'side_view = sheet.add_view("side")' in augmenting_source
+    assert 'detail_c_view = sheet.add_detail_view("C", around=hole1)' in augmenting_source
+
+
+@pytest.mark.parametrize(
+    ("constraints", "message"),
+    [
+        (
+            ViewConstraints(
+                derived_source="authored",
+                derived=(ViewConstraint(ViewSpec("detail_bad", "detail", target=None)),),
+            ),
+            "non-canonical name",
+        ),
+        (
+            ViewConstraints(
+                derived_source="authored",
+                derived=(ViewConstraint(ViewSpec("detail_b", "detail", target=None)),),
+            ),
+            "no semantic target",
+        ),
+        (
+            ViewConstraints(
+                derived_source="authored",
+                derived=(
+                    ViewConstraint(ViewSpec("detail_b", "detail", target=("feature", object()))),
+                ),
+            ),
+            "target feature has no script binding",
+        ),
+        (
+            ViewConstraints(
+                derived_source="authored",
+                derived=(ViewConstraint(ViewSpec("detail_b", "detail", target=("at", 0.0))),),
+            ),
+            "unsupported target",
+        ),
+        (
+            ViewConstraints(relations=(ViewRelation("front", "above", "plan"),)),
+            "relation for automatic view",
+        ),
+        (
+            ViewConstraints(pins=(ViewPin("front", (10.0, 20.0)),)),
+            "pin for automatic view",
+        ),
+    ],
+)
+def test_emitter_fails_closed_when_a_view_constraint_has_no_public_script_form(
+    constraints, message
+):
+    sheet = _adopted_sheet()
+    with pytest.raises(ValueError, match=message):
+        emit_sheet_script(
+            sheet.model(),
+            "part",
+            "bad-view",
+            title="T",
+            number="N",
+            view_constraints=constraints,
+        )

--- a/tests/test_issue_1350_detected_takeover.py
+++ b/tests/test_issue_1350_detected_takeover.py
@@ -151,6 +151,73 @@ def test_takeover_rejects_contradictory_sources_atomically():
     assert sheet.view_constraints == before
 
 
+@pytest.mark.parametrize(
+    "invalid_declaration",
+    [
+        lambda sheet: sheet.view("bogus"),
+        lambda sheet: sheet.section_view("A"),
+        lambda sheet: sheet.detail_view("B", object()),
+    ],
+)
+def test_invalid_authored_view_declarations_do_not_poison_a_detected_sheet(
+    invalid_declaration,
+):
+    sheet = Sheet.from_part(_counterbored_blind_part())
+    before = sheet.view_constraints
+
+    with pytest.raises(ValueError):
+        invalid_declaration(sheet)
+    assert sheet.view_constraints == before
+
+    # A failed declaration left no hidden authored source behind, so the matching automatic
+    # takeover remains valid and produces the untouched detected baseline.
+    sheet.take_over(
+        dimensions="authored",
+        principal_views="automatic",
+        derived_views="automatic",
+    )
+    assert sheet.view_constraints.principal_source == "automatic"
+    assert sheet.view_constraints.derived_source == "automatic"
+
+
+@pytest.mark.parametrize("legacy_verb", ["section", "detail"])
+def test_legacy_derived_augmentations_conflict_atomically_in_both_orders(legacy_verb):
+    before_takeover = Sheet.from_part(_counterbored_blind_part())
+    with pytest.warns(DeprecationWarning):
+        if legacy_verb == "section":
+            before_takeover.section(_counterbore(before_takeover))
+        else:
+            before_takeover.detail()
+    before_constraints = before_takeover.view_constraints
+    with pytest.raises(ValueError, match=r"legacy section\(\)/detail\(\)"):
+        before_takeover.take_over(
+            dimensions="authored",
+            principal_views="automatic",
+            derived_views="authored",
+        )
+    assert before_takeover.view_constraints == before_constraints
+
+    after_takeover = Sheet.from_part(_counterbored_blind_part()).take_over(
+        dimensions="authored",
+        principal_views="automatic",
+        derived_views="authored",
+    )
+    before_constraints = after_takeover.view_constraints
+    before_options = dict(after_takeover._opts)
+    before_section = after_takeover._section
+    with (
+        pytest.warns(DeprecationWarning),
+        pytest.raises(ValueError, match="cannot follow an authored derived-view source"),
+    ):
+        if legacy_verb == "section":
+            after_takeover.section(_counterbore(after_takeover))
+        else:
+            after_takeover.detail()
+    assert after_takeover.view_constraints == before_constraints
+    assert after_takeover._opts == before_options
+    assert after_takeover._section == before_section
+
+
 def test_takeover_rejects_prior_explicit_sources_and_accepts_all_automatic():
     authored = Sheet.from_part(_counterbored_blind_part()).authored_dimensions()
     with pytest.raises(ValueError, match="authored dimension source"):
@@ -191,6 +258,22 @@ def test_takeover_rejects_prior_explicit_sources_and_accepts_all_automatic():
             principal_views="authored",
             derived_views="authored",
         )
+
+    pending_dimension = Sheet.from_part(_counterbored_blind_part())
+    envelope = next(
+        feature for feature in pending_dimension.features if feature.kind == "envelope"
+    )
+    with pytest.warns(SoftDeprecationWarning):
+        pending_dimension.add_dimension(envelope, "width.length")
+    before_views = pending_dimension.view_constraints
+    with pytest.raises(ValueError, match=r"conflicts with add_dimension\(\)"):
+        pending_dimension.take_over(
+            dimensions="authored",
+            principal_views="automatic",
+            derived_views="authored",
+        )
+    assert pending_dimension.view_constraints == before_views
+    assert set(pending_dimension.build().views) == {"front", "plan", "side", "iso", "section_aa"}
 
     all_automatic = Sheet.from_part(_counterbored_blind_part()).take_over(
         dimensions="automatic",
@@ -292,6 +375,21 @@ def test_emitter_preserves_authored_added_and_whole_view_constraints():
     assert 'front_view.below("iso", gap=3.0)' in source
     assert "front_view.pin((40.0, 50.0))" in source
 
+    namespace = {"part": _counterbored_blind_part()}
+    body = source.replace("\npart\n", "\n", 1)
+    exec(  # noqa: S102 - exercise exact authored-relation reconstruction
+        compile(body[: body.index("drawing = sheet.build()")], "<authored-layout-emit>", "exec"),
+        namespace,
+    )
+    regenerated = namespace["sheet"].view_constraints
+    assert [
+        (relation.subject, relation.relation, relation.reference, relation.gap)
+        for relation in regenerated.relations
+    ] == [
+        (relation.subject, relation.relation, relation.reference, relation.gap)
+        for relation in constraints.relations
+    ]
+
     augmenting = ViewConstraints(
         principal_source="automatic",
         added_principals=(ViewConstraint(ViewSpec("side", "principal")),),
@@ -310,9 +408,71 @@ def test_emitter_preserves_authored_added_and_whole_view_constraints():
     assert 'detail_c_view = sheet.add_detail_view("C", around=hole1)' in augmenting_source
 
 
+def test_emitter_round_trips_directional_relations_between_automatic_views():
+    sheet = _adopted_sheet()
+    sheet.row("front", "side", gap=2.0)
+    sheet.column("front", "plan", gap=4.0)
+
+    source = emit_sheet_script(
+        sheet.model(),
+        "part",
+        "automatic-layout",
+        title="T",
+        number="N",
+        view_constraints=sheet.view_constraints,
+    )
+    assert 'sheet.row("front", "side", gap=2.0)' in source
+    assert 'sheet.column("front", "plan", gap=4.0)' in source
+
+    namespace = {"part": _counterbored_blind_part()}
+    body = source.replace("\npart\n", "\n", 1)
+    exec(  # noqa: S102 - exercise the generated public Sheet source
+        compile(body[: body.index("drawing = sheet.build()")], "<layout-emit>", "exec"),
+        namespace,
+    )
+    regenerated = namespace["sheet"]
+    assert [
+        (relation.subject, relation.relation, relation.reference, relation.gap)
+        for relation in regenerated.view_constraints.relations
+    ] == [
+        (relation.subject, relation.relation, relation.reference, relation.gap)
+        for relation in sheet.view_constraints.relations
+    ]
+
+
 @pytest.mark.parametrize(
     ("constraints", "message"),
     [
+        (
+            ViewConstraints(
+                principal_source="automatic",
+                principals=(ViewConstraint(ViewSpec("front", "principal")),),
+            ),
+            "principal views with source 'automatic'",
+        ),
+        (
+            ViewConstraints(
+                principal_source="authored",
+                principals=(
+                    ViewConstraint(ViewSpec("front", "principal", camera=(0.0, 0.0, 1.0))),
+                ),
+            ),
+            "do not express camera",
+        ),
+        (
+            ViewConstraints(
+                principal_source="authored",
+                principals=(ViewConstraint(ViewSpec("front", "principal", target=("at", 0.0))),),
+            ),
+            "principal view 'front' with a target",
+        ),
+        (
+            ViewConstraints(
+                derived_source="authored",
+                derived=(ViewConstraint(ViewSpec("front", "principal", target=("at", 0.0))),),
+            ),
+            "derived view 'front' with kind 'principal'",
+        ),
         (
             ViewConstraints(
                 derived_source="authored",
@@ -344,8 +504,16 @@ def test_emitter_preserves_authored_added_and_whole_view_constraints():
             "unsupported target",
         ),
         (
-            ViewConstraints(relations=(ViewRelation("front", "above", "plan"),)),
-            "relation for automatic view",
+            ViewConstraints(relations=(ViewRelation("front", "align_x", "plan"),)),
+            "align_x relation for automatic view",
+        ),
+        (
+            ViewConstraints(
+                principal_source="authored",
+                principals=(ViewConstraint(ViewSpec("front", "principal")),),
+                relations=(ViewRelation("front", "align_x", "plan", gap=1.0),),
+            ),
+            "alignment verbs do not accept a gap",
         ),
         (
             ViewConstraints(pins=(ViewPin("front", (10.0, 20.0)),)),


### PR DESCRIPTION
Closes #1350

## Summary
- add an atomic `Sheet.take_over()` path that preserves detected features and fluent handles
- independently accept, replace, or suppress principal and derived automatic views while enforcing the ADR 0018 dimension/view source rules
- emit adopted view constraints as editable public `Sheet` source, failing closed when an exact public form is unavailable
- cover retained counterbore/blind-bore identity, view-source order independence, duplicate-section prevention, and emitter execution parity

## Verification
- independent correctness and API/emitter reviews: no blocker, major, minor, or nit findings remain
- `scripts/pr-check --full`: 4,945 passed, 5 skipped, 2 xfailed; 95.25% total coverage; 100% changed-line coverage
- ADR merge-gate review: aligned with ADR 0011, 0014, 0015, 0016, and 0018
- no recognizer code changed; no upstream recognizer issue required