### PR TITLE
Let structured notes satisfy coverage requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### Added
 
+- Feature-linked Sheet notes can explicitly satisfy one or more canonical requirement ids with
+  `.note(..., satisfies=(...))`. Placed structured notes retain each requirement's identity in
+  coverage reports and generated scripts without masquerading as dimensions or parsing prose;
+  removing the note restores the ordinary missing/suppressed diagnostics (#1351).
 - `Sheet.from_part(...).take_over(...)` now adopts detected features in place while choosing
   authored or automatic dimension, principal-view, and derived-view sources explicitly. This
   preserves detected handles, supports automatic principal views with authored requirements,

--- a/README.md
+++ b/README.md
@@ -123,6 +123,23 @@ a chainable handle (`sheet.hole(bore)`) that the aspect and `control(...)` verbs
 targets are placed automatically — the view and strip are derived from the referenced
 feature or face, with `view=`/`side=` overrides.
 
+A feature-linked note can explicitly satisfy requirements that are legitimately communicated
+as one compound shop instruction instead of separate dimensions. Use the canonical ids exposed
+by the handle; free prose alone never changes coverage:
+
+```python
+assert "counterbore.diameter" in hole.dimension_ids()
+hole.note(
+    "PROFILED BORE: ⌀14 × 8 DEEP",
+    satisfies=("counterbore.diameter", "counterbore.depth"),
+)
+```
+
+Each id remains an independent requirement in lint output, reported as
+`satisfied_by_structured_note`; the assertion counts only if the normal placement solve places
+the note. Generated Sheet scripts preserve the structured claim. Invalid, duplicate, ambiguous,
+or face-only claims fail at declaration time.
+
 ### From a part to an object-referenced script
 
 `draftwright part.step --script` writes an editable `Sheet` script. When you built the part

--- a/README.md
+++ b/README.md
@@ -135,10 +135,11 @@ hole.note(
 )
 ```
 
-Each id remains an independent requirement in lint output, reported as
-`satisfied_by_structured_note`; the assertion counts only if the normal placement solve places
-the note. Generated Sheet scripts preserve the structured claim. Invalid, duplicate, ambiguous,
-or face-only claims fail at declaration time.
+Each id remains independent provenance in `drawing.registry.satisfaction_of(annotation_name)`;
+the semantic family outcomes report `satisfied_by_structured_note`, while
+`drawing.lint_summary()["quality"]["completeness"]` aggregates the count. The assertion counts
+only if the normal placement solve places the note. Generated Sheet scripts preserve the
+structured claim. Invalid, duplicate, ambiguous, or face-only claims fail at declaration time.
 
 ### From a part to an object-referenced script
 

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -86,7 +86,16 @@ def _decode_hole_location_fact(fact):
     return feature, parameter, point
 
 
-def place_annotation(registry, items, obj, name=None, view=None, feature=None, measurement=None):
+def place_annotation(
+    registry,
+    items,
+    obj,
+    name=None,
+    view=None,
+    feature=None,
+    measurement=None,
+    satisfaction=None,
+):
     """The annotation-placement primitive (#817): register *obj* under *name* — replacing any
     prior object of that name (dropped from the render list *items*) so a name maps to one
     object — append it to *items*, and record its owning *view* + source *feature* in *registry*.
@@ -94,13 +103,15 @@ def place_annotation(registry, items, obj, name=None, view=None, feature=None, m
     annotations without reaching into the ``Drawing``. Returns *obj*.
 
     *measurement* is the `DimensionId` *obj* draws, where the caller holds one (#1002) —
-    one axis finer than *feature*, since a feature has several measurements."""
+    one axis finer than *feature*, since a feature has several measurements. *satisfaction*
+    is the separate set of requirements a structured note explicitly satisfies (#1351); it
+    never claims that the note drew a measurement."""
     displaced = registry.named(name) if name is not None else None
     if displaced is not None:
         items.remove(displaced)
     annotate(obj, name)
     items.append(obj)
-    registry.add(obj, name, view, feature, measurement)
+    registry.add(obj, name, view, feature, measurement, satisfaction)
     return obj
 
 

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -2660,18 +2660,23 @@ def place_strip_candidates(
     for name, dim in solved:
         # Record feature provenance (ADR 0010): the drain-time seam for corridor-placed
         # dims — `features` maps this batch's names to their source IR feature.
-        placement = {
-            "view": view,
-            "feature": (features or {}).get(name),
-            "measurement": (measurements or {}).get(name),
-        }
+        feature = (features or {}).get(name)
+        measurement = (measurements or {}).get(name)
         # Preserve the established duck-typed ``ctx.place`` contract for callers that do
         # not participate in structured-note authority. Only a candidate carrying the new
         # provenance axis receives the keyword (#1351).
         satisfaction = (satisfactions or {}).get(name)
         if satisfaction is not None:
-            placement["satisfaction"] = satisfaction
-        ctx.place(dim, name, **placement)
+            ctx.place(
+                dim,
+                name,
+                view=view,
+                feature=feature,
+                measurement=measurement,
+                satisfaction=satisfaction,
+            )
+        else:
+            ctx.place(dim, name, view=view, feature=feature, measurement=measurement)
     if tp is not None:
         tp["unplaced"] = [n for n, _ in todo]
         trace.end_pass(tp)  # folds a standalone pass's items; no-op when corridor-nested

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -1901,6 +1901,9 @@ class CorridorCandidate:
     # way at drain, one axis finer: `feature` says which hole, this says which of its
     # measurements. ``None`` for a candidate whose renderer places directly (#754).
     measurement: object | None = None
+    # Structured-note authority carried by this placed annotation (#1351), kept distinct
+    # from dimensional ink in the registry.
+    satisfaction: object | None = None
     # Real stacking-axis + perpendicular footprint ``(w, h)`` in page-mm, or ``None`` to
     # use the dimension default ``(tier, tier)``. Wide/tall occupants (a GD&T feature
     # control frame is ~24×6 mm) set this so the strip solve reserves their true extent
@@ -2005,6 +2008,7 @@ def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=(), *, k
     # no-op for the unmigrated ones that still pass the feature itself.
     feats = {c.name: resolve_feature(c.feature) for c in kept if c.feature is not None}
     meas = {c.name: c.measurement for c in kept if c.measurement is not None}
+    satisfactions = {c.name: c.satisfaction for c in kept if c.satisfaction is not None}
     sizes = {c.name: c.size for c in kept if c.size is not None}  # real footprint (#61)
     forbid = {c.name: c.forbid for c in kept if c.forbid is not None}  # title-block box (#481)
     prio = {c.name: c.priority for c in kept if c.priority}  # over-capacity survival rank (#357)
@@ -2023,6 +2027,7 @@ def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=(), *, k
             ctx=ctx,
             features=feats,
             measurements=meas,
+            satisfactions=satisfactions,
             sizes=sizes,
             forbid=forbid,
             priorities=prio,
@@ -2050,6 +2055,7 @@ def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=(), *, k
                 corner_reserves=corner_reserves,
                 features=feats,
                 measurements=meas,
+                satisfactions=satisfactions,
                 sizes=sizes,
                 forbid=forbid,
                 priorities=prio,
@@ -2148,7 +2154,7 @@ class PlacementContext:
     # per-ctx (per-run) index is correct (mirrors the old ``Drawing._hole_feature_index``).
     _hole_feature_index: Any = field(default=None, repr=False)
 
-    def place(self, obj, name=None, view=None, feature=None, measurement=None):
+    def place(self, obj, name=None, view=None, feature=None, measurement=None, satisfaction=None):
         """Place an annotation onto the drawing through this context (#817) — the render passes'
         door to the placement primitive, so a pass never reaches into the ``Drawing`` (ADR 0005
         §2). Registers *obj* under *name* (owning *view* + source *feature*) and appends it to the
@@ -2169,6 +2175,7 @@ class PlacementContext:
             view,
             resolve_feature(feature),
             measurement,
+            satisfaction,
         )
 
     def feature_of_hole_at(self, location):
@@ -2314,6 +2321,7 @@ def place_strip_candidates(
     force=False,
     features=None,
     measurements=None,
+    satisfactions=None,
     sizes=None,
     forbid=None,
     priorities=None,
@@ -2658,6 +2666,7 @@ def place_strip_candidates(
             view=view,
             feature=(features or {}).get(name),
             measurement=(measurements or {}).get(name),
+            satisfaction=(satisfactions or {}).get(name),
         )
     if tp is not None:
         tp["unplaced"] = [n for n, _ in todo]

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -2660,14 +2660,18 @@ def place_strip_candidates(
     for name, dim in solved:
         # Record feature provenance (ADR 0010): the drain-time seam for corridor-placed
         # dims — `features` maps this batch's names to their source IR feature.
-        ctx.place(
-            dim,
-            name,
-            view=view,
-            feature=(features or {}).get(name),
-            measurement=(measurements or {}).get(name),
-            satisfaction=(satisfactions or {}).get(name),
-        )
+        placement = {
+            "view": view,
+            "feature": (features or {}).get(name),
+            "measurement": (measurements or {}).get(name),
+        }
+        # Preserve the established duck-typed ``ctx.place`` contract for callers that do
+        # not participate in structured-note authority. Only a candidate carrying the new
+        # provenance axis receives the keyword (#1351).
+        satisfaction = (satisfactions or {}).get(name)
+        if satisfaction is not None:
+            placement["satisfaction"] = satisfaction
+        ctx.place(dim, name, **placement)
     if tp is not None:
         tp["unplaced"] = [n for n, _ in todo]
         trace.end_pass(tp)  # folds a standalone pass's items; no-op when corridor-nested

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -105,7 +105,7 @@ from draftwright.layout import StripCandidate, plan_strip
 # drifts (#875 review). `as` form so the re-export is deliberate, not an unused import.
 from draftwright.model.callout import _first as _first
 from draftwright.model.callout import hole_callout_spec as hole_callout_spec
-from draftwright.model.compiled import FeatureRef, resolve_feature
+from draftwright.model.compiled import DimensionId, FeatureRef, resolve_feature
 from draftwright.model.ir import (
     AUTHORED_DIMENSION_KINDS,
     ChamferFeature,
@@ -5716,6 +5716,9 @@ def render_gdt(dwg, model, a, *, ctx) -> int:
     for i, item in enumerate(items):
         name = f"m_gdt{i}"
         source_ids = _pmi_source_ids(item)
+        satisfaction = tuple(
+            DimensionId(item.origin, parameter) for parameter in getattr(item, "satisfies", ())
+        )
         vk = views.get(item.view)
         if vk is None or item.side not in ("above", "below", "left", "right"):
             ctx.record_issue(
@@ -5800,6 +5803,7 @@ def render_gdt(dwg, model, a, *, ctx) -> int:
             _feat=item.origin or item,
             _tb=tb_box,
             _source=source_ids,
+            _satisfaction=satisfaction,
         ):
             # Fallthrough (#481): the declared/derived side is full — try the OPPOSITE side of
             # the same view before dropping, so a congested default still places somewhere
@@ -5849,7 +5853,13 @@ def render_gdt(dwg, model, a, *, ctx) -> int:
                     dim = _bld(pos, _hz=hz)
                     if _box_hits(_anno_box(dim), (_tb,)):  # would overlap the title block — skip
                         continue
-                    ctx.place(dim, nm, view=_v, feature=_feat)  # relaxed side
+                    ctx.place(
+                        dim,
+                        nm,
+                        view=_v,
+                        feature=_feat,
+                        satisfaction=_satisfaction,
+                    )  # relaxed side
                     ctx.record_issue(
                         "info",
                         "gdt_side_relaxed",
@@ -5888,6 +5898,7 @@ def render_gdt(dwg, model, a, *, ctx) -> int:
                 # Declared frames belong to their decorated feature. An imported frame has
                 # external source provenance but no separately-owned geometric IR feature.
                 feature=item.origin or item,
+                satisfaction=satisfaction or None,
                 size=size,
                 # Even a force-kept frame must not stack into the title block (#481 review) —
                 # place_strip_candidates rejects a placement hitting this box, then on_drop's

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -619,10 +619,16 @@ def _record_callout_drop(
     """
     ctx.coverage.drop_diam(diam)
     count = int(getattr(callout, "covers_count", 1) or 1)
+    measurements = tuple(getattr(callout, "measurements", ()))
+    owners: list[object] = []
+    for measurement in measurements:
+        owner = getattr(measurement, "feature", None)
+        if owner is not None and not any(candidate is owner for candidate in owners):
+            owners.append(owner)
+    profile_owner = owners[0] if len(owners) == 1 else feat
     for profile in getattr(callout, "covers_profiles", ()):
         for _ in range(count):
-            ctx.coverage.drop_profile(profile)
-    measurements = tuple(getattr(callout, "measurements", ()))
+            ctx.coverage.drop_profile(profile, profile_owner)
     hole_requirements = (
         tuple(
             (feat, requirement) for requirement in getattr(callout, "covers_hole_requirements", ())

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -3302,6 +3302,7 @@ class Drawing:
                 self.part,
                 self,
                 assembly=self.assembly,
+                recognition=recognition,
                 **prof_kw,
             )
             model = self._part_model
@@ -3366,6 +3367,8 @@ class Drawing:
                 self.part,
                 self.items,
                 recognition=recognition,
+                features=getattr(model, "features", ()) if model is not None else (),
+                registry=self._registry,
                 dropped_profiles=self._coverage.dropped_profiles,
                 assembly=self.assembly,
             )

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -3370,6 +3370,7 @@ class Drawing:
                 features=getattr(model, "features", ()) if model is not None else (),
                 registry=self._registry,
                 dropped_profiles=self._coverage.dropped_profiles,
+                dropped_profile_evidence=self._coverage.dropped_profile_evidence,
                 assembly=self.assembly,
             )
             issues += lint_flat_coverage(

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -3296,6 +3296,7 @@ class Drawing:
                 assembly=self.assembly,
                 holes=holes,
                 bosses=bosses,
+                registry=self._registry,
             )
             issues += lint_axial_coverage(
                 self.part,

--- a/src/draftwright/linting/_registry.py
+++ b/src/draftwright/linting/_registry.py
@@ -1,0 +1,32 @@
+"""Compatibility reads for optional annotation-registry provenance axes."""
+
+from __future__ import annotations
+
+
+def satisfaction_of(registry, name) -> tuple:
+    """Read one optional satisfaction axis, or return empty for a pre-axis registry."""
+    reader = getattr(registry, "satisfaction_of", None)
+    if registry is None or not callable(reader):
+        return ()
+    return tuple(reader(name))
+
+
+def satisfaction_ids(registry) -> set:
+    """Return all placed structured-note authority from any registry-shaped object."""
+    if registry is None:
+        return set()
+    return {identity for name in registry.names() for identity in satisfaction_of(registry, name)}
+
+
+def annotation_owner(registry, annotation):
+    """Return the feature owning *annotation*, if the registry exposes that identity."""
+    named = getattr(registry, "named", None)
+    feature_of = getattr(registry, "feature_of", None)
+    if registry is None or not callable(named) or not callable(feature_of):
+        return None
+    for name in registry.names():
+        if named(name) is annotation:
+            owner = feature_of(name)
+            if owner is not None:
+                return owner
+    return None

--- a/src/draftwright/linting/channel_coverage.py
+++ b/src/draftwright/linting/channel_coverage.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 from b123d_recognisers import RecognitionResult, has_multi_axis_plates
 
+from draftwright.linting._registry import satisfaction_ids, satisfaction_of
 from draftwright.linting.issues import LintIssue
 
 ChannelRequirementState = Literal[
@@ -70,7 +71,7 @@ def _state(feature, parameter, *, placed, satisfied, suppressed, dropped, regist
         return "dropped"
     associated = registry.names_for_feature(feature)
     if any(
-        not registry.measurement_of(name) and not registry.satisfaction_of(name)
+        not registry.measurement_of(name) and not satisfaction_of(registry, name)
         for name in associated
     ):
         return "unverifiable"
@@ -106,9 +107,7 @@ def channel_requirement_outcomes(
     placed = {
         measurement for name in registry.names() for measurement in registry.measurement_of(name)
     }
-    satisfied = {
-        identity for name in registry.names() for identity in registry.satisfaction_of(name)
-    }
+    satisfied = satisfaction_ids(registry)
     suppressed = {
         (omission.feature, omission.parameter_id)
         for omission in omissions

--- a/src/draftwright/linting/channel_coverage.py
+++ b/src/draftwright/linting/channel_coverage.py
@@ -9,7 +9,14 @@ from b123d_recognisers import RecognitionResult, has_multi_axis_plates
 
 from draftwright.linting.issues import LintIssue
 
-ChannelRequirementState = Literal["placed", "suppressed", "dropped", "missing", "unverifiable"]
+ChannelRequirementState = Literal[
+    "placed",
+    "satisfied_by_structured_note",
+    "suppressed",
+    "dropped",
+    "missing",
+    "unverifiable",
+]
 
 
 @dataclass(frozen=True)
@@ -50,17 +57,22 @@ def _matches(measurement, feature, parameter: str) -> bool:
     )
 
 
-def _state(feature, parameter, *, placed, suppressed, dropped, registry):
+def _state(feature, parameter, *, placed, satisfied, suppressed, dropped, registry):
     if feature is None:
         return "unverifiable"
     if any(_matches(measurement, feature, parameter) for measurement in placed):
         return "placed"
+    if any(_matches(identity, feature, parameter) for identity in satisfied):
+        return "satisfied_by_structured_note"
     if (feature, parameter) in suppressed:
         return "suppressed"
     if any(_matches(measurement, feature, parameter) for measurement in dropped):
         return "dropped"
     associated = registry.names_for_feature(feature)
-    if any(not registry.measurement_of(name) for name in associated):
+    if any(
+        not registry.measurement_of(name) and not registry.satisfaction_of(name)
+        for name in associated
+    ):
         return "unverifiable"
     return "missing"
 
@@ -93,6 +105,9 @@ def channel_requirement_outcomes(
 
     placed = {
         measurement for name in registry.names() for measurement in registry.measurement_of(name)
+    }
+    satisfied = {
+        identity for name in registry.names() for identity in registry.satisfaction_of(name)
     }
     suppressed = {
         (omission.feature, omission.parameter_id)
@@ -147,6 +162,7 @@ def channel_requirement_outcomes(
                         feature,
                         parameter,
                         placed=placed,
+                        satisfied=satisfied,
                         suppressed=suppressed,
                         dropped=dropped,
                         registry=registry,
@@ -176,7 +192,7 @@ def lint_channel_coverage(
     }
     issues = []
     for outcome in channel_requirement_outcomes(recognition, features, registry, omissions):
-        if outcome.state in {"placed", "dropped"}:
+        if outcome.state in {"placed", "satisfied_by_structured_note", "dropped"}:
             continue
         issues.append(
             LintIssue(

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -69,6 +69,14 @@ _RECON_POS_TOL = 0.5
 _LOCATION_AXIS_TOL = 1.0
 
 
+def _registry_satisfactions(registry) -> set:
+    """Return placed structured authority from old or current registry-shaped objects."""
+    satisfaction_of = getattr(registry, "satisfaction_of", None)
+    if registry is None or not callable(satisfaction_of):
+        return set()
+    return {identity for name in registry.names() for identity in satisfaction_of(name)}
+
+
 def _location_ref(owner, point) -> HoleRef:
     """Location identity with an irrelevant through-axis coordinate removed.
 
@@ -324,9 +332,7 @@ def lint_feature_coverage(
         # Structured note authority is a semantic assertion, not prose parsing. Resolve only
         # canonical diameter parameters on the exact feature carried by each DimensionId;
         # malformed identities contribute nothing rather than guessing (#1351).
-        identities = {
-            identity for name in registry.names() for identity in registry.satisfaction_of(name)
-        }
+        identities = _registry_satisfactions(registry)
         for identity in identities:
             feature = getattr(identity, "feature", None)
             parameter_id = getattr(identity, "parameter", None)
@@ -444,16 +450,11 @@ def lint_location_coverage(
     dim_verts: dict[str, list] = {}
     structured_locations: set[tuple[object, str, HoleRef]] = set()
     registry = getattr(dwg, "registry", None)
-    satisfied_locations = (
-        {
-            identity.feature
-            for name in registry.names()
-            for identity in registry.satisfaction_of(name)
-            if getattr(identity, "parameter", None) == "location"
-        }
-        if registry is not None
-        else set()
-    )
+    satisfied_locations = {
+        identity.feature
+        for identity in _registry_satisfactions(registry)
+        if getattr(identity, "parameter", None) == "location"
+    }
     for name, ann in dwg.iter_annotations():
         view = dwg.view_of(name)
         if view is None:
@@ -948,11 +949,7 @@ def lint_prismatic_coverage(
     severity: Literal["info", "warning"] = "info" if assembly else "warning"
     pairs_by_view: dict[str, list] = {}
     registry = getattr(dwg, "registry", None)
-    satisfied_ids = (
-        {identity for name in registry.names() for identity in registry.satisfaction_of(name)}
-        if registry is not None
-        else set()
-    )
+    satisfied_ids = _registry_satisfactions(registry)
 
     def satisfied(feature, parameter: str) -> bool:
         return any(
@@ -1392,11 +1389,7 @@ def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET, recognition=None)
         if registry is not None
         else set()
     )
-    satisfied_ids = (
-        {identity for name in registry.names() for identity in registry.satisfaction_of(name)}
-        if registry is not None
-        else set()
-    )
+    satisfied_ids = _registry_satisfactions(registry)
     # Match structured step-length authority back to the recognition-owned physical band by
     # its axial span. This preserves the denominator and prevents an unrelated declared step
     # from certifying one merely because both share the same role (#1351, ADR 0017).
@@ -1514,11 +1507,7 @@ def lint_boss_height_coverage(part, dwg, features, assembly=None, omissions=()) 
         if registry is not None
         else set()
     )
-    satisfied = (
-        {identity for name in registry.names() for identity in registry.satisfaction_of(name)}
-        if registry is not None
-        else set()
-    )
+    satisfied = _registry_satisfactions(registry)
     conveyed = {
         omission.feature
         for omission in omissions

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -324,23 +324,25 @@ def lint_feature_coverage(
         # Structured note authority is a semantic assertion, not prose parsing. Resolve only
         # canonical diameter parameters on the exact feature carried by each DimensionId;
         # malformed identities contribute nothing rather than guessing (#1351).
-        for name in registry.names():
-            for identity in registry.satisfaction_of(name):
-                feature = getattr(identity, "feature", None)
-                parameter_id = getattr(identity, "parameter", None)
-                parameter = next(
-                    (
-                        item
-                        for item in getattr(feature, "parameters", lambda: ())()
-                        if item.parameter_id == parameter_id and item.kind == "diameter"
-                    ),
-                    None,
-                )
-                if parameter is None:
-                    continue
-                value = float(parameter.value)
-                mentioned.add(value)
-                provided[value] = provided.get(value, 0) + int(getattr(feature, "count", 1) or 1)
+        identities = {
+            identity for name in registry.names() for identity in registry.satisfaction_of(name)
+        }
+        for identity in identities:
+            feature = getattr(identity, "feature", None)
+            parameter_id = getattr(identity, "parameter", None)
+            parameter = next(
+                (
+                    item
+                    for item in getattr(feature, "parameters", lambda: ())()
+                    if item.parameter_id == parameter_id and item.kind == "diameter"
+                ),
+                None,
+            )
+            if parameter is None:
+                continue
+            value = float(parameter.value)
+            mentioned.add(value)
+            provided[value] = provided.get(value, 0) + int(getattr(feature, "count", 1) or 1)
     for ann in annotations:
         if isinstance(ann, TitleBlock):
             continue
@@ -441,6 +443,17 @@ def lint_location_coverage(
     marks: dict[str, list] = {}
     dim_verts: dict[str, list] = {}
     structured_locations: set[tuple[object, str, HoleRef]] = set()
+    registry = getattr(dwg, "registry", None)
+    satisfied_locations = (
+        {
+            identity.feature
+            for name in registry.names()
+            for identity in registry.satisfaction_of(name)
+            if getattr(identity, "parameter", None) == "location"
+        }
+        if registry is not None
+        else set()
+    )
     for name, ann in dwg.iter_annotations():
         view = dwg.view_of(name)
         if view is None:
@@ -470,7 +483,8 @@ def lint_location_coverage(
     # O(holes × model-features × members) rescan and preserves the documented
     # external-producer contract: no ``Drawing.model()`` method is required.
     feature_index: dict[tuple[str, HoleRef], set[object]] = {}
-    for feature in {owner for owner, _parameter, _point in structured_locations}:
+    semantic_owners = {owner for owner, _parameter, _point in structured_locations}
+    for feature in semantic_owners | satisfied_locations:
         frame = getattr(feature, "frame", None)
         if frame is None:
             continue
@@ -503,7 +517,7 @@ def lint_location_coverage(
         page_axes = VIEW_AXES[view]
 
         def _axis_covered(model_axis):
-            semantic = any(
+            semantic = any(owner in features for owner in satisfied_locations) or any(
                 owner in features and parameter.endswith(f".{model_axis}") and point == ref
                 for owner, parameter, point in structured_locations
             )
@@ -933,6 +947,18 @@ def lint_prismatic_coverage(
         assembly = len(part.solids()) > 1
     severity: Literal["info", "warning"] = "info" if assembly else "warning"
     pairs_by_view: dict[str, list] = {}
+    registry = getattr(dwg, "registry", None)
+    satisfied_ids = (
+        {identity for name in registry.names() for identity in registry.satisfaction_of(name)}
+        if registry is not None
+        else set()
+    )
+
+    def satisfied(feature, parameter: str) -> bool:
+        return any(
+            identity.feature == feature and identity.parameter == parameter
+            for identity in satisfied_ids
+        )
 
     def pairs(view: str):
         return pairs_by_view.setdefault(view, _dimension_endpoint_pairs(dwg, view))
@@ -970,24 +996,46 @@ def lint_prismatic_coverage(
                 ),
                 None,
             )
-            size_x = owner is not None and _pair_covers(ps, 0, x0, x1, tol, owner=owner)
-            size_y = owner is not None and _pair_covers(ps, 1, y0, y1, tol, owner=owner)
+            parameter_by_axis = (
+                {
+                    owner.long_axis: "pad_length.length",
+                    owner.width_axis: "pad_width.length",
+                }
+                if owner is not None
+                else {}
+            )
+            size_x = owner is not None and (
+                _pair_covers(ps, 0, x0, x1, tol, owner=owner)
+                or satisfied(owner, parameter_by_axis["x"])
+            )
+            size_y = owner is not None and (
+                _pair_covers(ps, 1, y0, y1, tol, owner=owner)
+                or satisfied(owner, parameter_by_axis["y"])
+            )
             located_x = (
-                abs(pad.x0 - bb.min.X) <= tol
-                or abs(pad.x1 - bb.max.X) <= tol
-                or any(
-                    _pair_covers(ps, 0, edge, bound, tol)
-                    for edge in (bx0, bx1)
-                    for bound in (x0, x1, xc_page)
+                owner is not None
+                and satisfied(owner, "location")
+                or (
+                    abs(pad.x0 - bb.min.X) <= tol
+                    or abs(pad.x1 - bb.max.X) <= tol
+                    or any(
+                        _pair_covers(ps, 0, edge, bound, tol)
+                        for edge in (bx0, bx1)
+                        for bound in (x0, x1, xc_page)
+                    )
                 )
             )
             located_y = (
-                abs(pad.y0 - bb.min.Y) <= tol
-                or abs(pad.y1 - bb.max.Y) <= tol
-                or any(
-                    _pair_covers(pairs("side"), 0, edge, bound, tol)
-                    for edge in (sby0, sby1)
-                    for bound in (sy0, sy1, syc)
+                owner is not None
+                and satisfied(owner, "location")
+                or (
+                    abs(pad.y0 - bb.min.Y) <= tol
+                    or abs(pad.y1 - bb.max.Y) <= tol
+                    or any(
+                        _pair_covers(pairs("side"), 0, edge, bound, tol)
+                        for edge in (sby0, sby1)
+                        for bound in (sy0, sy1, syc)
+                    )
                 )
             )
             if not (size_x and size_y and located_x and located_y):
@@ -1008,17 +1056,17 @@ def lint_prismatic_coverage(
     model_pockets = []
     for feature in features:
         if getattr(feature, "kind", None) == "pocket":
-            model_pockets.append((feature, (feature.frame.origin,), False))
+            model_pockets.append((feature, feature, (feature.frame.origin,), False))
         elif getattr(feature, "kind", None) == "pocket_pattern":
-            model_pockets.append((feature.member, tuple(feature.members), True))
+            model_pockets.append((feature.member, feature, tuple(feature.members), True))
     missing_ir = 0
 
     def pocket_owner(pocket):
         source_location = pocket.location
         return next(
             (
-                f
-                for f, locations, is_pattern in model_pockets
+                owner
+                for f, owner, locations, is_pattern in model_pockets
                 if f.width_axis == pocket.width_axis
                 and f.long_axis == pocket.long_axis
                 and abs(f.width - pocket.width) <= tol
@@ -1047,8 +1095,11 @@ def lint_prismatic_coverage(
     bb = bbox if bbox is not None else part.bounding_box()
     centre = bb.center()
     for pocket in pocket_inventory:
-        if pocket_owner(pocket) is None:
+        owner = pocket_owner(pocket)
+        if owner is None:
             missing_ir += 1
+            continue
+        if satisfied(owner, "location"):
             continue
         if getattr(pocket, "edge_anchored", False):
             continue
@@ -1209,8 +1260,8 @@ def lint_prismatic_coverage(
     return issues
 
 
-def _axial_covered_from_drawing(part, dwg, prof, tol: float = 0.6) -> int:
-    """How many of a turned part's step lengths are dimensioned **in the drawing**
+def _axial_covered_from_drawing(part, dwg, prof, tol: float = 0.6) -> set[int]:
+    """Which turned-profile step lengths are dimensioned **in the drawing**
     — a step counts as covered when some profile-view ``Dimension`` has witnesses
     at both of its shoulders' page positions. Drawing-derived, so it judges any
     producer (not the engine's :class:`CoverageState` side channel).
@@ -1277,7 +1328,7 @@ def _axial_covered_from_drawing(part, dwg, prof, tol: float = 0.6) -> int:
                 ):
                     covered_steps.add(i)
                     break
-    return len(covered_steps)
+    return covered_steps
 
 
 def _overall_axial_extent_is_dimensioned(part, dwg, prof, tol: float = 0.6) -> bool:
@@ -1304,14 +1355,15 @@ def _overall_axial_extent_is_dimensioned(part, dwg, prof, tol: float = 0.6) -> b
     return False
 
 
-def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET) -> list:
+def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET, recognition=None) -> list:
     """Report a stepped turned part whose axial step lengths are undimensioned.
 
     A turned part can have every diameter called out yet be unmanufacturable: with
     no shoulder located, the lengths are unknown (the drive-screw gap). A complete
-    chain dimensions all ``n`` steps; coverage is counted **from the drawing**
-    (:func:`_axial_covered_from_drawing`), not a build-time side channel — so it
-    judges any producer. A shortfall yields one ``axial_length_missing`` issue.
+    chain dimensions all ``n`` steps; coverage is counted from placed drawing witnesses or
+    placed structured-note provenance joined to the same physical spans, not a build-time
+    side channel — so it judges any producer. A shortfall yields one
+    ``axial_length_missing`` issue.
 
     *dwg* is the drawing, duck-typed (needs ``at``/``annotations``/``view_of``).
 
@@ -1322,6 +1374,9 @@ def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET) -> list:
     *prof* may be supplied (the single inventory, #244) to skip re-detection;
     omitted, it is detected here. A sentinel distinguishes "not supplied" from a
     valid ``prof=None`` (non-turned part).
+
+    ``recognition`` supplies the run-owned groove inventory used only to evidence-gate a
+    structured ``groove.length`` claim; an unrelated declared groove cannot fill the count.
     """
     if prof is _UNSET:
         prof = TurnedProfile.from_steps(recognise_turned_steps(part))
@@ -1330,13 +1385,76 @@ def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET) -> list:
     if assembly is None:
         assembly = len(part.solids()) > 1
     n = len(prof.steps)
-    covered = _axial_covered_from_drawing(part, dwg, prof)
+    covered_steps = _axial_covered_from_drawing(part, dwg, prof)
+    registry = getattr(dwg, "registry", None)
+    placed_ids = (
+        {identity for name in registry.names() for identity in registry.measurement_of(name)}
+        if registry is not None
+        else set()
+    )
+    satisfied_ids = (
+        {identity for name in registry.names() for identity in registry.satisfaction_of(name)}
+        if registry is not None
+        else set()
+    )
+    # Match structured step-length authority back to the recognition-owned physical band by
+    # its axial span. This preserves the denominator and prevents an unrelated declared step
+    # from certifying one merely because both share the same role (#1351, ADR 0017).
+    axis_index = "xyz".index(prof.axis)
+    for identity in satisfied_ids:
+        feature = getattr(identity, "feature", None)
+        if (
+            getattr(identity, "parameter", None) != "step.length"
+            or getattr(feature, "kind", None) != "step"
+        ):
+            continue
+        span = getattr(feature, "span", None)
+        if span is None:
+            continue
+        lo, hi = sorted(float(point[axis_index]) for point in span)
+        for index, step in enumerate(prof.steps):
+            if abs(lo - float(step.lo)) <= 1e-3 and abs(hi - float(step.hi)) <= 1e-3:
+                covered_steps.add(index)
+                break
+    covered = len(covered_steps)
     # A groove band's axial extent is dimensioned by its width callout, not a step length, so
     # detect.py leaves it out of the step-length chain (#606). Count each *rendered* groove-width
     # callout on the turning axis as covering its band — so a fully-dimensioned grooved shaft
     # (N−1 step lengths + the groove width) is not flagged (#628); a *dropped* groove callout
     # leaves its band uncovered, so a genuine gap still fires (reconcile rendered, not intent).
     covered += sum(1 for name in dwg.annotations() if name.startswith(f"m_groove_{prof.axis}"))
+    placed_grooves = {
+        identity.feature
+        for identity in placed_ids
+        if getattr(identity, "parameter", None) == "groove.length"
+    }
+    physical_grooves = {
+        (
+            groove.axis,
+            round(float(groove.width), 3),
+            round(float(groove.diameter), 3),
+            tuple(round(float(value), 3) for value in groove.at),
+        )
+        for groove in getattr(recognition, "grooves", ())
+    }
+    satisfied_grooves = {
+        identity.feature
+        for identity in satisfied_ids
+        if getattr(identity, "parameter", None) == "groove.length"
+        and getattr(identity.feature, "kind", None) == "groove"
+        and identity.feature not in placed_grooves
+    }
+    covered += sum(
+        1
+        for feature in satisfied_grooves
+        if (
+            feature.axis,
+            round(float(feature.width), 3),
+            round(float(feature.diameter), 3),
+            tuple(round(float(value), 3) for value in feature.frame.origin),
+        )
+        in physical_grooves
+    )
     if covered >= n:
         return []
     # #955: when placement drops the complete chain, its specific warning already says the
@@ -1345,7 +1463,6 @@ def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET) -> list:
     # part's total extent is now stated. The drop is a required half of this condition: an
     # authored drawing that chooses only the overall extent still lacks shoulder locations
     # and must continue to receive ``axial_length_missing``.
-    registry = getattr(dwg, "registry", None)
     chain_drop_reported = any(
         issue.code == "step_dim_dropped" for issue in getattr(registry, "issues", ())
     )
@@ -1397,6 +1514,11 @@ def lint_boss_height_coverage(part, dwg, features, assembly=None, omissions=()) 
         if registry is not None
         else set()
     )
+    satisfied = (
+        {identity for name in registry.names() for identity in registry.satisfaction_of(name)}
+        if registry is not None
+        else set()
+    )
     conveyed = {
         omission.feature
         for omission in omissions
@@ -1406,6 +1528,10 @@ def lint_boss_height_coverage(part, dwg, features, assembly=None, omissions=()) 
         1
         for boss in bosses
         if boss not in conveyed
+        and not any(
+            identity.feature == boss and identity.parameter == "boss_height.length"
+            for identity in satisfied
+        )
         and not any(isinstance(ann, Dimension) for ann in dwg.annotations_of(boss).values())
     )
     if not missing:

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -55,6 +55,7 @@ from draftwright._core import (
     _fmt,
     _xyz,
 )
+from draftwright.linting._registry import annotation_owner, satisfaction_ids
 from draftwright.linting.issues import LintIssue
 from draftwright.linting.profiled_bore_coverage import profiled_bore_key
 from draftwright.view_plan import VIEW_AXES
@@ -67,14 +68,6 @@ _UNSET = object()  # sentinel: distinguishes "not supplied" from a valid prof=No
 _RECON_DIA_TOL = 0.2
 _RECON_POS_TOL = 0.5
 _LOCATION_AXIS_TOL = 1.0
-
-
-def _registry_satisfactions(registry) -> set:
-    """Return placed structured authority from old or current registry-shaped objects."""
-    satisfaction_of = getattr(registry, "satisfaction_of", None)
-    if registry is None or not callable(satisfaction_of):
-        return set()
-    return {identity for name in registry.names() for identity in satisfaction_of(name)}
 
 
 def _location_ref(owner, point) -> HoleRef:
@@ -177,6 +170,10 @@ class CoverageState:
         # Exact profiled-bore specifications dropped with those callouts. Diameter alone
         # cannot distinguish equal-major profiles with different A/F or orientation (#1061).
         self._dropped_profiles: list[tuple] = []
+        # The same events with their compiler-owned feature when available. The legacy
+        # spec-only list remains for compatibility; critique uses this richer identity to
+        # avoid combining a drop on A with placed authority on A to certify B (#1351).
+        self._dropped_profile_evidence: list[tuple[tuple, object | None]] = []
 
     # -- pattern coverage -----------------------------------------------------
 
@@ -211,14 +208,16 @@ class CoverageState:
         """Clear dropped-diameter tracking (top of _auto_annotate)."""
         self._dropped_callout_diams = []
         self._dropped_profiles = []
+        self._dropped_profile_evidence = []
 
     def drop_diam(self, diam) -> None:
         """Record a diameter dropped by the per-view callout cap."""
         self._dropped_callout_diams.append(diam)
 
-    def drop_profile(self, profile: tuple) -> None:
+    def drop_profile(self, profile: tuple, owner=None) -> None:
         """Record an exact profiled-bore specification whose callout was dropped."""
         self._dropped_profiles.append(profile)
+        self._dropped_profile_evidence.append((profile, owner))
 
     @property
     def dropped_diams(self) -> list:
@@ -229,6 +228,11 @@ class CoverageState:
     def dropped_profiles(self) -> list[tuple]:
         """Profile specifications already reported by ``callout_dropped``."""
         return self._dropped_profiles
+
+    @property
+    def dropped_profile_evidence(self) -> list[tuple[tuple, object | None]]:
+        """Dropped profile specifications paired with their exact IR owner when known."""
+        return self._dropped_profile_evidence
 
     # -- transactional snapshot (#647) ----------------------------------------
 
@@ -242,16 +246,18 @@ class CoverageState:
             set(self._scattered_hole_docs),
             list(self._dropped_callout_diams),
             list(self._dropped_profiles),
+            list(self._dropped_profile_evidence),
         )
 
     def restore(self, snap: tuple) -> None:
         """Restore the collections captured by :meth:`snapshot`."""
-        pc, ph, shd, dropped, dropped_profiles = snap
+        pc, ph, shd, dropped, dropped_profiles, dropped_profile_evidence = snap
         self._pattern_callouts = set(pc)
         self._patterned_holes = set(ph)
         self._scattered_hole_docs = set(shd)
         self._dropped_callout_diams = list(dropped)
         self._dropped_profiles = list(dropped_profiles)
+        self._dropped_profile_evidence = list(dropped_profile_evidence)
 
 
 def lint_feature_coverage(
@@ -327,12 +333,27 @@ def lint_feature_coverage(
 
     mentioned: set[float] = set()
     text_mentioned: set[float] = set()
-    provided: dict[float, int] = {}
+    # One physical owner can carry the same requirement in several representations (for
+    # example, both a callout and a manufacturing note). Union those authorities by exact
+    # owner/value before counting them; summing annotations lets one documented bore certify
+    # an identical undocumented sibling (#1351 review).
+    owned_provided: dict[tuple[int, float], int] = {}
+    unowned_provided: dict[float, int] = {}
+
+    def provide(value, count, owner=None) -> None:
+        value = float(value)
+        count = int(count or 1)
+        if owner is None:
+            unowned_provided[value] = unowned_provided.get(value, 0) + count
+            return
+        key = (id(owner), value)
+        owned_provided[key] = max(owned_provided.get(key, 0), count)
+
     if registry is not None:
         # Structured note authority is a semantic assertion, not prose parsing. Resolve only
         # canonical diameter parameters on the exact feature carried by each DimensionId;
         # malformed identities contribute nothing rather than guessing (#1351).
-        identities = _registry_satisfactions(registry)
+        identities = satisfaction_ids(registry)
         for identity in identities:
             feature = getattr(identity, "feature", None)
             parameter_id = getattr(identity, "parameter", None)
@@ -348,7 +369,7 @@ def lint_feature_coverage(
                 continue
             value = float(parameter.value)
             mentioned.add(value)
-            provided[value] = provided.get(value, 0) + int(getattr(feature, "count", 1) or 1)
+            provide(value, getattr(feature, "count", 1), feature)
     for ann in annotations:
         if isinstance(ann, TitleBlock):
             continue
@@ -361,7 +382,11 @@ def lint_feature_coverage(
         count = getattr(ann, "covers_count", 1)
         for v in structured_diameters:
             mentioned.add(v)
-            provided[v] = provided.get(v, 0) + count
+            provide(v, count, annotation_owner(registry, ann))
+
+    provided: dict[float, int] = dict(unowned_provided)
+    for (_owner_id, value), count in owned_provided.items():
+        provided[value] = provided.get(value, 0) + count
 
     exclude = exclude or ()
     issues = [
@@ -452,7 +477,7 @@ def lint_location_coverage(
     registry = getattr(dwg, "registry", None)
     satisfied_locations = {
         identity.feature
-        for identity in _registry_satisfactions(registry)
+        for identity in satisfaction_ids(registry)
         if getattr(identity, "parameter", None) == "location"
     }
     for name, ann in dwg.iter_annotations():
@@ -949,7 +974,7 @@ def lint_prismatic_coverage(
     severity: Literal["info", "warning"] = "info" if assembly else "warning"
     pairs_by_view: dict[str, list] = {}
     registry = getattr(dwg, "registry", None)
-    satisfied_ids = _registry_satisfactions(registry)
+    satisfied_ids = satisfaction_ids(registry)
 
     def satisfied(feature, parameter: str) -> bool:
         return any(
@@ -1389,7 +1414,7 @@ def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET, recognition=None)
         if registry is not None
         else set()
     )
-    satisfied_ids = _registry_satisfactions(registry)
+    satisfied_ids = satisfaction_ids(registry)
     # Match structured step-length authority back to the recognition-owned physical band by
     # its axial span. This preserves the denominator and prevents an unrelated declared step
     # from certifying one merely because both share the same role (#1351, ADR 0017).
@@ -1507,7 +1532,7 @@ def lint_boss_height_coverage(part, dwg, features, assembly=None, omissions=()) 
         if registry is not None
         else set()
     )
-    satisfied = _registry_satisfactions(registry)
+    satisfied = satisfaction_ids(registry)
     conveyed = {
         omission.feature
         for omission in omissions

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -255,6 +255,7 @@ def lint_feature_coverage(
     assembly=None,
     holes=None,
     bosses=None,
+    registry=None,
 ) -> list:
     """Coarse completeness check: report part diameters with no callout (#80).
 
@@ -295,6 +296,10 @@ def lint_feature_coverage(
     yields a ``feature_count_mismatch`` warning. A diameter covered by any
     free-text ø-label is exempt from the count check — text labels carry no
     count semantics. Location coverage remains out of scope (#93).
+
+    A placed feature-linked note may instead carry explicit ``DimensionId``
+    satisfaction provenance. Only canonical diameter parameters on that exact
+    feature contribute; the note's prose is never parsed for this purpose (#1351).
     """
     z_cyls, cross_cyls = cyls if cyls is not None else analyse_cylinders(part)
     if holes is None:
@@ -315,6 +320,27 @@ def lint_feature_coverage(
     mentioned: set[float] = set()
     text_mentioned: set[float] = set()
     provided: dict[float, int] = {}
+    if registry is not None:
+        # Structured note authority is a semantic assertion, not prose parsing. Resolve only
+        # canonical diameter parameters on the exact feature carried by each DimensionId;
+        # malformed identities contribute nothing rather than guessing (#1351).
+        for name in registry.names():
+            for identity in registry.satisfaction_of(name):
+                feature = getattr(identity, "feature", None)
+                parameter_id = getattr(identity, "parameter", None)
+                parameter = next(
+                    (
+                        item
+                        for item in getattr(feature, "parameters", lambda: ())()
+                        if item.parameter_id == parameter_id and item.kind == "diameter"
+                    ),
+                    None,
+                )
+                if parameter is None:
+                    continue
+                value = float(parameter.value)
+                mentioned.add(value)
+                provided[value] = provided.get(value, 0) + int(getattr(feature, "count", 1) or 1)
     for ann in annotations:
         if isinstance(ann, TitleBlock):
             continue

--- a/src/draftwright/linting/flat_coverage.py
+++ b/src/draftwright/linting/flat_coverage.py
@@ -14,6 +14,7 @@ from typing import Literal
 from b123d_recognisers import RecognitionResult
 
 from draftwright._geometry import _canonical_axis_direction
+from draftwright.linting._registry import satisfaction_ids, satisfaction_of
 from draftwright.linting.issues import LintIssue
 
 FlatRequirementState = Literal[
@@ -120,9 +121,7 @@ def flat_requirement_outcomes(
     placed = {
         measurement for name in registry.names() for measurement in registry.measurement_of(name)
     }
-    satisfied = {
-        identity for name in registry.names() for identity in registry.satisfaction_of(name)
-    }
+    satisfied = satisfaction_ids(registry)
     authored_suppressions = {
         (omission.feature, omission.parameter_id)
         for omission in omissions
@@ -169,7 +168,7 @@ def flat_requirement_outcomes(
                 state = (
                     "unverifiable"
                     if any(
-                        not registry.measurement_of(name) and not registry.satisfaction_of(name)
+                        not registry.measurement_of(name) and not satisfaction_of(registry, name)
                         for name in associated_names
                     )
                     else "missing"

--- a/src/draftwright/linting/flat_coverage.py
+++ b/src/draftwright/linting/flat_coverage.py
@@ -16,7 +16,14 @@ from b123d_recognisers import RecognitionResult
 from draftwright._geometry import _canonical_axis_direction
 from draftwright.linting.issues import LintIssue
 
-FlatRequirementState = Literal["placed", "suppressed", "dropped", "missing", "unverifiable"]
+FlatRequirementState = Literal[
+    "placed",
+    "satisfied_by_structured_note",
+    "suppressed",
+    "dropped",
+    "missing",
+    "unverifiable",
+]
 
 
 @dataclass(frozen=True, order=True)
@@ -113,6 +120,9 @@ def flat_requirement_outcomes(
     placed = {
         measurement for name in registry.names() for measurement in registry.measurement_of(name)
     }
+    satisfied = {
+        identity for name in registry.names() for identity in registry.satisfaction_of(name)
+    }
     authored_suppressions = {
         (omission.feature, omission.parameter_id)
         for omission in omissions
@@ -138,6 +148,12 @@ def flat_requirement_outcomes(
                 for measurement in placed
             ):
                 state = "placed"
+            elif any(
+                _matches(identity, *requirement_id)
+                for requirement_id in expected
+                for identity in satisfied
+            ):
+                state = "satisfied_by_structured_note"
             elif all(requirement_id in authored_suppressions for requirement_id in expected):
                 state = "suppressed"
             elif any(
@@ -152,7 +168,10 @@ def flat_requirement_outcomes(
                 }
                 state = (
                     "unverifiable"
-                    if any(not registry.measurement_of(name) for name in associated_names)
+                    if any(
+                        not registry.measurement_of(name) and not registry.satisfaction_of(name)
+                        for name in associated_names
+                    )
                     else "missing"
                 )
         outcomes.append(
@@ -186,7 +205,7 @@ def lint_flat_coverage(
         # `flat_dropped` is already a user-facing build issue. Its measurement identity is
         # what proves this outcome; emitting a second warning here would score one defect
         # twice, contrary to the existing coverage/drop de-duplication contract.
-        if outcome.state in {"placed", "dropped"}:
+        if outcome.state in {"placed", "satisfied_by_structured_note", "dropped"}:
             continue
         stock = (
             f"{outcome.axis.upper()} stock along {outcome.axis_direction} at axis line "

--- a/src/draftwright/linting/hole_coverage.py
+++ b/src/draftwright/linting/hole_coverage.py
@@ -502,6 +502,22 @@ def _evidence_parameter(parameter: str) -> str:
     return parameter
 
 
+def _satisfaction_parameter(parameter: str) -> str | None:
+    """The exact public claim that may satisfy one physical ledger requirement.
+
+    Placed compound callouts legitimately let one diameter mark prove THRU/count and let one
+    location unit prove its component axes. Structured authority is narrower: synthetic
+    THRU/count facts are not addressable claims, while the public ``location`` unit is (#1351).
+    """
+    if parameter in {"bore.through", "grouping.count"}:
+        return None
+    if parameter.startswith(
+        ("location.location.", "location_pattern.location.", "location_off_axis.")
+    ):
+        return "location"
+    return parameter
+
+
 def _location_members(feature, parameter: str):
     return _members(feature)
 
@@ -712,9 +728,13 @@ def _state(features, parameter, *, member_count, evidence_index, suppressed, tur
         # requirement needs every separately declared physical member tied to the mark.
         if all(per_feature) if "location" in parameter else any(per_feature):
             return "placed"
-    satisfied = [(feature, evidence_parameter) in evidence_index.satisfied for feature in features]
-    if all(satisfied) if "location" in parameter else any(satisfied):
-        return "satisfied_by_structured_note"
+    satisfaction_parameter = _satisfaction_parameter(parameter)
+    if satisfaction_parameter is not None:
+        satisfied = [
+            (feature, satisfaction_parameter) in evidence_index.satisfied for feature in features
+        ]
+        if all(satisfied) if "location" in parameter else any(satisfied):
+            return "satisfied_by_structured_note"
     if all((feature, evidence_parameter) in suppressed for feature in features):
         return "suppressed"
     drop_parameter = (

--- a/src/draftwright/linting/hole_coverage.py
+++ b/src/draftwright/linting/hole_coverage.py
@@ -16,6 +16,7 @@ from b123d_recognisers import HoleSpec, RecognitionResult, countersink_matches_h
 
 from draftwright._core import _decode_hole_location_fact
 from draftwright._geometry import _END_ON, _is_principal_axis
+from draftwright.linting._registry import satisfaction_ids
 from draftwright.linting.issues import LintIssue, is_placement_drop
 
 HoleRequirementState = Literal[
@@ -545,12 +546,11 @@ def _normalised_location(feature, point) -> tuple[float, float, float]:
 def _index_hole_evidence(registry) -> _HoleEvidence:
     placed = set()
     satisfied: set[tuple[object, str]] = set()
-    for name in registry.names():
-        for identity in registry.satisfaction_of(name):
-            feature = getattr(identity, "feature", None)
-            parameter = getattr(identity, "parameter", None)
-            if feature is not None and isinstance(parameter, str):
-                satisfied.add((feature, parameter))
+    for identity in satisfaction_ids(registry):
+        feature = getattr(identity, "feature", None)
+        parameter = getattr(identity, "parameter", None)
+        if feature is not None and isinstance(parameter, str):
+            satisfied.add((feature, parameter))
     requirement_counts: dict[tuple[object, str], set[int]] = defaultdict(set)
     locations: dict[tuple[object, str], set[tuple[float, float, float]]] = defaultdict(set)
     centers: dict[object, set[tuple[tuple[float, float, float], str]]] = defaultdict(set)

--- a/src/draftwright/linting/hole_coverage.py
+++ b/src/draftwright/linting/hole_coverage.py
@@ -18,7 +18,14 @@ from draftwright._core import _decode_hole_location_fact
 from draftwright._geometry import _END_ON, _is_principal_axis
 from draftwright.linting.issues import LintIssue, is_placement_drop
 
-HoleRequirementState = Literal["placed", "suppressed", "dropped", "missing", "unverifiable"]
+HoleRequirementState = Literal[
+    "placed",
+    "satisfied_by_structured_note",
+    "suppressed",
+    "dropped",
+    "missing",
+    "unverifiable",
+]
 HoleSourceKind = Literal["hole", "hole_pattern"]
 _DIRECTION_PROJECTION_REL_TOL = 1e-6
 
@@ -502,6 +509,7 @@ def _location_members(feature, parameter: str):
 @dataclass
 class _HoleEvidence:
     placed: set[tuple[object, str]]
+    satisfied: set[tuple[object, str]]
     dropped: set[tuple[object, str]]
     requirement_counts: dict[tuple[object, str], set[int]]
     locations: dict[tuple[object, str], set[tuple[float, float, float]]]
@@ -520,6 +528,13 @@ def _normalised_location(feature, point) -> tuple[float, float, float]:
 
 def _index_hole_evidence(registry) -> _HoleEvidence:
     placed = set()
+    satisfied: set[tuple[object, str]] = set()
+    for name in registry.names():
+        for identity in registry.satisfaction_of(name):
+            feature = getattr(identity, "feature", None)
+            parameter = getattr(identity, "parameter", None)
+            if feature is not None and isinstance(parameter, str):
+                satisfied.add((feature, parameter))
     requirement_counts: dict[tuple[object, str], set[int]] = defaultdict(set)
     locations: dict[tuple[object, str], set[tuple[float, float, float]]] = defaultdict(set)
     centers: dict[object, set[tuple[tuple[float, float, float], str]]] = defaultdict(set)
@@ -608,6 +623,7 @@ def _index_hole_evidence(registry) -> _HoleEvidence:
     )
     return _HoleEvidence(
         placed,
+        satisfied,
         dropped,
         requirement_counts,
         locations,
@@ -696,6 +712,9 @@ def _state(features, parameter, *, member_count, evidence_index, suppressed, tur
         # requirement needs every separately declared physical member tied to the mark.
         if all(per_feature) if "location" in parameter else any(per_feature):
             return "placed"
+    satisfied = [(feature, evidence_parameter) in evidence_index.satisfied for feature in features]
+    if all(satisfied) if "location" in parameter else any(satisfied):
+        return "satisfied_by_structured_note"
     if all((feature, evidence_parameter) in suppressed for feature in features):
         return "suppressed"
     drop_parameter = (
@@ -1066,7 +1085,7 @@ def lint_hole_coverage(
     }
     issues = []
     for outcome in hole_requirement_outcomes(recognition, features, registry, omissions):
-        if outcome.state in {"placed", "dropped"}:
+        if outcome.state in {"placed", "satisfied_by_structured_note", "dropped"}:
             continue
         noun = "hole" if outcome.source_kind == "hole" else f"{outcome.member_count}-hole pattern"
         issues.append(

--- a/src/draftwright/linting/polygonal_stock_coverage.py
+++ b/src/draftwright/linting/polygonal_stock_coverage.py
@@ -9,7 +9,14 @@ from b123d_recognisers import RecognitionResult
 
 from draftwright.linting.issues import LintIssue
 
-PolygonalStockState = Literal["placed", "suppressed", "dropped", "missing", "unverifiable"]
+PolygonalStockState = Literal[
+    "placed",
+    "satisfied_by_structured_note",
+    "suppressed",
+    "dropped",
+    "missing",
+    "unverifiable",
+]
 
 
 @dataclass(frozen=True)
@@ -55,6 +62,9 @@ def polygonal_stock_outcomes(recognition, features, registry, omissions=()):
     placed = {
         measurement for name in registry.names() for measurement in registry.measurement_of(name)
     }
+    satisfied = {
+        identity for name in registry.names() for identity in registry.satisfaction_of(name)
+    }
     suppressed = {
         (omission.feature, omission.parameter_id)
         for omission in omissions
@@ -77,6 +87,11 @@ def polygonal_stock_outcomes(recognition, features, registry, omissions=()):
                 for measurement in placed
             ):
                 state = "placed"
+            elif any(
+                identity.feature == feature and identity.parameter == parameter
+                for identity in satisfied
+            ):
+                state = "satisfied_by_structured_note"
             elif (feature, parameter) in suppressed:
                 state = "suppressed"
             elif any(
@@ -103,7 +118,7 @@ def lint_polygonal_stock_coverage(
     }
     issues = []
     for outcome in polygonal_stock_outcomes(recognition, features, registry, omissions):
-        if outcome.state in {"placed", "dropped"}:
+        if outcome.state in {"placed", "satisfied_by_structured_note", "dropped"}:
             continue
         issues.append(
             LintIssue(

--- a/src/draftwright/linting/polygonal_stock_coverage.py
+++ b/src/draftwright/linting/polygonal_stock_coverage.py
@@ -7,6 +7,7 @@ from typing import Literal
 
 from b123d_recognisers import RecognitionResult
 
+from draftwright.linting._registry import satisfaction_ids
 from draftwright.linting.issues import LintIssue
 
 PolygonalStockState = Literal[
@@ -62,9 +63,7 @@ def polygonal_stock_outcomes(recognition, features, registry, omissions=()):
     placed = {
         measurement for name in registry.names() for measurement in registry.measurement_of(name)
     }
-    satisfied = {
-        identity for name in registry.names() for identity in registry.satisfaction_of(name)
-    }
+    satisfied = satisfaction_ids(registry)
     suppressed = {
         (omission.feature, omission.parameter_id)
         for omission in omissions

--- a/src/draftwright/linting/profiled_bore_coverage.py
+++ b/src/draftwright/linting/profiled_bore_coverage.py
@@ -58,6 +58,8 @@ def lint_profiled_bore_coverage(
     annotations,
     *,
     recognition: RecognitionResult | None,
+    features=(),
+    registry=None,
     dropped_profiles=(),
     assembly=None,
 ) -> list[LintIssue]:
@@ -95,6 +97,32 @@ def lint_profiled_bore_coverage(
             annotation, "covers_profiles", ()
         ):
             provided[profiled_bore_key(profile, axis, through, major, across, direction)] += count
+
+    # A placed structured note may carry the two addressable dimensional requirements of a
+    # double-D profile. Join them back to the recognition-owned physical key; neither prose nor
+    # mere IR presence contributes. Pattern owners retain their physical member count (#1351).
+    if registry is not None:
+        satisfied: dict[object, set[str]] = {}
+        for name in registry.names():
+            for identity in registry.satisfaction_of(name):
+                satisfied.setdefault(identity.feature, set()).add(identity.parameter)
+        required_parameters = {"bore.diameter", "profile_across_flats.length"}
+        for feature in features:
+            if not required_parameters <= satisfied.get(feature, set()):
+                continue
+            bore = getattr(feature, "member", feature)
+            if getattr(bore, "profile", None) != "double_d":
+                continue
+            provided[
+                profiled_bore_key(
+                    "double_d",
+                    feature.frame.axis,
+                    bore.through,
+                    bore.diameter,
+                    bore.across_flats,
+                    bore.profile_direction,
+                )
+            ] += int(getattr(feature, "count", 1) or 1)
 
     dropped = Counter(
         profiled_bore_key(profile, axis, through, major, across, direction)

--- a/src/draftwright/linting/profiled_bore_coverage.py
+++ b/src/draftwright/linting/profiled_bore_coverage.py
@@ -14,7 +14,10 @@ from typing import Literal
 from b123d_recognisers import RecognitionResult
 
 from draftwright._geometry import _fmt
+from draftwright.linting._registry import annotation_owner, satisfaction_ids
 from draftwright.linting.issues import LintIssue
+
+_SITE_TOL = 0.5
 
 
 def _axis_letter(value) -> str:
@@ -53,6 +56,23 @@ def profiled_bore_key(profile, axis, through, major, across, direction) -> tuple
     )
 
 
+def _site(point, axis) -> tuple[float, float, float]:
+    """Physical profile site with the through-axis coordinate made irrelevant."""
+    result = [round(float(component), 3) for component in point]
+    result["xyz".index(_axis_letter(axis))] = 0.0
+    return (result[0], result[1], result[2])
+
+
+def _feature_sites(feature) -> tuple[tuple[float, float, float], ...]:
+    members = tuple(getattr(feature, "members", ()) or ())
+    points = members or (feature.frame.origin,)
+    return tuple(_site(point, feature.frame.axis) for point in points)
+
+
+def _same_site(first, second) -> bool:
+    return all(abs(a - b) <= _SITE_TOL for a, b in zip(first, second, strict=True))
+
+
 def lint_profiled_bore_coverage(
     part,
     annotations,
@@ -61,6 +81,7 @@ def lint_profiled_bore_coverage(
     features=(),
     registry=None,
     dropped_profiles=(),
+    dropped_profile_evidence=None,
     assembly=None,
 ) -> list[LintIssue]:
     """Report physical double-D requirements not documented by placed callouts.
@@ -76,36 +97,67 @@ def lint_profiled_bore_coverage(
             "lint_profiled_bore_coverage() requires the run's RecognitionResult; "
             f"got {type(recognition).__name__}"
         )
-    required = Counter(
-        profiled_bore_key(
-            "double_d",
-            bore.axis,
-            bore.through,
-            bore.major_diameter,
-            bore.across_flats,
-            bore.flat_direction,
+    physical = tuple(
+        (
+            profiled_bore_key(
+                "double_d",
+                bore.axis,
+                bore.through,
+                bore.major_diameter,
+                bore.across_flats,
+                bore.flat_direction,
+            ),
+            _site(bore.location, bore.axis),
         )
         for bore in recognition.double_d_bores
     )
+    required = Counter(key for key, _site_key in physical)
     if not required:
         return []
 
-    provided: Counter = Counter()
+    covered: set[int] = set()
+    unowned: Counter = Counter()
+
+    def cover_owner(owner, key, count) -> None:
+        if owner is None:
+            unowned[key] += int(count or 1)
+            return
+        remaining = int(count or 1)
+        for owner_site in _feature_sites(owner):
+            match = next(
+                (
+                    index
+                    for index, (physical_key, physical_site) in enumerate(physical)
+                    if index not in covered
+                    and physical_key == key
+                    and _same_site(owner_site, physical_site)
+                ),
+                None,
+            )
+            if match is not None:
+                covered.add(match)
+                remaining -= 1
+                if remaining <= 0:
+                    break
+
     for annotation in annotations:
         count = int(getattr(annotation, "covers_count", 1) or 1)
         for profile, axis, through, major, across, direction in getattr(
             annotation, "covers_profiles", ()
         ):
-            provided[profiled_bore_key(profile, axis, through, major, across, direction)] += count
+            cover_owner(
+                annotation_owner(registry, annotation),
+                profiled_bore_key(profile, axis, through, major, across, direction),
+                count,
+            )
 
     # A placed structured note may carry the two addressable dimensional requirements of a
     # double-D profile. Join them back to the recognition-owned physical key; neither prose nor
     # mere IR presence contributes. Pattern owners retain their physical member count (#1351).
     if registry is not None:
         satisfied: dict[object, set[str]] = {}
-        for name in registry.names():
-            for identity in registry.satisfaction_of(name):
-                satisfied.setdefault(identity.feature, set()).add(identity.parameter)
+        for identity in satisfaction_ids(registry):
+            satisfied.setdefault(identity.feature, set()).add(identity.parameter)
         required_parameters = {"bore.diameter", "profile_across_flats.length"}
         for feature in features:
             if not required_parameters <= satisfied.get(feature, set()):
@@ -113,7 +165,8 @@ def lint_profiled_bore_coverage(
             bore = getattr(feature, "member", feature)
             if getattr(bore, "profile", None) != "double_d":
                 continue
-            provided[
+            cover_owner(
+                feature,
                 profiled_bore_key(
                     "double_d",
                     feature.frame.axis,
@@ -121,13 +174,43 @@ def lint_profiled_bore_coverage(
                     bore.diameter,
                     bore.across_flats,
                     bore.profile_direction,
-                )
-            ] += int(getattr(feature, "count", 1) or 1)
+                ),
+                getattr(feature, "count", 1),
+            )
 
-    dropped = Counter(
-        profiled_bore_key(profile, axis, through, major, across, direction)
-        for profile, axis, through, major, across, direction in dropped_profiles
+    provided = Counter(unowned)
+    provided.update(physical[index][0] for index in covered)
+
+    dropped_covered: set[int] = set()
+    unowned_dropped: Counter = Counter()
+    evidence = (
+        tuple(dropped_profile_evidence)
+        if dropped_profile_evidence is not None
+        else tuple((profile, None) for profile in dropped_profiles)
     )
+    for profile, owner in evidence:
+        profile_name, axis, through, major, across, direction = profile
+        key = profiled_bore_key(profile_name, axis, through, major, across, direction)
+        if owner is None:
+            unowned_dropped[key] += 1
+            continue
+        for owner_site in _feature_sites(owner):
+            match = next(
+                (
+                    index
+                    for index, (physical_key, physical_site) in enumerate(physical)
+                    if index not in covered
+                    and index not in dropped_covered
+                    and physical_key == key
+                    and _same_site(owner_site, physical_site)
+                ),
+                None,
+            )
+            if match is not None:
+                dropped_covered.add(match)
+                break
+    dropped = Counter(unowned_dropped)
+    dropped.update(physical[index][0] for index in dropped_covered)
     if assembly is None:
         assembly = len(part.solids()) > 1
     severity: Literal["info", "warning"] = "info" if assembly else "warning"
@@ -135,7 +218,11 @@ def lint_profiled_bore_coverage(
     for key, need in sorted(required.items()):
         _profile, axis, _through, major, across, direction = key
         have = provided[key]
-        if have + dropped[key] >= need:
+        # Legacy callers may still supply specification-only drops. They can suppress a
+        # duplicate report when nothing landed, but cannot safely combine with owner-resolved
+        # authority. Run-owned evidence carries exact owner/site and may combine normally.
+        drop_credit = dropped[key] if dropped_profile_evidence is not None or have == 0 else 0
+        if have + drop_credit >= need:
             continue
         issues.append(
             LintIssue(

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -18,7 +18,8 @@ Completeness is deliberately marked partial.  Only the feature families with a s
 for the missing physical denominator.
 
 Its scalar is therefore named ``audited_score``, not ``score``.  A part reaches 1.0 whenever
-every requirement recognition *did* identify was placed, however much of the part it missed:
+every requirement recognition *did* identify was placed or explicitly satisfied by structured
+note authority, however much of the part it missed:
 what was never recognised never became a requirement, so it is absent from the ledger rather
 than counted against it.  (Where nothing auditable was recognised at all, the component
 reports ``available: False`` and a ``None`` score — not a perfect one.)  The qualifier
@@ -38,7 +39,14 @@ from draftwright.linting.issues import LintIssue, is_placement_drop
 from draftwright.linting.polygonal_stock_coverage import polygonal_stock_outcomes
 from draftwright.linting.slot_coverage import slot_requirement_outcomes
 
-_OUTCOME_STATES = ("placed", "suppressed", "dropped", "missing", "unverifiable")
+_OUTCOME_STATES = (
+    "placed",
+    "satisfied_by_structured_note",
+    "suppressed",
+    "dropped",
+    "missing",
+    "unverifiable",
+)
 
 # Structural diagnostics that describe whether the composed sheet remains readable. Placement
 # drops have their own explicit inventory below because a ``*_dropped`` suffix alone cannot
@@ -584,7 +592,8 @@ def _completeness_component(recognition, features, registry, omissions, issues) 
         if getattr(recognition, attribute, ())
     }
     unaudited = sorted(recognised - set(_AUDITED_FAMILIES))
-    audited_score = counts["placed"] / requirements if requirements else None
+    covered = counts["placed"] + counts["satisfied_by_structured_note"]
+    audited_score = covered / requirements if requirements else None
     if requirements:
         reason = (
             "audited_score covers recognized requirements in audited families only; it is "

--- a/src/draftwright/linting/slot_coverage.py
+++ b/src/draftwright/linting/slot_coverage.py
@@ -14,6 +14,7 @@ from typing import Literal
 
 from b123d_recognisers import RecognitionResult
 
+from draftwright.linting._registry import satisfaction_ids, satisfaction_of
 from draftwright.linting.issues import LintIssue
 
 SlotRequirementState = Literal[
@@ -213,7 +214,7 @@ def _state(feature, parameter, *, placed, satisfied, suppressed, dropped, regist
         return "dropped"
     associated = registry.names_for_feature(feature)
     if any(
-        not registry.measurement_of(name) and not registry.satisfaction_of(name)
+        not registry.measurement_of(name) and not satisfaction_of(registry, name)
         for name in associated
     ):
         return "unverifiable"
@@ -268,9 +269,7 @@ def slot_requirement_outcomes(
     placed = {
         measurement for name in registry.names() for measurement in registry.measurement_of(name)
     }
-    satisfied = {
-        identity for name in registry.names() for identity in registry.satisfaction_of(name)
-    }
+    satisfied = satisfaction_ids(registry)
     suppressed = {
         (omission.feature, omission.parameter_id)
         for omission in omissions

--- a/src/draftwright/linting/slot_coverage.py
+++ b/src/draftwright/linting/slot_coverage.py
@@ -16,7 +16,14 @@ from b123d_recognisers import RecognitionResult
 
 from draftwright.linting.issues import LintIssue
 
-SlotRequirementState = Literal["placed", "suppressed", "dropped", "missing", "unverifiable"]
+SlotRequirementState = Literal[
+    "placed",
+    "satisfied_by_structured_note",
+    "suppressed",
+    "dropped",
+    "missing",
+    "unverifiable",
+]
 SlotSourceKind = Literal["slot", "slot_pattern"]
 
 
@@ -195,15 +202,20 @@ def _physical_requirement_count(kind: SlotSourceKind, source) -> int:
     return 5 if _pattern_key(source)[0] == "linear" else 6
 
 
-def _state(feature, parameter, *, placed, suppressed, dropped, registry):
+def _state(feature, parameter, *, placed, satisfied, suppressed, dropped, registry):
     if any(_matches(measurement, feature, parameter) for measurement in placed):
         return "placed"
+    if any(_matches(identity, feature, parameter) for identity in satisfied):
+        return "satisfied_by_structured_note"
     if (feature, parameter) in suppressed:
         return "suppressed"
     if any(_matches(measurement, feature, parameter) for measurement in dropped):
         return "dropped"
     associated = registry.names_for_feature(feature)
-    if any(not registry.measurement_of(name) for name in associated):
+    if any(
+        not registry.measurement_of(name) and not registry.satisfaction_of(name)
+        for name in associated
+    ):
         return "unverifiable"
     return "missing"
 
@@ -256,6 +268,9 @@ def slot_requirement_outcomes(
     placed = {
         measurement for name in registry.names() for measurement in registry.measurement_of(name)
     }
+    satisfied = {
+        identity for name in registry.names() for identity in registry.satisfaction_of(name)
+    }
     suppressed = {
         (omission.feature, omission.parameter_id)
         for omission in omissions
@@ -298,6 +313,7 @@ def slot_requirement_outcomes(
                     feature,
                     parameter,
                     placed=placed,
+                    satisfied=satisfied,
                     suppressed=suppressed,
                     dropped=dropped,
                     registry=registry,
@@ -328,7 +344,7 @@ def lint_slot_coverage(
     }
     issues = []
     for outcome in slot_requirement_outcomes(recognition, features, registry, omissions):
-        if outcome.state in {"placed", "dropped"}:
+        if outcome.state in {"placed", "satisfied_by_structured_note", "dropped"}:
             continue
         noun = "slot" if outcome.source_kind == "slot" else f"{outcome.member_count}-slot pattern"
         issues.append(

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -57,6 +57,7 @@ from draftwright.model.ir import (
     EnvelopeFeature,
     Feature,
     HoleFeature,
+    Note,
     PartModel,
     PatternFeature,
     PocketFeature,
@@ -1434,6 +1435,20 @@ def compile_dimensions(
     must plan for itself.  Callers supplying *groups* have already resolved that constraint;
     the exact model/groups identity check below prevents substituting another plan.
     """
+    # PartModel.features is intentionally editable public IR, so construction-time validation
+    # alone cannot protect a model mutated afterward. Recheck at the compiler boundary before
+    # any structured-note authority can reach placement or critique (#1351).
+    model._validate_structured_note_origins()
+    for feature in model.features:
+        if (
+            isinstance(feature, Note)
+            and "location" in feature.satisfies
+            and location_datum(feature.origin) is None
+        ):
+            raise ValueError(
+                "structured note satisfies='location' targets a feature with no planned "
+                "location measurement"
+            )
     planned = (
         tuple(groups)
         if groups is not None

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -45,6 +45,7 @@ from draftwright.model.ir import (
     ControlFrame,
     CylindricalReference,
     DatumRef,
+    DimensionParameterId,
     EnvelopeFeature,
     ExternalSpurGearFeature,
     Feature,
@@ -2019,11 +2020,21 @@ def finish(ra, ref, part=None, *, view=None, side=None) -> Finish:
     return Finish(frame=Frame(site, axis), ra=ra, view=v, side=s, origin=origin)
 
 
-def note(text, ref, part=None, *, view=None, side=None, satisfies: tuple[str, ...] = ()) -> Note:
+def note(
+    text,
+    ref,
+    part=None,
+    *,
+    view=None,
+    side=None,
+    satisfies: tuple[DimensionParameterId, ...] = (),
+) -> Note:
     """A free-text manufacturing note (#488) on a leader to *ref* — a feature or a planar face
     (ADR 0011 P2c). The shop callouts detection can't infer: thread specs (``M3x0.5 TAP``),
     ``DEBURR``, chip-relief, knurl. Placed like the GD&T items (a first-class ADR 0009 corridor
-    candidate), not the dimension planner."""
+    candidate), not the dimension planner. ``satisfies`` explicitly names canonical
+    measurement roles that this note carries; the claim takes effect only if the note is
+    placed, and is never inferred by parsing its prose (#1351)."""
     text = str(text).strip()
     if not text:
         raise ValueError("note needs text (e.g. 'M3x0.5 TAP')")

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -2019,7 +2019,7 @@ def finish(ra, ref, part=None, *, view=None, side=None) -> Finish:
     return Finish(frame=Frame(site, axis), ra=ra, view=v, side=s, origin=origin)
 
 
-def note(text, ref, part=None, *, view=None, side=None) -> Note:
+def note(text, ref, part=None, *, view=None, side=None, satisfies: tuple[str, ...] = ()) -> Note:
     """A free-text manufacturing note (#488) on a leader to *ref* — a feature or a planar face
     (ADR 0011 P2c). The shop callouts detection can't infer: thread specs (``M3x0.5 TAP``),
     ``DEBURR``, chip-relief, knurl. Placed like the GD&T items (a first-class ADR 0009 corridor
@@ -2029,7 +2029,14 @@ def note(text, ref, part=None, *, view=None, side=None) -> Note:
         raise ValueError("note needs text (e.g. 'M3x0.5 TAP')")
     v, s, site, axis = _surface_target(ref, part, view=view, side=side)
     origin = ref if isinstance(ref, Feature) else None
-    return Note(frame=Frame(site, axis), text=text, view=v, side=s, origin=origin)
+    return Note(
+        frame=Frame(site, axis),
+        text=text,
+        view=v,
+        side=s,
+        origin=origin,
+        satisfies=satisfies,
+    )
 
 
 def control_frame(

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -1831,7 +1831,7 @@ class Note:
     # carries (#1351). Kept separate from ``parameters()``: the note does not become a
     # dimension, and coverage can distinguish a drawn measurement from an authored semantic
     # assertion instead of parsing prose.
-    satisfies: tuple[str, ...] = ()
+    satisfies: tuple[DimensionParameterId, ...] = ()
     kind: ClassVar[str] = "note"
 
     def __post_init__(self) -> None:
@@ -1846,6 +1846,11 @@ class Note:
         if not isinstance(self.origin, Feature):
             raise ValueError("a note with satisfies= must target a dimensionable feature")
         available = {parameter.parameter_id for parameter in self.origin.parameters()}
+        # ``location`` is the one addressable dimension with no DimParameter. IR can validate
+        # its spelling here; the Sheet/compiler boundaries validate planner-owned eligibility
+        # without reversing the IR -> planner dependency (ADR 0015).
+        if "location" in self.satisfies:
+            available.add("location")
         invalid = sorted(set(self.satisfies) - available)
         if invalid:
             raise ValueError(
@@ -1935,3 +1940,21 @@ class PartModel:
     # authored set is planned with ``suppressed=True`` and keeps its value, so the group
     # retains its engineering data and a later pass can still see what was left out.
     authored_dimensions: tuple[RequestedDimension, ...] | None = None
+
+    def __post_init__(self) -> None:
+        self._validate_structured_note_origins()
+
+    def _validate_structured_note_origins(self) -> None:
+        """Require every authority-bearing note to target this exact mutable inventory."""
+        # Structured authority must terminate at a feature in this exact IR inventory. Value
+        # equality is unsafe when two identical holes are distinct physical requirements, and
+        # an external origin cannot round-trip or join recognition evidence (#1351).
+        for feature in self.features:
+            if (
+                isinstance(feature, Note)
+                and feature.satisfies
+                and not any(candidate is feature.origin for candidate in self.features)
+            ):
+                raise ValueError(
+                    "structured note origin must be the identical feature in PartModel.features"
+                )

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -1827,7 +1827,31 @@ class Note:
     view: str
     side: str
     origin: object | None = None
+    # Canonical ParameterIds whose manufacturing requirements this authored note explicitly
+    # carries (#1351). Kept separate from ``parameters()``: the note does not become a
+    # dimension, and coverage can distinguish a drawn measurement from an authored semantic
+    # assertion instead of parsing prose.
+    satisfies: tuple[str, ...] = ()
     kind: ClassVar[str] = "note"
+
+    def __post_init__(self) -> None:
+        if not self.satisfies:
+            return
+        if not isinstance(self.satisfies, tuple) or any(
+            not isinstance(parameter, str) or not parameter.strip() for parameter in self.satisfies
+        ):
+            raise ValueError("note satisfies= must be a tuple of non-empty parameter ids")
+        if len(set(self.satisfies)) != len(self.satisfies):
+            raise ValueError("note satisfies= contains duplicate parameter ids")
+        if not isinstance(self.origin, Feature):
+            raise ValueError("a note with satisfies= must target a dimensionable feature")
+        available = {parameter.parameter_id for parameter in self.origin.parameters()}
+        invalid = sorted(set(self.satisfies) - available)
+        if invalid:
+            raise ValueError(
+                f"note satisfies= names invalid parameter id(s) {invalid} for "
+                f"{type(self.origin).__name__}; choose from {sorted(available)}"
+            )
 
     def parameters(self) -> list[DimParameter]:
         return []

--- a/src/draftwright/registry.py
+++ b/src/draftwright/registry.py
@@ -74,6 +74,11 @@ class AnnotationRegistry:
         # would have to be widened again later, and worse, would make the audit's
         # "exact when present" promise false for a callout's other measurements.
         self._anno_measurement: dict = {}
+        # name -> DimensionIds a placed structured note explicitly satisfies (#1351).
+        # Separate from ``_anno_measurement`` because a note carries manufacturing authority
+        # without pretending to be dimensional ink; coverage and quality reports must retain
+        # that distinction. Like every identity axis, this is snapshot/restored transactionally.
+        self._anno_satisfaction: dict = {}
         self._pinned: set = set()
         self._build_issues: list = []
 
@@ -114,6 +119,14 @@ class AnnotationRegistry:
         ids: tuple = self._anno_measurement.get(name, ())
         return ids
 
+    def satisfaction_of(self, name) -> tuple:
+        """The ``DimensionId`` requirements *name* satisfies as structured note authority.
+
+        This provenance is deliberately separate from :meth:`measurement_of`: a note can
+        meet a requirement without pretending to draw a dimension (#1351)."""
+        ids: tuple = self._anno_satisfaction.get(name, ())
+        return ids
+
     def names_for_feature(self, feature) -> list:
         """Every annotation name owned by *feature* (matched by value equality, so a
         feature from ``dwg.model()`` finds the annotations rendered for it) (#398).
@@ -149,6 +162,7 @@ class AnnotationRegistry:
             "anno_view": dict(self._anno_view),
             "anno_feature": dict(self._anno_feature),
             "anno_measurement": dict(self._anno_measurement),
+            "anno_satisfaction": dict(self._anno_satisfaction),
             "pinned": set(self._pinned),
         }
 
@@ -162,6 +176,8 @@ class AnnotationRegistry:
         self._anno_feature.update(snap.get("anno_feature", {}))
         self._anno_measurement.clear()
         self._anno_measurement.update(snap.get("anno_measurement", {}))
+        self._anno_satisfaction.clear()
+        self._anno_satisfaction.update(snap.get("anno_satisfaction", {}))
         self._pinned.clear()
         self._pinned.update(snap["pinned"])
 
@@ -184,6 +200,7 @@ class AnnotationRegistry:
             "view": self._anno_view.get(name),
             "feature": self._anno_feature.get(name),
             "measurement": self._anno_measurement.get(name, ()),
+            "satisfaction": self._anno_satisfaction.get(name, ()),
             "pinned": name in self._pinned,
         }
 
@@ -213,12 +230,17 @@ class AnnotationRegistry:
             self._anno_measurement[name] = ids
         else:
             self._anno_measurement.pop(name, None)
+        satisfactions = _as_ids(identity.get("satisfaction"))
+        if satisfactions:
+            self._anno_satisfaction[name] = satisfactions
+        else:
+            self._anno_satisfaction.pop(name, None)
         if identity.get("pinned"):
             self._pinned.add(name)
         else:
             self._pinned.discard(name)
 
-    def add(self, obj, name, view, feature=None, measurement=None):
+    def add(self, obj, name, view, feature=None, measurement=None, satisfaction=None):
         """Register *obj* under *name* and record its owning *view* (and source *feature*).
 
         Returns the object previously registered under *name* (so the caller can
@@ -252,6 +274,11 @@ class AnnotationRegistry:
                 self._anno_measurement[name] = ids
             else:
                 self._anno_measurement.pop(name, None)
+            satisfactions = _as_ids(satisfaction)
+            if satisfactions:
+                self._anno_satisfaction[name] = satisfactions
+            else:
+                self._anno_satisfaction.pop(name, None)
         return displaced
 
     def remove(self, name):
@@ -262,6 +289,7 @@ class AnnotationRegistry:
             self._anno_view.pop(name, None)
             self._anno_feature.pop(name, None)
             self._anno_measurement.pop(name, None)
+            self._anno_satisfaction.pop(name, None)
         return obj
 
     def clear(self, keep) -> dict:
@@ -274,6 +302,9 @@ class AnnotationRegistry:
         self._anno_view = {n: v for n, v in self._anno_view.items() if n in keep_set}
         self._anno_feature = {n: f for n, f in self._anno_feature.items() if n in keep_set}
         self._anno_measurement = {n: m for n, m in self._anno_measurement.items() if n in keep_set}
+        self._anno_satisfaction = {
+            n: s for n, s in self._anno_satisfaction.items() if n in keep_set
+        }
         return kept_named
 
     # -- pins -----------------------------------------------------------------

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -472,7 +472,7 @@ class _Hole(_Nameable):
         self,
         text,
         *,
-        satisfies: tuple[str, ...] = (),
+        satisfies: tuple[DimensionParameterId, ...] = (),
         view: str | None = None,
         side: str | None = None,
     ) -> _Hole:
@@ -559,12 +559,16 @@ class _Dim(_Nameable):
         self,
         text,
         *,
-        satisfies: tuple[str, ...] = (),
+        satisfies: tuple[DimensionParameterId, ...] = (),
         view: str | None = None,
         side: str | None = None,
     ) -> _Dim:
-        """A free-text manufacturing note on a leader to this feature (#488).
-        ``diameter(knurl).note("KNURL 0.8 STRAIGHT")``; ``view``/``side`` override the strip."""
+        """A manufacturing note on a leader to this feature (#488).
+
+        ``diameter(knurl).note("KNURL 0.8 STRAIGHT")``; ``satisfies`` explicitly names
+        canonical parameter ids returned by ``dimension_ids()`` that the placed note meets
+        instead of a drawn dimension. Plain prose has no coverage effect; ``view``/``side``
+        override the strip (#1351)."""
         self._sheet._gdt_note(text, self._i, view=view, side=side, satisfies=satisfies)
         return self
 
@@ -755,7 +759,7 @@ class _Params(_Nameable):
         text,
         ref=None,
         *,
-        satisfies: tuple[str, ...] = (),
+        satisfies: tuple[DimensionParameterId, ...] = (),
         view: str | None = None,
         side: str | None = None,
     ) -> _Params:
@@ -764,7 +768,10 @@ class _Params(_Nameable):
         (previously this raised, because the forwarded ``Sheet.note`` needs a target). An explicit
         *ref* (a face or feature) still forwards to :meth:`Sheet.note`, preserving the handle's
         forwarding contract for ``sheet.slot(...).note("DEBURR", face)``. Returns the handle
-        (chainable); ``view``/``side`` override the derived strip."""
+        (chainable). ``satisfies`` explicitly names canonical parameter ids from
+        ``dimension_ids()`` that the placed note meets instead of a drawn dimension;
+        plain prose has no coverage effect. ``view``/``side`` override the derived strip
+        (#1351)."""
         if ref is None:
             self._sheet._gdt_note(text, self._i, view=view, side=side, satisfies=satisfies)
         else:
@@ -1138,7 +1145,7 @@ class Sheet:
         and token-binds that provenance exactly like the public GD&T verbs."""
         src_token = None
         if (
-            getattr(feature, "kind", None) in ("control_frame", "datum_ref")
+            getattr(feature, "kind", None) in ("control_frame", "datum_ref", "note")
             and feature.origin is not None
         ):
             src_token = self._declared_token(feature.origin, verb=f"add() {feature.kind} origin")
@@ -1146,6 +1153,19 @@ class Sheet:
                 feature = replace(
                     feature,
                     origin=self._features[self._index_of_token(src_token)],
+                )
+            elif getattr(feature, "satisfies", ()):
+                raise ValueError(
+                    "add() structured note origin must be a feature already managed by this "
+                    "Sheet; use that feature's handle.note(...)"
+                )
+            if (
+                "location" in getattr(feature, "satisfies", ())
+                and _location_role(feature.origin) is None
+            ):
+                raise ValueError(
+                    "add() structured note satisfies='location' targets a feature with no "
+                    "planned location measurement"
                 )
         self._features.append(feature)
         self._bind_gdt_source(self._token_at(len(self._features) - 1), src_token)
@@ -1581,7 +1601,7 @@ class Sheet:
         text,
         ref,
         *,
-        satisfies: tuple[str, ...] = (),
+        satisfies: tuple[DimensionParameterId, ...] = (),
         view: str | None = None,
         side: str | None = None,
     ) -> Sheet:
@@ -1592,6 +1612,15 @@ class Sheet:
         ``satisfies`` may name canonical parameter ids only when *ref* is a feature; it grants
         coverage only when this structured note is placed, never by parsing its prose (#1351)."""
         target, src = self._gdt_ref(ref)
+        if satisfies and src is None:
+            raise ValueError(
+                "note satisfies= must target a feature already managed by this Sheet; "
+                "use its handle or the exact feature from sheet.features"
+            )
+        if "location" in satisfies and _location_role(target) is None:
+            raise ValueError(
+                "note satisfies='location' targets a feature with no planned location measurement"
+            )
         self._append_gdt(
             _declare_note(
                 text,
@@ -1989,10 +2018,20 @@ class Sheet:
         self._append_gdt(item, self._token_at(src_index))
 
     def _gdt_note(
-        self, text, src_index: int, *, view=None, side=None, satisfies: tuple[str, ...] = ()
+        self,
+        text,
+        src_index: int,
+        *,
+        view=None,
+        side=None,
+        satisfies: tuple[DimensionParameterId, ...] = (),
     ) -> None:
         """A note declared through a fluent handle — like :meth:`_gdt_finish`, sources provenance
         from the feature INDEX so a later size verb on the same handle can't strand it."""
+        if "location" in satisfies and _location_role(self._features[src_index]) is None:
+            raise ValueError(
+                "note satisfies='location' targets a feature with no planned location measurement"
+            )
         item = _declare_note(
             text,
             self._features[src_index],

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -468,10 +468,20 @@ class _Hole(_Nameable):
         self._sheet._gdt_finish(ra, self._i, view=view, side=side)
         return self
 
-    def note(self, text, *, view: str | None = None, side: str | None = None) -> _Hole:
-        """A free-text manufacturing note on a leader to this hole (#488). ``.note("M3x0.5 TAP")``
-        — the shop callout; ``view``/``side`` override the derived strip."""
-        self._sheet._gdt_note(text, self._i, view=view, side=side)
+    def note(
+        self,
+        text,
+        *,
+        satisfies: tuple[str, ...] = (),
+        view: str | None = None,
+        side: str | None = None,
+    ) -> _Hole:
+        """A manufacturing note on a leader to this hole (#488).
+
+        ``satisfies`` explicitly names canonical parameter ids from :meth:`dimension_ids` that
+        the placed note meets instead of a drawn dimension. Plain prose has no coverage effect;
+        ``view``/``side`` override the derived strip (#1351)."""
+        self._sheet._gdt_note(text, self._i, view=view, side=side, satisfies=satisfies)
         return self
 
     def _set(self, **kw) -> _Hole:
@@ -545,10 +555,17 @@ class _Dim(_Nameable):
         self._sheet._gdt_finish(ra, self._i, view=view, side=side)
         return self
 
-    def note(self, text, *, view: str | None = None, side: str | None = None) -> _Dim:
+    def note(
+        self,
+        text,
+        *,
+        satisfies: tuple[str, ...] = (),
+        view: str | None = None,
+        side: str | None = None,
+    ) -> _Dim:
         """A free-text manufacturing note on a leader to this feature (#488).
         ``diameter(knurl).note("KNURL 0.8 STRAIGHT")``; ``view``/``side`` override the strip."""
-        self._sheet._gdt_note(text, self._i, view=view, side=side)
+        self._sheet._gdt_note(text, self._i, view=view, side=side, satisfies=satisfies)
         return self
 
     def knurl(
@@ -733,7 +750,15 @@ class _Params(_Nameable):
         )
         return self
 
-    def note(self, text, ref=None, *, view: str | None = None, side: str | None = None) -> _Params:
+    def note(
+        self,
+        text,
+        ref=None,
+        *,
+        satisfies: tuple[str, ...] = (),
+        view: str | None = None,
+        side: str | None = None,
+    ) -> _Params:
         """A free-text manufacturing note (#841). With no *ref* the note anchors to THIS feature —
         ``sheet.slot(...).note("5X OBROUND SLOT")`` — mirroring :meth:`_Hole.note` / :meth:`_Dim.note`
         (previously this raised, because the forwarded ``Sheet.note`` needs a target). An explicit
@@ -741,9 +766,9 @@ class _Params(_Nameable):
         forwarding contract for ``sheet.slot(...).note("DEBURR", face)``. Returns the handle
         (chainable); ``view``/``side`` override the derived strip."""
         if ref is None:
-            self._sheet._gdt_note(text, self._i, view=view, side=side)
+            self._sheet._gdt_note(text, self._i, view=view, side=side, satisfies=satisfies)
         else:
-            self._sheet.note(text, ref, view=view, side=side)
+            self._sheet.note(text, ref, view=view, side=side, satisfies=satisfies)
         return self
 
 
@@ -1551,13 +1576,33 @@ class Sheet:
         self._append_gdt(_declare_finish(ra, target, self._part, view=view, side=side), src)
         return self
 
-    def note(self, text, ref, *, view: str | None = None, side: str | None = None) -> Sheet:
-        """Declare a free-text manufacturing note (#488) on a leader to *ref* — a build123d planar
+    def note(
+        self,
+        text,
+        ref,
+        *,
+        satisfies: tuple[str, ...] = (),
+        view: str | None = None,
+        side: str | None = None,
+    ) -> Sheet:
+        """Declare a manufacturing note (#488) on a leader to *ref* — a build123d planar
         face or a feature. The shop callouts detection can't infer: thread specs
         (``sheet.note("M3x0.5 TAP", bore)``), ``DEBURR``, chip-relief, knurl. Placed like the GD&T
-        items, clear of the views/title block; ``view``/``side`` override the derived strip."""
+        items, clear of the views/title block; ``view``/``side`` override the derived strip.
+        ``satisfies`` may name canonical parameter ids only when *ref* is a feature; it grants
+        coverage only when this structured note is placed, never by parsing its prose (#1351)."""
         target, src = self._gdt_ref(ref)
-        self._append_gdt(_declare_note(text, target, self._part, view=view, side=side), src)
+        self._append_gdt(
+            _declare_note(
+                text,
+                target,
+                self._part,
+                view=view,
+                side=side,
+                satisfies=satisfies,
+            ),
+            src,
+        )
         return self
 
     # -- view declaration (ADR 0018) ---------------------------------------
@@ -1943,10 +1988,19 @@ class Sheet:
         item = _declare_finish(ra, self._features[src_index], self._part, view=view, side=side)
         self._append_gdt(item, self._token_at(src_index))
 
-    def _gdt_note(self, text, src_index: int, *, view=None, side=None) -> None:
+    def _gdt_note(
+        self, text, src_index: int, *, view=None, side=None, satisfies: tuple[str, ...] = ()
+    ) -> None:
         """A note declared through a fluent handle — like :meth:`_gdt_finish`, sources provenance
         from the feature INDEX so a later size verb on the same handle can't strand it."""
-        item = _declare_note(text, self._features[src_index], self._part, view=view, side=side)
+        item = _declare_note(
+            text,
+            self._features[src_index],
+            self._part,
+            view=view,
+            side=side,
+            satisfies=satisfies,
+        )
         self._append_gdt(item, self._token_at(src_index))
 
     def _append_gdt(self, item, src_token) -> None:

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -1071,7 +1071,9 @@ def _binding(f, line: str, counts: dict[str, int]) -> str | None:
     ``None`` for a kind with no declarative verb: its "line" is a comment, and
     ``rotational1 = # …`` does not parse.
     """
-    if line.lstrip().startswith("#"):
+    # Fluent ``handle.note(...)`` returns the origin handle, not the appended Note. Binding
+    # that expression as ``note1`` would therefore lie about which feature the name denotes.
+    if f.kind == "note" or line.lstrip().startswith("#"):
         return None
     counts[f.kind] = counts.get(f.kind, 0) + 1
     return f"{f.kind}{counts[f.kind]}"
@@ -1389,11 +1391,18 @@ def _feature_block(
     the wrong hole, which still runs.
 
     Lines are grouped under section sub-headers (with a repeat tally) and each carries a
-    trailing describing comment. Runs are CONSECUTIVE in the given order — no reorder.
+    trailing describing comment. Geometric features retain their consecutive order. Notes
+    are dependent aspect statements, so they are emitted after the independently bindable
+    features; this lets an identity-preserving public reorder put a note before its origin
+    without making the generated relationship impossible to spell (#1351).
     """
     if not features:
         return ["# ── Features: none detected ──"], {}
-    out = [f"# ── Features ({len(features)}): {_manifest(features)} ──"]
+    source_features = tuple(features)
+    out = [f"# ── Features ({len(source_features)}): {_manifest(source_features)} ──"]
+    features = tuple(f for f in source_features if f.kind != "note") + tuple(
+        f for f in source_features if f.kind == "note"
+    )
     counts: dict[str, int] = {}
     names: dict[int, str] = {}
     i = 0
@@ -1410,6 +1419,7 @@ def _feature_block(
             origin_ref = names.get(id(f.origin)) if gdt_with_origin else None
             if (
                 gdt_with_origin
+                and (f.kind != "note" or bool(f.satisfies))
                 and f.origin is not None
                 and getattr(f.origin, "kind", None) != "pmi"
                 and origin_ref is None

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -597,6 +597,11 @@ def _feature_line(
         return _control_frame_line(f, origin_ref)
     if k == "datum_ref":
         return _datum_ref_line(f, origin_ref)
+    if k == "note" and origin_ref is not None:
+        kwargs = [f"view={f.view!r}", f"side={f.side!r}"]
+        if f.satisfies:
+            kwargs.append(f"satisfies={f.satisfies!r}")
+        return f"{origin_ref}.note({f.text!r}, {', '.join(kwargs)})"
     if k == "envelope":
         if part_envelope is not None and f == part_envelope:
             # `sheet.envelope()` defaults to the whole part and now measures its SOLIDS with a
@@ -864,8 +869,8 @@ def _feature_line(
             f'sheet.plate(axis="{f.axis}", lo={_n(f.lo)}, hi={_n(f.hi)}, u={_n(f.u)}, v={_n(f.v)})'
         )
     # Kinds with no declarative verb: flag inline so they aren't silently lost. Since #945 every
-    # geometric kind has a verb, so this catches the remaining aspect kinds
-    # (finish/note) and, more usefully, a newly added kind whose emit line nobody wrote.
+    # geometric kind has a verb, so this catches bare-face aspects that cannot be rebound and,
+    # more usefully, a newly added kind whose emit line nobody wrote.
     return f"# {k} @ {_pt(f.frame.origin)} — no declarative verb yet; drawn by the auto-pass"
 
 
@@ -1401,7 +1406,7 @@ def _feature_block(
         summary = _run_summary(run)
         out.append(f"#   {section}" + (f" · {summary}" if summary else "") + " ─────")
         for f in run:
-            gdt_with_origin = f.kind in ("control_frame", "datum_ref")
+            gdt_with_origin = f.kind in ("control_frame", "datum_ref", "note")
             origin_ref = names.get(id(f.origin)) if gdt_with_origin else None
             if (
                 gdt_with_origin
@@ -1412,6 +1417,11 @@ def _feature_block(
                 raise ValueError(
                     f"emit_sheet_script(): cannot preserve a {f.kind} whose origin has "
                     "no emitted binding"
+                )
+            if f.kind == "note" and f.satisfies and origin_ref is None:
+                raise ValueError(
+                    "emit_sheet_script(): cannot preserve structured note satisfaction "
+                    "without its feature binding"
                 )
             nominal_parameter = {
                 "step": "step.diameter",

--- a/tests/test_issue_1351_structured_note_coverage.py
+++ b/tests/test_issue_1351_structured_note_coverage.py
@@ -11,6 +11,8 @@ from build123d import Align, Box, Cylinder, Pos
 
 from draftwright import Sheet
 from draftwright.linting.hole_coverage import hole_requirement_outcomes
+from draftwright.linting.profiled_bore_coverage import lint_profiled_bore_coverage
+from draftwright.linting.quality import quality_components
 from draftwright.linting.slot_coverage import slot_requirement_outcomes
 from draftwright.model import DimensionParameterId, PartModel, pocket
 from draftwright.model.compiled import compile_dimensions
@@ -467,6 +469,153 @@ def test_compound_profiled_bore_note_covers_both_exact_profile_requirements():
     )
     drawing.remove(note_name)
     assert any(issue.code == "profiled_bore_not_dimensioned" for issue in drawing.lint())
+
+
+def test_callout_and_note_on_one_profile_do_not_cover_an_identical_sibling():
+    center = (Align.CENTER, Align.CENTER, Align.CENTER)
+    cutter = Cylinder(5, 20, align=center) & Box(7.2, 20, 30, align=center)
+    part = Box(60, 30, 10, align=center) - Pos(-15, 0, 0) * cutter - Pos(15, 0, 0) * cutter
+    sheet = Sheet.from_part(part).take_over(
+        dimensions="authored", principal_views="automatic", derived_views="authored"
+    )
+    bores = [feature for feature in sheet.features if feature.kind == "hole"]
+    first = min(bores, key=lambda feature: feature.frame.origin[0])
+    sheet.dimension(first, "bore.diameter")
+    sheet.dimension(first, "profile_across_flats.length")
+    sheet.of(first).note(
+        "DOUBLE-D PROFILE",
+        satisfies=("bore.diameter", "profile_across_flats.length"),
+    )
+
+    drawing = sheet.build()
+    issues = drawing.lint()
+    warning = next(issue for issue in issues if issue.code == "profiled_bore_not_dimensioned")
+    assert "document 1" in warning.message
+
+    bore = drawing.recognition().double_d_bores[0]
+    dropped = (
+        "double_d",
+        bore.axis,
+        bore.through,
+        bore.major_diameter,
+        bore.across_flats,
+        bore.flat_direction,
+    )
+    drop_reconciled = lint_profiled_bore_coverage(
+        part,
+        drawing.items,
+        recognition=drawing.recognition(),
+        features=drawing.model().features,
+        registry=drawing.registry,
+        dropped_profiles=(dropped,),
+    )
+    assert any(issue.code == "profiled_bore_not_dimensioned" for issue in drop_reconciled)
+
+    same_owner_drop = lint_profiled_bore_coverage(
+        part,
+        drawing.items,
+        recognition=drawing.recognition(),
+        features=drawing.model().features,
+        registry=drawing.registry,
+        dropped_profile_evidence=((dropped, first),),
+    )
+    assert any(issue.code == "profiled_bore_not_dimensioned" for issue in same_owner_drop)
+
+    second = max(bores, key=lambda feature: feature.frame.origin[0])
+    sibling_drop = lint_profiled_bore_coverage(
+        part,
+        drawing.items,
+        recognition=drawing.recognition(),
+        features=drawing.model().features,
+        registry=drawing.registry,
+        dropped_profile_evidence=((dropped, second),),
+    )
+    assert not sibling_drop
+
+
+def test_profile_note_must_match_the_recognised_physical_site():
+    center = (Align.CENTER, Align.CENTER, Align.CENTER)
+    cutter = Cylinder(5, 20, align=center) & Box(7.2, 20, 30, align=center)
+    part = Box(30, 30, 10, align=center) - cutter
+    sheet = Sheet(part)
+    phantom = sheet.double_d_bore(
+        major_diameter=10,
+        across_flats=7.2,
+        at=(8, 0, 5),
+        axis="z",
+        depth=10,
+        profile_direction=(1, 0, 0),
+    )
+    sheet.authored_dimensions()
+    phantom.note(
+        "DOUBLE-D PROFILE",
+        satisfies=("bore.diameter", "profile_across_flats.length"),
+    )
+
+    codes = {issue.code for issue in sheet.build().lint()}
+    assert "profiled_bore_not_dimensioned" in codes
+    assert "declared_feature_absent" in codes
+
+
+def test_callout_and_note_on_one_diameter_do_not_cover_an_identical_sibling():
+    center = (Align.CENTER, Align.CENTER, Align.CENTER)
+    part = (
+        Box(60, 30, 10, align=center)
+        - Pos(-15, 0, 0) * Cylinder(3, 20, align=center)
+        - Pos(15, 0, 2.5) * Cylinder(3, 5, align=center)
+    )
+    sheet = Sheet.from_part(part).take_over(
+        dimensions="authored", principal_views="automatic", derived_views="authored"
+    )
+    holes = [feature for feature in sheet.features if feature.kind == "hole"]
+    first = min(holes, key=lambda feature: feature.frame.origin[0])
+    sheet.dimension(first, "bore.diameter")
+    sheet.of(first).note("DIAMETER 6", satisfies=("bore.diameter",))
+
+    warning = next(
+        issue for issue in sheet.build().lint() if issue.code == "feature_count_mismatch"
+    )
+    assert "account for 1" in warning.message
+
+
+def test_pre_satisfaction_registry_shape_remains_a_valid_consumer_boundary():
+    drawing = _sheet(note=True, satisfies=_SATISFIES).build()
+    drawing.lint()  # declared builds acquire critique recognition lazily
+
+    class LegacyRegistry:
+        """The public reads available before structured satisfaction provenance."""
+
+        def __init__(self, inner):
+            self._inner = inner
+            self.issues = inner.issues
+
+        def names(self):
+            return self._inner.names()
+
+        def named(self, name):
+            return self._inner.named(name)
+
+        def measurement_of(self, name):
+            return self._inner.measurement_of(name)
+
+    legacy = LegacyRegistry(drawing.registry)
+    recognition = drawing.recognition()
+    features = drawing.model().features
+    omissions = compile_dimensions(drawing.model()).diagnostics
+
+    outcomes = hole_requirement_outcomes(recognition, features, legacy, omissions)
+    assert outcomes
+    quality = quality_components(
+        recognition=recognition,
+        features=features,
+        registry=legacy,
+        omissions=omissions,
+        issues=[],
+        error_penalty=0.2,
+        warning_penalty=0.1,
+        has_asserted_content=True,
+    )
+    assert quality["completeness"]["available"] is True
 
 
 def test_structured_note_authority_is_shared_by_non_hole_requirement_ledgers():

--- a/tests/test_issue_1351_structured_note_coverage.py
+++ b/tests/test_issue_1351_structured_note_coverage.py
@@ -1,0 +1,190 @@
+"""Structured feature notes carry explicit requirement coverage without parsing prose (#1351)."""
+
+from __future__ import annotations
+
+from typing import cast
+
+import pytest
+from b123d_recognisers import recognise_slots
+from build123d import Box, Cylinder, Pos
+
+from draftwright import Sheet
+from draftwright.linting.hole_coverage import hole_requirement_outcomes
+from draftwright.linting.slot_coverage import slot_requirement_outcomes
+from draftwright.model import DimensionParameterId
+from draftwright.model.compiled import compile_dimensions
+from draftwright.sheet_emit import emit_sheet_script
+
+_SATISFIES = ("counterbore.diameter", "counterbore.depth")
+
+
+def _part():
+    return Box(60, 40, 20) - Cylinder(4, 40) - Pos(0, 0, 6) * Cylinder(7, 8)
+
+
+def _sheet(*, note: bool, satisfies: tuple[str, ...] = ()) -> Sheet:
+    sheet = Sheet.from_part(_part(), page="A3").take_over(
+        dimensions="authored",
+        principal_views="automatic",
+        derived_views="authored",
+    )
+    counterbore = next(
+        feature for feature in sheet.features if feature.kind == "hole" and feature.cbore
+    )
+    handle = sheet.of(counterbore)
+    for parameter_id in handle.dimension_ids():
+        if parameter_id not in _SATISFIES:
+            sheet.dimension(handle, cast(DimensionParameterId, parameter_id))
+    for feature in sheet.features:
+        if feature.kind == "envelope":
+            for parameter in feature.parameters():
+                sheet.dimension(feature, parameter.parameter_id)
+    if note:
+        handle.note(
+            "PROFILED BORE: diameter 14 x 8 DEEP",
+            satisfies=satisfies,
+        )
+    return sheet
+
+
+def _counterbore_states(drawing) -> dict[str, str]:
+    drawing.lint()  # declared builds acquire critique recognition lazily
+    return {
+        outcome.parameter_id: outcome.state
+        for outcome in hole_requirement_outcomes(
+            drawing._build.recognition,  # acceptance checks the public drawing's run inventory
+            drawing.model().features,
+            drawing.registry,
+            drawing._build.omissions,
+        )
+        if outcome.parameter_id in _SATISFIES
+    }
+
+
+def test_structured_note_satisfies_omitted_roles_without_becoming_a_dimension():
+    drawing = _sheet(note=True, satisfies=_SATISFIES).build()
+
+    assert _counterbore_states(drawing) == {
+        parameter: "satisfied_by_structured_note" for parameter in _SATISFIES
+    }
+    satisfaction_names = [
+        name for name in drawing.registry.names() if drawing.registry.satisfaction_of(name)
+    ]
+    assert len(satisfaction_names) == 1
+    assert drawing.registry.measurement_of(satisfaction_names[0]) == ()
+    assert {
+        identity.parameter for identity in drawing.registry.satisfaction_of(satisfaction_names[0])
+    } == set(_SATISFIES)
+
+    issues = drawing.lint()
+    assert not [
+        issue
+        for issue in issues
+        if issue.code == "hole_requirement_suppressed"
+        and any(parameter in issue.message for parameter in _SATISFIES)
+    ]
+    assert not [
+        issue
+        for issue in issues
+        if issue.code == "feature_not_dimensioned" and "ø14" in issue.message
+    ]
+    completeness = drawing.lint_summary()["quality"]["completeness"]
+    assert completeness["satisfied_by_structured_note"] == 2
+    assert completeness["audited_score"] == 1.0
+
+
+@pytest.mark.parametrize("with_note", [False, True])
+def test_prose_without_structured_satisfaction_cannot_silence_coverage(with_note):
+    drawing = _sheet(note=with_note).build()
+
+    assert _counterbore_states(drawing) == {parameter: "suppressed" for parameter in _SATISFIES}
+    issues = drawing.lint()
+    suppressed = [
+        issue
+        for issue in issues
+        if issue.code == "hole_requirement_suppressed"
+        and any(parameter in issue.message for parameter in _SATISFIES)
+    ]
+    assert len(suppressed) == 2
+    assert any(
+        issue.code == "feature_not_dimensioned" and "ø14" in issue.message for issue in issues
+    )
+
+
+@pytest.mark.parametrize(
+    ("satisfies", "message"),
+    [
+        (("counterbore.diameter", "counterbore.diameter"), "duplicate parameter ids"),
+        (("bore.depth",), "invalid parameter id"),
+        (("counterbore",), "invalid parameter id"),
+    ],
+)
+def test_invalid_or_ambiguous_satisfaction_claims_fail_before_mutating_the_sheet(
+    satisfies, message
+):
+    sheet = _sheet(note=False)
+    handle = sheet.of(next(feature for feature in sheet.features if feature.kind == "hole"))
+    before = tuple(sheet.features)
+
+    with pytest.raises(ValueError, match=message):
+        handle.note("PROFILED BORE", satisfies=satisfies)
+
+    assert tuple(sheet.features) == before
+
+
+def test_structured_note_round_trips_through_generated_sheet_source():
+    sheet = _sheet(note=True, satisfies=_SATISFIES)
+    source = emit_sheet_script(
+        sheet.model(),
+        "part",
+        "structured-note",
+        title="T",
+        number="N",
+        page="A3",
+    )
+    assert ".note(" in source
+    assert f"satisfies={_SATISFIES!r}" in source
+
+    namespace = {"part": _part()}
+    body = source.replace("\npart\n", "\n", 1)
+    exec(  # noqa: S102 - exercise the generated public Sheet source
+        compile(body[: body.index("drawing = sheet.build()")], "<structured-note>", "exec"),
+        namespace,
+    )
+    regenerated = namespace["sheet"]
+    note = next(feature for feature in regenerated.features if feature.kind == "note")
+    assert note.satisfies == _SATISFIES
+    assert note.origin in regenerated.features
+
+
+def test_structured_note_authority_is_shared_by_non_hole_requirement_ledgers():
+    part = Box(100, 70, 10) - Pos(22, -11, 0) * Box(30, 8, 20)
+    (source,) = recognise_slots(part)
+    sheet = Sheet(part)
+    handle = sheet.slot(
+        width=source.width,
+        length=source.length,
+        long_axis=source.long_axis,
+        width_axis=source.width_axis,
+        depth_axis=source.depth_axis,
+        w_center=source.w_center,
+        lo=source.lo,
+        hi=source.hi,
+        at=source.location,
+    )
+    sheet.dimension(sheet.envelope(), "width.length")  # authored: slot roles are omitted
+    handle.note("MILL 8 WIDE SLOT", satisfies=("slot_width.length",))
+    drawing = sheet.build()
+    drawing.lint()
+
+    states = {
+        outcome.parameter_id: outcome.state
+        for outcome in slot_requirement_outcomes(
+            drawing.recognition(),
+            drawing.model().features,
+            drawing.registry,
+            compile_dimensions(drawing.model()).diagnostics,
+        )
+    }
+    assert states["slot_width.length"] == "satisfied_by_structured_note"
+    assert states["slot_length.length"] == "suppressed"

--- a/tests/test_issue_1351_structured_note_coverage.py
+++ b/tests/test_issue_1351_structured_note_coverage.py
@@ -2,27 +2,32 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from typing import cast
 
 import pytest
 from b123d_recognisers import recognise_slots
-from build123d import Box, Cylinder, Pos
+from build123d import Align, Box, Cylinder, Pos
 
 from draftwright import Sheet
 from draftwright.linting.hole_coverage import hole_requirement_outcomes
 from draftwright.linting.slot_coverage import slot_requirement_outcomes
-from draftwright.model import DimensionParameterId
+from draftwright.model import DimensionParameterId, PartModel, pocket
 from draftwright.model.compiled import compile_dimensions
+from draftwright.model.declare import note as declare_note
 from draftwright.sheet_emit import emit_sheet_script
 
-_SATISFIES = ("counterbore.diameter", "counterbore.depth")
+_SATISFIES: tuple[DimensionParameterId, ...] = (
+    "counterbore.diameter",
+    "counterbore.depth",
+)
 
 
 def _part():
     return Box(60, 40, 20) - Cylinder(4, 40) - Pos(0, 0, 6) * Cylinder(7, 8)
 
 
-def _sheet(*, note: bool, satisfies: tuple[str, ...] = ()) -> Sheet:
+def _sheet(*, note: bool, satisfies: tuple[DimensionParameterId, ...] = ()) -> Sheet:
     sheet = Sheet.from_part(_part(), page="A3").take_over(
         dimensions="authored",
         principal_views="automatic",
@@ -52,10 +57,10 @@ def _counterbore_states(drawing) -> dict[str, str]:
     return {
         outcome.parameter_id: outcome.state
         for outcome in hole_requirement_outcomes(
-            drawing._build.recognition,  # acceptance checks the public drawing's run inventory
+            drawing.recognition(),
             drawing.model().features,
             drawing.registry,
-            drawing._build.omissions,
+            compile_dimensions(drawing.model()).diagnostics,
         )
         if outcome.parameter_id in _SATISFIES
     }
@@ -91,6 +96,9 @@ def test_structured_note_satisfies_omitted_roles_without_becoming_a_dimension():
     completeness = drawing.lint_summary()["quality"]["completeness"]
     assert completeness["satisfied_by_structured_note"] == 2
     assert completeness["audited_score"] == 1.0
+
+    drawing.remove(satisfaction_names[0])
+    assert _counterbore_states(drawing) == {parameter: "suppressed" for parameter in _SATISFIES}
 
 
 @pytest.mark.parametrize("with_note", [False, True])
@@ -132,6 +140,17 @@ def test_invalid_or_ambiguous_satisfaction_claims_fail_before_mutating_the_sheet
     assert tuple(sheet.features) == before
 
 
+def test_synthesised_location_claim_uses_planner_owned_eligibility():
+    sheet = _sheet(note=False)
+    envelope = sheet.envelope()
+    before = tuple(sheet.features)
+
+    with pytest.raises(ValueError, match="no planned location measurement"):
+        envelope.note("LOCATED", satisfies=("location",))
+
+    assert tuple(sheet.features) == before
+
+
 def test_structured_note_round_trips_through_generated_sheet_source():
     sheet = _sheet(note=True, satisfies=_SATISFIES)
     source = emit_sheet_script(
@@ -155,6 +174,299 @@ def test_structured_note_round_trips_through_generated_sheet_source():
     note = next(feature for feature in regenerated.features if feature.kind == "note")
     assert note.satisfies == _SATISFIES
     assert note.origin in regenerated.features
+    assert _counterbore_states(regenerated.build()) == {
+        parameter: "satisfied_by_structured_note" for parameter in _SATISFIES
+    }
+
+
+def test_structured_note_round_trip_survives_identity_preserving_feature_reorder():
+    sheet = _sheet(note=True, satisfies=_SATISFIES)
+    sheet.features.reverse()
+    drawing = sheet.build()
+    source = emit_sheet_script(
+        drawing.model(), "part", "structured-note-reordered", title="T", number="N", page="A3"
+    )
+
+    namespace = {"part": _part()}
+    body = source.replace("\npart\n", "\n", 1)
+    exec(  # noqa: S102 - exercise the generated public Sheet source
+        compile(body[: body.index("drawing = sheet.build()")], "<structured-note>", "exec"),
+        namespace,
+    )
+    regenerated = namespace["sheet"]
+    note = next(feature for feature in regenerated.features if feature.kind == "note")
+    assert note.satisfies == _SATISFIES
+    assert note.origin in regenerated.features
+    assert not any(name.startswith("note") for name in namespace)
+
+
+def test_structured_authority_requires_a_feature_owned_by_the_sheet():
+    sheet = _sheet(note=False)
+    owned = next(feature for feature in sheet.features if feature.kind == "hole")
+    external_equal_clone = replace(owned)
+    before = tuple(sheet.features)
+
+    with pytest.raises(ValueError, match="managed by this Sheet"):
+        sheet.note("EXTERNAL", external_equal_clone, satisfies=("bore.diameter",))
+    assert tuple(sheet.features) == before
+
+    structured = declare_note("EXTERNAL", external_equal_clone, satisfies=("bore.diameter",))
+    with pytest.raises(ValueError, match="managed by this Sheet"):
+        sheet.add(structured)
+    assert tuple(sheet.features) == before
+
+    with pytest.raises(ValueError, match="identical feature in PartModel.features"):
+        PartModel(
+            bbox=_part().bounding_box(),
+            orientation=None,
+            features=[structured],
+            authored_dimensions=(),
+        )
+
+    managed = declare_note("MANAGED", owned, satisfies=("bore.diameter",))
+    mutable_model = PartModel(
+        bbox=_part().bounding_box(),
+        orientation=None,
+        features=[owned, managed],
+        authored_dimensions=(),
+    )
+    mutable_model.features.remove(owned)
+    with pytest.raises(ValueError, match="identical feature in PartModel.features"):
+        compile_dimensions(mutable_model)
+
+
+def test_unplaced_structured_note_grants_no_coverage_authority():
+    sheet = _sheet(note=False)
+    owned = next(feature for feature in sheet.features if feature.kind == "hole" and feature.cbore)
+    invalid_target = replace(
+        declare_note("PROFILED BORE", owned, satisfies=_SATISFIES),
+        view="not-a-view",
+    )
+    sheet.add(invalid_target)
+    drawing = sheet.build()
+
+    assert any(issue.code == "gdt_dropped" for issue in drawing.lint())
+    assert not any(drawing.registry.satisfaction_of(name) for name in drawing.registry.names())
+    assert _counterbore_states(drawing) == {parameter: "suppressed" for parameter in _SATISFIES}
+
+
+def test_diameter_claim_does_not_inherit_synthetic_through_or_group_count_authority():
+    part = Box(60, 40, 20) - Cylinder(3, 40)
+    sheet = Sheet.from_part(part).take_over(
+        dimensions="authored", principal_views="automatic", derived_views="authored"
+    )
+    hole = next(feature for feature in sheet.features if feature.kind == "hole")
+    sheet.of(hole).note("DIAMETER 6 ONLY", satisfies=("bore.diameter",))
+    drawing = sheet.build()
+    drawing.lint()
+    states = {
+        outcome.parameter_id: outcome.state
+        for outcome in hole_requirement_outcomes(
+            drawing.recognition(),
+            drawing.model().features,
+            drawing.registry,
+            compile_dimensions(drawing.model()).diagnostics,
+        )
+    }
+    assert states["bore.diameter"] == "satisfied_by_structured_note"
+    assert states["bore.through"] == "suppressed"
+
+    grouped_part = (
+        Box(80, 50, 20) - Pos(-15, 0, 0) * Cylinder(3, 40) - Pos(15, 0, 0) * Cylinder(3, 40)
+    )
+    grouped = Sheet.from_part(grouped_part).take_over(
+        dimensions="authored", principal_views="automatic", derived_views="authored"
+    )
+    grouped_hole = next(feature for feature in grouped.features if feature.kind == "hole")
+    grouped.of(grouped_hole).note("DIAMETER 6 ONLY", satisfies=("bore.diameter",))
+    grouped_drawing = grouped.build()
+    grouped_drawing.lint()
+    grouped_states = {
+        outcome.parameter_id: outcome.state
+        for outcome in hole_requirement_outcomes(
+            grouped_drawing.recognition(),
+            grouped_drawing.model().features,
+            grouped_drawing.registry,
+            compile_dimensions(grouped_drawing.model()).diagnostics,
+        )
+    }
+    assert grouped_states["grouping.count"] == "suppressed"
+
+
+def test_duplicate_notes_do_not_multiply_one_requirement_identity_into_physical_count():
+    part = Box(80, 50, 20) - Pos(-15, 0, 0) * Cylinder(3, 40) - Pos(15, 0, 10) * Cylinder(3, 8)
+    sheet = Sheet.from_part(part).take_over(
+        dimensions="authored", principal_views="automatic", derived_views="authored"
+    )
+    through = next(
+        feature for feature in sheet.features if feature.kind == "hole" and feature.through
+    )
+    sheet.note("DIAMETER 6", through, satisfies=("bore.diameter",))
+    sheet.note("INSPECT DIAMETER 6", through, satisfies=("bore.diameter",))
+    drawing = sheet.build()
+
+    mismatch = [issue for issue in drawing.lint() if issue.code == "feature_count_mismatch"]
+    assert len(mismatch) == 1
+    assert "account for 1" in mismatch[0].message
+
+
+def test_location_is_a_valid_synthesised_role_and_satisfies_both_required_axes():
+    part = Box(60, 40, 20) - Pos(12, 7, 0) * Cylinder(3, 40)
+    sheet = Sheet.from_part(part).take_over(
+        dimensions="authored", principal_views="automatic", derived_views="authored"
+    )
+    hole = next(feature for feature in sheet.features if feature.kind == "hole")
+    handle = sheet.of(hole)
+    assert "location" in handle.dimension_ids()
+    handle.note("HOLE CENTRE X12 Y7", satisfies=("location",))
+    drawing = sheet.build()
+    issues = drawing.lint()
+
+    outcomes = hole_requirement_outcomes(
+        drawing.recognition(),
+        drawing.model().features,
+        drawing.registry,
+        compile_dimensions(drawing.model()).diagnostics,
+    )
+    location_states = {
+        outcome.state for outcome in outcomes if outcome.parameter_id.startswith("location.")
+    }
+    assert location_states == {"satisfied_by_structured_note"}
+    assert not any(issue.code == "feature_not_located" for issue in issues)
+
+
+@pytest.mark.parametrize(
+    ("kind", "part", "missing_code"),
+    [
+        ("pocket", Box(60, 50, 40) - Pos(20, 8, 5) * Box(20, 16, 18), "pocket_not_located"),
+        (
+            "pad",
+            Box(60, 50, 10) + Pos(15, 8, 10) * Box(20, 16, 10),
+            "pad_footprint_not_defined",
+        ),
+    ],
+)
+def test_prismatic_location_authority_joins_the_exact_physical_feature(kind, part, missing_code):
+    sheet = Sheet.from_part(part).take_over(
+        dimensions="authored", principal_views="automatic", derived_views="authored"
+    )
+    feature = next(item for item in sheet.features if item.kind == kind)
+    for parameter in feature.parameters():
+        sheet.dimension(feature, parameter.parameter_id)
+    sheet.note("LOCATED BY AUTHORED COORDINATES", feature, satisfies=("location",))
+    drawing = sheet.build()
+
+    assert not any(issue.code == missing_code for issue in drawing.lint())
+    note_name = next(
+        name for name in drawing.registry.names() if drawing.registry.satisfaction_of(name)
+    )
+    drawing.remove(note_name)
+    assert any(issue.code == missing_code for issue in drawing.lint())
+
+
+def test_pocket_pattern_location_authority_stays_on_the_pattern_owner():
+    part = Box(100, 60, 30) - Pos(-20, 5, 10) * Box(15, 10, 15) - Pos(20, 5, 10) * Box(15, 10, 15)
+    sheet = Sheet(part)
+    member = pocket(
+        width=10,
+        length=15,
+        depth=12.5,
+        long_axis="x",
+        width_axis="y",
+        depth_axis="z",
+        lo=-7.5,
+        hi=7.5,
+        w_center=5,
+        at=(0, 5, 8.75),
+    )
+    pattern = sheet.pocket_pattern(member, kind="linear", count=2, pitch=40, direction=(1, 0, 0))
+    for parameter_id in pattern.dimension_ids():
+        if parameter_id != "location":
+            sheet.dimension(pattern, cast(DimensionParameterId, parameter_id))
+    pattern.note("POCKET ARRAY LOCATED X/Y", satisfies=("location",))
+    drawing = sheet.build()
+
+    assert not any(issue.code == "pocket_not_located" for issue in drawing.lint())
+    note_name = next(
+        name for name in drawing.registry.names() if drawing.registry.satisfaction_of(name)
+    )
+    drawing.remove(note_name)
+    assert any(issue.code == "pocket_not_located" for issue in drawing.lint())
+
+
+def test_boss_height_coverage_accepts_exact_structured_authority():
+    boss_solid = Pos(0, 0, 24) * Cylinder(7, 10)
+    part = Box(90, 64, 38) + boss_solid
+    sheet = Sheet(part)
+    boss = sheet.boss(boss_solid)
+    sheet.dimension(sheet.envelope(), "width.length")
+    boss.note("BOSS PROJECTS 10", satisfies=("boss_height.length",))
+    drawing = sheet.build()
+
+    assert not any(issue.code == "boss_height_missing" for issue in drawing.lint())
+
+
+def test_axial_step_note_joins_the_exact_recognised_span():
+    part = Cylinder(15, 30) + Pos(0, 0, 30) * Cylinder(8, 30)
+    sheet = Sheet.from_part(part).take_over(
+        dimensions="authored", principal_views="automatic", derived_views="authored"
+    )
+    for step in [feature for feature in sheet.features if feature.kind == "step"]:
+        sheet.note("AXIAL SEGMENT", step, satisfies=("step.length",))
+    drawing = sheet.build()
+
+    assert not any(issue.code == "axial_length_missing" for issue in drawing.lint())
+    note_name = next(
+        name for name in drawing.registry.names() if drawing.registry.satisfaction_of(name)
+    )
+    drawing.remove(note_name)
+    assert any(issue.code == "axial_length_missing" for issue in drawing.lint())
+
+
+def test_groove_length_authority_requires_exact_physical_band_correspondence():
+    part = Cylinder(10, 40) - (Cylinder(10, 4) - Cylinder(8, 4))
+
+    def drawing_with_groove(*, wrong_axis: bool):
+        sheet = Sheet.from_part(part).take_over(
+            dimensions="authored", principal_views="automatic", derived_views="authored"
+        )
+        step = next(feature for feature in sheet.features if feature.kind == "step")
+        sheet.note("ONE AXIAL SEGMENT", step, satisfies=("step.length",))
+        if wrong_axis:
+            groove = sheet.groove(axis="x", width=4, diameter=16, at=(0, 0, 0))
+            groove.note("4 WIDE GROOVE", satisfies=("groove.length",))
+        else:
+            physical = next(feature for feature in sheet.features if feature.kind == "groove")
+            sheet.note("4 WIDE GROOVE", physical, satisfies=("groove.length",))
+        return sheet.build()
+
+    exact = drawing_with_groove(wrong_axis=False)
+    assert not any(issue.code == "axial_length_missing" for issue in exact.lint())
+
+    unrelated = drawing_with_groove(wrong_axis=True)
+    assert any(issue.code == "axial_length_missing" for issue in unrelated.lint())
+
+
+def test_compound_profiled_bore_note_covers_both_exact_profile_requirements():
+    center = (Align.CENTER, Align.CENTER, Align.CENTER)
+    cutter = Cylinder(5, 20, align=center) & Box(7.2, 20, 30, align=center)
+    part = Box(30, 30, 10, align=center) - cutter
+    sheet = Sheet.from_part(part).take_over(
+        dimensions="authored", principal_views="automatic", derived_views="authored"
+    )
+    bore = next(feature for feature in sheet.features if feature.kind == "hole")
+    sheet.of(bore).note(
+        "DOUBLE-D 10 MAJOR × 7.2 A/F THRU",
+        satisfies=("bore.diameter", "profile_across_flats.length"),
+    )
+    drawing = sheet.build()
+
+    assert not any(issue.code == "profiled_bore_not_dimensioned" for issue in drawing.lint())
+    note_name = next(
+        name for name in drawing.registry.names() if drawing.registry.satisfaction_of(name)
+    )
+    drawing.remove(note_name)
+    assert any(issue.code == "profiled_bore_not_dimensioned" for issue in drawing.lint())
 
 
 def test_structured_note_authority_is_shared_by_non_hole_requirement_ledgers():

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -154,7 +154,14 @@ def test_identity_of_reapply_round_trips_every_axis():
     # exactly the tool this identity exists to feed (#1002, Codex r2).
     r = AnnotationRegistry()
     obj, feat = object(), object()
-    r.add(obj, "d1", "front", feature=feat, measurement=("bore.depth",))
+    r.add(
+        obj,
+        "d1",
+        "front",
+        feature=feat,
+        measurement=("bore.depth",),
+        satisfaction=("counterbore.depth",),
+    )
     r.pin("d1")
     ident = r.identity_of("d1")
 
@@ -163,6 +170,7 @@ def test_identity_of_reapply_round_trips_every_axis():
         "view": None,
         "feature": None,
         "measurement": (),
+        "satisfaction": (),
         "pinned": False,
     }
 
@@ -171,6 +179,7 @@ def test_identity_of_reapply_round_trips_every_axis():
     assert r.view_of("d1") == "front"
     assert r.feature_of("d1") is feat
     assert r.measurement_of("d1") == ("bore.depth",)
+    assert r.satisfaction_of("d1") == ("counterbore.depth",)
     assert r.is_pinned("d1")
 
 
@@ -178,12 +187,20 @@ def test_reapply_clears_axes_the_identity_does_not_carry():
     # Authoritative, not additive: a restore must never leave the name wearing metadata
     # from whatever briefly held the slot.
     r = AnnotationRegistry()
-    r.add(object(), "d1", "plan", feature=object(), measurement=("width.length",))
+    r.add(
+        object(),
+        "d1",
+        "plan",
+        feature=object(),
+        measurement=("width.length",),
+        satisfaction=("height.length",),
+    )
     r.pin("d1")
     r.reapply("d1", {"view": "front", "feature": None, "measurement": (), "pinned": False})
     assert r.view_of("d1") == "front"
     assert r.feature_of("d1") is None
     assert r.measurement_of("d1") == ()
+    assert r.satisfaction_of("d1") == ()
     assert not r.is_pinned("d1")
 
 


### PR DESCRIPTION
## Summary

- add explicit `satisfies=(...)` authority to feature-linked manufacturing notes
- record placed structured-note authority separately from drawn measurement provenance
- reconcile exact roles against recognition-owned physical owners/sites across hole, slot, flat, channel, polygonal-stock, prismatic, axial, boss-height, location, and profiled-bore coverage
- preserve Sheet-script round trips, mutable-IR validation, placement/drop transactionality, and legacy registry-shaped consumers

## Safety properties

- prose alone never grants coverage
- unplaced or removed notes grant no authority
- invalid roles, external feature clones, stale physical sites, and non-locatable `location` claims fail closed
- one owner cannot be counted twice through a callout plus a note
- a placed or dropped annotation for one feature cannot certify an identical sibling

## Verification

- independent correctness and API/round-trip review iterated until only nits remained
- `scripts/pr-check --full`: 4,971 passed, 5 skipped, 2 xfailed
- total coverage 95.22%; diff coverage 95%
- Ruff, formatting, mypy, documentation build, audit ratchets, emitter execution/round-trip, and transactional snapshot tests pass

No recognizer change is required; this consumes the existing run-owned recognition inventory.

Closes #1351
