### PR TITLE
Make manufacturing PDF text searchable

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -29,7 +29,18 @@ if TYPE_CHECKING:
 
     from draftwright.compose import StripDepths
 
-from build123d import Align, BoundBox, Compound, Edge, Location, Mode, Shape, Text, Vector
+from build123d import (
+    Align,
+    BoundBox,
+    Compound,
+    Edge,
+    FontStyle,
+    Location,
+    Mode,
+    Shape,
+    Text,
+    Vector,
+)
 from build123d_drafting.helpers import (
     Dimension,
     TitleBlock,
@@ -373,6 +384,7 @@ def _text_size(
     font_size: float,
     font_path: str | None = PLEX_MONO,
     font: str = "Arial",
+    font_style: FontStyle = FontStyle.REGULAR,
 ) -> tuple[float, float]:
     """Measured rendered (width, height) (page-mm) of *text* at *font_size*.
 
@@ -394,10 +406,41 @@ def _text_size(
         font_size=font_size,
         font=font,
         font_path=font_path,
+        font_style=font_style,
         align=(Align.CENTER, Align.CENTER),
         mode=Mode.PRIVATE,
     ).bounding_box()
     return (bb.size.X, bb.size.Y)
+
+
+@functools.lru_cache(maxsize=32)
+def _text_line_spacing_em(
+    font_size: float,
+    font_path: str | None = PLEX_MONO,
+    font: str = "Arial",
+) -> float:
+    """Return OCCT's actual newline advance for a regular face, in em units.
+
+    The advance is face-dependent (Plex Mono is 1.3 em; named Arial on macOS is
+    about 1.15 em).  Measure the same repeated glyph twice through build123d so
+    the invisible PDF layer follows the renderer instead of baking either value.
+    """
+    probe = Text(
+        txt="A\nA",
+        font_size=font_size,
+        font=font,
+        font_path=font_path,
+        font_style=FontStyle.REGULAR,
+        align=(Align.CENTER, Align.CENTER),
+        mode=Mode.PRIVATE,
+    )
+    centres = sorted(
+        ((face.bounding_box().min.Y + face.bounding_box().max.Y) / 2.0 for face in probe.faces()),
+        reverse=True,
+    )
+    if len(centres) < 2:  # pragma: no cover - defensive for a pathological font
+        return 1.3
+    return abs(centres[0] - centres[-1]) / font_size
 
 
 def _text_width(text: str, font_size: float, font_path: str = PLEX_MONO) -> float:

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -1218,16 +1218,25 @@ def _make_title_block(dwg, a: Analysis):
     drawn-by cell bbox (for the hyperlink rect). Shared by :func:`_add_title_block` (which adds
     it, last) and :func:`_title_block_box` (which measures its footprint for GD&T avoidance, #481)
     so the two never drift."""
+    title = _font_safe_text(a.title)
+    number = _font_safe_text(a.number)
+    tolerance = _font_safe_text(a.tolerance)
+    designed_by = _font_safe_text(_attribution_author(a.drawn_by))
+    material = _font_safe_text(a.material)
+    date = _font_safe_text(a.date)
+    revision = _font_safe_text(a.revision)
+    legal_owner = _font_safe_text(a.company)
+    scale = format_drawing_scale(a.SCALE)
     tb = TitleBlock(
-        _font_safe_text(a.title),
-        _font_safe_text(a.number),
-        scale=format_drawing_scale(a.SCALE),
-        general_tolerance=_font_safe_text(a.tolerance),
-        designed_by=_font_safe_text(_attribution_author(a.drawn_by)),
-        material=_font_safe_text(a.material),
-        date=_font_safe_text(a.date),
-        revision=_font_safe_text(a.revision),
-        legal_owner=_font_safe_text(a.company),
+        title,
+        number,
+        scale=scale,
+        general_tolerance=tolerance,
+        designed_by=designed_by,
+        material=material,
+        date=date,
+        revision=revision,
+        legal_owner=legal_owner,
         width=a.TB_W,
         # Title block renders in condensed sans (the tight ISO 7200 cells), a
         # different face from the monospace dimensions — so it carries its own
@@ -1242,7 +1251,37 @@ def _make_title_block(dwg, a: Analysis):
     # than hardcoded column fractions, so the hyperlink rect tracks any upstream
     # TitleBlock layout change. Build-frame bbox; translated to page space below.
     cell = tb.drawn_by_cell_bbox()
-    tb = tb.locate(Location((a.PAGE_W - a.TB_W - _TB_CLEAR, _TB_CLEAR, 0)))
+    bx, by = a.PAGE_W - a.TB_W - _TB_CLEAR, _TB_CLEAR
+    tb = tb.locate(Location((bx, by, 0)))
+
+    # Retain authoritative title-block values at their public cell centres for the PDF semantic
+    # text layer.  The visible block stays path-rendered; these specs merely let export embed the
+    # same bundled condensed face as invisible selectable text without parsing SVG geometry.
+    fields = (
+        ("title", title),
+        ("drawing_number", number),
+        ("scale", scale),
+        ("material", material),
+        ("revision", revision or date),
+        ("general_tolerance", tolerance),
+        ("designed_by", designed_by),
+        ("legal_owner", legal_owner),
+    )
+    specs = []
+    for field, value in fields:
+        if not value:
+            continue
+        box = tb.cell_bbox(field)
+        specs.append(
+            (
+                value,
+                bx + (box["min_x"] + box["max_x"]) / 2.0,
+                by + (box["min_y"] + box["max_y"]) / 2.0,
+                dwg.draft.font_size,
+                PLEX_SANS_CONDENSED,
+            )
+        )
+    tb.pdf_text_specs = tuple(specs)
     return tb, cell
 
 

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -174,6 +174,53 @@ def callout_from_spec(spec, draft, count) -> HoleCallout | None:
         suffix=suffix,
         draft=draft,
     )
+    # Retain token-level text positions from the exact layout recipe used by
+    # ``HoleCallout``.  Whole-label centring is not equivalent for compound callouts:
+    # vector symbols consume fixed-width cells while text tokens use font metrics.
+    h = draft.font_size
+    gap = 0.45 * h
+    sym_w = h
+    visible_tokens: list[tuple[str, str]] = []
+    if count:
+        visible_tokens.append(("text", f"{count}×"))
+    visible_tokens.extend((("sym", "diameter"), ("text", dia)))
+    if spec["through"]:
+        visible_tokens.append(("text", "THRU"))
+    elif depth is not None:
+        visible_tokens.extend((("sym", "depth"), ("text", depth)))
+    if cbore_dia is not None:
+        visible_tokens.extend((("sym", "counterbore"), ("sym", "diameter"), ("text", cbore_dia)))
+        if cbore_depth is not None:
+            visible_tokens.extend((("sym", "depth"), ("text", cbore_depth)))
+    if csink_dia is not None:
+        visible_tokens.extend((("sym", "countersink"), ("sym", "diameter"), ("text", csink_dia)))
+        if csink_angle is not None:
+            visible_tokens.append(("text", f"× {csink_angle}°"))
+    if suffix:
+        visible_tokens.append(("text", suffix))
+
+    font_path = getattr(draft, "font_path", DEFAULT_FONT_PATH)
+    font_name = getattr(draft, "font", "Arial")
+    x = 0.0
+    token_specs: list[tuple[str, float, float, float, str | None, str, str, str]] = []
+    for kind, value in visible_tokens:
+        if kind == "sym":
+            # Diameter has a faithful Unicode compatibility glyph.  The remaining
+            # manufacturing symbols stay vector-only, as permitted by #1352.
+            if value == "diameter":
+                token_specs.append(
+                    ("ø", x + sym_w / 2.0, 0.0, h, font_path, font_name, "center", "middle")
+                )
+            x += sym_w + gap
+        else:
+            token_specs.append((value, x, 0.0, h, font_path, font_name, "left", "middle"))
+            x += _text_size(value, h, font_path, font_name)[0] + gap
+    cb = callout.bounding_box()
+    ccx, ccy = (cb.min.X + cb.max.X) / 2.0, (cb.min.Y + cb.max.Y) / 2.0
+    callout.pdf_text_relative_specs = tuple(
+        (value, px - ccx, py - ccy, size, path, name, h_align, v_align)
+        for value, px, py, size, path, name, h_align, v_align in token_specs
+    )
     # ``HoleCallout`` renders ISO symbols as geometry and consequently exposes an empty
     # helper-level label. Preserve an equivalent semantic string at this sole construction
     # seam so critique, audit and downstream tooling can identify what the geometry says.
@@ -5780,7 +5827,7 @@ def render_gdt(dwg, model, a, *, ctx) -> int:
                     pos if abs(dx) >= _MIN_LEADER else _px + math.copysign(_MIN_LEADER, dx or 1.0)
                 )
                 elbow = (pos, _py)
-            return Leader(
+            leader = Leader(
                 tip=tip,
                 elbow=elbow,
                 label="",
@@ -5789,6 +5836,13 @@ def render_gdt(dwg, model, a, *, ctx) -> int:
                 all_around=getattr(_it, "all_around", False),
                 all_over=getattr(_it, "all_over", False),
             )
+            if _it.kind == "note":
+                # The outer leader intentionally has label="" because the visible
+                # payload is a TextBlock callout.  Preserve the authored note and the
+                # TextBlock's 1.6-em line pitch for the semantic PDF layer.
+                leader.pdf_text = _font_safe_text(_it.text)
+                leader.pdf_text_line_spacing = 1.6
+            return leader
 
         def _drop(
             nm,

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -58,6 +58,7 @@ from draftwright._core import (
     _legible_locations,
     _log,
     _solve_strip_ys,
+    _text_line_spacing_em,
     _text_size,
     _title_block_box,
     _tol_suffix,
@@ -202,24 +203,36 @@ def callout_from_spec(spec, draft, count) -> HoleCallout | None:
     font_path = getattr(draft, "font_path", DEFAULT_FONT_PATH)
     font_name = getattr(draft, "font", "Arial")
     x = 0.0
-    token_specs: list[tuple[str, float, float, float, str | None, str, str, str]] = []
+    token_specs: list[tuple[str, float, float, float, str | None, str, str, str, str]] = []
     for kind, value in visible_tokens:
         if kind == "sym":
             # Diameter has a faithful Unicode compatibility glyph.  The remaining
             # manufacturing symbols stay vector-only, as permitted by #1352.
             if value == "diameter":
                 token_specs.append(
-                    ("ø", x + sym_w / 2.0, 0.0, h, font_path, font_name, "center", "middle")
+                    (
+                        "ø",
+                        x + sym_w / 2.0,
+                        0.0,
+                        h,
+                        font_path,
+                        font_name,
+                        "REGULAR",
+                        "center",
+                        "middle",
+                    )
                 )
             x += sym_w + gap
         else:
-            token_specs.append((value, x, 0.0, h, font_path, font_name, "left", "middle"))
+            token_specs.append(
+                (value, x, 0.0, h, font_path, font_name, "REGULAR", "left", "middle")
+            )
             x += _text_size(value, h, font_path, font_name)[0] + gap
     cb = callout.bounding_box()
     ccx, ccy = (cb.min.X + cb.max.X) / 2.0, (cb.min.Y + cb.max.Y) / 2.0
     callout.pdf_text_relative_specs = tuple(
-        (value, px - ccx, py - ccy, size, path, name, h_align, v_align)
-        for value, px, py, size, path, name, h_align, v_align in token_specs
+        (value, px - ccx, py - ccy, size, path, name, style, h_align, v_align)
+        for value, px, py, size, path, name, style, h_align, v_align in token_specs
     )
     # ``HoleCallout`` renders ISO symbols as geometry and consequently exposes an empty
     # helper-level label. Preserve an equivalent semantic string at this sole construction
@@ -5726,6 +5739,77 @@ def _gdt_glyph(item, draft):
     return SurfaceFinish(item.ra, position=(0.0, 0.0), draft=draft)
 
 
+def _gdt_pdf_text_specs(glyph, item, draft) -> tuple:
+    """Token-level semantic text in coordinates relative to *glyph*'s centre.
+
+    GD&T characteristic/diameter/material-condition rings and surface-finish marks remain
+    vector geometry. Their adjacent values and datum letters use the exact cell anchors from
+    the helper renderer so selection aligns without treating the whole compound glyph as one
+    centred string.
+    """
+    box = glyph.bounding_box()
+    gcx, gcy = (box.min.X + box.max.X) / 2.0, (box.min.Y + box.max.Y) / 2.0
+    h = draft.font_size
+    font_path = getattr(draft, "font_path", DEFAULT_FONT_PATH)
+    font_name = getattr(draft, "font", "Arial")
+    specs = []
+
+    def add(value, x, y, size=h, *, h_align="center"):
+        specs.append(
+            (
+                _font_safe_text(value),
+                x - gcx,
+                y - gcy,
+                size,
+                font_path,
+                font_name,
+                "REGULAR",
+                h_align,
+                "middle",
+            )
+        )
+
+    if item.kind == "datum_ref":
+        x0, y0, x1, y1 = glyph.label_bbox
+        add(glyph.label, (x0 + x1) / 2.0, (y0 + y1) / 2.0)
+        return tuple(specs)
+    if item.kind == "finish":
+        x0, y0, x1, y1 = glyph.label_bbox
+        add(glyph.label, (x0 + x1) / 2.0, (y0 + y1) / 2.0)
+        return tuple(specs)
+    if item.kind != "control_frame":
+        return ()
+
+    # Mirror helpers._gdt_tol_cell / _gdt_datum_cell. The renderer deliberately
+    # uses regular text even when the surrounding Draft requests another style.
+    H = 2.0 * h
+    pad, diameter_radius, modifier_radius = 0.6 * h, 0.42 * h, 0.62 * h
+    x = H + pad
+    if item.diameter:
+        diameter_cx = x + diameter_radius
+        add("ø", diameter_cx, H / 2.0)
+        x = diameter_cx + diameter_radius + pad
+    tolerance_width = _text_size(item.tolerance, h, font_path, font_name)[0]
+    tolerance_cx = x + tolerance_width / 2.0
+    add(item.tolerance, tolerance_cx, H / 2.0)
+    x = tolerance_cx + tolerance_width / 2.0 + pad
+    if item.modifier:
+        modifier_cx = x + modifier_radius
+        add(item.modifier.upper(), modifier_cx, H / 2.0, size=0.8 * h)
+
+    tolerance_cell_width = (
+        pad
+        + tolerance_width
+        + pad
+        + (2.0 * diameter_radius + pad if item.diameter else 0.0)
+        + (2.0 * modifier_radius + pad if item.modifier else 0.0)
+    )
+    datum_start = H + tolerance_cell_width
+    for index, letter in enumerate(item.datums):
+        add(letter, datum_start + (index + 0.5) * H, H / 2.0)
+    return tuple(specs)
+
+
 def render_gdt(dwg, model, a, *, ctx) -> int:
     """Place declared GD&T frames / datum symbols / surface finishes (#61) as first-class
     ADR 0009 corridor candidates — registered into the SAME strip the feature's dimensions
@@ -5838,10 +5922,17 @@ def render_gdt(dwg, model, a, *, ctx) -> int:
             )
             if _it.kind == "note":
                 # The outer leader intentionally has label="" because the visible
-                # payload is a TextBlock callout.  Preserve the authored note and the
-                # TextBlock's 1.6-em line pitch for the semantic PDF layer.
+                # payload is a TextBlock callout. Preserve the authored note and measure
+                # the embedded Text renderer's face-dependent newline pitch for PDF.
                 leader.pdf_text = _font_safe_text(_it.text)
-                leader.pdf_text_line_spacing = 1.6
+                leader.pdf_text_font_style = "REGULAR"
+                leader.pdf_text_line_spacing = _text_line_spacing_em(
+                    draft.font_size,
+                    getattr(draft, "font_path", DEFAULT_FONT_PATH),
+                    getattr(draft, "font", "Arial"),
+                )
+            else:
+                leader.pdf_text_relative_specs = _gdt_pdf_text_specs(g, _it, draft)
             return leader
 
         def _drop(

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -101,6 +101,7 @@ def _profiled_callout_leader(*, callout, **kw):
         )
     leader = Leader(callout=callout, **kw)
     leader.label = semantic_label
+    leader.pdf_text_relative_specs = tuple(getattr(callout, "pdf_text_relative_specs", ()))
     leader.covers_profiles = getattr(callout, "covers_profiles", ())
     leader.covers_hole_requirements = getattr(callout, "covers_hole_requirements", ())
     leader.source_ids = tuple(getattr(callout, "source_ids", ()))

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -3816,6 +3816,62 @@ class Drawing:
                             source_face_options, key=lambda item: item[0]
                         )
                         if len(source_faces) == 1:
+                            source_vertices = source_faces[0].vertices()
+                            target_vertices = glyph_faces[0].vertices()
+                            if (
+                                len(source_vertices) == len(target_vertices)
+                                and len(source_vertices) > 1
+                            ):
+                                source_points = [(point.X, point.Y) for point in source_vertices]
+                                target_points = [(point.X, point.Y) for point in target_vertices]
+                                source_mean = (
+                                    sum(point[0] for point in source_points) / len(source_points),
+                                    sum(point[1] for point in source_points) / len(source_points),
+                                )
+                                target_mean = (
+                                    sum(point[0] for point in target_points) / len(target_points),
+                                    sum(point[1] for point in target_points) / len(target_points),
+                                )
+                                dot = cross = source_norm = target_norm = 0.0
+                                for source, target in zip(
+                                    source_points, target_points, strict=True
+                                ):
+                                    sx, sy = (
+                                        source[0] - source_mean[0],
+                                        source[1] - source_mean[1],
+                                    )
+                                    tx, ty = (
+                                        target[0] - target_mean[0],
+                                        target[1] - target_mean[1],
+                                    )
+                                    dot += sx * tx + sy * ty
+                                    cross += sx * ty - sy * tx
+                                    source_norm += sx * sx + sy * sy
+                                    target_norm += tx * tx + ty * ty
+                                if source_norm > 1e-12 and target_norm > 1e-12:
+                                    angle = math.atan2(cross, dot)
+                                    scale = math.sqrt(target_norm / source_norm)
+                                    cos_angle, sin_angle = math.cos(angle), math.sin(angle)
+                                    error = 0.0
+                                    for source, target in zip(
+                                        source_points, target_points, strict=True
+                                    ):
+                                        sx, sy = (
+                                            source[0] - source_mean[0],
+                                            source[1] - source_mean[1],
+                                        )
+                                        predicted = (
+                                            target_mean[0]
+                                            + scale * (cos_angle * sx - sin_angle * sy),
+                                            target_mean[1]
+                                            + scale * (sin_angle * sx + cos_angle * sy),
+                                        )
+                                        error += math.dist(predicted, target) ** 2
+                                    if error / target_norm < 1e-12:
+                                        shape_matches.append(
+                                            (error, candidate, math.degrees(angle))
+                                        )
+                                        continue
 
                             def line_directions(face):
                                 directions = []

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -73,6 +73,7 @@ from draftwright.export import (
     set_dxf_metadata,
     write_dxf,
 )
+from draftwright.fonts import PLEX_MONO
 from draftwright.intents import Intent
 from draftwright.layout import FitBoxTrace, fit_box
 from draftwright.linting import (
@@ -113,6 +114,8 @@ from draftwright.projection import (
 from draftwright.recognition_cache import RecognitionCache
 from draftwright.registry import AnnotationRegistry
 from draftwright.repair import repair_drawing
+
+_PDF_VECTOR_ONLY_TEXT = str.maketrans("⌴⌵↧", "   ")
 
 # Codes that check standards/geometry correctness rather than pure page
 # layout. Grouped so a caller (and the #30 repair loop) can tell a wrong
@@ -3626,14 +3629,61 @@ class Drawing:
     def _pdf_text_runs(self):
         """Return semantic text overlaid on path-rendered PDF glyphs.
 
-        Scope is deliberately limited to text whose authoritative source and
-        final page geometry are both retained: unrotated free notes and generic tables.
-        Other annotations remain path-only until their renderers expose the
-        same information without reverse-engineering exported geometry.
+        The visible glyphs remain paths.  Dimensions, leaders and notes expose
+        their authoritative label plus final label geometry; tables retain their
+        source rows; the title block retains public-cell-centred value specs.
+        Unsupported feature symbols stay path-only while adjacent text remains
+        selectable, rather than forcing the complete callout back to outlines.
         """
         groups = []
         fs = self.draft.font_size
         pad = self.draft.pad_around_text
+        mono = getattr(self.draft, "font_path", None) or PLEX_MONO
+
+        def semantic_text(value) -> str:
+            # The bundled faces do not carry the geometric counterbore,
+            # countersink or depth glyphs.  They remain visibly rendered by the
+            # existing vector callout; spaces keep the neighbouring supported
+            # terms separate in copied/searchable text.
+            return _font_safe_text(value).translate(_PDF_VECTOR_ONLY_TEXT)
+
+        def text_rotation(annotation) -> float:
+            explicit = getattr(annotation, "pdf_text_rotation", None)
+            if explicit is not None:
+                return float(explicit)
+            polygon = getattr(annotation, "label_polygon", None)
+            if polygon and len(polygon) >= 2:
+                (x0, y0), (x1, y1) = polygon[:2]
+                return math.degrees(math.atan2(y1 - y0, x1 - x0))
+            return 0.0
+
+        def centred_runs(value, label_box, font_size, rotation, font_path):
+            lines = semantic_text(value).splitlines()
+            if not lines:
+                return []
+            x0, y0, x1, y1 = label_box
+            cx, cy = (x0 + x1) / 2.0, (y0 + y1) / 2.0
+            angle = math.radians(rotation)
+            sin_angle, cos_angle = math.sin(angle), math.cos(angle)
+            runs = []
+            for index, line in enumerate(lines):
+                if not line:
+                    continue
+                local_y = ((len(lines) - 1) / 2.0 - index) * font_size
+                runs.append(
+                    _PDFTextRun(
+                        line,
+                        cx - sin_angle * local_y,
+                        cy + cos_angle * local_y,
+                        font_size,
+                        rotation,
+                        font_path,
+                        "center",
+                        "middle",
+                    )
+                )
+            return runs
+
         for _name, annotation in self._registry.iter_named():
             box = annotation.bounding_box()
             rows = getattr(annotation, "table_rows", None)
@@ -3648,30 +3698,35 @@ class Drawing:
                         if cell:
                             runs.append(
                                 _PDFTextRun(
-                                    _font_safe_text(cell),
+                                    semantic_text(cell),
                                     box.min.X + lefts[ci] + pad,
                                     baseline,
                                     fs,
+                                    font_path=mono,
                                 )
                             )
+            elif specs := getattr(annotation, "pdf_text_specs", None):
+                for value, x, y, font_size, font_path in specs:
+                    runs.append(
+                        _PDFTextRun(
+                            semantic_text(value),
+                            x,
+                            y,
+                            font_size,
+                            font_path=font_path,
+                            h_align="center",
+                            v_align="middle",
+                        )
+                    )
             else:
                 value = getattr(annotation, "pdf_text", None)
-                rotation = getattr(annotation, "pdf_text_rotation", 0.0)
-                # An axis-aligned bounding box cannot recover a rotated note's
-                # original text origin. Leave those path-only until the note
-                # renderer retains its anchor/alignment transform explicitly.
-                if value and not rotation:
-                    lines = str(value).splitlines() or [str(value)]
-                    for index, line in enumerate(lines):
-                        if line:
-                            runs.append(
-                                _PDFTextRun(
-                                    line,
-                                    box.min.X,
-                                    box.max.Y - (index + 1) * fs,
-                                    fs,
-                                )
-                            )
+                if value is None:
+                    value = getattr(annotation, "label", None)
+                label_box = getattr(annotation, "label_bbox", None)
+                if value and label_box:
+                    runs.extend(
+                        centred_runs(value, label_box, fs, text_rotation(annotation), mono)
+                    )
             if runs:
                 groups.append((-box.max.Y, box.min.X, runs))
         return tuple(run for _top, _left, runs in sorted(groups) for run in runs)

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -32,10 +32,13 @@ else:
 
 from b123d_recognisers import analyse_cylinders
 from build123d import (
+    Align,
     Color,
     ExportSVG,
     LineType,
     Location,
+    Mode,
+    Text,
 )
 from build123d_drafting.helpers import DEFAULT_FONT_PATH
 
@@ -3649,6 +3652,7 @@ class Drawing:
         drawing_font_path = getattr(self.draft, "font_path", DEFAULT_FONT_PATH)
         drawing_font_name = getattr(self.draft, "font", "Arial")
         drawing_font_style = getattr(getattr(self.draft, "font_style", None), "name", "REGULAR")
+        raw_basic_matches: dict[int, tuple[str, float]] = {}
 
         def semantic_text(value) -> str:
             # The bundled faces do not carry the geometric counterbore,
@@ -3661,7 +3665,7 @@ class Drawing:
             """Possible visible labels when an external helper discarded constructor args."""
             bare_zero = draft._number_with_units(0.0, display_units=False)
             unit_zero = draft._number_with_units(0.0, display_units=True)
-            unit_suffix = unit_zero.removeprefix(bare_zero)
+            unit_suffix = unit_zero.removeprefix(bare_zero) if draft.display_units else ""
             candidates = [value, draft._number_with_units(annotation.measured_length)]
             if unit_suffix and not value.endswith(unit_suffix):
                 candidates.append(value + unit_suffix)
@@ -3670,16 +3674,17 @@ class Drawing:
             upper, minus, lower = limits.partition(" -")
             if separator and minus and prefix == bare_value:
                 # Helper compatibility metadata reverses asymmetric tuple limits relative
-                # to the visible string. This grammar is authoritative: proportional ink
-                # bounds cannot reliably break the equal-advance ordering tie.
-                return [f"{prefix} +{lower} -{upper}{unit_suffix}"]
+                # to the visible auto-generated string. Keep the authored candidate too;
+                # exact live ink bounds distinguish an explicit lookalike label.
+                candidates.insert(0, f"{prefix} +{lower} -{upper}{unit_suffix}")
             return list(dict.fromkeys(candidates))
 
         def text_rotation(annotation) -> float:
             def upright(angle: float) -> float:
-                if math.isclose(abs(angle), 90.0, abs_tol=1e-6):
+                angle = (angle + 90.0) % 180.0 - 90.0
+                if math.isclose(angle, -90.0, abs_tol=1e-6):
                     return 90.0
-                return angle if -90.0 < angle <= 90.0 else angle - math.copysign(180.0, angle)
+                return angle
 
             live_rotation = float(getattr(annotation.location.orientation, "Z", 0.0))
             explicit = getattr(annotation, "pdf_text_rotation", None)
@@ -3698,6 +3703,8 @@ class Drawing:
                         + live_rotation
                     )
             if getattr(annotation, "is_basic", False):
+                if match := raw_basic_matches.get(id(annotation)):
+                    return match[1]
                 # Raw helper geometry has already absorbed its constructor rotation; live
                 # location transforms are reflected by ``segments`` too. Match the helper's
                 # operation order: upright the pre-transform axis, then reapply both.
@@ -3734,6 +3741,8 @@ class Drawing:
                     x0, y0, x1, y1 = label_box
                     inset = 0.05 * fs
                     centres = []
+                    glyph_faces = []
+                    glyph_boxes = []
                     for face in annotation.faces():
                         face_box = face.bounding_box()
                         if (
@@ -3746,13 +3755,79 @@ class Drawing:
                         ):
                             centre = face.center()
                             centres.append((centre.X, centre.Y))
+                            glyph_faces.append(face)
+                            glyph_boxes.append(face_box)
+                    shape_matches = []
+                    for candidate in raw_dimension_candidates(
+                        annotation, getattr(annotation, "label", ""), self.draft
+                    ):
+                        source_faces = Text(
+                            txt=candidate,
+                            font_size=fs,
+                            font=drawing_font_name,
+                            font_style=self.draft.font_style,
+                            font_path=drawing_font_path,
+                            align=(Align.CENTER, Align.CENTER),
+                            mode=Mode.PRIVATE,
+                        ).faces()
+                        if len(source_faces) != len(glyph_faces) or len(source_faces) < 2:
+                            continue
+                        source_centres = [face.center() for face in source_faces]
+                        source_mean = (
+                            sum(point.X for point in source_centres) / len(source_centres),
+                            sum(point.Y for point in source_centres) / len(source_centres),
+                        )
+                        target_mean = (
+                            sum(point[0] for point in centres) / len(centres),
+                            sum(point[1] for point in centres) / len(centres),
+                        )
+                        dot = cross = 0.0
+                        for source, target in zip(source_centres, centres, strict=True):
+                            sx, sy = source.X - source_mean[0], source.Y - source_mean[1]
+                            tx, ty = target[0] - target_mean[0], target[1] - target_mean[1]
+                            dot += sx * tx + sy * ty
+                            cross += sx * ty - sy * tx
+                        if math.hypot(dot, cross) < 1e-9:
+                            continue
+                        angle = math.atan2(cross, dot)
+                        cos_angle, sin_angle = math.cos(angle), math.sin(angle)
+                        error = 0.0
+                        for source, source_face, target, target_face in zip(
+                            source_centres,
+                            source_faces,
+                            centres,
+                            glyph_faces,
+                            strict=True,
+                        ):
+                            sx, sy = source.X - source_mean[0], source.Y - source_mean[1]
+                            predicted = (
+                                target_mean[0] + cos_angle * sx - sin_angle * sy,
+                                target_mean[1] + sin_angle * sx + cos_angle * sy,
+                            )
+                            error += math.dist(predicted, target) ** 2
+                            error += (source_face.area - target_face.area) ** 2
+                        shape_matches.append((error, candidate, math.degrees(angle)))
+                    if shape_matches:
+                        _error, matched_text, matched_angle = min(shape_matches)
+                        raw_basic_matches[id(annotation)] = (matched_text, matched_angle)
+                        return matched_angle
                     xy = 0.0
                     if centres:
                         mx = sum(point[0] for point in centres) / len(centres)
                         my = sum(point[1] for point in centres) / len(centres)
                         xy = sum((point[0] - mx) * (point[1] - my) for point in centres)
-                    actual_w = x1 - x0 - 0.8 * fs
-                    actual_h = y1 - y0 - 0.8 * fs
+                    actual_w = (
+                        max(box.max.X for box in glyph_boxes)
+                        - min(box.min.X for box in glyph_boxes)
+                        if glyph_boxes
+                        else x1 - x0 - 0.8 * fs
+                    )
+                    actual_h = (
+                        max(box.max.Y for box in glyph_boxes)
+                        - min(box.min.Y for box in glyph_boxes)
+                        if glyph_boxes
+                        else y1 - y0 - 0.8 * fs
+                    )
                     matches = []
                     for candidate in raw_dimension_candidates(
                         annotation, getattr(annotation, "label", ""), self.draft
@@ -3922,7 +3997,11 @@ class Drawing:
                             if getattr(annotation, "is_basic", False):
                                 x0, y0, x1, y1 = label_box
                                 actual = (x1 - x0, y1 - y0)
-                                angle = math.radians(rotation)
+                                transform = math.radians(
+                                    float(getattr(annotation, "_init_rot", 0.0))
+                                    + float(getattr(annotation.location.orientation, "Z", 0.0))
+                                )
+                                base_angle = math.radians(rotation) - transform
 
                                 def geometry_error(candidate):
                                     width, height = _text_size(
@@ -3932,13 +4011,21 @@ class Drawing:
                                         run_font_name,
                                         run_font_style_enum,
                                     )
+                                    frame_width = (
+                                        abs(width * math.cos(base_angle))
+                                        + abs(height * math.sin(base_angle))
+                                        + 0.8 * run_font_size
+                                    )
+                                    frame_height = (
+                                        abs(width * math.sin(base_angle))
+                                        + abs(height * math.cos(base_angle))
+                                        + 0.8 * run_font_size
+                                    )
                                     predicted = (
-                                        abs(width * math.cos(angle))
-                                        + abs(height * math.sin(angle))
-                                        + 0.8 * run_font_size,
-                                        abs(width * math.sin(angle))
-                                        + abs(height * math.cos(angle))
-                                        + 0.8 * run_font_size,
+                                        abs(frame_width * math.cos(transform))
+                                        + abs(frame_height * math.sin(transform)),
+                                        abs(frame_width * math.sin(transform))
+                                        + abs(frame_height * math.cos(transform)),
                                     )
                                     return math.dist(actual, predicted)
 
@@ -3960,7 +4047,12 @@ class Drawing:
                                     )[0]
                                     return abs(width - visible_width)
 
-                            value = min(candidates, key=geometry_error)
+                            match = raw_basic_matches.get(id(annotation))
+                            value = (
+                                match[0]
+                                if match is not None and match[0] in candidates
+                                else min(candidates, key=geometry_error)
+                            )
                     if not hasattr(annotation, "measured_length"):
                         run_font_style = getattr(annotation, "pdf_text_font_style", "REGULAR")
                     runs.extend(

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -121,6 +121,27 @@ from draftwright.recognition_cache import RecognitionCache
 from draftwright.registry import AnnotationRegistry
 from draftwright.repair import repair_drawing
 
+
+def _exact_vertex_rotation(source_vertices, target_vertices) -> float | None:
+    """Rotation when two ordered outlines differ only by translation/scale/rotation."""
+    if len(source_vertices) != len(target_vertices) or len(source_vertices) < 2:
+        return None
+    source = [complex(point.X, point.Y) for point in source_vertices]
+    target = [complex(point.X, point.Y) for point in target_vertices]
+    source_mean, target_mean = sum(source) / len(source), sum(target) / len(target)
+    source = [point - source_mean for point in source]
+    target = [point - target_mean for point in target]
+    source_norm = sum(abs(point) ** 2 for point in source)
+    target_norm = sum(abs(point) ** 2 for point in target)
+    if min(source_norm, target_norm) < 1e-12:
+        return None
+    transform = sum(t * s.conjugate() for s, t in zip(source, target, strict=True)) / source_norm
+    error = sum(abs(transform * s - t) ** 2 for s, t in zip(source, target, strict=True))
+    if error / target_norm >= 1e-12:
+        return None
+    return math.degrees(math.atan2(transform.imag, transform.real))
+
+
 _PDF_VECTOR_ONLY_TEXT = str.maketrans("⌴⌵↧", "   ")
 
 # Codes that check standards/geometry correctness rather than pure page
@@ -3816,62 +3837,12 @@ class Drawing:
                             source_face_options, key=lambda item: item[0]
                         )
                         if len(source_faces) == 1:
-                            source_vertices = source_faces[0].vertices()
-                            target_vertices = glyph_faces[0].vertices()
-                            if (
-                                len(source_vertices) == len(target_vertices)
-                                and len(source_vertices) > 1
-                            ):
-                                source_points = [(point.X, point.Y) for point in source_vertices]
-                                target_points = [(point.X, point.Y) for point in target_vertices]
-                                source_mean = (
-                                    sum(point[0] for point in source_points) / len(source_points),
-                                    sum(point[1] for point in source_points) / len(source_points),
-                                )
-                                target_mean = (
-                                    sum(point[0] for point in target_points) / len(target_points),
-                                    sum(point[1] for point in target_points) / len(target_points),
-                                )
-                                dot = cross = source_norm = target_norm = 0.0
-                                for source, target in zip(
-                                    source_points, target_points, strict=True
-                                ):
-                                    sx, sy = (
-                                        source[0] - source_mean[0],
-                                        source[1] - source_mean[1],
-                                    )
-                                    tx, ty = (
-                                        target[0] - target_mean[0],
-                                        target[1] - target_mean[1],
-                                    )
-                                    dot += sx * tx + sy * ty
-                                    cross += sx * ty - sy * tx
-                                    source_norm += sx * sx + sy * sy
-                                    target_norm += tx * tx + ty * ty
-                                if source_norm > 1e-12 and target_norm > 1e-12:
-                                    angle = math.atan2(cross, dot)
-                                    scale = math.sqrt(target_norm / source_norm)
-                                    cos_angle, sin_angle = math.cos(angle), math.sin(angle)
-                                    error = 0.0
-                                    for source, target in zip(
-                                        source_points, target_points, strict=True
-                                    ):
-                                        sx, sy = (
-                                            source[0] - source_mean[0],
-                                            source[1] - source_mean[1],
-                                        )
-                                        predicted = (
-                                            target_mean[0]
-                                            + scale * (cos_angle * sx - sin_angle * sy),
-                                            target_mean[1]
-                                            + scale * (sin_angle * sx + cos_angle * sy),
-                                        )
-                                        error += math.dist(predicted, target) ** 2
-                                    if error / target_norm < 1e-12:
-                                        shape_matches.append(
-                                            (error, candidate, math.degrees(angle))
-                                        )
-                                        continue
+                            exact_rotation = _exact_vertex_rotation(
+                                source_faces[0].vertices(), glyph_faces[0].vertices()
+                            )
+                            if exact_rotation is not None:
+                                shape_matches.append((0.0, candidate, exact_rotation))
+                                continue
 
                             def line_directions(face):
                                 directions = []

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -3674,6 +3674,8 @@ class Drawing:
         drawing_font_name = getattr(self.draft, "font", "Arial")
         drawing_font_style = getattr(getattr(self.draft, "font_style", None), "name", "REGULAR")
         raw_basic_matches: dict[int, tuple[str, float]] = {}
+        raw_basic_exact_matches: set[int] = set()
+        raw_basic_unresolved: set[int] = set()
 
         def semantic_text(value) -> str:
             # The bundled faces do not carry the geometric counterbore,
@@ -3833,16 +3835,23 @@ class Drawing:
                             source_face_options.append((font_error, faces))
                         if not source_face_options:
                             continue
+                        if len(glyph_faces) == 1:
+                            for _font_error, exact_faces in source_face_options:
+                                exact_rotation = _exact_vertex_rotation(
+                                    exact_faces[0].vertices(), glyph_faces[0].vertices()
+                                )
+                                if exact_rotation is not None:
+                                    raw_basic_exact_matches.add(id(annotation))
+                                    shape_matches.append((0.0, candidate, exact_rotation))
+                                    break
+                            else:
+                                exact_rotation = None
+                            if exact_rotation is not None:
+                                continue
                         _font_error, source_faces = min(
                             source_face_options, key=lambda item: item[0]
                         )
                         if len(source_faces) == 1:
-                            exact_rotation = _exact_vertex_rotation(
-                                source_faces[0].vertices(), glyph_faces[0].vertices()
-                            )
-                            if exact_rotation is not None:
-                                shape_matches.append((0.0, candidate, exact_rotation))
-                                continue
 
                             def line_directions(face):
                                 directions = []
@@ -3989,6 +3998,12 @@ class Drawing:
                         ):
                             error += (source_face.area - target_face.area) ** 2
                         shape_matches.append((error, candidate, math.degrees(angle)))
+                    if len(glyph_faces) == 1 and id(annotation) not in raw_basic_exact_matches:
+                        # External helpers discard their construction Draft.  A guessed
+                        # face can put selectable text far from custom-font ink, so retain
+                        # the helper's visible vector glyph unless its outline proves the
+                        # semantic face and rotation exactly.
+                        raw_basic_unresolved.add(id(annotation))
                     if shape_matches:
                         _error, matched_text, matched_angle = min(shape_matches)
                         matched_angle = raw_basic_text_angle(matched_angle)
@@ -4132,6 +4147,8 @@ class Drawing:
                                 else raw_dimension_candidates(annotation, value, dimension_draft)
                             )
                             rotation = text_rotation(annotation)
+                            if id(annotation) in raw_basic_unresolved:
+                                continue
                             if getattr(annotation, "is_basic", False):
                                 x0, y0, x1, y1 = label_box
                                 actual = (x1 - x0, y1 - y0)

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -3679,14 +3679,24 @@ class Drawing:
                 candidates.insert(0, f"{prefix} +{lower} -{upper}{unit_suffix}")
             return list(dict.fromkeys(candidates))
 
-        def raw_dimension_label_is_freeform(annotation, value):
+        def raw_dimension_label_is_freeform(annotation, value, draft):
             """Whether retained helper metadata can only have come from ``label=``."""
             numeric_prefix = value.split(" ±", 1)[0].split(" +", 1)[0]
             try:
-                return not math.isclose(
+                measured_value = float(annotation.measured_length)
+                if not math.isclose(
                     float(numeric_prefix),
-                    float(annotation.measured_length),
+                    measured_value,
                     abs_tol=1e-9,
+                ):
+                    return True
+                # A numerically equivalent label can still be authored text (for
+                # example ``label="1"`` when the active draft would render ``1.0``).
+                # Raw helpers discard that constructor provenance, so preserve the
+                # spelling whenever it differs from this drawing's automatic form.
+                return value == numeric_prefix and value != draft._number_with_units(
+                    measured_value,
+                    display_units=False,
                 )
             except ValueError:
                 return True
@@ -3765,6 +3775,10 @@ class Drawing:
                             centre = face.center()
                             centres.append((centre.X, centre.Y))
                             glyph_faces.append(face)
+                    if glyph_faces:
+                        min_area = max(face.area for face in glyph_faces) * 0.01
+                        glyph_faces = [face for face in glyph_faces if face.area >= min_area]
+                        centres = [(face.center().X, face.center().Y) for face in glyph_faces]
                     shape_matches: list[tuple[float, str, float]] = []
                     for candidate in raw_dimension_candidates(
                         annotation, getattr(annotation, "label", ""), self.draft
@@ -3929,6 +3943,7 @@ class Drawing:
                         shape_matches.append((error, candidate, math.degrees(angle)))
                     if shape_matches:
                         _error, matched_text, matched_angle = min(shape_matches)
+                        matched_angle = raw_basic_text_angle(matched_angle)
                         raw_basic_matches[id(annotation)] = (matched_text, matched_angle)
                         return matched_angle
             polygon = getattr(annotation, "label_polygon", None)
@@ -4058,7 +4073,11 @@ class Drawing:
                             # External raw helpers retain no label/tolerance constructor args.
                             # Compare the few possible unit renderings to the live label geometry;
                             # this also preserves explicit custom labels (their own width wins).
-                            raw_freeform = raw_dimension_label_is_freeform(annotation, value)
+                            raw_freeform = raw_dimension_label_is_freeform(
+                                annotation,
+                                value,
+                                dimension_draft,
+                            )
                             candidates = (
                                 [value]
                                 if raw_freeform

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -37,6 +37,7 @@ from build123d import (
     LineType,
     Location,
 )
+from build123d_drafting.helpers import DEFAULT_FONT_PATH
 
 from draftwright._core import (
     _MARGIN,
@@ -2830,6 +2831,7 @@ class Drawing:
         # overlay (notably its established ⌀ -> ø compatibility substitution).
         n.pdf_text = _font_safe_text(text)
         n.pdf_text_rotation = float(rotation)
+        n.pdf_text_line_spacing = 1.3
         if name is None:
             i = 0
             while (name := f"note{i}") in self._registry:
@@ -3638,7 +3640,8 @@ class Drawing:
         groups = []
         fs = self.draft.font_size
         pad = self.draft.pad_around_text
-        mono = getattr(self.draft, "font_path", None) or PLEX_MONO
+        drawing_font_path = getattr(self.draft, "font_path", DEFAULT_FONT_PATH)
+        drawing_font_name = getattr(self.draft, "font", "Arial")
 
         def semantic_text(value) -> str:
             # The bundled faces do not carry the geometric counterbore,
@@ -3648,16 +3651,32 @@ class Drawing:
             return _font_safe_text(value).translate(_PDF_VECTOR_ONLY_TEXT)
 
         def text_rotation(annotation) -> float:
+            live_rotation = float(getattr(annotation.location.orientation, "Z", 0.0))
             explicit = getattr(annotation, "pdf_text_rotation", None)
             if explicit is not None:
-                return float(explicit)
+                return float(explicit) + live_rotation
+            if getattr(annotation, "is_basic", False):
+                # A basic dimension's keep-clear polygon is its axis-aligned frame,
+                # not its rotated text.  Its first shaft span retains the live text axis.
+                for start, end in getattr(annotation, "segments", ()):
+                    dx, dy = end[0] - start[0], end[1] - start[1]
+                    if math.hypot(dx, dy) > 1e-9:
+                        return math.degrees(math.atan2(dy, dx))
             polygon = getattr(annotation, "label_polygon", None)
             if polygon and len(polygon) >= 2:
                 (x0, y0), (x1, y1) = polygon[:2]
                 return math.degrees(math.atan2(y1 - y0, x1 - x0))
-            return 0.0
+            return live_rotation
 
-        def centred_runs(value, label_box, font_size, rotation, font_path):
+        def centred_runs(
+            value,
+            label_box,
+            font_size,
+            rotation,
+            font_path,
+            font_name="Arial",
+            line_spacing=1.3,
+        ):
             lines = semantic_text(value).splitlines()
             if not lines:
                 return []
@@ -3669,7 +3688,7 @@ class Drawing:
             for index, line in enumerate(lines):
                 if not line:
                     continue
-                local_y = ((len(lines) - 1) / 2.0 - index) * font_size
+                local_y = ((len(lines) - 1) / 2.0 - index) * font_size * line_spacing
                 runs.append(
                     _PDFTextRun(
                         line,
@@ -3678,13 +3697,14 @@ class Drawing:
                         font_size,
                         rotation,
                         font_path,
+                        font_name,
                         "center",
                         "middle",
                     )
                 )
             return runs
 
-        for _name, annotation in self._registry.iter_named():
+        for ordinal, (_name, annotation) in enumerate(self._registry.iter_named()):
             box = annotation.bounding_box()
             rows = getattr(annotation, "table_rows", None)
             runs = []
@@ -3702,22 +3722,36 @@ class Drawing:
                                     box.min.X + lefts[ci] + pad,
                                     baseline,
                                     fs,
-                                    font_path=mono,
+                                    font_path=PLEX_MONO,
                                 )
                             )
             elif specs := getattr(annotation, "pdf_text_specs", None):
                 for value, x, y, font_size, font_path in specs:
-                    runs.append(
-                        _PDFTextRun(
-                            semantic_text(value),
-                            x,
-                            y,
-                            font_size,
-                            font_path=font_path,
-                            h_align="center",
-                            v_align="middle",
+                    runs.extend(centred_runs(value, (x, y, x, y), font_size, 0.0, font_path))
+            elif specs := getattr(annotation, "pdf_text_relative_specs", None):
+                label_box = getattr(annotation, "label_bbox", None)
+                if label_box:
+                    cx = (label_box[0] + label_box[2]) / 2.0
+                    cy = (label_box[1] + label_box[3]) / 2.0
+                    rotation = text_rotation(annotation)
+                    angle = math.radians(rotation)
+                    cos_angle, sin_angle = math.cos(angle), math.sin(angle)
+                    for spec in specs:
+                        value, rx, ry, size, path, name, *align = spec
+                        h_align, v_align = align or ("center", "middle")
+                        runs.append(
+                            _PDFTextRun(
+                                semantic_text(value),
+                                cx + cos_angle * rx - sin_angle * ry,
+                                cy + sin_angle * rx + cos_angle * ry,
+                                size,
+                                rotation,
+                                path,
+                                name,
+                                h_align,
+                                v_align,
+                            )
                         )
-                    )
             else:
                 value = getattr(annotation, "pdf_text", None)
                 if value is None:
@@ -3725,11 +3759,19 @@ class Drawing:
                 label_box = getattr(annotation, "label_bbox", None)
                 if value and label_box:
                     runs.extend(
-                        centred_runs(value, label_box, fs, text_rotation(annotation), mono)
+                        centred_runs(
+                            value,
+                            label_box,
+                            fs,
+                            text_rotation(annotation),
+                            drawing_font_path,
+                            drawing_font_name,
+                            getattr(annotation, "pdf_text_line_spacing", 1.3),
+                        )
                     )
             if runs:
-                groups.append((-box.max.Y, box.min.X, runs))
-        return tuple(run for _top, _left, runs in sorted(groups) for run in runs)
+                groups.append((-box.max.Y, box.min.X, ordinal, runs))
+        return tuple(run for _top, _left, _ordinal, runs in sorted(groups) for run in runs)
 
     def export(
         self, out=None, *, formats=None, svg=None, dxf=None, dpi: int = 150

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -17,6 +17,7 @@ import tempfile
 import warnings
 from dataclasses import dataclass
 from dataclasses import field as dataclasses_field
+from itertools import permutations
 from typing import TYPE_CHECKING, Any, NamedTuple
 
 if TYPE_CHECKING:
@@ -140,6 +141,22 @@ def _exact_vertex_rotation(source_vertices, target_vertices) -> float | None:
     if error / target_norm >= 1e-12:
         return None
     return math.degrees(math.atan2(transform.imag, transform.real))
+
+
+def _exact_face_rotation(source_faces, target_faces) -> float | None:
+    """Exact outline rotation independent of disconnected-face enumeration order."""
+    if len(source_faces) != len(target_faces) or not source_faces or len(source_faces) > 6:
+        return None
+    source_vertices = [vertex for face in source_faces for vertex in face.vertices()]
+    source_counts = [len(face.vertices()) for face in source_faces]
+    for ordered_targets in permutations(target_faces):
+        if source_counts != [len(face.vertices()) for face in ordered_targets]:
+            continue
+        target_vertices = [vertex for face in ordered_targets for vertex in face.vertices()]
+        rotation = _exact_vertex_rotation(source_vertices, target_vertices)
+        if rotation is not None:
+            return rotation
+    return None
 
 
 _PDF_VECTOR_ONLY_TEXT = str.maketrans("⌴⌵↧", "   ")
@@ -3835,16 +3852,8 @@ class Drawing:
                         if not source_face_options:
                             continue
                         if len(candidate) == 1:
-                            target_vertices = [
-                                vertex for face in glyph_faces for vertex in face.vertices()
-                            ]
                             for _font_error, exact_faces in source_face_options:
-                                source_vertices = [
-                                    vertex for face in exact_faces for vertex in face.vertices()
-                                ]
-                                exact_rotation = _exact_vertex_rotation(
-                                    source_vertices, target_vertices
-                                )
+                                exact_rotation = _exact_face_rotation(exact_faces, glyph_faces)
                                 if exact_rotation is not None:
                                     raw_basic_exact_matches.add(id(annotation))
                                     shape_matches.append((0.0, candidate, exact_rotation))

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -3670,8 +3670,9 @@ class Drawing:
             upper, minus, lower = limits.partition(" -")
             if separator and minus and prefix == bare_value:
                 # Helper compatibility metadata reverses asymmetric tuple limits relative
-                # to the visible string. Equal-width geometry cannot select the right order.
-                candidates.insert(0, f"{prefix} +{lower} -{upper}{unit_suffix}")
+                # to the visible string. This grammar is authoritative: proportional ink
+                # bounds cannot reliably break the equal-advance ordering tie.
+                return [f"{prefix} +{lower} -{upper}{unit_suffix}"]
             return list(dict.fromkeys(candidates))
 
         def text_rotation(annotation) -> float:
@@ -3688,12 +3689,23 @@ class Drawing:
             if spec is not None and hasattr(annotation, "measured_length"):
                 dx, dy = spec.p2[0] - spec.p1[0], spec.p2[1] - spec.p1[1]
                 if math.hypot(dx, dy) > 1e-9:
-                    return upright(
-                        math.degrees(math.atan2(dy, dx))
+                    # Dimension first makes its path label upright, then BaseSketchObject
+                    # applies constructor/live transforms to the whole annotation. Do not
+                    # upright-normalise again after those transforms: 120° must remain 120°.
+                    return (
+                        upright(math.degrees(math.atan2(dy, dx)))
                         + float(spec.kwargs.get("rotation", 0.0))
                         + live_rotation
                     )
             if getattr(annotation, "is_basic", False):
+                # Raw helper geometry has already absorbed its constructor rotation; live
+                # location transforms are reflected by ``segments`` too. Match the helper's
+                # operation order: upright the pre-transform axis, then reapply both.
+                transform_rotation = float(getattr(annotation, "_init_rot", 0.0)) + live_rotation
+
+                def raw_basic_text_angle(final_axis: float) -> float:
+                    return upright(final_axis - transform_rotation) + transform_rotation
+
                 # A basic dimension's keep-clear polygon is its axis-aligned frame,
                 # not its rotated text. For short labels, distinguish collinear shaft spans,
                 # parallel witness
@@ -3707,13 +3719,14 @@ class Drawing:
                     angle = math.degrees(math.atan2(dy, dx))
                     bx, by = b1[0] - b0[0], b1[1] - b0[1]
                     if abs(dx * by - dy * bx) > 1e-7:
-                        return upright(angle)
+                        return raw_basic_text_angle(angle)
                     separation = dx * (b0[1] - a0[1]) - dy * (b0[0] - a0[0])
-                    return upright(angle if abs(separation) < 1e-7 else angle + 90.0)
+                    axis = angle if abs(separation) < 1e-7 else angle + 90.0
+                    return raw_basic_text_angle(axis)
                 for start, end in ink:
                     dx, dy = end[0] - start[0], end[1] - start[1]
                     if math.hypot(dx, dy) > 1e-9:
-                        return upright(math.degrees(math.atan2(dy, dx)))
+                        return raw_basic_text_angle(math.degrees(math.atan2(dy, dx)))
                 # An extremely wide label can consume every shaft and witness span. Recover
                 # angle magnitude from the rotated text AABB (the frame adds a known pad),
                 # using glyph-face covariance only for the sign.
@@ -3774,7 +3787,8 @@ class Drawing:
                         )
                     if matches:
                         magnitude = min(matches)[1]
-                        return upright(-magnitude if xy < 0.0 else magnitude)
+                        axis = -magnitude if xy < 0.0 else magnitude
+                        return raw_basic_text_angle(axis)
             polygon = getattr(annotation, "label_polygon", None)
             if polygon and len(polygon) >= 2:
                 (x0, y0), (x1, y1) = polygon[:2]

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -3803,9 +3803,8 @@ class Drawing:
                         glyph_faces = [face for face in glyph_faces if face.area >= min_area]
                         centres = [(face.center().X, face.center().Y) for face in glyph_faces]
                     shape_matches: list[tuple[float, str, float]] = []
-                    for candidate in raw_dimension_candidates(
-                        annotation, getattr(annotation, "label", ""), self.draft
-                    ):
+                    raw_label = str(getattr(annotation, "label", ""))
+                    for candidate in raw_dimension_candidates(annotation, raw_label, self.draft):
                         source_face_options = []
                         for font_path in dict.fromkeys((drawing_font_path, DEFAULT_FONT_PATH)):
                             faces = Text(
@@ -3835,10 +3834,16 @@ class Drawing:
                             source_face_options.append((font_error, faces))
                         if not source_face_options:
                             continue
-                        if len(glyph_faces) == 1:
+                        if len(candidate) == 1:
+                            target_vertices = [
+                                vertex for face in glyph_faces for vertex in face.vertices()
+                            ]
                             for _font_error, exact_faces in source_face_options:
+                                source_vertices = [
+                                    vertex for face in exact_faces for vertex in face.vertices()
+                                ]
                                 exact_rotation = _exact_vertex_rotation(
-                                    exact_faces[0].vertices(), glyph_faces[0].vertices()
+                                    source_vertices, target_vertices
                                 )
                                 if exact_rotation is not None:
                                     raw_basic_exact_matches.add(id(annotation))
@@ -3998,7 +4003,7 @@ class Drawing:
                         ):
                             error += (source_face.area - target_face.area) ** 2
                         shape_matches.append((error, candidate, math.degrees(angle)))
-                    if len(glyph_faces) == 1 and id(annotation) not in raw_basic_exact_matches:
+                    if len(raw_label) == 1 and id(annotation) not in raw_basic_exact_matches:
                         # External helpers discard their construction Draft.  A guessed
                         # face can put selectable text far from custom-font ink, so retain
                         # the helper's visible vector glyph unless its outline proves the

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -3657,38 +3657,124 @@ class Drawing:
             # terms separate in copied/searchable text.
             return _font_safe_text(value).translate(_PDF_VECTOR_ONLY_TEXT)
 
+        def raw_dimension_candidates(annotation, value, draft):
+            """Possible visible labels when an external helper discarded constructor args."""
+            bare_zero = draft._number_with_units(0.0, display_units=False)
+            unit_zero = draft._number_with_units(0.0, display_units=True)
+            unit_suffix = unit_zero.removeprefix(bare_zero)
+            candidates = [value, draft._number_with_units(annotation.measured_length)]
+            if unit_suffix and not value.endswith(unit_suffix):
+                candidates.append(value + unit_suffix)
+            bare_value = draft._number_with_units(annotation.measured_length, display_units=False)
+            prefix, separator, limits = value.partition(" +")
+            upper, minus, lower = limits.partition(" -")
+            if separator and minus and prefix == bare_value:
+                # Helper compatibility metadata reverses asymmetric tuple limits relative
+                # to the visible string. Equal-width geometry cannot select the right order.
+                candidates.insert(0, f"{prefix} +{lower} -{upper}{unit_suffix}")
+            return list(dict.fromkeys(candidates))
+
         def text_rotation(annotation) -> float:
             def upright(angle: float) -> float:
+                if math.isclose(abs(angle), 90.0, abs_tol=1e-6):
+                    return 90.0
                 return angle if -90.0 < angle <= 90.0 else angle - math.copysign(180.0, angle)
 
             live_rotation = float(getattr(annotation.location.orientation, "Z", 0.0))
             explicit = getattr(annotation, "pdf_text_rotation", None)
             if explicit is not None:
                 return float(explicit) + live_rotation
+            spec = getattr(annotation, "_dw_spec", None)
+            if spec is not None and hasattr(annotation, "measured_length"):
+                dx, dy = spec.p2[0] - spec.p1[0], spec.p2[1] - spec.p1[1]
+                if math.hypot(dx, dy) > 1e-9:
+                    return upright(
+                        math.degrees(math.atan2(dy, dx))
+                        + float(spec.kwargs.get("rotation", 0.0))
+                        + live_rotation
+                    )
             if getattr(annotation, "is_basic", False):
-                # Engine-built dimensions retain their authored endpoints even when a wide
-                # basic label consumes both shaft spans. Prefer that authoritative text axis
-                # over reverse-engineering whichever strokes survived helper rendering.
-                if (spec := getattr(annotation, "_dw_spec", None)) is not None:
-                    dx, dy = spec.p2[0] - spec.p1[0], spec.p2[1] - spec.p1[1]
-                    if math.hypot(dx, dy) > 1e-9:
-                        return upright(math.degrees(math.atan2(dy, dx)) + live_rotation)
                 # A basic dimension's keep-clear polygon is its axis-aligned frame,
-                # not its rotated text. For an external raw helper dimension, distinguish
-                # surviving collinear shaft spans from two parallel witness lines; text runs
-                # along the former and perpendicular to the latter.
+                # not its rotated text. For short labels, distinguish collinear shaft spans,
+                # parallel witness
+                # lines, and the mixed one-shaft/one-witness case. Helper span order puts
+                # a surviving shaft before witnesses.
                 segments = list(getattr(annotation, "segments", ()))
                 ink = segments[:-4] if len(segments) >= 4 else segments
                 if len(ink) == 2:
-                    (a0, a1), (b0, _b1) = ink
+                    (a0, a1), (b0, b1) = ink
                     dx, dy = a1[0] - a0[0], a1[1] - a0[1]
-                    cross = dx * (b0[1] - a0[1]) - dy * (b0[0] - a0[0])
                     angle = math.degrees(math.atan2(dy, dx))
-                    return upright(angle if abs(cross) < 1e-7 else angle + 90.0)
+                    bx, by = b1[0] - b0[0], b1[1] - b0[1]
+                    if abs(dx * by - dy * bx) > 1e-7:
+                        return upright(angle)
+                    separation = dx * (b0[1] - a0[1]) - dy * (b0[0] - a0[0])
+                    return upright(angle if abs(separation) < 1e-7 else angle + 90.0)
                 for start, end in ink:
                     dx, dy = end[0] - start[0], end[1] - start[1]
                     if math.hypot(dx, dy) > 1e-9:
                         return upright(math.degrees(math.atan2(dy, dx)))
+                # An extremely wide label can consume every shaft and witness span. Recover
+                # angle magnitude from the rotated text AABB (the frame adds a known pad),
+                # using glyph-face covariance only for the sign.
+                if label_box := getattr(annotation, "label_bbox", None):
+                    x0, y0, x1, y1 = label_box
+                    inset = 0.05 * fs
+                    centres = []
+                    for face in annotation.faces():
+                        face_box = face.bounding_box()
+                        if (
+                            face_box.min.X >= x0 + inset
+                            and face_box.max.X <= x1 - inset
+                            and face_box.min.Y >= y0 + inset
+                            and face_box.max.Y <= y1 - inset
+                            and face_box.size.X <= 2.0 * fs
+                            and face_box.size.Y <= 2.0 * fs
+                        ):
+                            centre = face.center()
+                            centres.append((centre.X, centre.Y))
+                    xy = 0.0
+                    if centres:
+                        mx = sum(point[0] for point in centres) / len(centres)
+                        my = sum(point[1] for point in centres) / len(centres)
+                        xy = sum((point[0] - mx) * (point[1] - my) for point in centres)
+                    actual_w = x1 - x0 - 0.8 * fs
+                    actual_h = y1 - y0 - 0.8 * fs
+                    matches = []
+                    for candidate in raw_dimension_candidates(
+                        annotation, getattr(annotation, "label", ""), self.draft
+                    ):
+                        width, height = _text_size(
+                            candidate,
+                            fs,
+                            drawing_font_path,
+                            drawing_font_name,
+                            self.draft.font_style,
+                        )
+                        if abs(width - height) < 1e-9:
+                            continue
+                        cos_plus_sin = (actual_w + actual_h) / (width + height)
+                        cos_minus_sin = (actual_w - actual_h) / (width - height)
+                        cos_angle = (cos_plus_sin + cos_minus_sin) / 2.0
+                        sin_angle = (cos_plus_sin - cos_minus_sin) / 2.0
+                        if min(cos_angle, sin_angle) < -1e-6:
+                            continue
+                        cos_angle = max(0.0, cos_angle)
+                        sin_angle = max(0.0, sin_angle)
+                        magnitude = math.degrees(math.atan2(sin_angle, cos_angle))
+                        predicted = (
+                            width * math.cos(math.radians(magnitude))
+                            + height * math.sin(math.radians(magnitude)),
+                            width * math.sin(math.radians(magnitude))
+                            + height * math.cos(math.radians(magnitude)),
+                        )
+                        circle_error = abs(cos_angle**2 + sin_angle**2 - 1.0)
+                        matches.append(
+                            (math.dist((actual_w, actual_h), predicted) + circle_error, magnitude)
+                        )
+                    if matches:
+                        magnitude = min(matches)[1]
+                        return upright(-magnitude if xy < 0.0 else magnitude)
             polygon = getattr(annotation, "label_polygon", None)
             if polygon and len(polygon) >= 2:
                 (x0, y0), (x1, y1) = polygon[:2]
@@ -3790,8 +3876,19 @@ class Drawing:
                     value = getattr(annotation, "label", None)
                 label_box = getattr(annotation, "label_bbox", None)
                 if value and label_box:
+                    run_font_size = fs
+                    run_font_path = drawing_font_path
+                    run_font_name = drawing_font_name
+                    run_font_style = drawing_font_style
+                    run_font_style_enum = self.draft.font_style
                     if hasattr(annotation, "measured_length"):
                         spec = getattr(annotation, "_dw_spec", None)
+                        dimension_draft = spec.draft if spec is not None else self.draft
+                        run_font_size = dimension_draft.font_size
+                        run_font_path = getattr(dimension_draft, "font_path", DEFAULT_FONT_PATH)
+                        run_font_name = getattr(dimension_draft, "font", "Arial")
+                        run_font_style_enum = dimension_draft.font_style
+                        run_font_style = getattr(dimension_draft.font_style, "name", "REGULAR")
                         if spec is not None and spec.kwargs.get("label") is None:
                             # The engine owns this construction spec, including tolerance;
                             # reproduce the exact helper-rendered label rather than its
@@ -3804,16 +3901,9 @@ class Drawing:
                             # External raw helpers retain no label/tolerance constructor args.
                             # Compare the few possible unit renderings to the live label geometry;
                             # this also preserves explicit custom labels (their own width wins).
-                            bare_zero = self.draft._number_with_units(0.0, display_units=False)
-                            unit_zero = self.draft._number_with_units(0.0, display_units=True)
-                            unit_suffix = unit_zero.removeprefix(bare_zero)
-                            candidates = [
-                                value,
-                                self.draft._number_with_units(annotation.measured_length),
-                            ]
-                            if unit_suffix and not value.endswith(unit_suffix):
-                                candidates.append(value + unit_suffix)
-                            candidates = list(dict.fromkeys(candidates))
+                            candidates = raw_dimension_candidates(
+                                annotation, value, dimension_draft
+                            )
                             rotation = text_rotation(annotation)
                             if getattr(annotation, "is_basic", False):
                                 x0, y0, x1, y1 = label_box
@@ -3823,18 +3913,18 @@ class Drawing:
                                 def geometry_error(candidate):
                                     width, height = _text_size(
                                         candidate,
-                                        fs,
-                                        drawing_font_path,
-                                        drawing_font_name,
-                                        self.draft.font_style,
+                                        run_font_size,
+                                        run_font_path,
+                                        run_font_name,
+                                        run_font_style_enum,
                                     )
                                     predicted = (
                                         abs(width * math.cos(angle))
                                         + abs(height * math.sin(angle))
-                                        + 0.8 * fs,
+                                        + 0.8 * run_font_size,
                                         abs(width * math.sin(angle))
                                         + abs(height * math.cos(angle))
-                                        + 0.8 * fs,
+                                        + 0.8 * run_font_size,
                                     )
                                     return math.dist(actual, predicted)
 
@@ -3849,28 +3939,25 @@ class Drawing:
                                 def geometry_error(candidate):
                                     width = _text_size(
                                         candidate,
-                                        fs,
-                                        drawing_font_path,
-                                        drawing_font_name,
-                                        self.draft.font_style,
+                                        run_font_size,
+                                        run_font_path,
+                                        run_font_name,
+                                        run_font_style_enum,
                                     )[0]
                                     return abs(width - visible_width)
 
                             value = min(candidates, key=geometry_error)
-                    font_style = (
-                        drawing_font_style
-                        if hasattr(annotation, "measured_length")
-                        else getattr(annotation, "pdf_text_font_style", "REGULAR")
-                    )
+                    if not hasattr(annotation, "measured_length"):
+                        run_font_style = getattr(annotation, "pdf_text_font_style", "REGULAR")
                     runs.extend(
                         centred_runs(
                             value,
                             label_box,
-                            fs,
+                            run_font_size,
                             text_rotation(annotation),
-                            drawing_font_path,
-                            drawing_font_name,
-                            font_style,
+                            run_font_path,
+                            run_font_name,
+                            run_font_style,
                             getattr(annotation, "pdf_text_line_spacing", None),
                         )
                     )

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -3783,17 +3783,38 @@ class Drawing:
                     for candidate in raw_dimension_candidates(
                         annotation, getattr(annotation, "label", ""), self.draft
                     ):
-                        source_faces = Text(
-                            txt=candidate,
-                            font_size=fs,
-                            font=drawing_font_name,
-                            font_style=self.draft.font_style,
-                            font_path=drawing_font_path,
-                            align=(Align.CENTER, Align.CENTER),
-                            mode=Mode.PRIVATE,
-                        ).faces()
-                        if len(source_faces) != len(glyph_faces) or not source_faces:
+                        source_face_options = []
+                        for font_path in dict.fromkeys((drawing_font_path, DEFAULT_FONT_PATH)):
+                            faces = Text(
+                                txt=candidate,
+                                font_size=fs,
+                                font=drawing_font_name,
+                                font_style=self.draft.font_style,
+                                font_path=font_path,
+                                align=(Align.CENTER, Align.CENTER),
+                                mode=Mode.PRIVATE,
+                            ).faces()
+                            if len(faces) != len(glyph_faces) or not faces:
+                                continue
+
+                            def face_ratio(face):
+                                box = face.oriented_bounding_box()
+                                sizes = sorted((box.size.X, box.size.Y, box.size.Z), reverse=True)
+                                return sizes[0] / max(sizes[1], 1e-12)
+
+                            source_area = sum(face.area for face in faces)
+                            target_area = sum(face.area for face in glyph_faces)
+                            font_error = sum(
+                                abs(source.area / source_area - target.area / target_area)
+                                + abs(math.log(face_ratio(source) / face_ratio(target)))
+                                for source, target in zip(faces, glyph_faces, strict=True)
+                            )
+                            source_face_options.append((font_error, faces))
+                        if not source_face_options:
                             continue
+                        _font_error, source_faces = min(
+                            source_face_options, key=lambda item: item[0]
+                        )
                         if len(source_faces) == 1:
 
                             def line_directions(face):

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -3679,6 +3679,18 @@ class Drawing:
                 candidates.insert(0, f"{prefix} +{lower} -{upper}{unit_suffix}")
             return list(dict.fromkeys(candidates))
 
+        def raw_dimension_label_is_freeform(annotation, value):
+            """Whether retained helper metadata can only have come from ``label=``."""
+            numeric_prefix = value.split(" ±", 1)[0].split(" +", 1)[0]
+            try:
+                return not math.isclose(
+                    float(numeric_prefix),
+                    float(annotation.measured_length),
+                    abs_tol=1e-9,
+                )
+            except ValueError:
+                return True
+
         def text_rotation(annotation) -> float:
             def upright(angle: float) -> float:
                 angle = (angle + 90.0) % 180.0 - 90.0
@@ -3742,7 +3754,6 @@ class Drawing:
                     inset = 0.05 * fs
                     centres = []
                     glyph_faces = []
-                    glyph_boxes = []
                     for face in annotation.faces():
                         face_box = face.bounding_box()
                         if (
@@ -3750,14 +3761,11 @@ class Drawing:
                             and face_box.max.X <= x1 - inset
                             and face_box.min.Y >= y0 + inset
                             and face_box.max.Y <= y1 - inset
-                            and face_box.size.X <= 2.0 * fs
-                            and face_box.size.Y <= 2.0 * fs
                         ):
                             centre = face.center()
                             centres.append((centre.X, centre.Y))
                             glyph_faces.append(face)
-                            glyph_boxes.append(face_box)
-                    shape_matches = []
+                    shape_matches: list[tuple[float, str, float]] = []
                     for candidate in raw_dimension_candidates(
                         annotation, getattr(annotation, "label", ""), self.draft
                     ):
@@ -3770,20 +3778,135 @@ class Drawing:
                             align=(Align.CENTER, Align.CENTER),
                             mode=Mode.PRIVATE,
                         ).faces()
-                        if len(source_faces) != len(glyph_faces) or len(source_faces) < 2:
+                        if len(source_faces) != len(glyph_faces) or not source_faces:
                             continue
-                        source_centres = [face.center() for face in source_faces]
+                        if len(source_faces) == 1:
+
+                            def line_directions(face):
+                                directions = []
+                                for edge in face.edges():
+                                    if getattr(edge.geom_type, "name", "") != "LINE":
+                                        continue
+                                    tangent = edge.tangent_at(0.5)
+                                    directions.append(
+                                        (
+                                            math.degrees(math.atan2(tangent.Y, tangent.X)) % 180.0,
+                                            edge.length,
+                                        )
+                                    )
+                                return directions
+
+                            def direction_stats(directions, angle):
+                                matching = [
+                                    weight
+                                    for direction, weight in directions
+                                    if abs((direction - angle + 90.0) % 180.0 - 90.0) < 1e-5
+                                ]
+                                return sum(matching), len(matching)
+
+                            source_directions = line_directions(source_faces[0])
+                            target_directions = line_directions(glyph_faces[0])
+                            source_horizontal, source_horizontal_count = direction_stats(
+                                source_directions, 0.0
+                            )
+                            source_vertical, source_vertical_count = direction_stats(
+                                source_directions, 90.0
+                            )
+                            source_axis_total = source_horizontal + source_vertical
+                            if source_axis_total > 1e-9 and target_directions:
+                                axis_matches = []
+                                source_share = source_horizontal / source_axis_total
+                                for direction, _weight in target_directions:
+                                    for angle in (direction, direction - 90.0):
+                                        target_horizontal, target_horizontal_count = (
+                                            direction_stats(target_directions, angle)
+                                        )
+                                        target_vertical, target_vertical_count = direction_stats(
+                                            target_directions, angle + 90.0
+                                        )
+                                        target_axis_total = target_horizontal + target_vertical
+                                        if target_axis_total > 1e-9:
+                                            axis_matches.append(
+                                                (
+                                                    abs(
+                                                        source_share
+                                                        - target_horizontal / target_axis_total
+                                                    )
+                                                    + (
+                                                        abs(
+                                                            source_horizontal_count
+                                                            - target_horizontal_count
+                                                        )
+                                                        + abs(
+                                                            source_vertical_count
+                                                            - target_vertical_count
+                                                        )
+                                                    )
+                                                    / max(
+                                                        1,
+                                                        source_horizontal_count
+                                                        + source_vertical_count,
+                                                    ),
+                                                    angle,
+                                                )
+                                            )
+                                if axis_matches:
+                                    error, angle = min(axis_matches)
+                                    shape_matches.append((error, candidate, angle))
+                                    continue
+                            source_obb = source_faces[0].oriented_bounding_box()
+                            target_obb = glyph_faces[0].oriented_bounding_box()
+                            source_axes = sorted(
+                                (
+                                    (source_obb.size.X, source_obb.plane.x_dir),
+                                    (source_obb.size.Y, source_obb.plane.y_dir),
+                                    (source_obb.size.Z, source_obb.plane.z_dir),
+                                ),
+                                key=lambda item: item[0],
+                                reverse=True,
+                            )
+                            target_axes = sorted(
+                                (
+                                    (target_obb.size.X, target_obb.plane.x_dir),
+                                    (target_obb.size.Y, target_obb.plane.y_dir),
+                                    (target_obb.size.Z, target_obb.plane.z_dir),
+                                ),
+                                key=lambda item: item[0],
+                                reverse=True,
+                            )
+                            if min(source_axes[1][0], target_axes[1][0]) < 1e-9:
+                                continue
+                            source_ratio = source_axes[0][0] / source_axes[1][0]
+                            target_ratio = target_axes[0][0] / target_axes[1][0]
+                            aspect_error = abs(math.log(source_ratio / target_ratio))
+                            source_dir = source_axes[0][1]
+                            target_dir = target_axes[0][1]
+                            dot = source_dir.X * target_dir.X + source_dir.Y * target_dir.Y
+                            cross = source_dir.X * target_dir.Y - source_dir.Y * target_dir.X
+                            shape_matches.append(
+                                (
+                                    aspect_error,
+                                    candidate,
+                                    math.degrees(math.atan2(cross, dot)),
+                                )
+                            )
+                            continue
+                        else:
+                            source_points = [
+                                (face.center().X, face.center().Y) for face in source_faces
+                            ]
+                            target_points = centres
                         source_mean = (
-                            sum(point.X for point in source_centres) / len(source_centres),
-                            sum(point.Y for point in source_centres) / len(source_centres),
+                            sum(point[0] for point in source_points) / len(source_points),
+                            sum(point[1] for point in source_points) / len(source_points),
                         )
                         target_mean = (
-                            sum(point[0] for point in centres) / len(centres),
-                            sum(point[1] for point in centres) / len(centres),
+                            sum(point[0] for point in target_points) / len(target_points),
+                            sum(point[1] for point in target_points) / len(target_points),
                         )
                         dot = cross = 0.0
-                        for source, target in zip(source_centres, centres, strict=True):
-                            sx, sy = source.X - source_mean[0], source.Y - source_mean[1]
+                        for source, target in zip(source_points, target_points, strict=True):
+                            sx, sy = source[0] - source_mean[0], source[1] - source_mean[1]
                             tx, ty = target[0] - target_mean[0], target[1] - target_mean[1]
                             dot += sx * tx + sy * ty
                             cross += sx * ty - sy * tx
@@ -3792,78 +3915,22 @@ class Drawing:
                         angle = math.atan2(cross, dot)
                         cos_angle, sin_angle = math.cos(angle), math.sin(angle)
                         error = 0.0
-                        for source, source_face, target, target_face in zip(
-                            source_centres,
-                            source_faces,
-                            centres,
-                            glyph_faces,
-                            strict=True,
-                        ):
-                            sx, sy = source.X - source_mean[0], source.Y - source_mean[1]
+                        for source, target in zip(source_points, target_points, strict=True):
+                            sx, sy = source[0] - source_mean[0], source[1] - source_mean[1]
                             predicted = (
                                 target_mean[0] + cos_angle * sx - sin_angle * sy,
                                 target_mean[1] + sin_angle * sx + cos_angle * sy,
                             )
                             error += math.dist(predicted, target) ** 2
+                        for source_face, target_face in zip(
+                            source_faces, glyph_faces, strict=True
+                        ):
                             error += (source_face.area - target_face.area) ** 2
                         shape_matches.append((error, candidate, math.degrees(angle)))
                     if shape_matches:
                         _error, matched_text, matched_angle = min(shape_matches)
                         raw_basic_matches[id(annotation)] = (matched_text, matched_angle)
                         return matched_angle
-                    xy = 0.0
-                    if centres:
-                        mx = sum(point[0] for point in centres) / len(centres)
-                        my = sum(point[1] for point in centres) / len(centres)
-                        xy = sum((point[0] - mx) * (point[1] - my) for point in centres)
-                    actual_w = (
-                        max(box.max.X for box in glyph_boxes)
-                        - min(box.min.X for box in glyph_boxes)
-                        if glyph_boxes
-                        else x1 - x0 - 0.8 * fs
-                    )
-                    actual_h = (
-                        max(box.max.Y for box in glyph_boxes)
-                        - min(box.min.Y for box in glyph_boxes)
-                        if glyph_boxes
-                        else y1 - y0 - 0.8 * fs
-                    )
-                    matches = []
-                    for candidate in raw_dimension_candidates(
-                        annotation, getattr(annotation, "label", ""), self.draft
-                    ):
-                        width, height = _text_size(
-                            candidate,
-                            fs,
-                            drawing_font_path,
-                            drawing_font_name,
-                            self.draft.font_style,
-                        )
-                        if abs(width - height) < 1e-9:
-                            continue
-                        cos_plus_sin = (actual_w + actual_h) / (width + height)
-                        cos_minus_sin = (actual_w - actual_h) / (width - height)
-                        cos_angle = (cos_plus_sin + cos_minus_sin) / 2.0
-                        sin_angle = (cos_plus_sin - cos_minus_sin) / 2.0
-                        if min(cos_angle, sin_angle) < -1e-6:
-                            continue
-                        cos_angle = max(0.0, cos_angle)
-                        sin_angle = max(0.0, sin_angle)
-                        magnitude = math.degrees(math.atan2(sin_angle, cos_angle))
-                        predicted = (
-                            width * math.cos(math.radians(magnitude))
-                            + height * math.sin(math.radians(magnitude)),
-                            width * math.sin(math.radians(magnitude))
-                            + height * math.cos(math.radians(magnitude)),
-                        )
-                        circle_error = abs(cos_angle**2 + sin_angle**2 - 1.0)
-                        matches.append(
-                            (math.dist((actual_w, actual_h), predicted) + circle_error, magnitude)
-                        )
-                    if matches:
-                        magnitude = min(matches)[1]
-                        axis = -magnitude if xy < 0.0 else magnitude
-                        return raw_basic_text_angle(axis)
             polygon = getattr(annotation, "label_polygon", None)
             if polygon and len(polygon) >= 2:
                 (x0, y0), (x1, y1) = polygon[:2]
@@ -3965,6 +4032,7 @@ class Drawing:
                     value = getattr(annotation, "label", None)
                 label_box = getattr(annotation, "label_bbox", None)
                 if value and label_box:
+                    raw_freeform = False
                     run_font_size = fs
                     run_font_path = drawing_font_path
                     run_font_name = drawing_font_name
@@ -3990,8 +4058,11 @@ class Drawing:
                             # External raw helpers retain no label/tolerance constructor args.
                             # Compare the few possible unit renderings to the live label geometry;
                             # this also preserves explicit custom labels (their own width wins).
-                            candidates = raw_dimension_candidates(
-                                annotation, value, dimension_draft
+                            raw_freeform = raw_dimension_label_is_freeform(annotation, value)
+                            candidates = (
+                                [value]
+                                if raw_freeform
+                                else raw_dimension_candidates(annotation, value, dimension_draft)
                             )
                             rotation = text_rotation(annotation)
                             if getattr(annotation, "is_basic", False):
@@ -4053,6 +4124,25 @@ class Drawing:
                                 if match is not None and match[0] in candidates
                                 else min(candidates, key=geometry_error)
                             )
+                            if raw_freeform:
+                                polygon = getattr(annotation, "label_polygon", None)
+                                if polygon:
+                                    visible_width = math.dist(polygon[0], polygon[1])
+                                    unit_width, unit_height = _text_size(
+                                        value,
+                                        1.0,
+                                        run_font_path,
+                                        run_font_name,
+                                        run_font_style_enum,
+                                    )
+                                    if getattr(annotation, "is_basic", False):
+                                        unit_width = (
+                                            abs(unit_width * math.cos(base_angle))
+                                            + abs(unit_height * math.sin(base_angle))
+                                            + 0.8
+                                        )
+                                    if unit_width > 1e-9:
+                                        run_font_size = visible_width / unit_width
                     if not hasattr(annotation, "measured_length"):
                         run_font_style = getattr(annotation, "pdf_text_font_style", "REGULAR")
                     runs.extend(

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -3658,20 +3658,37 @@ class Drawing:
             return _font_safe_text(value).translate(_PDF_VECTOR_ONLY_TEXT)
 
         def text_rotation(annotation) -> float:
+            def upright(angle: float) -> float:
+                return angle if -90.0 < angle <= 90.0 else angle - math.copysign(180.0, angle)
+
             live_rotation = float(getattr(annotation.location.orientation, "Z", 0.0))
             explicit = getattr(annotation, "pdf_text_rotation", None)
             if explicit is not None:
                 return float(explicit) + live_rotation
             if getattr(annotation, "is_basic", False):
+                # Engine-built dimensions retain their authored endpoints even when a wide
+                # basic label consumes both shaft spans. Prefer that authoritative text axis
+                # over reverse-engineering whichever strokes survived helper rendering.
+                if (spec := getattr(annotation, "_dw_spec", None)) is not None:
+                    dx, dy = spec.p2[0] - spec.p1[0], spec.p2[1] - spec.p1[1]
+                    if math.hypot(dx, dy) > 1e-9:
+                        return upright(math.degrees(math.atan2(dy, dx)) + live_rotation)
                 # A basic dimension's keep-clear polygon is its axis-aligned frame,
-                # not its rotated text.  Its first shaft span retains the live text axis.
-                for start, end in getattr(annotation, "segments", ()):
+                # not its rotated text. For an external raw helper dimension, distinguish
+                # surviving collinear shaft spans from two parallel witness lines; text runs
+                # along the former and perpendicular to the latter.
+                segments = list(getattr(annotation, "segments", ()))
+                ink = segments[:-4] if len(segments) >= 4 else segments
+                if len(ink) == 2:
+                    (a0, a1), (b0, _b1) = ink
+                    dx, dy = a1[0] - a0[0], a1[1] - a0[1]
+                    cross = dx * (b0[1] - a0[1]) - dy * (b0[0] - a0[0])
+                    angle = math.degrees(math.atan2(dy, dx))
+                    return upright(angle if abs(cross) < 1e-7 else angle + 90.0)
+                for start, end in ink:
                     dx, dy = end[0] - start[0], end[1] - start[1]
                     if math.hypot(dx, dy) > 1e-9:
-                        angle = math.degrees(math.atan2(dy, dx))
-                        return (
-                            angle if -90.0 < angle <= 90.0 else angle - math.copysign(180.0, angle)
-                        )
+                        return upright(math.degrees(math.atan2(dy, dx)))
             polygon = getattr(annotation, "label_polygon", None)
             if polygon and len(polygon) >= 2:
                 (x0, y0), (x1, y1) = polygon[:2]
@@ -3773,33 +3790,73 @@ class Drawing:
                     value = getattr(annotation, "label", None)
                 label_box = getattr(annotation, "label_bbox", None)
                 if value and label_box:
-                    # A raw helper Dimension with label=None visibly renders units while its
-                    # compatibility metadata remains unitless.  Sanctioned Draftwright verbs
-                    # supply explicit labels; this width check preserves the deprecated raw-add
-                    # case without changing an explicit custom label.
-                    if (
-                        hasattr(annotation, "measured_length")
-                        and not getattr(annotation, "is_basic", False)
-                        and (polygon := getattr(annotation, "label_polygon", None))
-                    ):
-                        rendered = self.draft._number_with_units(annotation.measured_length)
-                        visible_width = math.dist(polygon[0], polygon[1])
-                        value_width = _text_size(
-                            value,
-                            fs,
-                            drawing_font_path,
-                            drawing_font_name,
-                            self.draft.font_style,
-                        )[0]
-                        rendered_width = _text_size(
-                            rendered,
-                            fs,
-                            drawing_font_path,
-                            drawing_font_name,
-                            self.draft.font_style,
-                        )[0]
-                        if abs(rendered_width - visible_width) < abs(value_width - visible_width):
-                            value = rendered
+                    if hasattr(annotation, "measured_length"):
+                        spec = getattr(annotation, "_dw_spec", None)
+                        if spec is not None and spec.kwargs.get("label") is None:
+                            # The engine owns this construction spec, including tolerance;
+                            # reproduce the exact helper-rendered label rather than its
+                            # intentionally unitless compatibility metadata.
+                            value = spec.draft._number_with_units(
+                                annotation.measured_length,
+                                spec.kwargs.get("tolerance"),
+                            )
+                        elif spec is None:
+                            # External raw helpers retain no label/tolerance constructor args.
+                            # Compare the few possible unit renderings to the live label geometry;
+                            # this also preserves explicit custom labels (their own width wins).
+                            bare_zero = self.draft._number_with_units(0.0, display_units=False)
+                            unit_zero = self.draft._number_with_units(0.0, display_units=True)
+                            unit_suffix = unit_zero.removeprefix(bare_zero)
+                            candidates = [
+                                value,
+                                self.draft._number_with_units(annotation.measured_length),
+                            ]
+                            if unit_suffix and not value.endswith(unit_suffix):
+                                candidates.append(value + unit_suffix)
+                            candidates = list(dict.fromkeys(candidates))
+                            rotation = text_rotation(annotation)
+                            if getattr(annotation, "is_basic", False):
+                                x0, y0, x1, y1 = label_box
+                                actual = (x1 - x0, y1 - y0)
+                                angle = math.radians(rotation)
+
+                                def geometry_error(candidate):
+                                    width, height = _text_size(
+                                        candidate,
+                                        fs,
+                                        drawing_font_path,
+                                        drawing_font_name,
+                                        self.draft.font_style,
+                                    )
+                                    predicted = (
+                                        abs(width * math.cos(angle))
+                                        + abs(height * math.sin(angle))
+                                        + 0.8 * fs,
+                                        abs(width * math.sin(angle))
+                                        + abs(height * math.cos(angle))
+                                        + 0.8 * fs,
+                                    )
+                                    return math.dist(actual, predicted)
+
+                            else:
+                                polygon = getattr(annotation, "label_polygon", None)
+                                visible_width = (
+                                    math.dist(polygon[0], polygon[1])
+                                    if polygon
+                                    else label_box[2] - label_box[0]
+                                )
+
+                                def geometry_error(candidate):
+                                    width = _text_size(
+                                        candidate,
+                                        fs,
+                                        drawing_font_path,
+                                        drawing_font_name,
+                                        self.draft.font_style,
+                                    )[0]
+                                    return abs(width - visible_width)
+
+                            value = min(candidates, key=geometry_error)
                     font_style = (
                         drawing_font_style
                         if hasattr(annotation, "measured_length")

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -49,6 +49,8 @@ from draftwright._core import (
     _log,
     _table_metrics,
     _tag_sequence,
+    _text_line_spacing_em,
+    _text_size,
     _tol_suffix,
     place_annotation,
 )
@@ -2831,7 +2833,11 @@ class Drawing:
         # overlay (notably its established ⌀ -> ø compatibility substitution).
         n.pdf_text = _font_safe_text(text)
         n.pdf_text_rotation = float(rotation)
-        n.pdf_text_line_spacing = 1.3
+        n.pdf_text_line_spacing = _text_line_spacing_em(
+            self.draft.font_size,
+            getattr(self.draft, "font_path", DEFAULT_FONT_PATH),
+            getattr(self.draft, "font", "Arial"),
+        )
         if name is None:
             i = 0
             while (name := f"note{i}") in self._registry:
@@ -3642,6 +3648,7 @@ class Drawing:
         pad = self.draft.pad_around_text
         drawing_font_path = getattr(self.draft, "font_path", DEFAULT_FONT_PATH)
         drawing_font_name = getattr(self.draft, "font", "Arial")
+        drawing_font_style = getattr(getattr(self.draft, "font_style", None), "name", "REGULAR")
 
         def semantic_text(value) -> str:
             # The bundled faces do not carry the geometric counterbore,
@@ -3661,7 +3668,10 @@ class Drawing:
                 for start, end in getattr(annotation, "segments", ()):
                     dx, dy = end[0] - start[0], end[1] - start[1]
                     if math.hypot(dx, dy) > 1e-9:
-                        return math.degrees(math.atan2(dy, dx))
+                        angle = math.degrees(math.atan2(dy, dx))
+                        return (
+                            angle if -90.0 < angle <= 90.0 else angle - math.copysign(180.0, angle)
+                        )
             polygon = getattr(annotation, "label_polygon", None)
             if polygon and len(polygon) >= 2:
                 (x0, y0), (x1, y1) = polygon[:2]
@@ -3675,7 +3685,8 @@ class Drawing:
             rotation,
             font_path,
             font_name="Arial",
-            line_spacing=1.3,
+            font_style="REGULAR",
+            line_spacing=None,
         ):
             lines = semantic_text(value).splitlines()
             if not lines:
@@ -3684,6 +3695,8 @@ class Drawing:
             cx, cy = (x0 + x1) / 2.0, (y0 + y1) / 2.0
             angle = math.radians(rotation)
             sin_angle, cos_angle = math.sin(angle), math.cos(angle)
+            if line_spacing is None:
+                line_spacing = _text_line_spacing_em(font_size, font_path, font_name)
             runs = []
             for index, line in enumerate(lines):
                 if not line:
@@ -3695,11 +3708,12 @@ class Drawing:
                         cx - sin_angle * local_y,
                         cy + cos_angle * local_y,
                         font_size,
-                        rotation,
-                        font_path,
-                        font_name,
-                        "center",
-                        "middle",
+                        rotation=rotation,
+                        font_path=font_path,
+                        font_name=font_name,
+                        font_style=font_style,
+                        h_align="center",
+                        v_align="middle",
                     )
                 )
             return runs
@@ -3737,7 +3751,7 @@ class Drawing:
                     angle = math.radians(rotation)
                     cos_angle, sin_angle = math.cos(angle), math.sin(angle)
                     for spec in specs:
-                        value, rx, ry, size, path, name, *align = spec
+                        value, rx, ry, size, path, name, style, *align = spec
                         h_align, v_align = align or ("center", "middle")
                         runs.append(
                             _PDFTextRun(
@@ -3745,11 +3759,12 @@ class Drawing:
                                 cx + cos_angle * rx - sin_angle * ry,
                                 cy + sin_angle * rx + cos_angle * ry,
                                 size,
-                                rotation,
-                                path,
-                                name,
-                                h_align,
-                                v_align,
+                                rotation=rotation,
+                                font_path=path,
+                                font_name=name,
+                                font_style=style,
+                                h_align=h_align,
+                                v_align=v_align,
                             )
                         )
             else:
@@ -3758,6 +3773,38 @@ class Drawing:
                     value = getattr(annotation, "label", None)
                 label_box = getattr(annotation, "label_bbox", None)
                 if value and label_box:
+                    # A raw helper Dimension with label=None visibly renders units while its
+                    # compatibility metadata remains unitless.  Sanctioned Draftwright verbs
+                    # supply explicit labels; this width check preserves the deprecated raw-add
+                    # case without changing an explicit custom label.
+                    if (
+                        hasattr(annotation, "measured_length")
+                        and not getattr(annotation, "is_basic", False)
+                        and (polygon := getattr(annotation, "label_polygon", None))
+                    ):
+                        rendered = self.draft._number_with_units(annotation.measured_length)
+                        visible_width = math.dist(polygon[0], polygon[1])
+                        value_width = _text_size(
+                            value,
+                            fs,
+                            drawing_font_path,
+                            drawing_font_name,
+                            self.draft.font_style,
+                        )[0]
+                        rendered_width = _text_size(
+                            rendered,
+                            fs,
+                            drawing_font_path,
+                            drawing_font_name,
+                            self.draft.font_style,
+                        )[0]
+                        if abs(rendered_width - visible_width) < abs(value_width - visible_width):
+                            value = rendered
+                    font_style = (
+                        drawing_font_style
+                        if hasattr(annotation, "measured_length")
+                        else getattr(annotation, "pdf_text_font_style", "REGULAR")
+                    )
                     runs.extend(
                         centred_runs(
                             value,
@@ -3766,7 +3813,8 @@ class Drawing:
                             text_rotation(annotation),
                             drawing_font_path,
                             drawing_font_name,
-                            getattr(annotation, "pdf_text_line_spacing", 1.3),
+                            font_style,
+                            getattr(annotation, "pdf_text_line_spacing", None),
                         )
                     )
             if runs:

--- a/src/draftwright/export.py
+++ b/src/draftwright/export.py
@@ -37,9 +37,28 @@ class _PDFTextRun:
     y: float
     font_size: float
     rotation: float = 0.0
-    font_path: str = PLEX_MONO
+    font_path: str | None = PLEX_MONO
+    font_name: str = "Arial"
     h_align: str = "left"
     v_align: str = "baseline"
+
+
+@lru_cache(maxsize=16)
+def _resolved_semantic_font_path(font_path: str | None, font_name: str) -> str:
+    """Resolve the same regular face used by build123d's text renderer.
+
+    A ``None`` path is a deliberate opt-out from Draftwright's pinned font: build123d
+    resolves ``draft.font`` through OCCT.  Ask that same manager for the concrete file so
+    ReportLab embeds the matching face instead of silently substituting Plex Mono.
+    """
+    if font_path is not None:
+        return font_path
+
+    from build123d import FontStyle
+    from build123d.text import FONT_ASPECT, FontManager
+
+    face = FontManager().find_font(font_name, FontStyle.REGULAR)
+    return str(face.FontPath(FONT_ASPECT[FontStyle.REGULAR]).ToCString())
 
 
 @lru_cache(maxsize=16)
@@ -297,9 +316,24 @@ def _render_pdf(svg_path: str, pdf_path: str, link_rect=None, text_runs=()) -> N
 
             k = 72.0 / 25.4
             for run in text_runs:
-                font_name = _semantic_font_name(run.font_path)
+                font_path = _resolved_semantic_font_path(run.font_path, run.font_name)
+                font_name = _semantic_font_name(font_path)
                 if font_name not in pdfmetrics.getRegisteredFontNames():
-                    pdfmetrics.registerFont(TTFont(font_name, run.font_path))
+                    try:
+                        pdfmetrics.registerFont(TTFont(font_name, font_path))
+                    except Exception:  # noqa: BLE001 - CFF/single-stroke faces are not TTFont
+                        # Geometry supports more font formats than ReportLab's TTFont
+                        # subsetter.  Keep export/search total with the bundled Unicode face;
+                        # the normal pinned TTF path above still matches visible metrics.
+                        _log.warning(
+                            "PDF semantic font %s cannot be embedded; using bundled Plex Mono",
+                            font_path,
+                            exc_info=True,
+                        )
+                        font_path = PLEX_MONO
+                        font_name = _semantic_font_name(font_path)
+                        if font_name not in pdfmetrics.getRegisteredFontNames():
+                            pdfmetrics.registerFont(TTFont(font_name, font_path))
                 font_size = run.font_size * k
                 dx = 0.0
                 if run.h_align == "center":

--- a/src/draftwright/export.py
+++ b/src/draftwright/export.py
@@ -381,6 +381,26 @@ def _render_pdf(svg_path: str, pdf_path: str, link_rect=None, text_runs=()) -> N
                     text.setTextOrigin(origin_x, origin_y)
                 text.textOut(run.text)
                 canvas.drawText(text)
+                if cos_angle < -1e-9:
+                    # Poppler can reorder a leftward run even though its physical text boxes
+                    # are correct. Keep that aligned run for selection, then add a logical
+                    # companion so exact term search remains portable across PDF readers.
+                    actual_text = "FEFF" + run.text.encode("utf-16-be").hex().upper()
+                    logical = canvas.beginText()
+                    logical.setTextRenderMode(3)
+                    logical.setFont(font_name, font_size)
+                    logical.setTextTransform(
+                        cos_angle,
+                        sin_angle,
+                        -sin_angle,
+                        cos_angle,
+                        origin_x,
+                        origin_y,
+                    )
+                    logical.textOut(" ")
+                    canvas.addLiteral(f"/Span << /ActualText <{actual_text}> >> BDC")
+                    canvas.drawText(logical)
+                    canvas.addLiteral("EMC")
         if link_rect is not None:
             k = 72.0 / 25.4
             x0, y0, x1, y1 = link_rect

--- a/src/draftwright/export.py
+++ b/src/draftwright/export.py
@@ -39,12 +39,15 @@ class _PDFTextRun:
     rotation: float = 0.0
     font_path: str | None = PLEX_MONO
     font_name: str = "Arial"
+    font_style: str = "REGULAR"
     h_align: str = "left"
     v_align: str = "baseline"
 
 
-@lru_cache(maxsize=16)
-def _resolved_semantic_font_path(font_path: str | None, font_name: str) -> str:
+@lru_cache(maxsize=32)
+def _resolved_semantic_font_path(
+    font_path: str | None, font_name: str, font_style: str = "REGULAR"
+) -> str:
     """Resolve the same regular face used by build123d's text renderer.
 
     A ``None`` path is a deliberate opt-out from Draftwright's pinned font: build123d
@@ -57,8 +60,9 @@ def _resolved_semantic_font_path(font_path: str | None, font_name: str) -> str:
     from build123d import FontStyle
     from build123d.text import FONT_ASPECT, FontManager
 
-    face = FontManager().find_font(font_name, FontStyle.REGULAR)
-    return str(face.FontPath(FONT_ASPECT[FontStyle.REGULAR]).ToCString())
+    style = FontStyle[font_style]
+    face = FontManager().find_font(font_name, style)
+    return str(face.FontPath(FONT_ASPECT[style]).ToCString())
 
 
 @lru_cache(maxsize=16)
@@ -315,25 +319,33 @@ def _render_pdf(svg_path: str, pdf_path: str, link_rect=None, text_runs=()) -> N
             from reportlab.pdfbase.ttfonts import TTFont
 
             k = 72.0 / 25.4
+            font_choices: dict[tuple[str | None, str, str], tuple[str, str]] = {}
             for run in text_runs:
-                font_path = _resolved_semantic_font_path(run.font_path, run.font_name)
-                font_name = _semantic_font_name(font_path)
-                if font_name not in pdfmetrics.getRegisteredFontNames():
-                    try:
-                        pdfmetrics.registerFont(TTFont(font_name, font_path))
-                    except Exception:  # noqa: BLE001 - CFF/single-stroke faces are not TTFont
-                        # Geometry supports more font formats than ReportLab's TTFont
-                        # subsetter.  Keep export/search total with the bundled Unicode face;
-                        # the normal pinned TTF path above still matches visible metrics.
-                        _log.warning(
-                            "PDF semantic font %s cannot be embedded; using bundled Plex Mono",
-                            font_path,
-                            exc_info=True,
-                        )
-                        font_path = PLEX_MONO
-                        font_name = _semantic_font_name(font_path)
-                        if font_name not in pdfmetrics.getRegisteredFontNames():
+                font_key = (run.font_path, run.font_name, run.font_style)
+                choice = font_choices.get(font_key)
+                if choice is None:
+                    font_path = _resolved_semantic_font_path(*font_key)
+                    font_name = _semantic_font_name(font_path)
+                    if font_name not in pdfmetrics.getRegisteredFontNames():
+                        try:
                             pdfmetrics.registerFont(TTFont(font_name, font_path))
+                        except Exception as exc:  # noqa: BLE001 - CFF/single-stroke faces
+                            # Geometry supports more font formats than ReportLab's TTFont
+                            # subsetter. Keep export/search total with the bundled Unicode face.
+                            # Cache the choice per export so a dense drawing warns/probes once.
+                            _log.warning(
+                                "PDF semantic font %s cannot be embedded (%s); "
+                                "using bundled Plex Mono",
+                                font_path,
+                                exc,
+                            )
+                            font_path = PLEX_MONO
+                            font_name = _semantic_font_name(font_path)
+                            if font_name not in pdfmetrics.getRegisteredFontNames():
+                                pdfmetrics.registerFont(TTFont(font_name, font_path))
+                    choice = (font_path, font_name)
+                    font_choices[font_key] = choice
+                font_path, font_name = choice
                 font_size = run.font_size * k
                 dx = 0.0
                 if run.h_align == "center":

--- a/src/draftwright/export.py
+++ b/src/draftwright/export.py
@@ -380,27 +380,16 @@ def _render_pdf(svg_path: str, pdf_path: str, link_rect=None, text_runs=()) -> N
                 else:
                     text.setTextOrigin(origin_x, origin_y)
                 text.textOut(run.text)
-                canvas.drawText(text)
                 if cos_angle < -1e-9:
-                    # Poppler can reorder a leftward run even though its physical text boxes
-                    # are correct. Keep that aligned run for selection, then add a logical
-                    # companion so exact term search remains portable across PDF readers.
+                    # Poppler can reorder a leftward run even though its geometry is correct.
+                    # ActualText is the PDF-standard logical representation for extraction;
+                    # its marked content retains the run's overall positioned ink bounds.
                     actual_text = "FEFF" + run.text.encode("utf-16-be").hex().upper()
-                    logical = canvas.beginText()
-                    logical.setTextRenderMode(3)
-                    logical.setFont(font_name, font_size)
-                    logical.setTextTransform(
-                        cos_angle,
-                        sin_angle,
-                        -sin_angle,
-                        cos_angle,
-                        origin_x,
-                        origin_y,
-                    )
-                    logical.textOut(" ")
                     canvas.addLiteral(f"/Span << /ActualText <{actual_text}> >> BDC")
-                    canvas.drawText(logical)
+                    canvas.drawText(text)
                     canvas.addLiteral("EMC")
+                else:
+                    canvas.drawText(text)
         if link_rect is not None:
             k = 72.0 / 25.4
             x0, y0, x1, y1 = link_rect

--- a/src/draftwright/export.py
+++ b/src/draftwright/export.py
@@ -12,8 +12,10 @@ shapes), so it sits below `make_drawing` in the import DAG and depends only on
 from __future__ import annotations
 
 import logging
+import math
 import re
 from dataclasses import dataclass
+from functools import lru_cache
 from pathlib import Path
 
 import ezdxf
@@ -35,6 +37,20 @@ class _PDFTextRun:
     y: float
     font_size: float
     rotation: float = 0.0
+    font_path: str = PLEX_MONO
+    h_align: str = "left"
+    v_align: str = "baseline"
+
+
+@lru_cache(maxsize=16)
+def _semantic_font_name(font_path: str) -> str:
+    """Return a stable reportlab registration name for one bundled font file."""
+    from hashlib import sha256
+
+    path = Path(font_path)
+    digest = sha256(path.read_bytes()).hexdigest()[:12]
+    stem = re.sub(r"[^A-Za-z0-9]+", "_", path.stem)
+    return f"Draftwright_{stem}_{digest}"
 
 
 def fix_svg_page_size(svg_path: str, page_w: float, page_h: float) -> None:
@@ -279,28 +295,44 @@ def _render_pdf(svg_path: str, pdf_path: str, link_rect=None, text_runs=()) -> N
             from reportlab.pdfbase import pdfmetrics
             from reportlab.pdfbase.ttfonts import TTFont
 
-            font_name = "Draftwright_IBMPlexMono_Semantic_v1"
-            if font_name not in pdfmetrics.getRegisteredFontNames():
-                pdfmetrics.registerFont(TTFont(font_name, PLEX_MONO))
             k = 72.0 / 25.4
             for run in text_runs:
+                font_name = _semantic_font_name(run.font_path)
+                if font_name not in pdfmetrics.getRegisteredFontNames():
+                    pdfmetrics.registerFont(TTFont(font_name, run.font_path))
+                font_size = run.font_size * k
+                dx = 0.0
+                if run.h_align == "center":
+                    dx = -pdfmetrics.stringWidth(run.text, font_name, font_size) / 2.0
+                elif run.h_align == "right":
+                    dx = -pdfmetrics.stringWidth(run.text, font_name, font_size)
+                elif run.h_align != "left":
+                    raise ValueError(f"unknown PDF text horizontal alignment {run.h_align!r}")
+                dy = 0.0
+                if run.v_align == "middle":
+                    ascent, descent = pdfmetrics.getAscentDescent(font_name, font_size)
+                    dy = -(ascent + descent) / 2.0
+                elif run.v_align != "baseline":
+                    raise ValueError(f"unknown PDF text vertical alignment {run.v_align!r}")
+
+                angle = math.radians(run.rotation)
+                cos_angle, sin_angle = math.cos(angle), math.sin(angle)
+                origin_x = run.x * k + cos_angle * dx - sin_angle * dy
+                origin_y = run.y * k + sin_angle * dx + cos_angle * dy
                 text = canvas.beginText()
                 text.setTextRenderMode(3)  # invisible, but retained for search/copy
-                text.setFont(font_name, run.font_size * k)
+                text.setFont(font_name, font_size)
                 if run.rotation:
-                    import math
-
-                    angle = math.radians(run.rotation)
                     text.setTextTransform(
-                        math.cos(angle),
-                        math.sin(angle),
-                        -math.sin(angle),
-                        math.cos(angle),
-                        run.x * k,
-                        run.y * k,
+                        cos_angle,
+                        sin_angle,
+                        -sin_angle,
+                        cos_angle,
+                        origin_x,
+                        origin_y,
                     )
                 else:
-                    text.setTextOrigin(run.x * k, run.y * k)
+                    text.setTextOrigin(origin_x, origin_y)
                 text.textOut(run.text)
                 canvas.drawText(text)
         if link_rect is not None:

--- a/src/draftwright/export.py
+++ b/src/draftwright/export.py
@@ -58,9 +58,43 @@ def _resolved_semantic_font_path(
         return font_path
 
     from build123d import FontStyle
-    from build123d.text import FONT_ASPECT, FontManager
 
     style = FontStyle[font_style]
+    try:
+        from build123d.text import FONT_ASPECT, FontManager
+    except ModuleNotFoundError as exc:
+        if exc.name != "build123d.text":  # pragma: no cover - broken installation
+            raise
+
+        # build123d 0.10 resolves fonts inline in Compound.make_text(); the public
+        # FontManager wrapper arrived in 0.11.  Mirror the 0.10 renderer so the
+        # invisible PDF face remains the one that produced the visible outlines.
+        import os
+        import sys
+
+        from OCP.Font import (
+            Font_FA_Bold,
+            Font_FA_BoldItalic,
+            Font_FA_Italic,
+            Font_FA_Regular,
+            Font_FontMgr,
+        )
+        from OCP.TCollection import TCollection_AsciiString
+
+        if sys.platform.startswith("linux"):
+            os.environ["FONTCONFIG_FILE"] = "/etc/fonts/fonts.conf"
+            os.environ["FONTCONFIG_PATH"] = "/etc/fonts/"
+        font_aspect = {
+            FontStyle.REGULAR: Font_FA_Regular,
+            FontStyle.BOLD: Font_FA_Bold,
+            FontStyle.ITALIC: Font_FA_Italic,
+            FontStyle.BOLDITALIC: Font_FA_BoldItalic,
+        }[style]
+        face = Font_FontMgr.GetInstance_s().FindFont(
+            TCollection_AsciiString(font_name), font_aspect
+        )
+        return str(face.FontPath(font_aspect).ToCString())
+
     face = FontManager().find_font(font_name, style)
     return str(face.FontPath(FONT_ASPECT[style]).ToCString())
 

--- a/src/draftwright/export.py
+++ b/src/draftwright/export.py
@@ -72,25 +72,21 @@ def _resolved_semantic_font_path(
         import os
         import sys
 
-        from OCP.Font import (
-            Font_FA_Bold,
-            Font_FA_BoldItalic,
-            Font_FA_Italic,
-            Font_FA_Regular,
-            Font_FontMgr,
-        )
+        import OCP.Font as ocp_font
         from OCP.TCollection import TCollection_AsciiString
 
         if sys.platform.startswith("linux"):
             os.environ["FONTCONFIG_FILE"] = "/etc/fonts/fonts.conf"
             os.environ["FONTCONFIG_PATH"] = "/etc/fonts/"
-        font_aspect = {
-            FontStyle.REGULAR: Font_FA_Regular,
-            FontStyle.BOLD: Font_FA_Bold,
-            FontStyle.ITALIC: Font_FA_Italic,
-            FontStyle.BOLDITALIC: Font_FA_BoldItalic,
-        }[style]
-        face = Font_FontMgr.GetInstance_s().FindFont(
+        font_aspects = {
+            FontStyle.REGULAR: ocp_font.Font_FA_Regular,
+            FontStyle.BOLD: ocp_font.Font_FA_Bold,
+            FontStyle.ITALIC: ocp_font.Font_FA_Italic,
+        }
+        if hasattr(FontStyle, "BOLDITALIC"):
+            font_aspects[FontStyle.BOLDITALIC] = ocp_font.Font_FA_BoldItalic
+        font_aspect = font_aspects[style]
+        face = ocp_font.Font_FontMgr.GetInstance_s().FindFont(
             TCollection_AsciiString(font_name), font_aspect
         )
         return str(face.FontPath(font_aspect).ToCString())

--- a/src/draftwright/export.py
+++ b/src/draftwright/export.py
@@ -383,7 +383,11 @@ def _render_pdf(svg_path: str, pdf_path: str, link_rect=None, text_runs=()) -> N
                 if cos_angle < -1e-9:
                     # Poppler can reorder a leftward run even though its geometry is correct.
                     # ActualText is the PDF-standard logical representation for extraction;
-                    # its marked content retains the run's overall positioned ink bounds.
+                    # its marked content retains the run's matrix and overall positioned ink
+                    # bounds. Replacement text is span-atomic: PDFium partitions that overall
+                    # AABB for partial-character selection, but whole-term selection stays on
+                    # the physical word. Keeping an unwrapped physical copy would instead
+                    # corrupt search/copy in every Poppler extraction mode.
                     actual_text = "FEFF" + run.text.encode("utf-16-be").hex().upper()
                     canvas.addLiteral(f"/Span << /ActualText <{actual_text}> >> BDC")
                     canvas.drawText(text)

--- a/tests/test_issue_1352_searchable_pdf_text.py
+++ b/tests/test_issue_1352_searchable_pdf_text.py
@@ -312,16 +312,34 @@ def test_basic_dimension_semantic_text_is_normalised_upright(tmp_path, start, en
 
 
 @pytest.mark.parametrize(
-    ("start", "end", "label", "label_offset_x", "expected"),
+    ("start", "end", "label", "label_offset_x", "rotation", "live_rotation", "expected"),
     [
-        ((50, 50, 0), (90, 50, 0), "X", -20, 0.0),
-        ((50, 50, 0), (50, 90, 0), "W" * 40, 0, 90.0),
-        ((50, 50, 0), (90, 90, 0), "W" * 40, 0, 45.0),
-        ((50, 90, 0), (90, 50, 0), "W" * 40, 0, -45.0),
+        ((50, 50, 0), (90, 50, 0), "X", -20, 0, 0, 0.0),
+        ((50, 50, 0), (50, 90, 0), "W" * 40, 0, 0, 0, 90.0),
+        ((50, 50, 0), (90, 90, 0), "W" * 40, 0, 0, 0, 45.0),
+        ((50, 90, 0), (90, 50, 0), "W" * 40, 0, 0, 0, -45.0),
+        (
+            (50, 50, 0),
+            (56.945927, 89.39231, 0),
+            "UPRIGHT",
+            0,
+            30,
+            0,
+            110.0,
+        ),
+        (
+            (50, 50, 0),
+            (56.945927, 89.39231, 0),
+            "UPRIGHT",
+            0,
+            30,
+            20,
+            130.0,
+        ),
     ],
 )
 def test_raw_basic_dimension_rotation_survives_missing_or_mixed_spans(
-    tmp_path, start, end, label, label_offset_x, expected
+    tmp_path, start, end, label, label_offset_x, rotation, live_rotation, expected
 ):
     drawing = build_drawing(Box(10, 10, 10), auto_dims=False)
     annotation = Dimension(
@@ -333,7 +351,9 @@ def test_raw_basic_dimension_rotation_survives_missing_or_mixed_spans(
         label=label,
         basic=True,
         label_offset_x=label_offset_x,
+        rotation=rotation,
     )
+    annotation.location = Location((0, 0, 0), (0, 0, live_rotation))
     drawing.registry.add(annotation, "raw_basic", view=None)
     drawing.items.append(annotation)
 
@@ -349,7 +369,8 @@ def test_raw_basic_dimension_rotation_survives_missing_or_mixed_spans(
         pdf.close()
 
 
-def test_engine_dimension_keeps_its_construction_draft_and_rotation(tmp_path):
+@pytest.mark.parametrize("rotation", [30, 120])
+def test_engine_dimension_keeps_its_construction_draft_and_rotation(tmp_path, rotation):
     drawing = build_drawing(Box(10, 10, 10), auto_dims=False)
     custom = Draft(font_size=5, font="Arial", font_style=FontStyle.BOLD)
     custom.font_path = None
@@ -363,14 +384,14 @@ def test_engine_dimension_keeps_its_construction_draft_and_rotation(tmp_path):
             name="tagged",
             basic=True,
             label="TAGGED",
-            rotation=30,
+            rotation=rotation,
         )
 
-    pdf_path = drawing.export(str(tmp_path / "tagged"), formats=("pdf",))["pdf"]
+    pdf_path = drawing.export(str(tmp_path / f"tagged_{rotation}"), formats=("pdf",))["pdf"]
     pdf, text_page, extracted = _pdf_text(pdf_path)
     try:
         assert _extracted_text_angle(text_page, extracted, "TAGGED") == pytest.approx(
-            30.0, abs=1.0
+            rotation, abs=1.0
         )
     finally:
         text_page.close()
@@ -408,6 +429,30 @@ def test_raw_helper_dimension_semantic_fallback_keeps_visible_label(
     pdf, text_page, extracted = _pdf_text(pdf_path)
     try:
         assert expected in extracted
+    finally:
+        text_page.close()
+        pdf.close()
+
+
+def test_raw_asymmetric_limits_keep_visible_order_without_units(tmp_path):
+    drawing = build_drawing(Box(10, 10, 10), auto_dims=False)
+    drawing.draft.display_units = False
+    annotation = Dimension(
+        (10, 10, 0),
+        (20, 10, 0),
+        "above",
+        10,
+        drawing.draft,
+        tolerance=(0.1, 0.2),
+    )
+    drawing.registry.add(annotation, "raw_limits", view=None)
+    drawing.items.append(annotation)
+
+    pdf_path = drawing.export(str(tmp_path / "raw_limits"), formats=("pdf",))["pdf"]
+    pdf, text_page, extracted = _pdf_text(pdf_path)
+    try:
+        assert "10.0 +0.1 -0.2" in extracted
+        assert "10.0 +0.2 -0.1" not in extracted
     finally:
         text_page.close()
         pdf.close()

--- a/tests/test_issue_1352_searchable_pdf_text.py
+++ b/tests/test_issue_1352_searchable_pdf_text.py
@@ -364,9 +364,12 @@ def test_raw_basic_dimension_rotation_survives_missing_or_mixed_spans(
     pdf, text_page, extracted = _pdf_text(pdf_path)
     try:
         assert label in extracted
-        assert _extracted_text_angle(text_page, extracted, label) == pytest.approx(
-            expected, abs=1.0
-        )
+        if math.cos(math.radians(expected)) < -1e-9:
+            _assert_first_character_overlaps_annotation(text_page, extracted, label, annotation)
+        else:
+            assert _extracted_text_angle(text_page, extracted, label) == pytest.approx(
+                expected, abs=1.0
+            )
     finally:
         text_page.close()
         pdf.close()
@@ -393,9 +396,13 @@ def test_engine_dimension_keeps_its_construction_draft_and_rotation(tmp_path, ro
     pdf_path = drawing.export(str(tmp_path / f"tagged_{rotation}"), formats=("pdf",))["pdf"]
     pdf, text_page, extracted = _pdf_text(pdf_path)
     try:
-        assert _extracted_text_angle(text_page, extracted, "TAGGED") == pytest.approx(
-            rotation, abs=1.0
-        )
+        if math.cos(math.radians(rotation)) < -1e-9:
+            annotation = drawing.get_annotation("tagged")
+            _assert_first_character_overlaps_annotation(text_page, extracted, "TAGGED", annotation)
+        else:
+            assert _extracted_text_angle(text_page, extracted, "TAGGED") == pytest.approx(
+                rotation, abs=1.0
+            )
     finally:
         text_page.close()
         pdf.close()
@@ -481,6 +488,33 @@ def test_raw_custom_limit_lookalike_is_not_rewritten(tmp_path):
         assert "10.0 +0.2 -0.1" in extracted
         assert "10.0 +0.1 -0.2" not in extracted
         assert "10.0 +0.2 -0.1mm" not in extracted
+    finally:
+        text_page.close()
+        pdf.close()
+
+
+def test_raw_numeric_freeform_label_keeps_authored_spelling(tmp_path):
+    drawing = build_drawing(Box(10, 10, 10), auto_dims=False)
+    annotation = Dimension(
+        (10, 10, 0),
+        (11, 10, 0),
+        "above",
+        10,
+        drawing.draft,
+        label="1",
+    )
+    drawing.registry.add(annotation, "raw_numeric_label", view=None)
+    drawing.items.append(annotation)
+
+    pdf_path = drawing.export(str(tmp_path / "raw_numeric_label"), formats=("pdf",))["pdf"]
+    pdf, text_page, extracted = _pdf_text(pdf_path)
+    page = text_page.parent
+    try:
+        assert any(
+            isinstance(item, pdfium.PdfTextObj) and item.extract() == "1"
+            for item in page.get_objects(textpage=text_page)
+        )
+        assert "1.0mm" not in extracted
     finally:
         text_page.close()
         pdf.close()
@@ -576,15 +610,26 @@ def test_poppler_keeps_a_term_whole_when_its_baseline_points_left(tmp_path):
     )
     drawing.registry.add(annotation, "leftward_text", view=None)
     drawing.items.append(annotation)
+    drawing.note("LEFTWARD", (150, 150), rotation=110, name="leftward_note")
+    note = drawing.get_annotation("leftward_note")
+    box = note.bounding_box()
+    note.location = Location(
+        (150 - (box.min.X + box.max.X) / 2, 150 - (box.min.Y + box.max.Y) / 2, 0)
+    )
 
     pdf_path = drawing.export(str(tmp_path / "poppler_rotation"), formats=("pdf",))["pdf"]
-    extracted = subprocess.run(
-        [executable, pdf_path, "-"],
-        check=True,
-        capture_output=True,
-        text=True,
-    ).stdout
-    assert "ANGLE" in extracted
+    for options in ((), ("-raw",), ("-layout",)):
+        extracted = subprocess.run(
+            [executable, *options, pdf_path, "-"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        lines = [line.strip() for line in extracted.splitlines() if line.strip()]
+        assert lines.count("ANGLE") == 1
+        assert lines.count("LEFTWARD") == 1
+        assert all("ANGLE" not in line or line == "ANGLE" for line in lines)
+        assert all("LEFTWARD" not in line or line == "LEFTWARD" for line in lines)
 
 
 def test_note_semantic_rotation_tracks_later_annotation_transform(tmp_path):

--- a/tests/test_issue_1352_searchable_pdf_text.py
+++ b/tests/test_issue_1352_searchable_pdf_text.py
@@ -448,7 +448,11 @@ def test_engine_dimension_keeps_its_construction_draft_and_rotation(tmp_path, ro
     finally:
         text_page.close()
         pdf.close()
-    assert b"Arial-BoldMT" in Path(pdf_path).read_bytes()
+    from reportlab.pdfbase.ttfonts import TTFont
+
+    resolved = _resolved_semantic_font_path(None, "Arial", "BOLD")
+    expected_postscript_name = TTFont("ResolvedArialBold", resolved).face.name
+    assert expected_postscript_name in Path(pdf_path).read_bytes()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_issue_1352_searchable_pdf_text.py
+++ b/tests/test_issue_1352_searchable_pdf_text.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import warnings
 from pathlib import Path
+from types import SimpleNamespace
 
 import pypdfium2 as pdfium
 import pytest
@@ -17,7 +18,7 @@ from PIL import Image, ImageChops
 
 from draftwright import Sheet, build_drawing
 from draftwright._core import _text_line_spacing_em
-from draftwright.drawing import Drawing
+from draftwright.drawing import Drawing, _exact_vertex_rotation
 from draftwright.export import _PDFTextRun, _render_pdf, _resolved_semantic_font_path
 from draftwright.fonts import PLEX_MONO, PLEX_SANS_CONDENSED
 
@@ -162,6 +163,27 @@ def _extracted_text_angle(text_page, extracted, value):
     x0, y0 = _character_centre(text_page, start)
     x1, y1 = _character_centre(text_page, start + len(value) - 1)
     return math.degrees(math.atan2(y1 - y0, x1 - x0))
+
+
+def test_exact_vertex_rotation_rejects_non_similarity():
+    def point(x, y):
+        return SimpleNamespace(X=x, Y=y)
+
+    assert _exact_vertex_rotation([], []) is None
+    assert (
+        _exact_vertex_rotation(
+            [point(0, 0), point(0, 0)],
+            [point(1, 1), point(1, 1)],
+        )
+        is None
+    )
+    assert (
+        _exact_vertex_rotation(
+            [point(0, 0), point(1, 0), point(0, 1)],
+            [point(0, 0), point(2, 0), point(0, 1)],
+        )
+        is None
+    )
 
 
 def test_multiline_notes_and_title_values_retain_visible_line_pitch(tmp_path):
@@ -692,6 +714,71 @@ def test_raw_drawing_font_single_curved_glyph_keeps_exact_rotation(
         )
         a, b, _c, _d, _e, _f = text_object.get_matrix().get()
         assert math.degrees(math.atan2(b, a)) == pytest.approx(expected, abs=1.0)
+    finally:
+        text_page.close()
+        pdf.close()
+
+
+@pytest.mark.parametrize(("axis", "expected"), [(45, 45.0), (-45, -45.0)])
+def test_raw_drawing_font_single_stroke_glyph_prefers_exact_face(tmp_path, axis, expected):
+    drawing = build_drawing(Box(10, 10, 10), auto_dims=False)
+    angle = math.radians(axis)
+    annotation = Dimension(
+        (50, 50, 0),
+        (50 + math.cos(angle), 50 + math.sin(angle), 0),
+        "above",
+        1,
+        drawing.draft,
+        label="1",
+        basic=True,
+    )
+    drawing.registry.add(annotation, "raw_single_stroke", view=None)
+    drawing.items.append(annotation)
+
+    pdf_path = drawing.export(str(tmp_path / f"raw_single_stroke_{axis}"), formats=("pdf",))["pdf"]
+    pdf, text_page, _extracted = _pdf_text(pdf_path)
+    try:
+        text_object = next(
+            item
+            for item in text_page.parent.get_objects(textpage=text_page)
+            if isinstance(item, pdfium.PdfTextObj) and item.extract().strip() == "1"
+        )
+        a, b, _c, _d, _e, _f = text_object.get_matrix().get()
+        assert math.degrees(math.atan2(b, a)) == pytest.approx(expected, abs=1.0)
+    finally:
+        text_page.close()
+        pdf.close()
+
+
+def test_raw_unknown_single_glyph_font_keeps_vector_fallback(tmp_path):
+    drawing = build_drawing(Box(10, 10, 10), auto_dims=False)
+    drawing.draft.font_size = 20
+    custom = Draft(font_size=20)
+    custom.font_path = PLEX_SANS_CONDENSED
+    angle = math.radians(-170)
+    annotation = Dimension(
+        (50, 50, 0),
+        (50 + math.cos(angle), 50 + math.sin(angle), 0),
+        "above",
+        10,
+        custom,
+        label="C",
+        basic=True,
+    )
+    box = annotation.bounding_box()
+    annotation.location = Location(
+        (100 - (box.min.X + box.max.X) / 2, 100 - (box.min.Y + box.max.Y) / 2, 0)
+    )
+    drawing.registry.add(annotation, "raw_custom_glyph", view=None)
+    drawing.items.append(annotation)
+
+    pdf_path = drawing.export(str(tmp_path / "raw_custom_glyph"), formats=("pdf",))["pdf"]
+    pdf, text_page, _extracted = _pdf_text(pdf_path)
+    try:
+        assert not any(
+            isinstance(item, pdfium.PdfTextObj) and item.extract().strip() == "C"
+            for item in text_page.parent.get_objects(textpage=text_page)
+        )
     finally:
         text_page.close()
         pdf.close()

--- a/tests/test_issue_1352_searchable_pdf_text.py
+++ b/tests/test_issue_1352_searchable_pdf_text.py
@@ -719,8 +719,11 @@ def test_raw_drawing_font_single_curved_glyph_keeps_exact_rotation(
         pdf.close()
 
 
-@pytest.mark.parametrize(("axis", "expected"), [(45, 45.0), (-45, -45.0)])
-def test_raw_drawing_font_single_stroke_glyph_prefers_exact_face(tmp_path, axis, expected):
+@pytest.mark.parametrize(
+    ("label", "axis", "expected"),
+    [("1", 45, 45.0), ("1", -45, -45.0), ("%", 45, 45.0)],
+)
+def test_raw_drawing_font_single_glyph_prefers_exact_outline(tmp_path, label, axis, expected):
     drawing = build_drawing(Box(10, 10, 10), auto_dims=False)
     angle = math.radians(axis)
     annotation = Dimension(
@@ -729,19 +732,21 @@ def test_raw_drawing_font_single_stroke_glyph_prefers_exact_face(tmp_path, axis,
         "above",
         1,
         drawing.draft,
-        label="1",
+        label=label,
         basic=True,
     )
-    drawing.registry.add(annotation, "raw_single_stroke", view=None)
+    drawing.registry.add(annotation, "raw_single_glyph", view=None)
     drawing.items.append(annotation)
 
-    pdf_path = drawing.export(str(tmp_path / f"raw_single_stroke_{axis}"), formats=("pdf",))["pdf"]
+    pdf_path = drawing.export(
+        str(tmp_path / f"raw_single_glyph_{label}_{axis}"), formats=("pdf",)
+    )["pdf"]
     pdf, text_page, _extracted = _pdf_text(pdf_path)
     try:
         text_object = next(
             item
             for item in text_page.parent.get_objects(textpage=text_page)
-            if isinstance(item, pdfium.PdfTextObj) and item.extract().strip() == "1"
+            if isinstance(item, pdfium.PdfTextObj) and item.extract().strip() == label
         )
         a, b, _c, _d, _e, _f = text_object.get_matrix().get()
         assert math.degrees(math.atan2(b, a)) == pytest.approx(expected, abs=1.0)
@@ -750,7 +755,8 @@ def test_raw_drawing_font_single_stroke_glyph_prefers_exact_face(tmp_path, axis,
         pdf.close()
 
 
-def test_raw_unknown_single_glyph_font_keeps_vector_fallback(tmp_path):
+@pytest.mark.parametrize("label", ["C", "%"])
+def test_raw_unknown_single_glyph_font_keeps_vector_fallback(tmp_path, label):
     drawing = build_drawing(Box(10, 10, 10), auto_dims=False)
     drawing.draft.font_size = 20
     custom = Draft(font_size=20)
@@ -762,7 +768,7 @@ def test_raw_unknown_single_glyph_font_keeps_vector_fallback(tmp_path):
         "above",
         10,
         custom,
-        label="C",
+        label=label,
         basic=True,
     )
     box = annotation.bounding_box()
@@ -772,11 +778,11 @@ def test_raw_unknown_single_glyph_font_keeps_vector_fallback(tmp_path):
     drawing.registry.add(annotation, "raw_custom_glyph", view=None)
     drawing.items.append(annotation)
 
-    pdf_path = drawing.export(str(tmp_path / "raw_custom_glyph"), formats=("pdf",))["pdf"]
+    pdf_path = drawing.export(str(tmp_path / f"raw_custom_glyph_{label}"), formats=("pdf",))["pdf"]
     pdf, text_page, _extracted = _pdf_text(pdf_path)
     try:
         assert not any(
-            isinstance(item, pdfium.PdfTextObj) and item.extract().strip() == "C"
+            isinstance(item, pdfium.PdfTextObj) and item.extract().strip() == label
             for item in text_page.parent.get_objects(textpage=text_page)
         )
     finally:

--- a/tests/test_issue_1352_searchable_pdf_text.py
+++ b/tests/test_issue_1352_searchable_pdf_text.py
@@ -671,9 +671,10 @@ def test_raw_drawing_font_single_curved_glyph_keeps_exact_rotation(
     )
     annotation.location = Location((0, 0, 0), (0, 0, live_rotation))
     box = annotation.bounding_box()
-    annotation.location = Location(
-        (100 - (box.min.X + box.max.X) / 2, 100 - (box.min.Y + box.max.Y) / 2, 0)
-    ) * annotation.location
+    annotation.location = (
+        Location((100 - (box.min.X + box.max.X) / 2, 100 - (box.min.Y + box.max.Y) / 2, 0))
+        * annotation.location
+    )
     drawing.registry.add(annotation, "raw_curved_glyph", view=None)
     drawing.items.append(annotation)
 

--- a/tests/test_issue_1352_searchable_pdf_text.py
+++ b/tests/test_issue_1352_searchable_pdf_text.py
@@ -907,6 +907,21 @@ def test_named_font_opt_out_resolves_the_renderer_face_and_style():
     assert regular != bold
 
 
+def test_named_font_opt_out_supports_build123d_010(monkeypatch):
+    import sys
+
+    _resolved_semantic_font_path.cache_clear()
+    monkeypatch.setitem(sys.modules, "build123d.text", None)
+    try:
+        regular = Path(_resolved_semantic_font_path(None, "Arial", "REGULAR"))
+        bold = Path(_resolved_semantic_font_path(None, "Arial", "BOLD"))
+    finally:
+        _resolved_semantic_font_path.cache_clear()
+
+    assert regular.is_file() and bold.is_file()
+    assert regular != bold
+
+
 def test_non_ttfont_semantic_face_falls_back_once_without_losing_text(
     tmp_path, monkeypatch, caplog
 ):

--- a/tests/test_issue_1352_searchable_pdf_text.py
+++ b/tests/test_issue_1352_searchable_pdf_text.py
@@ -755,6 +755,45 @@ def test_raw_drawing_font_single_glyph_prefers_exact_outline(tmp_path, label, ax
         pdf.close()
 
 
+def test_raw_same_face_multi_outline_glyph_ignores_face_order(tmp_path):
+    drawing = build_drawing(Box(10, 10, 10), auto_dims=False)
+    custom = Draft(font_size=20)
+    custom.font_path = drawing.draft.font_path
+    angle = math.radians(-170)
+    annotation = Dimension(
+        (50, 50, 0),
+        (50 + math.cos(angle), 50 + math.sin(angle), 0),
+        "above",
+        1,
+        custom,
+        label="%",
+        basic=True,
+        rotation=30,
+    )
+    annotation.location = Location((0, 0, 0), (0, 0, 20))
+    box = annotation.bounding_box()
+    annotation.location = (
+        Location((100 - (box.min.X + box.max.X) / 2, 100 - (box.min.Y + box.max.Y) / 2, 0))
+        * annotation.location
+    )
+    drawing.registry.add(annotation, "raw_multi_outline", view=None)
+    drawing.items.append(annotation)
+
+    pdf_path = drawing.export(str(tmp_path / "raw_multi_outline"), formats=("pdf",))["pdf"]
+    pdf, text_page, _extracted = _pdf_text(pdf_path)
+    try:
+        text_object = next(
+            item
+            for item in text_page.parent.get_objects(textpage=text_page)
+            if isinstance(item, pdfium.PdfTextObj) and item.extract().strip() == "%"
+        )
+        a, b, _c, _d, _e, _f = text_object.get_matrix().get()
+        assert math.degrees(math.atan2(b, a)) == pytest.approx(60.0, abs=1.0)
+    finally:
+        text_page.close()
+        pdf.close()
+
+
 @pytest.mark.parametrize("label", ["C", "%"])
 def test_raw_unknown_single_glyph_font_keeps_vector_fallback(tmp_path, label):
     drawing = build_drawing(Box(10, 10, 10), auto_dims=False)

--- a/tests/test_issue_1352_searchable_pdf_text.py
+++ b/tests/test_issue_1352_searchable_pdf_text.py
@@ -14,6 +14,7 @@ from build123d_drafting import Dimension
 from PIL import Image, ImageChops
 
 from draftwright import Sheet, build_drawing
+from draftwright._core import _text_line_spacing_em
 from draftwright.drawing import Drawing
 from draftwright.export import _PDFTextRun, _render_pdf, _resolved_semantic_font_path
 from draftwright.fonts import PLEX_MONO, PLEX_SANS_CONDENSED
@@ -143,13 +144,75 @@ def test_multiline_notes_and_title_values_retain_visible_line_pitch(tmp_path):
     try:
         assert "A\r\nB\r\nC\r\nD\r\nE\r\nF\r\nG" in extracted
         assert "TOP\r\nBOTTOM" in extracted
-        expected_pitch_points = 1.3 * drawing.draft.font_size * 72.0 / 25.4
+        expected_pitch_points = (
+            _text_line_spacing_em(
+                drawing.draft.font_size,
+                drawing.draft.font_path,
+                drawing.draft.font,
+            )
+            * drawing.draft.font_size
+            * 72.0
+            / 25.4
+        )
         note_indices = [extracted.index(line) for line in tuple("ABCDEFG")]
         centres = [_character_centre(text_page, index) for index in note_indices]
         assert all(
             upper[1] - lower[1] == pytest.approx(expected_pitch_points, abs=0.15)
             for upper, lower in zip(centres, centres[1:], strict=False)
         )
+    finally:
+        text_page.close()
+        pdf.close()
+
+
+def test_structured_multiline_note_uses_renderer_line_pitch(tmp_path):
+    part = Box(80, 50, 20)
+    top = max(part.faces(), key=lambda face: face.center().Z)
+    sheet = Sheet(part).auto_dimensions()
+    sheet.note("A\nB\nC", top, view="front", side="above")
+    drawing = sheet.build()
+
+    pdf_path = drawing.export(str(tmp_path / "structured_note"), formats=("pdf",))["pdf"]
+    pdf, text_page, extracted = _pdf_text(pdf_path)
+    try:
+        assert "A\r\nB\r\nC" in extracted
+        expected_pitch_points = (
+            _text_line_spacing_em(
+                drawing.draft.font_size,
+                drawing.draft.font_path,
+                drawing.draft.font,
+            )
+            * drawing.draft.font_size
+            * 72.0
+            / 25.4
+        )
+        centres = [_character_centre(text_page, extracted.index(line)) for line in "ABC"]
+        assert all(
+            math.dist(upper, lower) == pytest.approx(expected_pitch_points, abs=0.15)
+            for upper, lower in zip(centres, centres[1:], strict=False)
+        )
+    finally:
+        text_page.close()
+        pdf.close()
+
+
+def test_declared_gdt_values_and_datums_are_searchable(tmp_path):
+    part = Box(80, 50, 20) - Pos(0, 0, 0) * Cylinder(6, 20)
+    top = max(part.faces(), key=lambda face: face.center().Z)
+    sheet = Sheet(part).auto_dimensions()
+    hole = sheet.hole(Pos(0, 0, 0) * Cylinder(6, 20))
+    sheet.finish("7.77", top, view="front", side="above")
+    sheet.datum("Q", top, view="front", side="above")
+    sheet.control(hole).position("0.123", to="Q", diameter=True, modifier="M")
+    drawing = sheet.build()
+
+    pdf_path = drawing.export(str(tmp_path / "gdt"), formats=("pdf",))["pdf"]
+    pdf, text_page, extracted = _pdf_text(pdf_path)
+    try:
+        assert "7.77" in extracted
+        assert "Q" in extracted
+        assert "0.123" in extracted
+        assert "M" in extracted
     finally:
         text_page.close()
         pdf.close()
@@ -183,6 +246,45 @@ def test_semantic_order_tiebreak_and_basic_dimension_rotation_are_total(tmp_path
         pdf.close()
 
 
+@pytest.mark.parametrize(
+    ("start", "end", "expected"),
+    [
+        ((50, 10, 0), (10, 50, 0), -45.0),
+        ((20, 50, 0), (20, 10, 0), 90.0),
+    ],
+)
+def test_basic_dimension_semantic_text_is_normalised_upright(tmp_path, start, end, expected):
+    drawing = build_drawing(Box(10, 10, 10), auto_dims=False)
+    annotation = Dimension(start, end, (0, 1, 0), 10, drawing.draft, label="UPRIGHT", basic=True)
+    drawing.registry.add(annotation, "upright", view=None)
+    drawing.items.append(annotation)
+
+    pdf_path = drawing.export(str(tmp_path / f"upright_{expected}"), formats=("pdf",))["pdf"]
+    pdf, text_page, extracted = _pdf_text(pdf_path)
+    try:
+        assert _extracted_text_angle(text_page, extracted, "UPRIGHT") == pytest.approx(
+            expected, abs=1.0
+        )
+    finally:
+        text_page.close()
+        pdf.close()
+
+
+def test_raw_helper_dimension_semantic_fallback_keeps_visible_units(tmp_path):
+    drawing = build_drawing(Box(10, 10, 10), auto_dims=False)
+    annotation = Dimension((10, 10, 0), (20, 10, 0), "above", 10, drawing.draft)
+    drawing.registry.add(annotation, "raw_units", view=None)
+    drawing.items.append(annotation)
+
+    pdf_path = drawing.export(str(tmp_path / "raw_units"), formats=("pdf",))["pdf"]
+    pdf, text_page, extracted = _pdf_text(pdf_path)
+    try:
+        assert "10.0mm" in extracted
+    finally:
+        text_page.close()
+        pdf.close()
+
+
 def test_note_semantic_rotation_tracks_later_annotation_transform(tmp_path):
     drawing = build_drawing(Box(10, 10, 10), auto_dims=False)
     drawing.note("ROTATED", (100, 100), rotation=10, name="rotated")
@@ -199,12 +301,16 @@ def test_note_semantic_rotation_tracks_later_annotation_transform(tmp_path):
         pdf.close()
 
 
-def test_named_font_opt_out_resolves_the_renderer_face():
-    path = Path(_resolved_semantic_font_path(None, "Arial"))
-    assert path.is_file()
+def test_named_font_opt_out_resolves_the_renderer_face_and_style():
+    regular = Path(_resolved_semantic_font_path(None, "Arial", "REGULAR"))
+    bold = Path(_resolved_semantic_font_path(None, "Arial", "BOLD"))
+    assert regular.is_file() and bold.is_file()
+    assert regular != bold
 
 
-def test_non_ttfont_semantic_face_falls_back_without_losing_text(tmp_path, monkeypatch):
+def test_non_ttfont_semantic_face_falls_back_once_without_losing_text(
+    tmp_path, monkeypatch, caplog
+):
     from reportlab.pdfbase import ttfonts
 
     svg_path = tmp_path / "blank.svg"
@@ -228,13 +334,17 @@ def test_non_ttfont_semantic_face_falls_back_without_losing_text(tmp_path, monke
     _render_pdf(
         str(svg_path),
         str(pdf_path),
-        text_runs=(_PDFTextRun("FALLBACK", 10, 10, 3, font_path=str(unsupported)),),
+        text_runs=tuple(
+            _PDFTextRun(f"FALLBACK{index}", 10, 10 + index * 5, 3, font_path=str(unsupported))
+            for index in range(3)
+        ),
     )
 
     pdf, text_page, extracted = _pdf_text(str(pdf_path))
     try:
-        assert "FALLBACK" in extracted
+        assert all(f"FALLBACK{index}" in extracted for index in range(3))
         assert Path(PLEX_MONO).is_file()
+        assert sum("cannot be embedded" in record.message for record in caplog.records) == 1
     finally:
         text_page.close()
         pdf.close()

--- a/tests/test_issue_1352_searchable_pdf_text.py
+++ b/tests/test_issue_1352_searchable_pdf_text.py
@@ -9,8 +9,9 @@ from pathlib import Path
 
 import pypdfium2 as pdfium
 import pytest
-from build123d import Align, Box, Cylinder, Location, Pos
+from build123d import Align, Box, Cylinder, FontStyle, Location, Pos
 from build123d_drafting import Dimension
+from build123d_drafting.helpers import Draft
 from PIL import Image, ImageChops
 
 from draftwright import Sheet, build_drawing
@@ -64,6 +65,18 @@ def _assert_first_character_overlaps_annotation(text_page, extracted, text, anno
     x0, y0, x1, y1 = label_box
     assert left < x1 * k and right > x0 * k
     assert bottom < y1 * k and top > y0 * k
+
+
+def _assert_text_contains_run_anchor(text_page, extracted, text, point):
+    start = extracted.index(text)
+    boxes = [text_page.get_charbox(index) for index in range(start, start + len(text))]
+    left = min(box[0] for box in boxes)
+    bottom = min(box[1] for box in boxes)
+    right = max(box[2] for box in boxes)
+    top = max(box[3] for box in boxes)
+    k = 72.0 / 25.4
+    assert left <= point[0] * k <= right
+    assert bottom <= point[1] * k <= top
 
 
 def test_pdf_extracts_dimensions_callouts_notes_and_title_block_values(tmp_path):
@@ -231,6 +244,15 @@ def test_declared_gdt_values_and_datums_are_searchable(tmp_path):
         )
         _assert_first_character_overlaps_annotation(text_page, extracted, "0.123", control)
         _assert_first_character_overlaps_annotation(text_page, extracted, "7.77", finish)
+        for annotation, value in ((control, "0.123"), (finish, "7.77")):
+            spec = next(item for item in annotation.pdf_text_relative_specs if item[0] == value)
+            x0, y0, x1, y1 = annotation.label_bbox
+            _assert_text_contains_run_anchor(
+                text_page,
+                extracted,
+                value,
+                ((x0 + x1) / 2.0 + spec[1], (y0 + y1) / 2.0 + spec[2]),
+            )
     finally:
         text_page.close()
         pdf.close()
@@ -290,12 +312,80 @@ def test_basic_dimension_semantic_text_is_normalised_upright(tmp_path, start, en
 
 
 @pytest.mark.parametrize(
+    ("start", "end", "label", "label_offset_x", "expected"),
+    [
+        ((50, 50, 0), (90, 50, 0), "X", -20, 0.0),
+        ((50, 50, 0), (50, 90, 0), "W" * 40, 0, 90.0),
+        ((50, 50, 0), (90, 90, 0), "W" * 40, 0, 45.0),
+        ((50, 90, 0), (90, 50, 0), "W" * 40, 0, -45.0),
+    ],
+)
+def test_raw_basic_dimension_rotation_survives_missing_or_mixed_spans(
+    tmp_path, start, end, label, label_offset_x, expected
+):
+    drawing = build_drawing(Box(10, 10, 10), auto_dims=False)
+    annotation = Dimension(
+        start,
+        end,
+        "above",
+        4,
+        drawing.draft,
+        label=label,
+        basic=True,
+        label_offset_x=label_offset_x,
+    )
+    drawing.registry.add(annotation, "raw_basic", view=None)
+    drawing.items.append(annotation)
+
+    pdf_path = drawing.export(str(tmp_path / f"raw_basic_{expected}"), formats=("pdf",))["pdf"]
+    pdf, text_page, extracted = _pdf_text(pdf_path)
+    try:
+        assert label in extracted
+        assert _extracted_text_angle(text_page, extracted, label) == pytest.approx(
+            expected, abs=1.0
+        )
+    finally:
+        text_page.close()
+        pdf.close()
+
+
+def test_engine_dimension_keeps_its_construction_draft_and_rotation(tmp_path):
+    drawing = build_drawing(Box(10, 10, 10), auto_dims=False)
+    custom = Draft(font_size=5, font="Arial", font_style=FontStyle.BOLD)
+    custom.font_path = None
+    with pytest.warns(DeprecationWarning):
+        drawing.place_dim(
+            (20, 20, 0),
+            (60, 20, 0),
+            "above",
+            "front",
+            custom,
+            name="tagged",
+            basic=True,
+            label="TAGGED",
+            rotation=30,
+        )
+
+    pdf_path = drawing.export(str(tmp_path / "tagged"), formats=("pdf",))["pdf"]
+    pdf, text_page, extracted = _pdf_text(pdf_path)
+    try:
+        assert _extracted_text_angle(text_page, extracted, "TAGGED") == pytest.approx(
+            30.0, abs=1.0
+        )
+    finally:
+        text_page.close()
+        pdf.close()
+    assert b"Arial-BoldMT" in Path(pdf_path).read_bytes()
+
+
+@pytest.mark.parametrize(
     ("dimension_kwargs", "expected"),
     [
         ({}, "10.0mm"),
         ({"basic": True}, "10.0mm"),
         ({"tolerance": 0.1}, "10.0 ±0.1mm"),
         ({"basic": True, "tolerance": 0.1}, "10.0 ±0.1mm"),
+        ({"tolerance": (0.1, 0.2)}, "10.0 +0.1 -0.2mm"),
         ({"label": "CUSTOM"}, "CUSTOM"),
     ],
 )

--- a/tests/test_issue_1352_searchable_pdf_text.py
+++ b/tests/test_issue_1352_searchable_pdf_text.py
@@ -213,6 +213,24 @@ def test_declared_gdt_values_and_datums_are_searchable(tmp_path):
         assert "Q" in extracted
         assert "0.123" in extracted
         assert "M" in extracted
+        control = next(
+            drawing.get_annotation(name)
+            for name in drawing.annotations()
+            if any(
+                spec[0] == "0.123"
+                for spec in getattr(drawing.get_annotation(name), "pdf_text_relative_specs", ())
+            )
+        )
+        finish = next(
+            drawing.get_annotation(name)
+            for name in drawing.annotations()
+            if any(
+                spec[0] == "7.77"
+                for spec in getattr(drawing.get_annotation(name), "pdf_text_relative_specs", ())
+            )
+        )
+        _assert_first_character_overlaps_annotation(text_page, extracted, "0.123", control)
+        _assert_first_character_overlaps_annotation(text_page, extracted, "7.77", finish)
     finally:
         text_page.close()
         pdf.close()
@@ -251,6 +269,7 @@ def test_semantic_order_tiebreak_and_basic_dimension_rotation_are_total(tmp_path
     [
         ((50, 10, 0), (10, 50, 0), -45.0),
         ((20, 50, 0), (20, 10, 0), 90.0),
+        ((10, 10, 0), (20, 10, 0), 0.0),
     ],
 )
 def test_basic_dimension_semantic_text_is_normalised_upright(tmp_path, start, end, expected):
@@ -270,16 +289,35 @@ def test_basic_dimension_semantic_text_is_normalised_upright(tmp_path, start, en
         pdf.close()
 
 
-def test_raw_helper_dimension_semantic_fallback_keeps_visible_units(tmp_path):
+@pytest.mark.parametrize(
+    ("dimension_kwargs", "expected"),
+    [
+        ({}, "10.0mm"),
+        ({"basic": True}, "10.0mm"),
+        ({"tolerance": 0.1}, "10.0 ±0.1mm"),
+        ({"basic": True, "tolerance": 0.1}, "10.0 ±0.1mm"),
+        ({"label": "CUSTOM"}, "CUSTOM"),
+    ],
+)
+def test_raw_helper_dimension_semantic_fallback_keeps_visible_label(
+    tmp_path, dimension_kwargs, expected
+):
     drawing = build_drawing(Box(10, 10, 10), auto_dims=False)
-    annotation = Dimension((10, 10, 0), (20, 10, 0), "above", 10, drawing.draft)
+    annotation = Dimension(
+        (10, 10, 0),
+        (20, 10, 0),
+        "above",
+        10,
+        drawing.draft,
+        **dimension_kwargs,
+    )
     drawing.registry.add(annotation, "raw_units", view=None)
     drawing.items.append(annotation)
 
     pdf_path = drawing.export(str(tmp_path / "raw_units"), formats=("pdf",))["pdf"]
     pdf, text_page, extracted = _pdf_text(pdf_path)
     try:
-        assert "10.0mm" in extracted
+        assert expected in extracted
     finally:
         text_page.close()
         pdf.close()

--- a/tests/test_issue_1352_searchable_pdf_text.py
+++ b/tests/test_issue_1352_searchable_pdf_text.py
@@ -640,13 +640,60 @@ def test_raw_helper_default_font_recovers_challenging_single_glyph_rotations(
             text_object = next(
                 item
                 for item in page.get_objects(textpage=text_page)
-                if isinstance(item, pdfium.PdfTextObj) and item.extract() == label
+                if isinstance(item, pdfium.PdfTextObj) and item.extract().strip() == label
             )
             a, b, _c, _d, _e, _f = text_object.get_matrix().get()
             assert math.degrees(math.atan2(b, a)) == pytest.approx(expected, abs=1.0)
         finally:
             text_page.close()
             pdf.close()
+
+
+@pytest.mark.parametrize(
+    ("base_angle", "constructor_rotation", "live_rotation", "expected"),
+    [(-170, 0, 0, 10.0), (-45, 30, 20, 5.0)],
+)
+def test_raw_drawing_font_single_curved_glyph_keeps_exact_rotation(
+    tmp_path, base_angle, constructor_rotation, live_rotation, expected
+):
+    drawing = build_drawing(Box(10, 10, 10), auto_dims=False)
+    drawing.draft.font_size = 20
+    angle = math.radians(base_angle)
+    annotation = Dimension(
+        (50, 50, 0),
+        (50 + math.cos(angle), 50 + math.sin(angle), 0),
+        "above",
+        10,
+        drawing.draft,
+        label="C",
+        basic=True,
+        rotation=constructor_rotation,
+    )
+    annotation.location = Location((0, 0, 0), (0, 0, live_rotation))
+    box = annotation.bounding_box()
+    annotation.location = Location(
+        (100 - (box.min.X + box.max.X) / 2, 100 - (box.min.Y + box.max.Y) / 2, 0)
+    ) * annotation.location
+    drawing.registry.add(annotation, "raw_curved_glyph", view=None)
+    drawing.items.append(annotation)
+
+    pdf_path = drawing.export(
+        str(tmp_path / f"raw_curved_{base_angle}_{constructor_rotation}_{live_rotation}"),
+        formats=("pdf",),
+    )["pdf"]
+    pdf, text_page, _extracted = _pdf_text(pdf_path)
+    page = text_page.parent
+    try:
+        text_object = next(
+            item
+            for item in page.get_objects(textpage=text_page)
+            if isinstance(item, pdfium.PdfTextObj) and item.extract().strip() == "C"
+        )
+        a, b, _c, _d, _e, _f = text_object.get_matrix().get()
+        assert math.degrees(math.atan2(b, a)) == pytest.approx(expected, abs=1.0)
+    finally:
+        text_page.close()
+        pdf.close()
 
 
 def test_poppler_keeps_a_term_whole_when_its_baseline_points_left(tmp_path):

--- a/tests/test_issue_1352_searchable_pdf_text.py
+++ b/tests/test_issue_1352_searchable_pdf_text.py
@@ -336,6 +336,8 @@ def test_basic_dimension_semantic_text_is_normalised_upright(tmp_path, start, en
             20,
             130.0,
         ),
+        ((50, 50, 0), (90, 50, 0), "UPRIGHT", 0, 220, 0, -140.0),
+        ((50, 50, 0), (90, 50, 0), "UPRIGHT", 0, 400, 0, 40.0),
     ],
 )
 def test_raw_basic_dimension_rotation_survives_missing_or_mixed_spans(
@@ -453,6 +455,31 @@ def test_raw_asymmetric_limits_keep_visible_order_without_units(tmp_path):
     try:
         assert "10.0 +0.1 -0.2" in extracted
         assert "10.0 +0.2 -0.1" not in extracted
+        assert "10.0 +0.1 -0.2mm" not in extracted
+    finally:
+        text_page.close()
+        pdf.close()
+
+
+def test_raw_custom_limit_lookalike_is_not_rewritten(tmp_path):
+    drawing = build_drawing(Box(10, 10, 10), auto_dims=False)
+    annotation = Dimension(
+        (10, 10, 0),
+        (20, 10, 0),
+        "above",
+        10,
+        drawing.draft,
+        label="10.0 +0.2 -0.1",
+    )
+    drawing.registry.add(annotation, "custom_limits", view=None)
+    drawing.items.append(annotation)
+
+    pdf_path = drawing.export(str(tmp_path / "custom_limits"), formats=("pdf",))["pdf"]
+    pdf, text_page, extracted = _pdf_text(pdf_path)
+    try:
+        assert "10.0 +0.2 -0.1" in extracted
+        assert "10.0 +0.1 -0.2" not in extracted
+        assert "10.0 +0.2 -0.1mm" not in extracted
     finally:
         text_page.close()
         pdf.close()

--- a/tests/test_issue_1352_searchable_pdf_text.py
+++ b/tests/test_issue_1352_searchable_pdf_text.py
@@ -1,0 +1,108 @@
+"""#1352: PDF export retains searchable text without changing visible drawing ink."""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import pypdfium2 as pdfium
+from build123d import Align, Box, Cylinder, Pos
+from PIL import Image, ImageChops
+
+from draftwright import Sheet
+from draftwright.drawing import Drawing
+
+
+def _manufacturing_drawing():
+    part = Box(90, 60, 12, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    part -= Pos(-20, 0, 0) * Cylinder(1.25, 12)
+    part -= Pos(20, 0, 0) * Cylinder(4, 12)
+
+    sheet = Sheet(
+        part,
+        title="SEARCHABLE BRACKET",
+        number="DWG-1352",
+        material="AL 6061-T6",
+        drawn_by="QA",
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        sheet.auto_dimensions()
+    sheet.hole(diameter=2.5, at=(-20, 0, 6), axis="z", through=True).thread("M3x0.5")
+    sheet.hole(diameter=8, at=(20, 0, 6), axis="z", through=True).fit("H7")
+    drawing = sheet.build()
+    drawing.note("INSPECT DATUM A", (160, 185), name="inspection_note")
+    return drawing
+
+
+def _pdf_text(path: str):
+    pdf = pdfium.PdfDocument(path)
+    try:
+        page = pdf[0]
+        text_page = page.get_textpage()
+        return pdf, text_page, text_page.get_text_range()
+    except Exception:
+        pdf.close()
+        raise
+
+
+def _assert_first_character_overlaps_annotation(text_page, extracted, text, annotation):
+    first_char_box = text_page.get_charbox(extracted.index(text))
+    label_box = annotation.label_bbox
+    assert label_box is not None
+    k = 72.0 / 25.4
+    left, bottom, right, top = first_char_box
+    x0, y0, x1, y1 = label_box
+    assert left < x1 * k and right > x0 * k
+    assert bottom < y1 * k and top > y0 * k
+
+
+def test_pdf_extracts_dimensions_callouts_notes_and_title_block_values(tmp_path):
+    drawing = _manufacturing_drawing()
+    pdf_path = drawing.export(str(tmp_path / "semantic"), formats=("pdf",))["pdf"]
+    pdf, text_page, extracted = _pdf_text(pdf_path)
+    try:
+        assert "INSPECT DATUM A" in extracted
+        assert "M3x0.5" in extracted
+        assert "H7" in extracted
+        assert "SEARCHABLE BRACKET" in extracted
+        assert "DWG-1352" in extracted
+        assert "AL 6061-T6" in extracted
+        assert "QA / draftwright" in extracted
+
+        dimension_name = next(
+            name
+            for name in drawing.annotations()
+            if getattr(drawing.get_annotation(name), "label", None) == "65"
+        )
+        thread_name = next(
+            name
+            for name in drawing.annotations()
+            if "M3x0.5" in (getattr(drawing.get_annotation(name), "label", "") or "")
+        )
+        _assert_first_character_overlaps_annotation(
+            text_page, extracted, "65", drawing.get_annotation(dimension_name)
+        )
+        _assert_first_character_overlaps_annotation(
+            text_page, extracted, "ø2.5 THRU M3x0.5", drawing.get_annotation(thread_name)
+        )
+    finally:
+        text_page.close()
+        pdf.close()
+
+    data = Path(pdf_path).read_bytes()
+    assert b"/FontFile2" in data and b"/ToUnicode" in data
+    assert b"IBMPlexMono-Regular" in data
+    assert b"IBMPlexSansCond-Regular" in data
+
+
+def test_semantic_text_layer_does_not_change_rendered_pixels(tmp_path, monkeypatch):
+    drawing = _manufacturing_drawing()
+    semantic = drawing.export(str(tmp_path / "semantic"), formats=("png",))["png"]
+
+    monkeypatch.setattr(Drawing, "_pdf_text_runs", lambda _self: ())
+    path_only = drawing.export(str(tmp_path / "path_only"), formats=("png",))["png"]
+
+    semantic_image = Image.open(semantic).convert("RGBA")
+    path_only_image = Image.open(path_only).convert("RGBA")
+    assert ImageChops.difference(semantic_image, path_only_image).getbbox() is None

--- a/tests/test_issue_1352_searchable_pdf_text.py
+++ b/tests/test_issue_1352_searchable_pdf_text.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 import shutil
+import subprocess
 import warnings
 from pathlib import Path
 
@@ -483,6 +484,107 @@ def test_raw_custom_limit_lookalike_is_not_rewritten(tmp_path):
     finally:
         text_page.close()
         pdf.close()
+
+
+@pytest.mark.parametrize("basic", [False, True])
+def test_raw_freeform_dimension_from_a_different_draft_keeps_its_text(tmp_path, basic):
+    drawing = build_drawing(Box(10, 10, 10), auto_dims=False)
+    custom = Draft(
+        font_size=5,
+        font="Arial",
+        font_style=FontStyle.BOLD,
+        display_units=False,
+    )
+    custom.font_path = None
+    annotation = Dimension(
+        (20, 20, 0),
+        (60, 20, 0),
+        "above",
+        10,
+        custom,
+        label="BOLD",
+        basic=basic,
+    )
+    drawing.registry.add(annotation, "raw_custom_draft", view=None)
+    drawing.items.append(annotation)
+
+    pdf_path = drawing.export(str(tmp_path / f"raw_custom_{basic}"), formats=("pdf",))["pdf"]
+    pdf, text_page, extracted = _pdf_text(pdf_path)
+    try:
+        assert "BOLD" in extracted
+        assert "40.0mm" not in extracted
+    finally:
+        text_page.close()
+        pdf.close()
+
+
+@pytest.mark.parametrize(("axis", "expected"), [(-80, -30.0), (45, 95.0)])
+def test_raw_single_glyph_basic_dimension_recovers_rotation(tmp_path, axis, expected):
+    drawing = build_drawing(Box(10, 10, 10), auto_dims=False)
+    custom = Draft(font_size=20)
+    angle = math.radians(axis)
+    annotation = Dimension(
+        (50, 50, 0),
+        (50 + math.cos(angle), 50 + math.sin(angle), 0),
+        "above",
+        4,
+        custom,
+        label="R",
+        basic=True,
+        rotation=30,
+    )
+    annotation.location = Location((0, 0, 0), (0, 0, 20))
+    drawing.registry.add(annotation, "raw_single_glyph", view=None)
+    drawing.items.append(annotation)
+
+    pdf_path = drawing.export(str(tmp_path / f"single_{axis}"), formats=("pdf",))["pdf"]
+    pdf, text_page, extracted = _pdf_text(pdf_path)
+    page = text_page.parent
+    try:
+        assert "R" in extracted
+        text_object = next(
+            item
+            for item in page.get_objects(textpage=text_page)
+            if isinstance(item, pdfium.PdfTextObj) and item.extract() == "R"
+        )
+        a, b, _c, _d, _e, _f = text_object.get_matrix().get()
+        actual = math.degrees(math.atan2(b, a))
+        assert (actual - expected + 90.0) % 180.0 - 90.0 == pytest.approx(0.0, abs=1.0)
+    finally:
+        text_page.close()
+        pdf.close()
+
+
+def test_poppler_keeps_a_term_whole_when_its_baseline_points_left(tmp_path):
+    executable = shutil.which("pdftotext")
+    if executable is None:
+        pytest.skip("Poppler pdftotext is not installed")
+    drawing = build_drawing(Box(10, 10, 10), auto_dims=False)
+    annotation = Dimension(
+        (50, 50, 0),
+        (90, 50, 0),
+        "above",
+        4,
+        drawing.draft,
+        label="ANGLE",
+        basic=True,
+        rotation=110,
+    )
+    box = annotation.bounding_box()
+    annotation.location = Location(
+        (100 - (box.min.X + box.max.X) / 2, 100 - (box.min.Y + box.max.Y) / 2, 0)
+    )
+    drawing.registry.add(annotation, "leftward_text", view=None)
+    drawing.items.append(annotation)
+
+    pdf_path = drawing.export(str(tmp_path / "poppler_rotation"), formats=("pdf",))["pdf"]
+    extracted = subprocess.run(
+        [executable, pdf_path, "-"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert "ANGLE" in extracted
 
 
 def test_note_semantic_rotation_tracks_later_annotation_transform(tmp_path):

--- a/tests/test_issue_1352_searchable_pdf_text.py
+++ b/tests/test_issue_1352_searchable_pdf_text.py
@@ -68,6 +68,26 @@ def _assert_first_character_overlaps_annotation(text_page, extracted, text, anno
     assert bottom < y1 * k and top > y0 * k
 
 
+def _assert_term_selection_tracks_physical_object(text_page, extracted, text, expected_angle):
+    start = extracted.index(text)
+    boxes = [text_page.get_charbox(index) for index in range(start, start + len(text))]
+    selection_bounds = (
+        min(box[0] for box in boxes),
+        min(box[1] for box in boxes),
+        max(box[2] for box in boxes),
+        max(box[3] for box in boxes),
+    )
+    page = text_page.parent
+    text_object = next(
+        item
+        for item in page.get_objects(textpage=text_page)
+        if isinstance(item, pdfium.PdfTextObj) and item.extract() == text
+    )
+    assert selection_bounds == pytest.approx(text_object.get_bounds(), abs=0.1)
+    a, b, _c, _d, _e, _f = text_object.get_matrix().get()
+    assert math.degrees(math.atan2(b, a)) == pytest.approx(expected_angle, abs=1.0)
+
+
 def _assert_text_contains_run_anchor(text_page, extracted, text, point):
     start = extracted.index(text)
     boxes = [text_page.get_charbox(index) for index in range(start, start + len(text))]
@@ -589,6 +609,46 @@ def test_raw_single_glyph_basic_dimension_recovers_rotation(tmp_path, axis, expe
         pdf.close()
 
 
+@pytest.mark.parametrize(("axis", "expected"), [(-80, -30.0), (45, 95.0)])
+def test_raw_helper_default_font_recovers_challenging_single_glyph_rotations(
+    tmp_path, axis, expected
+):
+    for label in "BGCO069":
+        drawing = build_drawing(Box(10, 10, 10), auto_dims=False)
+        custom = Draft(font_size=20)
+        angle = math.radians(axis)
+        annotation = Dimension(
+            (50, 50, 0),
+            (50 + math.cos(angle), 50 + math.sin(angle), 0),
+            "above",
+            10,
+            custom,
+            label=label,
+            basic=True,
+            rotation=30,
+        )
+        annotation.location = Location((0, 0, 0), (0, 0, 20))
+        drawing.registry.add(annotation, "raw_single_glyph", view=None)
+        drawing.items.append(annotation)
+
+        pdf_path = drawing.export(
+            str(tmp_path / f"raw_challenging_{axis}_{label}"), formats=("pdf",)
+        )["pdf"]
+        pdf, text_page, _extracted = _pdf_text(pdf_path)
+        page = text_page.parent
+        try:
+            text_object = next(
+                item
+                for item in page.get_objects(textpage=text_page)
+                if isinstance(item, pdfium.PdfTextObj) and item.extract() == label
+            )
+            a, b, _c, _d, _e, _f = text_object.get_matrix().get()
+            assert math.degrees(math.atan2(b, a)) == pytest.approx(expected, abs=1.0)
+        finally:
+            text_page.close()
+            pdf.close()
+
+
 def test_poppler_keeps_a_term_whole_when_its_baseline_points_left(tmp_path):
     executable = shutil.which("pdftotext")
     if executable is None:
@@ -630,6 +690,14 @@ def test_poppler_keeps_a_term_whole_when_its_baseline_points_left(tmp_path):
         assert lines.count("LEFTWARD") == 1
         assert all("ANGLE" not in line or line == "ANGLE" for line in lines)
         assert all("LEFTWARD" not in line or line == "LEFTWARD" for line in lines)
+
+    pdf, text_page, extracted = _pdf_text(pdf_path)
+    try:
+        _assert_term_selection_tracks_physical_object(text_page, extracted, "ANGLE", 110)
+        _assert_term_selection_tracks_physical_object(text_page, extracted, "LEFTWARD", 110)
+    finally:
+        text_page.close()
+        pdf.close()
 
 
 def test_note_semantic_rotation_tracks_later_annotation_transform(tmp_path):

--- a/tests/test_issue_1352_searchable_pdf_text.py
+++ b/tests/test_issue_1352_searchable_pdf_text.py
@@ -2,15 +2,21 @@
 
 from __future__ import annotations
 
+import math
+import shutil
 import warnings
 from pathlib import Path
 
 import pypdfium2 as pdfium
-from build123d import Align, Box, Cylinder, Pos
+import pytest
+from build123d import Align, Box, Cylinder, Location, Pos
+from build123d_drafting import Dimension
 from PIL import Image, ImageChops
 
-from draftwright import Sheet
+from draftwright import Sheet, build_drawing
 from draftwright.drawing import Drawing
+from draftwright.export import _PDFTextRun, _render_pdf, _resolved_semantic_font_path
+from draftwright.fonts import PLEX_MONO, PLEX_SANS_CONDENSED
 
 
 def _manufacturing_drawing():
@@ -30,6 +36,8 @@ def _manufacturing_drawing():
         sheet.auto_dimensions()
     sheet.hole(diameter=2.5, at=(-20, 0, 6), axis="z", through=True).thread("M3x0.5")
     sheet.hole(diameter=8, at=(20, 0, 6), axis="z", through=True).fit("H7")
+    top_face = max(part.faces(), key=lambda face: face.center().Z)
+    sheet.note("DEBURR ALL EDGES", top_face, view="front", side="above")
     drawing = sheet.build()
     drawing.note("INSPECT DATUM A", (160, 185), name="inspection_note")
     return drawing
@@ -63,6 +71,7 @@ def test_pdf_extracts_dimensions_callouts_notes_and_title_block_values(tmp_path)
     pdf, text_page, extracted = _pdf_text(pdf_path)
     try:
         assert "INSPECT DATUM A" in extracted
+        assert "DEBURR ALL EDGES" in extracted
         assert "M3x0.5" in extracted
         assert "H7" in extracted
         assert "SEARCHABLE BRACKET" in extracted
@@ -84,7 +93,7 @@ def test_pdf_extracts_dimensions_callouts_notes_and_title_block_values(tmp_path)
             text_page, extracted, "65", drawing.get_annotation(dimension_name)
         )
         _assert_first_character_overlaps_annotation(
-            text_page, extracted, "ø2.5 THRU M3x0.5", drawing.get_annotation(thread_name)
+            text_page, extracted, "M3x0.5", drawing.get_annotation(thread_name)
         )
     finally:
         text_page.close()
@@ -106,3 +115,126 @@ def test_semantic_text_layer_does_not_change_rendered_pixels(tmp_path, monkeypat
     semantic_image = Image.open(semantic).convert("RGBA")
     path_only_image = Image.open(path_only).convert("RGBA")
     assert ImageChops.difference(semantic_image, path_only_image).getbbox() is None
+
+
+def _character_centre(text_page, index):
+    left, bottom, right, top = text_page.get_charbox(index)
+    return ((left + right) / 2.0, (bottom + top) / 2.0)
+
+
+def _extracted_text_angle(text_page, extracted, value):
+    start = extracted.index(value)
+    x0, y0 = _character_centre(text_page, start)
+    x1, y1 = _character_centre(text_page, start + len(value) - 1)
+    return math.degrees(math.atan2(y1 - y0, x1 - x0))
+
+
+def test_multiline_notes_and_title_values_retain_visible_line_pitch(tmp_path):
+    drawing = build_drawing(
+        Box(10, 10, 10),
+        auto_dims=False,
+        title="TOP\nBOTTOM",
+        number="D\n2",
+    )
+    drawing.note("A\nB\nC\nD\nE\nF\nG", (100, 100), name="multiline")
+
+    pdf_path = drawing.export(str(tmp_path / "multiline"), formats=("pdf",))["pdf"]
+    pdf, text_page, extracted = _pdf_text(pdf_path)
+    try:
+        assert "A\r\nB\r\nC\r\nD\r\nE\r\nF\r\nG" in extracted
+        assert "TOP\r\nBOTTOM" in extracted
+        expected_pitch_points = 1.3 * drawing.draft.font_size * 72.0 / 25.4
+        note_indices = [extracted.index(line) for line in tuple("ABCDEFG")]
+        centres = [_character_centre(text_page, index) for index in note_indices]
+        assert all(
+            upper[1] - lower[1] == pytest.approx(expected_pitch_points, abs=0.15)
+            for upper, lower in zip(centres, centres[1:], strict=False)
+        )
+    finally:
+        text_page.close()
+        pdf.close()
+
+
+def test_semantic_order_tiebreak_and_basic_dimension_rotation_are_total(tmp_path):
+    drawing = build_drawing(Box(10, 10, 10), auto_dims=False)
+    for index, label in enumerate(("AA", "BB")):
+        annotation = Dimension(
+            (10, 10, 0),
+            (50, 50, 0),
+            (0, 1, 0),
+            10,
+            drawing.draft,
+            label=label,
+            basic=index == 1,
+        )
+        # Deliberate overlap exercises export robustness. Production feature
+        # dimensions still enter through the verbs and placement solve.
+        drawing.registry.add(annotation, f"same_box_{index}", view=None)
+        drawing.items.append(annotation)
+
+    pdf_path = drawing.export(str(tmp_path / "same_box"), formats=("pdf",))["pdf"]
+    pdf, text_page, extracted = _pdf_text(pdf_path)
+    try:
+        assert "AA" in extracted and "BB" in extracted
+        assert _extracted_text_angle(text_page, extracted, "AA") == pytest.approx(45.0, abs=1.0)
+        assert _extracted_text_angle(text_page, extracted, "BB") == pytest.approx(45.0, abs=1.0)
+    finally:
+        text_page.close()
+        pdf.close()
+
+
+def test_note_semantic_rotation_tracks_later_annotation_transform(tmp_path):
+    drawing = build_drawing(Box(10, 10, 10), auto_dims=False)
+    drawing.note("ROTATED", (100, 100), rotation=10, name="rotated")
+    drawing.get_annotation("rotated").location = Location((0, 0, 0), (0, 0, 20))
+
+    pdf_path = drawing.export(str(tmp_path / "rotated"), formats=("pdf",))["pdf"]
+    pdf, text_page, extracted = _pdf_text(pdf_path)
+    try:
+        assert _extracted_text_angle(text_page, extracted, "ROTATED") == pytest.approx(
+            30.0, abs=1.0
+        )
+    finally:
+        text_page.close()
+        pdf.close()
+
+
+def test_named_font_opt_out_resolves_the_renderer_face():
+    path = Path(_resolved_semantic_font_path(None, "Arial"))
+    assert path.is_file()
+
+
+def test_non_ttfont_semantic_face_falls_back_without_losing_text(tmp_path, monkeypatch):
+    from reportlab.pdfbase import ttfonts
+
+    svg_path = tmp_path / "blank.svg"
+    svg_path.write_text(
+        '<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" '
+        'viewBox="0 0 100 100"><path d="M0 0 L1 1"/></svg>',
+        encoding="utf-8",
+    )
+    unsupported = tmp_path / "unsupported.otf"
+    shutil.copyfile(PLEX_SANS_CONDENSED, unsupported)
+    real_ttfont = ttfonts.TTFont
+
+    class RejectNonTTFont(real_ttfont):
+        def __init__(self, name, path, *args, **kwargs):
+            if Path(path) == unsupported:
+                raise ValueError("CFF-style font is not supported by ReportLab TTFont")
+            super().__init__(name, path, *args, **kwargs)
+
+    monkeypatch.setattr(ttfonts, "TTFont", RejectNonTTFont)
+    pdf_path = tmp_path / "fallback.pdf"
+    _render_pdf(
+        str(svg_path),
+        str(pdf_path),
+        text_runs=(_PDFTextRun("FALLBACK", 10, 10, 3, font_path=str(unsupported)),),
+    )
+
+    pdf, text_page, extracted = _pdf_text(str(pdf_path))
+    try:
+        assert "FALLBACK" in extracted
+        assert Path(PLEX_MONO).is_file()
+    finally:
+        text_page.close()
+        pdf.close()

--- a/tests/test_issue_1352_searchable_pdf_text.py
+++ b/tests/test_issue_1352_searchable_pdf_text.py
@@ -922,6 +922,31 @@ def test_named_font_opt_out_supports_build123d_010(monkeypatch):
     assert regular != bold
 
 
+def test_named_font_opt_out_supports_build123d_009(monkeypatch):
+    import sys
+    from enum import Enum
+    from types import ModuleType
+
+    class LegacyFontStyle(Enum):
+        REGULAR = 1
+        BOLD = 2
+        ITALIC = 3
+
+    legacy_build123d = ModuleType("build123d")
+    legacy_build123d.FontStyle = LegacyFontStyle
+    _resolved_semantic_font_path.cache_clear()
+    monkeypatch.setitem(sys.modules, "build123d", legacy_build123d)
+    monkeypatch.setitem(sys.modules, "build123d.text", None)
+    try:
+        regular = Path(_resolved_semantic_font_path(None, "Arial", "REGULAR"))
+        bold = Path(_resolved_semantic_font_path(None, "Arial", "BOLD"))
+    finally:
+        _resolved_semantic_font_path.cache_clear()
+
+    assert regular.is_file() and bold.is_file()
+    assert regular != bold
+
+
 def test_non_ttfont_semantic_face_falls_back_once_without_losing_text(
     tmp_path, monkeypatch, caplog
 ):

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -11572,7 +11572,7 @@ class TestDraftwrightAttribution:
 
         dwg = build_drawing(Box(60, 40, 20), auto_dims=False)
         dwg.note("INSPECT SURFACE ±0.1", (65, 55), name="inspection_note")
-        dwg.note("ROTATED PATH ONLY", (100, 55), rotation=45, name="rotated_note")
+        dwg.note("ROTATED NOTE", (100, 55), rotation=45, name="rotated_note")
         dwg.add_table(
             [("NOTES", "SIZE"), ("DEBURR", "⌀5 ±0.1")],
             name="notes_table",
@@ -11585,11 +11585,12 @@ class TestDraftwrightAttribution:
             text_page = page.get_textpage()
             extracted = text_page.get_text_range()
             first_char_box = text_page.get_charbox(extracted.index("INSPECT SURFACE"))
+            rotated_char_box = text_page.get_charbox(extracted.index("ROTATED NOTE"))
         finally:
             pdf.close()
 
         assert "INSPECT SURFACE ±0.1" in extracted
-        assert "ROTATED PATH ONLY" not in extracted
+        assert "ROTATED NOTE" in extracted
         assert "NOTES" in extracted and "DEBURR" in extracted
         # The visible drafting font's longstanding CAD compatibility glyph is
         # ø for source ⌀; copied text must match what the engineer sees.
@@ -11601,6 +11602,10 @@ class TestDraftwrightAttribution:
         left, bottom, right, top = first_char_box
         assert left < note_box.max.X * k and right > note_box.min.X * k
         assert bottom < note_box.max.Y * k and top > note_box.min.Y * k
+        rotated_box = dwg.get_annotation("rotated_note").bounding_box()
+        left, bottom, right, top = rotated_char_box
+        assert left < rotated_box.max.X * k and right > rotated_box.min.X * k
+        assert bottom < rotated_box.max.Y * k and top > rotated_box.min.Y * k
 
     def test_export_pdf_does_not_silently_discard_semantic_text(self, tmp_path, monkeypatch):
         from reportlab.pdfgen.canvas import Canvas


### PR DESCRIPTION
## Summary

- add a semantic PDF text layer for dimensions, callouts, notes, tables, and title-block values while retaining existing vector glyph ink
- embed and subset the bundled Plex faces with Unicode mapping for search, copy/paste, indexing, and accessibility
- preserve final annotation transforms, multiline geometry, tolerances, symbols, raw-helper compatibility, and leftward text extraction across PDF engines
- keep unsupported engineering symbols and unverifiable external raw single-glyph fonts as safe vector fallbacks

## Verification

- scripts/pr-check --full
- 5,018 passed, 5 skipped, 2 xfailed
- 95.18% overall coverage; 94% diff coverage
- Poppler default/raw/layout and PDFium extraction/selection matrices
- pixel-identical semantic-layer on/off rendering
- embedded subset FontFile2 and ToUnicode checks
- three independent exact-commit reviews: no blockers, majors, or minors; only documented nits remain

No new or updated recognizer is required.

Closes #1352