### PR TITLE
Add dimension view and side placement intent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,9 @@
 
 ### Fixed
 
+- Non-1:1 orthographic and isometric projection now scales extracted solids about the world
+  origin, matching the view-coordinate mapper and solver zones. Solids carrying a non-zero
+  build123d `Location` no longer shift their silhouette away from dimensions and callouts.
 - Notes and generic table cells now render U+2300 `⌀` with the established supported drafting
   glyph instead of IBM Plex Mono's missing-glyph square. The substitution happens at the one
   shared measurement/render seam, so source rows remain unchanged and table sizing stays exact

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- Referential and measured Sheet dimensions accept optional `view=` / `side=` placement
+  intent. Supported pairs survive IR/compiler and generated-script round trips, constrain
+  ordinary corridor candidates without exposing page coordinates, and fail clearly when a
+  renderer cannot honour the requested view/strip. Compound hole callouts can therefore be
+  authored to opposite sides of one end view while retaining normal solve and lint behavior
+  (#563).
 - Feature-linked Sheet notes can explicitly satisfy one or more canonical requirement ids with
   `.note(..., satisfies=(...))`. Placed structured notes retain each requirement's identity in
   coverage reports and generated scripts without masquerading as dimensions or parsing prose;

--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -95,11 +95,15 @@ source = emit_sheet_script(
 referential `DimensionIntent`. The handle never carries a replacement nominal and never chooses
 page coordinates. Use `format(decimals=n)` to preserve between 0 and 15 decimal places in the
 printed nominal while reconciliation, tolerance, suppression and provenance continue to read the
-numeric parameter from the feature. Trailing zeroes are intentional manufacturing display text:
+numeric parameter from the feature. Optional `view="front|plan|side"` and
+`side="above|below|left|right"` arguments select a supported semantic corridor when authored
+routing must override the derived default; the normal placement solve still chooses coordinates
+and reports capacity/crossing failures. Trailing zeroes are intentional manufacturing display text:
 
 ```python
 sheet.authored_dimensions()
 sheet.dimension(envelope, "width.length").format(decimals=2)  # 13.5 prints as 13.50
+sheet.dimension(tapped_hole, "bore.diameter", view="plan", side="left")
 ```
 
 ::: draftwright.sheet.DimensionIntent

--- a/src/draftwright/_geometry.py
+++ b/src/draftwright/_geometry.py
@@ -14,9 +14,10 @@ from __future__ import annotations
 import logging
 import math
 from dataclasses import dataclass
+from inspect import signature
 
 from b123d_recognisers import full_cylinders
-from build123d import Compound
+from build123d import Compound, Shape
 
 _log = logging.getLogger(__name__)
 
@@ -188,6 +189,23 @@ def _solids_body(part, src: str = "part"):
     ):
         _log.info("Dropping non-solid geometry from %s (PMI presentation data)", src)
     return body
+
+
+_SCALE_SUPPORTS_ABOUT = "about" in signature(Shape.scale).parameters
+
+
+def _scale_world(shape, factor: float):
+    """Scale a build123d shape about the world origin on every supported version.
+
+    build123d 0.9/0.10's factor-only ``Shape.scale`` uses the world origin. Version 0.11 added
+    ``about=`` and changed the default to ``shape.location.position``. Draftwright supports both
+    dependency lines, so select the signature once and state the same world-origin transform on
+    either API without converting analytic geometry through a general affine transform.
+    """
+
+    if _SCALE_SUPPORTS_ABOUT:
+        return shape.scale(factor, about=(0, 0, 0))
+    return shape.scale(factor)
 
 
 def _axis_letter(obj) -> str:

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -5410,6 +5410,16 @@ def _pmi_front_linear(dwg, a, ctx, rec, ax, label, name, primary, secondary, cen
         "right": a.fv_zones.right,
         "left": a.fv_zones.left,
     }
+    if rec.view is not None or rec.side is not None:
+        sides = [s for s in (primary, secondary) if rec.side is None or rec.side == s]
+        return _pmi_queue_options(
+            dwg,
+            ctx,
+            [_pmi_dim_spec(p1, p2, zones[s], label, name, "front", s, draft) for s in sides],
+            ax,
+            label,
+            rec,
+        )
     placed = False
     if avg >= center:
         placed = _pmi_queue_options(
@@ -5486,6 +5496,12 @@ def _place_pmi_record(dwg, a, ctx, rec, idx, bore_cfg, draft) -> bool:
             u, v = cfg["centre"](cx_f, cy_f, cz_f)
             if half_span_pg >= _MIN_INPLACE_BORE_HALF_MM:
                 p1, p2 = cfg["span"](cx_f, cy_f, cz_f, lo, hi)
+                order = tuple(
+                    s
+                    for s in cfg["order"]
+                    if (rec.view is None or rec.view == cfg["view"])
+                    and (rec.side is None or rec.side == s)
+                )
                 placed = _pmi_queue_options(
                     dwg,
                     ctx,
@@ -5493,13 +5509,19 @@ def _place_pmi_record(dwg, a, ctx, rec, idx, bore_cfg, draft) -> bool:
                         _pmi_dim_spec(
                             p1, p2, cfg["zones"][s], label, name_d, cfg["view"], s, draft
                         )
-                        for s in cfg["order"]
+                        for s in order
                     ],
                     ax,
                     label,
                     rec,
                 )
             else:
+                leader_order = tuple(
+                    s
+                    for s in cfg["leader_order"]
+                    if (rec.view is None or rec.view == cfg["view"])
+                    and (rec.side is None or rec.side == s)
+                )
                 placed = _pmi_queue_options(
                     dwg,
                     ctx,
@@ -5513,7 +5535,7 @@ def _place_pmi_record(dwg, a, ctx, rec, idx, bore_cfg, draft) -> bool:
                             s,
                             draft,
                         )
-                        for s in cfg["leader_order"]
+                        for s in leader_order
                     ],
                     ax,
                     label,
@@ -5533,6 +5555,48 @@ def _place_pmi_record(dwg, a, ctx, rec, idx, bore_cfg, draft) -> bool:
             _log.debug("PMI dim[%d] Z: degenerate reference", idx)
             _record_pmi_unrenderable(dwg, label, rec, ctx=ctx)
             return False
+
+    elif ax == "Y" and (rec.view is not None or rec.side is not None):
+        # A degenerate reference (no witness in EITHER candidate view) is a validation
+        # failure, not a placement one — report it distinctly (#562).
+        if (
+            _pmi_witness_from_bbox(rec, "side", a) is None
+            and _pmi_witness_from_bbox(rec, "plan", a) is None
+        ):
+            _log.debug("PMI dim[%d] Y: degenerate reference", idx)
+            _record_pmi_unrenderable(dwg, label, rec, ctx=ctx)
+            return False
+        # An authored target is an exact view/strip selection, still queued through the
+        # ordinary corridor solve. Build only matching candidates.
+        options = []
+        for target_view, target_side in (
+            ("side", "above"),
+            ("side", "below"),
+            ("plan", "left"),
+            ("plan", "right"),
+        ):
+            if rec.view is not None and rec.view != target_view:
+                continue
+            if rec.side is not None and rec.side != target_side:
+                continue
+            wp = _pmi_witness_from_bbox(rec, target_view, a)
+            if wp is None:
+                continue
+            p1, p2, _ = wp
+            zones = a.sv_zones if target_view == "side" else a.pv_zones
+            options.append(
+                _pmi_dim_spec(
+                    p1,
+                    p2,
+                    getattr(zones, target_side),
+                    label,
+                    name_y,
+                    target_view,
+                    target_side,
+                    draft,
+                )
+            )
+        placed = _pmi_queue_options(dwg, ctx, options, ax, label, rec)
 
     elif ax == "Y":
         # A degenerate reference (no witness in EITHER candidate view) is a validation

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -3520,7 +3520,11 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
         extent = env.dim(role=role)
         if extent is None or extent.span is None:
             continue
-        view = views_showing(axis, dwg.views, horizontal=True)
+        # A caller may override the derived view for this independent extent.  The planner
+        # has already proved that the selected projection can render the measurement and is
+        # present in the resolved view plan; placement still goes through the normal strip
+        # candidate solve below.
+        view = extent.view or views_showing(axis, dwg.views, horizontal=True)
         if view is None:
             # No planned view can carry it. Reported against the measurement, never dropped
             # in silence (ADR 0016 Amdt 6) — and this is exactly what the ADR 0018
@@ -4939,7 +4943,9 @@ def _record_pmi_drop(ctx, dwg, ax, label, rec):
     dominant-axis table above (X/Z→front, Y→side primary). Conflating the two
     mislabels every dropped bore diameter/radius (review finding, #351 PR-4a).
     """
-    if rec.pmi_kind in ("diameter", "radius"):
+    if rec.view is not None:
+        view = rec.view
+    elif rec.pmi_kind in ("diameter", "radius"):
         view = {"Z": "plan", "X": "side", "Y": "front"}.get(ax, "front")
     else:
         view = "front" if ax in ("X", "Z") else "side"
@@ -5410,8 +5416,8 @@ def _pmi_front_linear(dwg, a, ctx, rec, ax, label, name, primary, secondary, cen
         "right": a.fv_zones.right,
         "left": a.fv_zones.left,
     }
-    if rec.view is not None or rec.side is not None:
-        sides = [s for s in (primary, secondary) if rec.side is None or rec.side == s]
+    if rec.side is not None:
+        sides = [s for s in (primary, secondary) if rec.side == s]
         return _pmi_queue_options(
             dwg,
             ctx,
@@ -5566,25 +5572,23 @@ def _place_pmi_record(dwg, a, ctx, rec, idx, bore_cfg, draft) -> bool:
             _log.debug("PMI dim[%d] Y: degenerate reference", idx)
             _record_pmi_unrenderable(dwg, label, rec, ctx=ctx)
             return False
-        # An authored target is an exact view/strip selection, still queued through the
-        # ordinary corridor solve. Build only matching candidates.
+        # A side override selects an exact strip. A view-only override keeps the ordinary
+        # geometry-derived side within that projection instead of changing an unspecified
+        # policy merely because its sibling field was supplied.
+        target_view = rec.view or ("side" if rec.side in {"above", "below"} else "plan")
+        wp = _pmi_witness_from_bbox(rec, target_view, a)
         options = []
-        for target_view, target_side in (
-            ("side", "above"),
-            ("side", "below"),
-            ("plan", "left"),
-            ("plan", "right"),
-        ):
-            if rec.view is not None and rec.view != target_view:
-                continue
-            if rec.side is not None and rec.side != target_side:
-                continue
-            wp = _pmi_witness_from_bbox(rec, target_view, a)
-            if wp is None:
-                continue
-            p1, p2, _ = wp
+        if wp is not None:
+            p1, p2, avg = wp
             zones = a.sv_zones if target_view == "side" else a.pv_zones
-            options.append(
+            target_sides: tuple[str, ...]
+            if rec.side is not None:
+                target_sides = (rec.side,)
+            elif target_view == "side":
+                target_sides = ("above", "below") if avg >= a.SV_Y else ("below",)
+            else:
+                target_sides = ("right", "left") if avg >= a.PV_X else ("left", "right")
+            options = [
                 _pmi_dim_spec(
                     p1,
                     p2,
@@ -5595,7 +5599,8 @@ def _place_pmi_record(dwg, a, ctx, rec, idx, bore_cfg, draft) -> bool:
                     target_side,
                     draft,
                 )
-            )
+                for target_side in target_sides
+            ]
         placed = _pmi_queue_options(dwg, ctx, options, ax, label, rec)
 
     elif ax == "Y":

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -117,6 +117,7 @@ from draftwright.model.ir import (
     PocketFeature,
     SlotFeature,
     ThreadRequirement,
+    authored_dimension_target_view,
 )
 from draftwright.view_plan import views_showing
 
@@ -4943,8 +4944,14 @@ def _record_pmi_drop(ctx, dwg, ax, label, rec):
     dominant-axis table above (X/Z→front, Y→side primary). Conflating the two
     mislabels every dropped bore diameter/radius (review finding, #351 PR-4a).
     """
-    if rec.view is not None:
-        view = rec.view
+    selected_view = authored_dimension_target_view(
+        rec.pmi_kind,
+        ax,
+        getattr(rec, "view", None),
+        getattr(rec, "side", None),
+    )
+    if selected_view is not None:
+        view = selected_view
     elif rec.pmi_kind in ("diameter", "radius"):
         view = {"Z": "plan", "X": "side", "Y": "front"}.get(ax, "front")
     else:
@@ -5299,7 +5306,14 @@ def _pmi_dim_spec(p1, p2, strip, label, name, view, side, draft):
         return None
 
     def _build(pos, _q1=q1, _q2=q2, _side=side, _w=witness, _label=label):
-        dist = pos - _w if _side in ("above", "right") else _w - pos
+        # Dimension's extension-gap convention places the actual line one gap back toward
+        # its witnesses. Compensate so the solver's stacking coordinate is the rendered
+        # line/label coordinate, keeping the first tier outside the view silhouette.
+        dist = (
+            pos - _w + draft.extension_gap
+            if _side in ("above", "right")
+            else _w - pos + draft.extension_gap
+        )
         return _dim(_q1, _q2, _side, dist, draft, label=_label)
 
     order_coord = min(perp)

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -2299,8 +2299,9 @@ def _carve_and_place(cands_in, intervals, key_prefix_local, ctx: _StripCtx, *, a
 def _assemble_view_callouts(a, view_of_axis, groups, feature_keys, only, draft):
     """The ``by_view`` callout-assembly loop, promoted out of ``_annotate_holes`` (#638).
 
-    Returns ``(by_view, feat_of_callout)`` — one ``(locs, dia, callout, pat)`` spec per
-    surviving hole/pattern group keyed by target view, plus the callout→feature ``id()`` map.
+    Returns ``(by_view, feat_of_callout, side_of_callout)`` — one
+    ``(locs, dia, callout, pat)`` spec per surviving hole/pattern group keyed by target view,
+    plus callout→feature and callout→authored-side ``id()`` maps.
 
     The IR is the single grouping + geometry authority (#238 B2/B3, Amendment 6):
     build_part_model already split the holes into one DimensionGroup per pattern +
@@ -2314,6 +2315,7 @@ def _assemble_view_callouts(a, view_of_axis, groups, feature_keys, only, draft):
     # flows unchanged from here through the by_view/queue tuples to both emit sites, so an
     # id() map tags it there without threading a feature through the placement machinery.
     _feat_of_callout: dict[int, object] = {}
+    _side_of_callout: dict[int, str] = {}
     for g in groups:
         feat = g.feature
         if not isinstance(feat, HoleFeature | PatternFeature):
@@ -2343,10 +2345,15 @@ def _assemble_view_callouts(a, view_of_axis, groups, feature_keys, only, draft):
         callout = callout_from_spec(spec, draft, count)
         if callout is None:
             continue
-        view = view_of_axis[feat.frame.axis][0]
+        # The planner has validated this semantic projection against the renderer.  With no
+        # authored intent it is the same axis-derived view as before; with one it is the
+        # requested projection, still placed through the normal corridor solve.
+        view = g.view
         _feat_of_callout[id(callout)] = feat  # provenance (#408)
+        if g.side is not None:
+            _side_of_callout[id(callout)] = g.side
         by_view.setdefault(view, []).append((locs, dia, callout, pat))
-    return by_view, _feat_of_callout
+    return by_view, _feat_of_callout, _side_of_callout
 
 
 def _hc_name(only, view, i, hc_used):
@@ -2495,6 +2502,7 @@ def _place_queue(
     band_intervals,
     elbow_dx,
     feat_of_callout,
+    side_of_callout,
     hc_used,
     only,
     place_furniture,
@@ -2655,6 +2663,7 @@ def _place_queue(
         for s in queue:
             _locs, dia, callout, feat, natural_y, _rep = s
             owner = feat_of_callout.get(id(callout))
+            requested_side = side_of_callout.get(id(callout))
             ys: list[float] = []
             for y in (
                 source_final_y.get(id(s)),
@@ -2671,7 +2680,12 @@ def _place_queue(
                 if not any(abs(y - prior) <= 1e-6 for prior in ys):
                     ys.append(y)
 
-            def _raw_candidates(_s=s, _ys=tuple(ys), _owner=owner):
+            def _raw_candidates(
+                _s=s,
+                _ys=tuple(ys),
+                _owner=owner,
+                _requested_side=requested_side,
+            ):
                 for y in _ys:
                     tip, elbow = _leader_anchors(
                         _s,
@@ -2690,20 +2704,21 @@ def _place_queue(
                 # expose the opposite view boundary so a required callout can
                 # route clear rather than silently accepting a new Policy-B
                 # crossing.  The legacy resource floor below remains unchanged.
-                other_side = "left" if side == "right" else "right"
-                other_edge = vb[0] if other_side == "left" else vb[2]
-                for y in _ys:
-                    tip, elbow = _leader_anchors(
-                        _s,
-                        other_edge,
-                        other_side,
-                        y,
-                        to_page,
-                        elbow_dx,
-                        draft,
-                        a.SCALE,
-                    )
-                    yield (tip, elbow, _owner)
+                if _requested_side is None:
+                    other_side = "left" if side == "right" else "right"
+                    other_edge = vb[0] if other_side == "left" else vb[2]
+                    for y in _ys:
+                        tip, elbow = _leader_anchors(
+                            _s,
+                            other_edge,
+                            other_side,
+                            y,
+                            to_page,
+                            elbow_dx,
+                            draft,
+                            a.SCALE,
+                        )
+                        yield (tip, elbow, _owner)
 
             legacy_y = source_final_y.get(id(s))
 
@@ -2917,6 +2932,7 @@ def _place_planside_callouts(
     ctx,
     hc_used,
     feat_of_callout,
+    side_of_callout,
     only,
     place_furniture,
     plan,
@@ -3006,6 +3022,11 @@ def _place_planside_callouts(
         )
         can_right = (edge_right + elbow_dx) + gap + w <= right_limit
         can_left = edge_left is not None and (edge_left - elbow_dx) - gap - w >= a.margin
+        requested_side = side_of_callout.get(id(callout))
+        if requested_side == "right":
+            can_left = False
+        elif requested_side == "left":
+            can_right = False
 
         if not can_right and not can_left:
             _log.info("Hole callout ø%s skipped (no room)", _fmt(dia))
@@ -3038,6 +3059,7 @@ def _place_planside_callouts(
         band_intervals=band_intervals,
         elbow_dx=elbow_dx,
         feat_of_callout=feat_of_callout,
+        side_of_callout=side_of_callout,
         hc_used=hc_used,
         only=only,
         place_furniture=place_furniture,
@@ -3061,6 +3083,7 @@ def _place_planside_callouts(
             band_intervals=band_intervals,
             elbow_dx=elbow_dx,
             feat_of_callout=feat_of_callout,
+            side_of_callout=side_of_callout,
             hc_used=hc_used,
             only=only,
             place_furniture=place_furniture,
@@ -3126,7 +3149,7 @@ def _annotate_holes(
         for g in groups
     )
 
-    by_view, feat_of_callout = _assemble_view_callouts(
+    by_view, feat_of_callout, side_of_callout = _assemble_view_callouts(
         a, view_of_axis, groups, feature_keys, only, draft
     )
 
@@ -3176,6 +3199,7 @@ def _annotate_holes(
                 ctx=ctx,
                 hc_used=hc_used,
                 feat_of_callout=feat_of_callout,
+                side_of_callout=side_of_callout,
                 only=only,
                 place_furniture=place_furniture,
                 plan=plan,

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -44,7 +44,7 @@ from draftwright._core import (
     _log,
     _tol_suffix,
 )
-from draftwright._geometry import _leader_ink_polygons, _stroke_polygon
+from draftwright._geometry import _leader_ink_polygons, _scale_world, _stroke_polygon
 from draftwright.annotations._common import carve_free_segments, strip_obstacles
 from draftwright.annotations.leaders import feature_leader_fixed_conflicts
 from draftwright.model import plan_sections
@@ -764,7 +764,10 @@ def _render_detail(
     # dims against these coords before committing the view is what lets us drop the place-then-roll-
     # back (#840).
     try:
-        band_s = cropped.scale(detail_scale)
+        # Detail ViewCoordinates use the same world-origin scale as principal/iso views. A
+        # Boolean crop can preserve a retained solid's non-zero build123d Location, so direct
+        # 0.11 ``scale`` would move its silhouette away from those coordinates.
+        band_s = _scale_world(cropped, detail_scale)
         placed, placed_hid, coords = project_view_geometry(
             detail_scale, view_name, band_s, camera, up, (DX, DY), look_at=la, scaled=True
         )

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -1244,12 +1244,18 @@ def _build_drawing_once(
             # surface-finish, datum, and manufacturing-note aspects carry an explicit target
             # view in the IR and intentionally bypass the dimension planner.  Fail closed
             # before projection when an automatic reduction would erase one of those targets.
-            aspect_views = {
-                view
-                for feature in planning_model.features
-                if isinstance((view := getattr(feature, "view", None)), str)
-                and view in third_angle_view_names()
-            }
+            aspect_views = set()
+            for feature in planning_model.features:
+                view = getattr(feature, "view", None)
+                if getattr(feature, "kind", None) == "authored_dimension":
+                    view = authored_dimension_target_view(
+                        getattr(feature, "dimension_kind", ""),
+                        getattr(feature, "dominant_axis", ""),
+                        view,
+                        getattr(feature, "side", None),
+                    )
+                if isinstance(view, str) and view in third_angle_view_names():
+                    aspect_views.add(view)
             missing_aspect_views = tuple(sorted(aspect_views - set(candidate_views)))
             uncovered = missing_aspect_views
             reason = "annotation_view_required" if uncovered else None

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -622,7 +622,14 @@ def _assemble(
     # times — the root cause of #1135's hour-long build. This parameter is the seam where the
     # loop's intermediate assemblies will pass a cheap stand-in and only the final one the real
     # solid (#1137). Every caller currently takes the default, so nothing has changed yet.
-    part_s = (a.part if shape is None else shape).scale(a.SCALE)
+    # build123d scales about ``shape.location.position`` by default.  The solids-only body
+    # returned by ``_solids_body`` commonly carries the source primitive's placement as its
+    # Location (for a centred Box, its minimum corner), even though its bounding box and every
+    # analysis/projector coordinate are expressed in world space.  Scaling about that stored
+    # location moves the rendered silhouette away from the solver's world-origin projection at
+    # every non-1:1 scale.  Scale world geometry about the world origin explicitly so the view,
+    # ViewCoordinates and annotation zones retain one transform.
+    part_s = (a.part if shape is None else shape).scale(a.SCALE, about=(0, 0, 0))
 
     # ADR 0018: the views this drawing has, and where they go, come from ONE resolved plan
     # instead of three hardcoded calls whose cameras, page fields and layout meaning were

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -44,6 +44,7 @@ from draftwright._core import (
     _Projector,
     _tb_width,
 )
+from draftwright._geometry import _scale_world
 from draftwright._warnings import ScaleCompletenessWarning
 from draftwright.analysis import Analysis, _analyse, _apply_principal_view_pins
 from draftwright.annotations._common import (
@@ -622,14 +623,14 @@ def _assemble(
     # times — the root cause of #1135's hour-long build. This parameter is the seam where the
     # loop's intermediate assemblies will pass a cheap stand-in and only the final one the real
     # solid (#1137). Every caller currently takes the default, so nothing has changed yet.
-    # build123d scales about ``shape.location.position`` by default.  The solids-only body
+    # build123d 0.11 scales about ``shape.location.position`` by default. The solids-only body
     # returned by ``_solids_body`` commonly carries the source primitive's placement as its
     # Location (for a centred Box, its minimum corner), even though its bounding box and every
     # analysis/projector coordinate are expressed in world space.  Scaling about that stored
     # location moves the rendered silhouette away from the solver's world-origin projection at
     # every non-1:1 scale.  Scale world geometry about the world origin explicitly so the view,
     # ViewCoordinates and annotation zones retain one transform.
-    part_s = (a.part if shape is None else shape).scale(a.SCALE, about=(0, 0, 0))
+    part_s = _scale_world(a.part if shape is None else shape, a.SCALE)
 
     # ADR 0018: the views this drawing has, and where they go, come from ONE resolved plan
     # instead of three hardcoded calls whose cameras, page fields and layout meaning were

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -84,6 +84,7 @@ from draftwright.projection import (
 )
 from draftwright.view_plan import (
     ARRANGEMENTS,
+    UncoveredViewRequirement,
     ViewConstraints,
     ViewPlanIncomplete,
     resolve_from_analysis,
@@ -1193,6 +1194,36 @@ def _build_drawing_once(
         )
 
     a = analyse(reuse=_analysis_base, views=_views)
+    if _views is not None:
+        # Measured dimensions are model-routed (ADR 0015) and therefore do not enter
+        # plan_dimensions' requirement check.  An authored principal set is nevertheless
+        # a hard constraint: reject a measured mark targeting an absent projection before
+        # corridor placement can misreport the contradiction as a capacity drop.
+        explicit_model = (
+            _coerce_model(model, a.part, decorations, requested, authored)
+            if model is not None
+            else cast("PartModel", a.model if a.model is not None else build_model(a))
+        )
+        uncovered_measured = []
+        for feature in explicit_model.features:
+            feature_view = getattr(feature, "view", None)
+            if (
+                getattr(feature, "kind", None) != "authored_dimension"
+                or not isinstance(feature_view, str)
+                or feature_view in set(_views)
+            ):
+                continue
+            uncovered_measured.append(
+                UncoveredViewRequirement(
+                    identity=feature,
+                    label=getattr(feature, "source_id", "") or "measured_dimension",
+                    preferred_view=feature_view,
+                    eligible_views=(feature_view,),
+                    reason=f"is explicitly placed in `{feature_view}`",
+                )
+            )
+        if uncovered_measured:
+            raise ViewPlanIncomplete(_views, uncovered_measured)
     view_attempts: tuple[dict[str, object], ...] = ()
     view_status = "selected"
     if _select_automatic_views and _views is None and auto_dims:

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -76,6 +76,7 @@ from draftwright.model import (
     StepFeature,
     build_pmi_features,
 )
+from draftwright.model.ir import authored_dimension_target_view
 from draftwright.model.planner import plan_dimensions
 from draftwright.projection import (
     _bbox_within,
@@ -1206,7 +1207,12 @@ def _build_drawing_once(
         )
         uncovered_measured = []
         for feature in explicit_model.features:
-            feature_view = getattr(feature, "view", None)
+            feature_view = authored_dimension_target_view(
+                getattr(feature, "dimension_kind", ""),
+                getattr(feature, "dominant_axis", ""),
+                getattr(feature, "view", None),
+                getattr(feature, "side", None),
+            )
             if (
                 getattr(feature, "kind", None) != "authored_dimension"
                 or not isinstance(feature_view, str)

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -341,6 +341,7 @@ class StripDepths:
     left: float  # horizontal corridor left of FV/PV
     top: float = 0.0  # band above PV for tiered X-location dims (#121)
     pv_halo: float = 0.0  # balloon standoff band reserved around the plan view (#111)
+    fv_top: float = 0.0  # authored X-linear dimensions above the front view (#563)
 
 
 def _measure_strips(
@@ -437,6 +438,17 @@ def _compose_anno_boxes(
             AnnoBox("right", _est_right_strip_depth(n_steps, n_boss_h) + z_authored * slot)
         )
         boxes.append(AnnoBox("left", _STRIP_GAP + z_authored * slot))
+    x_front_above = sum(
+        1
+        for f in model.features
+        if f.kind == "authored_dimension"
+        and f.dominant_axis == "X"
+        and getattr(f, "dimension_kind", None) not in ("diameter", "radius", "angular")
+        and getattr(f, "view", None) == "front"
+        and getattr(f, "side", None) == "above"
+    )
+    if x_front_above:
+        boxes.append(AnnoBox("front_above", _STRIP_GAP + x_front_above * _SLOT_DIM_STEP))
     above = _est_pv_above_depth(model, font_size, pad_around_text)
     if above > 0:
         boxes.append(AnnoBox("above", above))  # tiered X-location dims above PV (#121)
@@ -460,6 +472,7 @@ def _footprint_from_boxes(boxes: list[AnnoBox]) -> StripDepths:
         left=max(_DIM_PAD, deepest("left")),
         top=deepest("above"),
         pv_halo=deepest("plan_halo"),
+        fv_top=deepest("front_above"),
     )
 
 
@@ -899,7 +912,7 @@ def _compose_view_blocks(
         "front": ViewBlock(
             fv_hw,
             fv_hh,
-            top=DIM_PAD - pv_below,
+            top=max(DIM_PAD - pv_below, strips.fv_top if strips else 0.0),
             right=gap_fv_sv,
             bottom=DIM_PAD,
             left=gap_left,

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -55,6 +55,7 @@ from draftwright._core import (
 )
 from draftwright.layout import fit_box
 from draftwright.model.callout import hole_callout_spec
+from draftwright.model.ir import authored_dimension_target_view
 from draftwright.view_plan import (
     ARRANGEMENTS,
     LayoutCandidate,
@@ -444,7 +445,13 @@ def _compose_anno_boxes(
         if f.kind == "authored_dimension"
         and f.dominant_axis == "X"
         and getattr(f, "dimension_kind", None) not in ("diameter", "radius", "angular")
-        and getattr(f, "view", None) == "front"
+        and authored_dimension_target_view(
+            getattr(f, "dimension_kind", ""),
+            getattr(f, "dominant_axis", ""),
+            getattr(f, "view", None),
+            getattr(f, "side", None),
+        )
+        == "front"
         and getattr(f, "side", None) == "above"
     )
     if x_front_above:

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -465,9 +465,15 @@ def _compose_anno_boxes(
             _reserve(target_view, target_side)
 
     slot = _SLOT_DIM_STEP + _STRIP_SPACING
-    left_count = sum(count for (view, side), count in authored_corridors.items() if side == "left")
-    right_count = sum(
-        count for (view, side), count in authored_corridors.items() if side == "right"
+    # Front and plan occupy disjoint vertical ranges, so their left/right tiers are
+    # reusable. Reserve the deepest one-view stack, not the sum of independent corridors.
+    left_count = max(
+        (count for (view, side), count in authored_corridors.items() if side == "left"),
+        default=0,
+    )
+    right_count = max(
+        (count for (view, side), count in authored_corridors.items() if side == "right"),
+        default=0,
     )
     if left_count:
         boxes.append(AnnoBox("left", _STRIP_GAP + left_count * slot))

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -471,18 +471,17 @@ def _compose_anno_boxes(
         (count for (view, side), count in authored_corridors.items() if side == "left"),
         default=0,
     )
-    right_count = max(
-        (count for (view, side), count in authored_corridors.items() if side == "right"),
-        default=0,
-    )
     if left_count:
         boxes.append(AnnoBox("left", _STRIP_GAP + left_count * slot))
-    if right_count:
-        # The front ladder baseline is already a separate right-side box above.  A plan-right
-        # stack is vertically disjoint from it (as front and plan measured stacks are from each
-        # other), so the footprint reducer must take their maximum, not charge the baseline and
-        # measured tiers additively.  Separate boxes express that compose-before-pack geometry.
-        boxes.append(AnnoBox("right", _STRIP_GAP + right_count * slot))
+    # Front-right measured dimensions share the automatic front height/step ladder and extend
+    # its stack. Plan-right dimensions are vertically disjoint from that whole front stack, so
+    # their independent box reuses its horizontal depth. The reducer takes the deeper box.
+    if front_right := authored_corridors.get(("front", "right"), 0):
+        boxes.append(
+            AnnoBox("right", _est_right_strip_depth(n_steps, n_boss_h) + front_right * slot)
+        )
+    if plan_right := authored_corridors.get(("plan", "right"), 0):
+        boxes.append(AnnoBox("right", _STRIP_GAP + plan_right * slot))
     vertical_box_side = {
         ("front", "above"): "front_above",
         ("front", "below"): "front_below",

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -478,9 +478,11 @@ def _compose_anno_boxes(
     if left_count:
         boxes.append(AnnoBox("left", _STRIP_GAP + left_count * slot))
     if right_count:
-        boxes.append(
-            AnnoBox("right", _est_right_strip_depth(n_steps, n_boss_h) + right_count * slot)
-        )
+        # The front ladder baseline is already a separate right-side box above.  A plan-right
+        # stack is vertically disjoint from it (as front and plan measured stacks are from each
+        # other), so the footprint reducer must take their maximum, not charge the baseline and
+        # measured tiers additively.  Separate boxes express that compose-before-pack geometry.
+        boxes.append(AnnoBox("right", _STRIP_GAP + right_count * slot))
     vertical_box_side = {
         ("front", "above"): "front_above",
         ("front", "below"): "front_below",

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -343,6 +343,11 @@ class StripDepths:
     top: float = 0.0  # band above PV for tiered X-location dims (#121)
     pv_halo: float = 0.0  # balloon standoff band reserved around the plan view (#111)
     fv_top: float = 0.0  # authored X-linear dimensions above the front view (#563)
+    fv_bottom: float = 0.0
+    pv_authored_top: float = 0.0
+    pv_bottom: float = 0.0
+    sv_top: float = 0.0
+    sv_bottom: float = 0.0
 
 
 def _measure_strips(
@@ -420,42 +425,67 @@ def _compose_anno_boxes(
         bore_depth += pad_around_text + arrow_length
         boxes.append(AnnoBox("right", bore_depth))  # FV/PV right bore callouts
         boxes.append(AnnoBox("left", bore_depth))  # FV/PV left bore callouts
-    # Authored Z-axis linear dimensions (Sheet.measured_dimension / AP242 PMI) render as height
-    # dims to the front LEFT/RIGHT strips (#562). The right strip already holds the
-    # envelope height + step ladder, but the left has only its _DIM_PAD floor, so an
-    # authored Z dim was queued and then dropped as "no room". Reserve a slot per authored
-    # Z dim on BOTH sides (they split by x position only at layout, so reserve
-    # conservatively) — enough depth for the corridor solve to place them.
-    z_authored = sum(
-        1
-        for f in model.features
-        if f.kind == "authored_dimension"
-        and f.dominant_axis == "Z"
-        and getattr(f, "dimension_kind", None) not in ("diameter", "radius", "angular")
+    # Measured placement hints are semantic corridor requirements and therefore part of
+    # compose-before-pack, not merely renderer filters. Resolve every valid explicit route;
+    # a view-only hint conservatively reserves both supported sides, while the legacy
+    # no-hint Z-linear path keeps its established both-side reservation (#562).
+    authored_corridors: dict[tuple[str, str], int] = {}
+
+    def _reserve(view: str, side: str) -> None:
+        key = (view, side)
+        authored_corridors[key] = authored_corridors.get(key, 0) + 1
+
+    for feature in model.features:
+        if getattr(feature, "kind", None) != "authored_dimension":
+            continue
+        kind = getattr(feature, "dimension_kind", "")
+        axis = getattr(feature, "dominant_axis", "")
+        view_hint = getattr(feature, "view", None)
+        side_hint = getattr(feature, "side", None)
+        if view_hint is None and side_hint is None:
+            if kind not in ("diameter", "radius", "angular") and axis == "Z":
+                _reserve("front", "left")
+                _reserve("front", "right")
+            continue
+        target_view = authored_dimension_target_view(kind, axis, view_hint, side_hint)
+        if target_view is None:
+            continue
+        sides: tuple[str, ...]
+        if side_hint is not None:
+            sides = (side_hint,)
+        elif kind in ("diameter", "radius") or axis == "X":
+            sides = ("above", "below")
+        elif axis == "Z":
+            sides = ("left", "right")
+        elif axis == "Y" and target_view == "side":
+            sides = ("above", "below")
+        else:
+            sides = ("left", "right")
+        for target_side in sides:
+            _reserve(target_view, target_side)
+
+    slot = _SLOT_DIM_STEP + _STRIP_SPACING
+    left_count = sum(count for (view, side), count in authored_corridors.items() if side == "left")
+    right_count = sum(
+        count for (view, side), count in authored_corridors.items() if side == "right"
     )
-    if z_authored:
-        slot = _SLOT_DIM_STEP + _STRIP_SPACING
+    if left_count:
+        boxes.append(AnnoBox("left", _STRIP_GAP + left_count * slot))
+    if right_count:
         boxes.append(
-            AnnoBox("right", _est_right_strip_depth(n_steps, n_boss_h) + z_authored * slot)
+            AnnoBox("right", _est_right_strip_depth(n_steps, n_boss_h) + right_count * slot)
         )
-        boxes.append(AnnoBox("left", _STRIP_GAP + z_authored * slot))
-    x_front_above = sum(
-        1
-        for f in model.features
-        if f.kind == "authored_dimension"
-        and f.dominant_axis == "X"
-        and getattr(f, "dimension_kind", None) not in ("diameter", "radius", "angular")
-        and authored_dimension_target_view(
-            getattr(f, "dimension_kind", ""),
-            getattr(f, "dominant_axis", ""),
-            getattr(f, "view", None),
-            getattr(f, "side", None),
-        )
-        == "front"
-        and getattr(f, "side", None) == "above"
-    )
-    if x_front_above:
-        boxes.append(AnnoBox("front_above", _STRIP_GAP + x_front_above * _SLOT_DIM_STEP))
+    vertical_box_side = {
+        ("front", "above"): "front_above",
+        ("front", "below"): "front_below",
+        ("plan", "above"): "plan_authored_above",
+        ("plan", "below"): "plan_below",
+        ("side", "above"): "side_above",
+        ("side", "below"): "side_below",
+    }
+    for corridor, box_side in vertical_box_side.items():
+        if count := authored_corridors.get(corridor, 0):
+            boxes.append(AnnoBox(box_side, _STRIP_GAP + count * slot))
     above = _est_pv_above_depth(model, font_size, pad_around_text)
     if above > 0:
         boxes.append(AnnoBox("above", above))  # tiered X-location dims above PV (#121)
@@ -480,6 +510,11 @@ def _footprint_from_boxes(boxes: list[AnnoBox]) -> StripDepths:
         top=deepest("above"),
         pv_halo=deepest("plan_halo"),
         fv_top=deepest("front_above"),
+        fv_bottom=deepest("front_below"),
+        pv_authored_top=deepest("plan_authored_above"),
+        pv_bottom=deepest("plan_below"),
+        sv_top=deepest("side_above"),
+        sv_bottom=deepest("side_below"),
     )
 
 
@@ -913,6 +948,8 @@ def _compose_view_blocks(
     # the tiered X-location dims, so reserve their real depth (strip_top) plus a
     # balloon row. When not ballooned, keep the historic DIM_PAD.
     pv_top = (max(DIM_PAD, strip_top) + halo) if halo > 0 else DIM_PAD
+    if strips is not None:
+        pv_top = max(pv_top, strips.pv_authored_top)
     sv_right_band = max(DIM_PAD, strips.right if (section and strips) else DIM_PAD)
 
     return {
@@ -921,7 +958,7 @@ def _compose_view_blocks(
             fv_hh,
             top=max(DIM_PAD - pv_below, strips.fv_top if strips else 0.0),
             right=gap_fv_sv,
-            bottom=DIM_PAD,
+            bottom=max(DIM_PAD, strips.fv_bottom if strips else 0.0),
             left=gap_left,
         ),
         "plan": ViewBlock(
@@ -929,10 +966,16 @@ def _compose_view_blocks(
             pv_hh,
             top=pv_top,
             right=gap_fv_sv,
-            bottom=max(pv_below, halo),
+            bottom=max(pv_below, halo, strips.pv_bottom if strips else 0.0),
             left=gap_left,
         ),
-        "side": ViewBlock(sv_hw, fv_hh, right=sv_right_band),
+        "side": ViewBlock(
+            sv_hw,
+            fv_hh,
+            top=strips.sv_top if strips else 0.0,
+            right=sv_right_band,
+            bottom=strips.sv_bottom if strips else 0.0,
+        ),
     }
 
 

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -188,6 +188,11 @@ class ApprovedDimension:
     #: Step details use presence of this fact to crop around correspondent stations rather
     #: than treating a fallback envelope-edge span as physical evidence (#915).
     support_bounds: tuple[float, float, float, float] | None = None
+    #: Optional semantic placement policy for this mark.  Most compound renderers use the
+    #: group policy; independent marks such as envelope extents consume these per-dimension
+    #: fields because one feature's dimensions legitimately scatter across views.
+    view: str | None = None
+    side: str | None = None
 
     @property
     def parameter_id(self) -> str:
@@ -1397,6 +1402,8 @@ def _compile_groups(planned) -> tuple[list[ApprovedGroup], list[Omission]]:
                 discriminator=pd.param.discriminator,
                 tolerance=pd.param.tolerance,
                 display_decimals=pd.display_decimals,
+                view=pd.view,
+                side=pd.side,
             )
             for pd in g.dims
             if not pd.suppressed

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -154,8 +154,9 @@ class ApprovedDimension:
     are drawn. A renderer holding one has nothing to decide about whether to draw it.
 
     ``span`` is in PART space; the renderer projects it. That is the split — the compiler
-    says "this measurement, this value, between these two points"; the renderer says which
-    view, which strip, which side, and what happens when it does not fit.
+    says "this measurement, this value, between these two points" and may carry an authored
+    semantic view/side on its group; the renderer creates candidates and the solve decides
+    coordinates and what happens when one does not fit.
     """
 
     id: DimensionId | None
@@ -388,6 +389,9 @@ class ApprovedGroup:
     ref: FeatureRef
     facts: FeatureFacts
     dims: tuple[ApprovedDimension, ...]
+    #: Optional authored strip intent.  The renderer turns this into an ordinary corridor
+    #: candidate; coordinates remain solver-owned.
+    side: str | None = None
 
     def dim(self, *, kind: str | None = None, role: str | None = None):
         """The first approved dimension matching *kind* and/or *role*, or ``None``.
@@ -1414,6 +1418,7 @@ def _compile_groups(planned) -> tuple[list[ApprovedGroup], list[Omission]]:
                 ref=FeatureRef(g.feature),
                 facts=FeatureFacts(g.feature),
                 dims=approved,
+                side=g.side,
             )
         )
     return out, omissions

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -70,6 +70,7 @@ from draftwright.model.ir import (
     SlotPatternFeature,
     StepFeature,
     StepLevelFeature,
+    validate_authored_dimension_placement,
 )
 
 # Fractional tolerance below which a slot object's two longest bbox spans count as "near-equal",
@@ -2111,6 +2112,8 @@ def measured_dimension(
     lowering_blockers: tuple[str, ...] = (),
     rendering_blockers: tuple[str, ...] = (),
     cylindrical_refs=(),
+    view: str | None = None,
+    side: str | None = None,
 ) -> AuthoredDimension:
     """A pre-authored drafting dimension from explicit measured values — the IR constructor
     behind :meth:`Sheet.measured_dimension` (#704: extracted so ``build_drawing(model=…)``
@@ -2162,6 +2165,7 @@ def measured_dimension(
         unresolved_bore = dom == "?" and dim_kind in ("diameter", "radius") and bbox is not None
         if not (unresolved_import or unresolved_bore):
             raise ValueError("measured_dimension() dominant_axis must be X, Y, or Z")
+    validate_authored_dimension_placement(dim_kind, dom, view, side, owner="measured_dimension()")
     cylinder_axes = {reference.principal_axis for reference in cylinders}
     if cylinders and (len(cylinder_axes) != 1 or "?" in cylinder_axes):
         if not imported_blocked:
@@ -2217,4 +2221,6 @@ def measured_dimension(
         lowering_blockers=tuple(str(reason) for reason in lowering_blockers),
         rendering_blockers=tuple(str(reason) for reason in rendering_blockers),
         cylindrical_refs=tuple(cylinders),
+        view=view,
+        side=side,
     )

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -36,6 +36,58 @@ if TYPE_CHECKING:
 
 Point = tuple[float, float, float]
 CylinderSense = Literal["external", "internal"]
+PLACEMENT_VIEWS = frozenset({"front", "plan", "side"})
+PLACEMENT_SIDES = frozenset({"above", "below", "left", "right"})
+
+
+def validate_placement_intent(view: str | None, side: str | None, *, owner: str) -> None:
+    """Validate the shared declarative view/strip vocabulary.
+
+    Compatibility with a particular renderer is checked where the dimension kind and
+    projection are known.  Keeping the vocabulary check here also protects hand-built IR.
+    """
+    if view is not None and view not in PLACEMENT_VIEWS:
+        raise ValueError(f"{owner} view must be one of {sorted(PLACEMENT_VIEWS)} (got {view!r})")
+    if side is not None and side not in PLACEMENT_SIDES:
+        raise ValueError(f"{owner} side must be one of {sorted(PLACEMENT_SIDES)} (got {side!r})")
+
+
+def validate_authored_dimension_placement(
+    dimension_kind: str,
+    dominant_axis: str,
+    view: str | None,
+    side: str | None,
+    *,
+    owner: str,
+) -> None:
+    """Reject a view/side pair for which the authored-dimension renderer has no candidate."""
+    validate_placement_intent(view, side, owner=owner)
+    if view is None and side is None:
+        return
+    valid_pairs: tuple[tuple[str, str], ...]
+    if dimension_kind in ("diameter", "radius"):
+        end_view = {"X": "side", "Y": "front", "Z": "plan"}.get(dominant_axis)
+        valid_pairs = () if end_view is None else ((end_view, "above"), (end_view, "below"))
+    else:
+        valid_pairs = {
+            "X": (("front", "above"), ("front", "below")),
+            "Z": (("front", "right"), ("front", "left")),
+            "Y": (
+                ("side", "above"),
+                ("side", "below"),
+                ("plan", "left"),
+                ("plan", "right"),
+            ),
+        }.get(dominant_axis, ())
+    if not any(
+        (view is None or candidate_view == view) and (side is None or candidate_side == side)
+        for candidate_view, candidate_side in valid_pairs
+    ):
+        choices = ", ".join(f"{v}/{s}" for v, s in valid_pairs) or "none"
+        raise ValueError(
+            f"{owner} cannot render {dimension_kind}/{dominant_axis} at "
+            f"{view or '*'}/{side or '*'}; supported placement(s): {choices}"
+        )
 
 
 def _finite_point3(name: str, value) -> Point:
@@ -1679,7 +1731,20 @@ class AuthoredDimension:
     # value is enough to render or correlate a diameter; generic linear dimensions still
     # require two reference stations.
     cylindrical_refs: tuple[CylindricalReference, ...] = ()
+    # Declarative projection/strip intent. These select ordinary corridor candidates;
+    # they are not page coordinates and do not bypass placement solving (ADR 0012/0014).
+    view: str | None = None
+    side: str | None = None
     kind: ClassVar[str] = "authored_dimension"
+
+    def __post_init__(self) -> None:
+        validate_authored_dimension_placement(
+            self.dimension_kind,
+            self.dominant_axis,
+            self.view,
+            self.side,
+            owner="authored dimension",
+        )
 
     @property
     def pmi_kind(self) -> str:
@@ -1884,8 +1949,10 @@ class RequestedDimension:
     through ``render_locations(pinned=…)`` for location dims only. Adding a third,
     pre-build spelling would scatter one concept across three layers, the same way the
     corridor priority scale was scattered before #894 consolidated it. The convergence
-    is tracked separately; this type stays free of placement state. It carries selection plus
-    optional display policy, while the measurement itself remains referential.
+    is tracked separately. ``view``/``side`` are not emphasis or frozen placement: they
+    select a semantic corridor whose candidates still enter the normal solve. This type
+    carries selection plus optional display/corridor policy, while the measurement itself
+    remains referential and coordinates remain absent.
     """
 
     feature: Feature
@@ -1898,8 +1965,18 @@ class RequestedDimension:
     #: identity still come from ``feature``; this controls only the compiler-owned text at
     #: the rendering boundary (#1349).  ``None`` preserves the existing automatic formatting.
     display_decimals: int | None = None
+    #: Optional semantic projection/strip preference. The planner validates renderer
+    #: compatibility; the placement engine still owns coordinates.
+    view: str | None = None
+    side: str | None = None
 
     def __post_init__(self) -> None:
+        validate_placement_intent(self.view, self.side, owner="requested dimension")
+        if self.role == "location" and (self.view is not None or self.side is not None):
+            raise ValueError(
+                "placement intent is unavailable for location dimensions: one location "
+                "may compile into multiple directional values"
+            )
         decimals = self.display_decimals
         if decimals is None:
             return

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -90,6 +90,32 @@ def validate_authored_dimension_placement(
         )
 
 
+def authored_dimension_target_view(
+    dimension_kind: str,
+    dominant_axis: str,
+    view: str | None,
+    side: str | None,
+) -> str | None:
+    """Resolve the principal view selected by an explicit measured-dimension hint.
+
+    A side can uniquely select a view even when ``view`` is omitted (for example a
+    Y-linear ``right`` strip can only be the plan view). ``None`` means both placement
+    fields were omitted and the renderer remains free to derive/fall back as before.
+    Callers validate the pair with :func:`validate_authored_dimension_placement` first.
+    """
+    if view is not None:
+        return view
+    if side is None:
+        return None
+    if dimension_kind in ("diameter", "radius"):
+        return {"X": "side", "Y": "front", "Z": "plan"}.get(dominant_axis)
+    if dominant_axis in {"X", "Z"}:
+        return "front"
+    if dominant_axis == "Y":
+        return "side" if side in {"above", "below"} else "plan"
+    return None
+
+
 def _finite_point3(name: str, value) -> Point:
     try:
         result = tuple(float(component) for component in value)

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -1012,6 +1012,43 @@ def _check_intent_policy_conflicts(model: PartModel) -> None:
 def _group_placement(feature: Feature, dims: list[PlannedDimension], planned_views=None):
     """Resolve one view/side for a compound group, or reject an unrenderable intent."""
     approved = [pd for pd in dims if not pd.suppressed]
+
+    # An envelope group is a feature-level compiler container, not one compound mark:
+    # width, depth, and height are independent dimensions which intentionally scatter
+    # across views (ADR 0016).  Validate each requested view independently and preserve it
+    # on the PlannedDimension; forcing them through the one-callout policy below would
+    # reject a perfectly valid width/front + depth/side pair.
+    if feature.kind == "envelope":
+        for pd in approved:
+            if pd.side is not None:
+                raise ValueError(
+                    f"envelope dimensions cannot render at {pd.view!r}/{pd.side!r}; "
+                    "supported sides for this renderer: none"
+                )
+            if pd.view is None:
+                continue
+            eligible_views = _parameter_view_preferences(feature, pd)
+            if pd.view not in eligible_views:
+                raise ValueError(
+                    f"envelope dimension {pd.param.parameter_id!r} cannot render in "
+                    f"{pd.view!r}; supported view(s): {list(eligible_views)}"
+                )
+        return _group_view(feature, planned_views), None
+
+    unsupported_pattern_intents = [
+        pd.param.parameter_id
+        for pd in approved
+        if isinstance(feature, PatternFeature)
+        and pd.param.role in {"pitch", "grid_pitch"}
+        and (pd.view is not None or pd.side is not None)
+    ]
+    if unsupported_pattern_intents:
+        raise ValueError(
+            "placement intent is unavailable for independently rendered pattern "
+            f"pitch dimension(s) {unsupported_pattern_intents}; omit view/side and let "
+            "the pitch renderer derive placement"
+        )
+
     views = {pd.view for pd in approved if pd.view is not None}
     sides = {pd.side for pd in approved if pd.side is not None}
     if len(views) > 1 or len(sides) > 1:
@@ -1033,11 +1070,6 @@ def _group_placement(feature: Feature, dims: list[PlannedDimension], planned_vie
                 f"{feature.kind} dimension(s) {incompatible} cannot render in "
                 f"{requested_view!r}; supported view(s): "
                 f"{sorted(set().union(*(_parameter_view_preferences(feature, pd) for pd in approved)))}"
-            )
-        if planned_views is not None and requested_view not in set(planned_views):
-            raise ValueError(
-                f"requested dimension view {requested_view!r} is not in the planned views "
-                f"{sorted(set(planned_views))}"
             )
     if requested_side is not None:
         supported = {
@@ -1236,7 +1268,14 @@ def _uncovered_group_requirements(
             # A correlated unit is one ADR 0016 identity.  Every member must be renderable;
             # report the unit once at the first unmet member rather than inflate the count.
             for pd in approved:
-                preferences = _parameter_view_preferences(group.feature, pd)
+                # An authored override is a hard requirement, not merely another eligible
+                # projection. Let ViewPlanIncomplete reject an automatic reduction that
+                # omitted it, so the builder can retain the requirement-preserving set.
+                preferences = (
+                    (pd.view,)
+                    if pd.view is not None
+                    else _parameter_view_preferences(group.feature, pd)
+                )
                 if planned.intersection(preferences):
                     continue
                 identity = DimensionId(group.feature, unit.id)

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -115,8 +115,9 @@ _CONVENTION = {
 @dataclass(frozen=True)
 class PlannedDimension:
     """A parameter plus its render *intent* — the planner's decision about how/whether
-    it is drawn, leaving the layout (zones/sides/coordinates) to the renderer
-    (ADR 0008 Amendment 4). `suppressed`/`reason` carry *model-level* suppression
+    it is drawn. An authored request may select a semantic view/side corridor; the renderer
+    and placement solve still own candidate geometry, capacity, and coordinates
+    (ADR 0008 Amendment 4 / ADR 0014). `suppressed`/`reason` carry *model-level* suppression
     (the planner sees the model, not the drawing-in-progress, so render-state
     suppression like "diameter already mentioned" stays in the renderer). `datum` is
     the reference a positional dim measures from, resolved from `param.refs` against
@@ -145,6 +146,10 @@ class PlannedDimension:
     # Per-intent display policy (#1349). The authoritative numeric value remains on ``param``;
     # legacy callout consumers use this field until they migrate to ``ApprovedDimension``.
     display_decimals: int | None = None
+    # Declarative projection/strip intent carried from the referential request.  Resolution
+    # happens once per compound group below; renderers never receive raw coordinates.
+    view: str | None = None
+    side: str | None = None
 
 
 # Correlated sets (ADR 0016 identity, tier 3): exact ``(feature kind, role)`` pairs
@@ -267,6 +272,7 @@ class DimensionGroup:
     feature: Feature
     view: str  # one view for the whole group
     units: tuple[AddressableDimension, ...]
+    side: str | None = None
 
     @property
     def dims(self) -> tuple[PlannedDimension, ...]:
@@ -966,14 +972,14 @@ def _authored_for(model, feature, param):
     return None
 
 
-def _check_display_policy_conflicts(model: PartModel) -> None:
-    """A semantic dimension cannot have two competing display authorities (#1349)."""
+def _check_intent_policy_conflicts(model: PartModel) -> None:
+    """A semantic dimension cannot have competing display or placement authorities."""
     requests = (
         model.authored_dimensions
         if model.authored_dimensions is not None
         else model.requested_dimensions
     )
-    seen: dict[tuple[int, str], int | None] = {}
+    seen: dict[tuple[int, str], tuple[int | None, str | None, str | None]] = {}
     for request in requests:
         targets: tuple[str, ...]
         if request.role == LOCATION_ROLE:
@@ -986,14 +992,72 @@ def _check_display_policy_conflicts(model: PartModel) -> None:
             )
         for parameter_id in targets:
             key = (id(request.feature), parameter_id)
-            previous = seen.get(key, request.display_decimals)
-            if key in seen and previous != request.display_decimals:
+            policy = (request.display_decimals, request.view, request.side)
+            previous = seen.get(key, policy)
+            if key in seen and previous != policy:
+                if previous[0] != policy[0]:
+                    raise ValueError(
+                        f"conflicting display precision for {parameter_id}: "
+                        f"{previous[0]!r} and {policy[0]!r}; repeat intent is idempotent "
+                        "only when its display policy agrees"
+                    )
                 raise ValueError(
-                    f"conflicting display precision for {parameter_id}: "
-                    f"{previous!r} and {request.display_decimals!r}; repeat intent is "
-                    "idempotent only when its display policy agrees"
+                    f"conflicting placement intent for {parameter_id}: "
+                    f"{previous[1:]!r} and {policy[1:]!r}; repeat intent is idempotent "
+                    "only when its placement policy agrees"
                 )
-            seen[key] = request.display_decimals
+            seen[key] = policy
+
+
+def _group_placement(feature: Feature, dims: list[PlannedDimension], planned_views=None):
+    """Resolve one view/side for a compound group, or reject an unrenderable intent."""
+    approved = [pd for pd in dims if not pd.suppressed]
+    views = {pd.view for pd in approved if pd.view is not None}
+    sides = {pd.side for pd in approved if pd.side is not None}
+    if len(views) > 1 or len(sides) > 1:
+        raise ValueError(
+            f"conflicting placement intent for one {feature.kind} callout: "
+            f"views={sorted(views)}, sides={sorted(sides)}"
+        )
+    requested_view = next(iter(views), None)
+    requested_side = next(iter(sides), None)
+    selected_view = requested_view or _group_view(feature, planned_views)
+    if requested_view is not None:
+        incompatible = [
+            pd.param.parameter_id
+            for pd in approved
+            if requested_view not in _parameter_view_preferences(feature, pd)
+        ]
+        if incompatible:
+            raise ValueError(
+                f"{feature.kind} dimension(s) {incompatible} cannot render in "
+                f"{requested_view!r}; supported view(s): "
+                f"{sorted(set().union(*(_parameter_view_preferences(feature, pd) for pd in approved)))}"
+            )
+        if planned_views is not None and requested_view not in set(planned_views):
+            raise ValueError(
+                f"requested dimension view {requested_view!r} is not in the planned views "
+                f"{sorted(set(planned_views))}"
+            )
+    if requested_side is not None:
+        supported = {
+            "plan": {"left", "right"},
+            "side": {"right"},
+            "front": {"below"},
+        }.get(selected_view or "", set())
+        if (
+            not isinstance(feature, HoleFeature | PatternFeature)
+            or requested_side not in supported
+        ):
+            choices = (
+                sorted(supported) if isinstance(feature, HoleFeature | PatternFeature) else []
+            )
+            raise ValueError(
+                f"{feature.kind} dimensions cannot render at "
+                f"{selected_view!r}/{requested_side!r}; supported sides for this renderer: "
+                f"{choices or 'none'}"
+            )
+    return selected_view, requested_side
 
 
 def authored_location_omitted(model, feature) -> bool:
@@ -1279,7 +1343,7 @@ def plan_dimensions(model: PartModel, *, planned_views=None) -> list[DimensionGr
     """Plan each feature's parameters into one `DimensionGroup` (anchor + single
     view + planned dims, each carrying its render intent — convention, model-level
     suppression, datum). No cross- or within-feature value de-duplication."""
-    _check_display_policy_conflicts(model)
+    _check_intent_policy_conflicts(model)
     if model.authored_dimensions is not None:
         _check_authored_targets(model)
     groups: list[DimensionGroup] = []
@@ -1336,10 +1400,12 @@ def plan_dimensions(model: PartModel, *, planned_views=None) -> list[DimensionGr
                     display_decimals=(
                         display_intent.display_decimals if display_intent is not None else None
                     ),
+                    view=display_intent.view if display_intent is not None else None,
+                    side=display_intent.side if display_intent is not None else None,
                 )
             )
         if dims:
-            selected_view = _group_view(feature, planned_views)
+            selected_view, selected_side = _group_placement(feature, dims, planned_views)
             groups.append(
                 DimensionGroup(
                     feature=feature,
@@ -1348,6 +1414,7 @@ def plan_dimensions(model: PartModel, *, planned_views=None) -> list[DimensionGr
                     # crossing the planner boundary when it is not actually selected.
                     view=selected_view or _preferred_group_view(feature),
                     units=_addressable(feature, dims),
+                    side=selected_side,
                 )
             )
     if planned_views is not None:

--- a/src/draftwright/projection.py
+++ b/src/draftwright/projection.py
@@ -288,7 +288,11 @@ def project_view_geometry(scale, name, shape, camera, up, position, *, look_at, 
     *scale* is the world→page scale the coordinates encode; *shape* is in world (unscaled) space
     unless *scaled* is True. *camera*/*up*/*look_at* are in scaled space (the standard-view
     convention). Raises ``ValueError`` when the projection is empty (bad camera/look_at)."""
-    shape_s = shape if scaled else shape.scale(scale)
+    # ViewCoordinates maps world points by an origin-based scale.  build123d's default is to
+    # scale about ``shape.location.position``; extracted solids often carry a non-zero Location,
+    # which would translate the silhouette away from that mapper.  Keep both sides of the
+    # projection contract in the same world-origin transform.
+    shape_s = shape if scaled else shape.scale(scale, about=(0, 0, 0))
     vis, hid = shape_s.project_to_viewport(camera, up, look_at)
     vl, hl = list(vis), list(hid)
     if not vl and not hl:
@@ -338,7 +342,7 @@ def _project_iso(dwg, a: Analysis, scale, shape_s=None):
     camera = (la[0] + off, la[1] - off, la[2] + off)
     dwg._add_view(
         "iso",
-        shape_s if shape_s is not None else a.part.scale(scale),
+        shape_s if shape_s is not None else a.part.scale(scale, about=(0, 0, 0)),
         camera,
         (0, 0, 1),
         (a.ISO_X, a.ISO_Y),

--- a/src/draftwright/projection.py
+++ b/src/draftwright/projection.py
@@ -35,6 +35,7 @@ from draftwright._core import (
 from draftwright._geometry import (
     MaterialField,
     _boxes_overlap,
+    _scale_world,
     material_field,
 )
 
@@ -288,11 +289,11 @@ def project_view_geometry(scale, name, shape, camera, up, position, *, look_at, 
     *scale* is the world→page scale the coordinates encode; *shape* is in world (unscaled) space
     unless *scaled* is True. *camera*/*up*/*look_at* are in scaled space (the standard-view
     convention). Raises ``ValueError`` when the projection is empty (bad camera/look_at)."""
-    # ViewCoordinates maps world points by an origin-based scale.  build123d's default is to
-    # scale about ``shape.location.position``; extracted solids often carry a non-zero Location,
-    # which would translate the silhouette away from that mapper.  Keep both sides of the
-    # projection contract in the same world-origin transform.
-    shape_s = shape if scaled else shape.scale(scale, about=(0, 0, 0))
+    # ViewCoordinates maps world points by an origin-based scale. build123d 0.11 defaults to
+    # ``shape.location.position``; extracted solids often carry a non-zero Location, which would
+    # translate the silhouette away from that mapper. Keep both sides of the projection contract
+    # in the same world-origin transform (the helper also preserves 0.9/0.10 compatibility).
+    shape_s = shape if scaled else _scale_world(shape, scale)
     vis, hid = shape_s.project_to_viewport(camera, up, look_at)
     vl, hl = list(vis), list(hid)
     if not vl and not hl:
@@ -342,7 +343,7 @@ def _project_iso(dwg, a: Analysis, scale, shape_s=None):
     camera = (la[0] + off, la[1] - off, la[2] + off)
     dwg._add_view(
         "iso",
-        shape_s if shape_s is not None else a.part.scale(scale, about=(0, 0, 0)),
+        shape_s if shape_s is not None else _scale_world(a.part, scale),
         camera,
         (0, 0, 1),
         (a.ISO_X, a.ISO_Y),

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -602,9 +602,9 @@ class _Dim(_Nameable):
 class DimensionIntent:
     """The handle :meth:`Sheet.add_dimension` returns (ADR 0016).
 
-    It is **not** a placement handle: it exposes no coordinate, no strip and no tier.
-    What it carries is the dimension's semantic identity — *a dimension line references;
-    the engine places*.
+    It exposes no coordinate or tier. Optional ``view=`` / ``side=`` are declared on the
+    verb as semantic corridor selection; the engine still solves the candidate's position —
+    *a dimension line references; the engine places*.
 
     ADR 0012's ``.pin()`` / ``.priority()`` are deliberately absent for now. The engine
     already has two spellings of "keep this put" at different layers, and adding a third
@@ -1182,6 +1182,8 @@ class Sheet:
         role: DimensionParameterId = _UNSET,  # type: ignore[assignment]
         *,
         axis: str | None = None,
+        view: str | None = None,
+        side: str | None = None,
         **removed,
     ) -> DimensionIntent:
         """`dimension(feature, role)` — the ADR 0016 referential verb. See
@@ -1203,6 +1205,11 @@ class Sheet:
         instead of a bare "missing 2 required positional arguments". The old shape never
         appeared in a release, so this refusal is the only notice it gets — a documented
         break (`docs/deprecations.md`).
+
+        ``view`` selects ``front``/``plan``/``side`` and ``side`` selects the corresponding
+        ``above``/``below``/``left``/``right`` corridor where that dimension renderer supports
+        it. They express authored placement intent, not page coordinates; invalid or
+        unrenderable pairs fail clearly during planning.
         """
         if removed:
             legacy = sorted(self._MEASURED_KEYWORDS & set(removed))
@@ -1216,10 +1223,16 @@ class Sheet:
             raise TypeError(f"dimension() got unexpected keyword(s) {sorted(removed)}")
         if feature is _UNSET or role is _UNSET:
             raise TypeError("dimension() requires a feature and a parameter id")
-        return self._authored_dimension(feature, role, axis=axis)
+        return self._authored_dimension(feature, role, axis=axis, view=view, side=side)
 
     def _authored_dimension(
-        self, feature, role: DimensionParameterId, *, axis: str | None = None
+        self,
+        feature,
+        role: DimensionParameterId,
+        *,
+        axis: str | None = None,
+        view: str | None = None,
+        side: str | None = None,
     ) -> DimensionIntent:
         """`dimension(feature, role)` — declare one member of the COMPLETE authored set.
 
@@ -1240,7 +1253,15 @@ class Sheet:
         # The CANONICAL spelling is stored, not what was typed (#963). Otherwise a generated
         # script's dialect depended on how its source model was authored — mirrored sets wrote
         # parameter ids, hand-authored sets echoed back whatever the author used.
-        self._authored.append({"token": token, "role": role, "discriminator": discriminator})
+        self._authored.append(
+            {
+                "token": token,
+                "role": role,
+                "discriminator": discriminator,
+                "view": view,
+                "side": side,
+            }
+        )
         return DimensionIntent(self, self._authored[-1])
 
     def measured_dimension(
@@ -1264,6 +1285,8 @@ class Sheet:
         lowering_blockers: tuple[str, ...] = (),
         rendering_blockers: tuple[str, ...] = (),
         cylindrical_refs=(),
+        view: str | None = None,
+        side: str | None = None,
     ) -> _Params:
         """Declare a drafting dimension from explicit **measured** values.
 
@@ -1283,6 +1306,8 @@ class Sheet:
         leave it blank. ``lowering_blockers`` carries the explicit reason a supported imported
         requirement could not safely enrich a canonical feature parameter;
         ``rendering_blockers`` carries the source-geometry reason it cannot be drawn truthfully.
+        ``view``/``side`` select a supported semantic corridor while leaving its actual
+        position to the normal placement solve.
         Delegates to :func:`draftwright.model.declare.measured_dimension` (#704), so
         ``build_drawing(model=…)`` callers can author the same feature without the façade.
         """
@@ -1306,6 +1331,8 @@ class Sheet:
                 lowering_blockers=lowering_blockers,
                 rendering_blockers=rendering_blockers,
                 cylindrical_refs=cylindrical_refs,
+                view=view,
+                side=side,
             )
         )
         # A handle like every other declaration verb (#922). A measured dimension carries its
@@ -2347,7 +2374,15 @@ class Sheet:
         self._authored_source = True
         return self
 
-    def add_dimension(self, feature, role: DimensionParameterId, *, axis: str | None = None):
+    def add_dimension(
+        self,
+        feature,
+        role: DimensionParameterId,
+        *,
+        axis: str | None = None,
+        view: str | None = None,
+        side: str | None = None,
+    ):
         """Augment the planner's set with one more measurement (ADR 0016 / #872).
 
         *feature* is a declared-feature handle (what :meth:`hole`, :meth:`boss`, … return),
@@ -2369,6 +2404,9 @@ class Sheet:
         pattern's two pitches. Omitting it there raises rather than picking one, because
         a silent coin toss between the row and column pitch is the kind of wrong a reader
         cannot see.
+
+        ``view``/``side`` have the same solver-owned placement semantics as on
+        :meth:`dimension`.
         """
         warnings.warn(
             "Sheet.add_dimension() is soft deprecated: still supported and NOT scheduled for "
@@ -2381,7 +2419,13 @@ class Sheet:
         token, _target, discriminator, role = self._resolve_measurement(
             feature, role, axis, "add_dimension"
         )
-        entry = {"token": token, "role": role, "discriminator": discriminator}
+        entry = {
+            "token": token,
+            "role": role,
+            "discriminator": discriminator,
+            "view": view,
+            "side": side,
+        }
         self._added_dimensions.append(entry)
         return DimensionIntent(self, entry)
 
@@ -2587,6 +2631,8 @@ class Sheet:
                 role=e["role"],
                 discriminator=e["discriminator"],
                 display_decimals=e.get("display_decimals"),
+                view=e.get("view"),
+                side=e.get("side"),
             )
             for e in self._added_dimensions
         )
@@ -2613,6 +2659,8 @@ class Sheet:
                 role=e["role"],
                 discriminator=e["discriminator"],
                 display_decimals=e.get("display_decimals"),
+                view=e.get("view"),
+                side=e.get("side"),
             )
             for e in self._authored
         )

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -460,6 +460,10 @@ def _measured_dimension_line(f) -> str:
         kw.append(f"rendering_blockers={f.rendering_blockers!r}")
     if getattr(f, "cylindrical_refs", ()):
         kw.append(f"cylindrical_refs={_cylindrical_refs_arg(f.cylindrical_refs)}")
+    if getattr(f, "view", None) is not None:
+        kw.append(f"view={f.view!r}")
+    if getattr(f, "side", None) is not None:
+        kw.append(f"side={f.side!r}")
     # `measured_dimension` since #873 — a generated script must not emit the transitional
     # overload, or every regenerated AP242 script would arrive pre-deprecated.
     return "sheet.measured_dimension(" + ", ".join(kw) + ")"
@@ -1251,6 +1255,13 @@ def _mirrored_requests(declared, declared_envelope=None):
 
 def _requested_display_decimals(model, feature, role, discriminator) -> int | None:
     """Precision attached to an augmenting intent mirrored as an authored line (#1349)."""
+    return _requested_intent_policy(model, feature, role, discriminator)[0]
+
+
+def _requested_intent_policy(
+    model, feature, role, discriminator
+) -> tuple[int | None, str | None, str | None]:
+    """Display and placement policy attached to an augmenting referential intent."""
     for request in model.requested_dimensions:
         if request.feature is not feature:
             continue
@@ -1263,8 +1274,12 @@ def _requested_display_decimals(model, feature, role, discriminator) -> int | No
             request.discriminator == discriminator or role.endswith(f".{request.discriminator}")
         ):
             continue
-        return cast(int | None, request.display_decimals)
-    return None
+        return (
+            cast(int | None, request.display_decimals),
+            cast(str | None, request.view),
+            cast(str | None, request.side),
+        )
+    return None, None, None
 
 
 def _dimension_block(model, names: dict[int, str], synthesised_envelope=None) -> list[str]:
@@ -1312,7 +1327,7 @@ def _dimension_block(model, names: dict[int, str], synthesised_envelope=None) ->
         ]
     requests = (
         [
-            (a.feature, a.role, a.discriminator, a.display_decimals)
+            (a.feature, a.role, a.discriminator, a.display_decimals, a.view, a.side)
             for a in model.authored_dimensions
         ]
         if model.authored_dimensions is not None
@@ -1325,7 +1340,7 @@ def _dimension_block(model, names: dict[int, str], synthesised_envelope=None) ->
         else [
             (
                 *request,
-                _requested_display_decimals(model, *request),
+                *_requested_intent_policy(model, *request),
             )
             for request in _mirrored_requests(model, synthesised_envelope)
         ]
@@ -1347,7 +1362,7 @@ def _dimension_block(model, names: dict[int, str], synthesised_envelope=None) ->
         # automatic one does, rather than in prose a reader has to trust.
         "sheet.authored_dimensions()",
     ]
-    for feature, role, discriminator, display_decimals in requests:
+    for feature, role, discriminator, display_decimals, view, side in requests:
         name = names.get(id(feature))
         if name is None:
             # Reachable for a kind with no declarative verb (its line is a comment, so it
@@ -1370,7 +1385,12 @@ def _dimension_block(model, names: dict[int, str], synthesised_envelope=None) ->
             if discriminator and "." not in role[role.find(".") + 1 :]
             else ""
         )
-        line = f'sheet.dimension({name}, "{role}"{axis})'
+        placement = ""
+        if view is not None:
+            placement += f', view="{view}"'
+        if side is not None:
+            placement += f', side="{side}"'
+        line = f'sheet.dimension({name}, "{role}"{axis}{placement})'
         if display_decimals is not None:
             line += f".format(decimals={display_decimals})"
         out.append(line)

--- a/tests/test_issue_1260_view_constraints.py
+++ b/tests/test_issue_1260_view_constraints.py
@@ -7,7 +7,7 @@ import warnings
 from types import SimpleNamespace
 
 import pytest
-from build123d import Box, Cylinder
+from build123d import Box, Compound, Cylinder, Pos
 
 import draftwright.builder as builder_mod
 import draftwright.projection as projection_mod
@@ -296,6 +296,21 @@ class TestBuildEffects:
         assert detail is not None
         assert detail.kind == "detail"
         assert detail.scale_factor == 2
+        assert not [issue for issue in drawing.lint() if issue.severity != "info"]
+
+    def test_translated_crop_and_detail_coordinates_share_world_origin_scale(self):
+        target = Pos(100, 0, 0) * (Box(8, 8, 2) - Cylinder(3, 4))
+        remote = Pos(-100, 0, 0) * Box(8, 8, 2)
+        sheet = Sheet(Compound(children=[target, remote]), page="A2").authored_dimensions()
+        hole = sheet.hole(diameter=6, at=(100, 0, 0), axis="z")
+        sheet.dimension(hole, "bore.diameter")
+        sheet.detail_view("B", around=hole).scale(2)
+
+        drawing = sheet.build()
+        x0, y0, x1, y1 = drawing.view_bounds("detail_b")
+        px, py, _ = drawing.at("detail_b", 100, 0, 0)
+        assert px == pytest.approx((x0 + x1) / 2)
+        assert py == pytest.approx((y0 + y1) / 2)
         assert not [issue for issue in drawing.lint() if issue.severity != "info"]
 
     def test_an_authored_iso_scale_is_rendered_exactly_and_never_auto_fitted(self, monkeypatch):

--- a/tests/test_issue_563_placement_intent.py
+++ b/tests/test_issue_563_placement_intent.py
@@ -9,6 +9,7 @@ import pytest
 from build123d import Align, Box, Cylinder, Pos, Rot
 
 from draftwright import Sheet
+from draftwright.compose import _compose_anno_boxes, _footprint_from_boxes
 from draftwright.model import DimensionParameterId
 from draftwright.model.compiled import compile_dimensions
 from draftwright.model.planner import plan_dimensions
@@ -318,6 +319,38 @@ def test_y_plan_measured_intents_participate_in_horizontal_composition(side):
     drawing = sheet.build()
     assert drawing.get_annotation("pmi_y_0")._dw_spec.side == side
     assert not [issue for issue in drawing.lint() if issue.severity != "info"]
+
+
+def test_compose_reserves_every_supported_measured_corridor_family():
+    sheet = Sheet(Box(40, 20, 10)).authored_dimensions()
+    cases = (
+        ("linear", "X", "front", None),
+        ("linear", "Z", "front", None),
+        ("linear", "Y", "side", None),
+        ("linear", "Y", "plan", None),
+        ("linear", "X", "front", "below"),
+        ("diameter", "Z", "plan", "above"),
+        ("diameter", "Z", "plan", "below"),
+        ("diameter", "X", "side", "above"),
+        ("diameter", "X", "side", "below"),
+    )
+    for index, (kind, axis, view, side) in enumerate(cases):
+        sheet.measured_dimension(
+            kind=kind,
+            value=10,
+            label=str(index),
+            dominant_axis=axis,
+            ref_bbox=(-5, -5, 0, 5, 5, 10),
+            ref_pts=[(-5, 0, 5), (5, 0, 5)],
+            view=view,
+            side=side,
+        )
+
+    footprint = _footprint_from_boxes(_compose_anno_boxes(sheet.model(), n_steps=0))
+    assert footprint.left > 0 and footprint.right > 0
+    assert footprint.fv_top > 0 and footprint.fv_bottom > 0
+    assert footprint.pv_authored_top > 0 and footprint.pv_bottom > 0
+    assert footprint.sv_top > 0 and footprint.sv_bottom > 0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_issue_563_placement_intent.py
+++ b/tests/test_issue_563_placement_intent.py
@@ -353,6 +353,27 @@ def test_compose_reserves_every_supported_measured_corridor_family():
     assert footprint.sv_top > 0 and footprint.sv_bottom > 0
 
 
+def test_front_and_plan_horizontal_corridors_reuse_the_same_depth():
+    def depth(routes):
+        sheet = Sheet(Box(80, 50, 30)).authored_dimensions()
+        for index, (axis, view) in enumerate(routes):
+            sheet.measured_dimension(
+                kind="linear",
+                value=10,
+                label=str(index),
+                dominant_axis=axis,
+                ref_bbox=(-5, -5, 0, 5, 5, 10),
+                ref_pts=[(0, 0, 0), (0, 0, 10)],
+                view=view,
+                side="left",
+            )
+        return _footprint_from_boxes(_compose_anno_boxes(sheet.model(), n_steps=0)).left
+
+    front = [("Z", "front")] * 5
+    plan = [("Y", "plan")] * 5
+    assert depth(front + plan) == max(depth(front), depth(plan))
+
+
 @pytest.mark.parametrize(
     ("view", "side", "message"),
     [

--- a/tests/test_issue_563_placement_intent.py
+++ b/tests/test_issue_563_placement_intent.py
@@ -453,6 +453,24 @@ def test_plan_right_corridor_does_not_force_feasible_a4_scale_reduction():
     assert not [issue for issue in drawing.lint() if issue.severity != "info"]
 
 
+def test_front_right_corridor_reserves_after_automatic_height_ladder():
+    sheet = Sheet(Box(40, 40, 40), page="A4").auto_dimensions()
+    sheet.measured_dimension(
+        kind="linear",
+        value=20,
+        label="20",
+        dominant_axis="Z",
+        ref_bbox=(-2, -2, -10, 2, 2, 10),
+        ref_pts=[(0, 0, -10), (0, 0, 10)],
+        view="front",
+        side="right",
+    )
+    drawing = sheet.build()
+    assert "pmi_z_0" in drawing.annotations()
+    assert "dim_height" in drawing.annotations()
+    assert not [issue for issue in drawing.lint() if issue.severity != "info"]
+
+
 @pytest.mark.parametrize(
     ("view", "side", "message"),
     [

--- a/tests/test_issue_563_placement_intent.py
+++ b/tests/test_issue_563_placement_intent.py
@@ -253,20 +253,21 @@ def test_view_only_measured_override_preserves_the_derived_side():
 
 
 def test_front_above_measured_intent_participates_in_view_composition():
-    sheet = Sheet(Box(60, 40, 20), page="A3").authored_dimensions()
-    sheet.measured_dimension(
-        kind="linear",
-        value=40,
-        label="40",
-        dominant_axis="X",
-        ref_bbox=(-20, -2, 4, 20, 2, 8),
-        ref_pts=[(-20, 0, 6), (20, 0, 6)],
-        view="front",
-        side="above",
-    )
-    drawing = sheet.build()
-    assert drawing.get_annotation("pmi_x_0")._dw_spec.side == "above"
-    assert not [issue for issue in drawing.lint() if issue.code == "pmi_dropped"]
+    for view in ("front", None):
+        sheet = Sheet(Box(60, 40, 20), page="A3").authored_dimensions()
+        sheet.measured_dimension(
+            kind="linear",
+            value=40,
+            label="40",
+            dominant_axis="X",
+            ref_bbox=(-20, -2, 4, 20, 2, 8),
+            ref_pts=[(-20, 0, 6), (20, 0, 6)],
+            view=view,
+            side="above",
+        )
+        drawing = sheet.build()
+        assert drawing.get_annotation("pmi_x_0")._dw_spec.side == "above"
+        assert not [issue for issue in drawing.lint() if issue.severity != "info"]
 
 
 def test_y_and_diameter_measured_intents_use_their_supported_exact_corridors():
@@ -374,6 +375,20 @@ def test_location_unknown_side_unavailable_view_and_missing_planned_view_fail_cl
     )
     with pytest.raises(ValueError, match="cannot be shown"):
         measured_missing.build()
+
+    side_only_missing = Sheet(Box(40, 20, 10)).authored_dimensions().authored_views()
+    side_only_missing.view("front")
+    side_only_missing.measured_dimension(
+        kind="linear",
+        value=20,
+        label="20",
+        dominant_axis="Y",
+        ref_bbox=(-10, -10, 2, 10, 10, 8),
+        ref_pts=[(0, -10, 5), (0, 10, 5)],
+        side="right",
+    )
+    with pytest.raises(ValueError, match="cannot be shown"):
+        side_only_missing.build()
 
 
 def test_pattern_pitch_placement_policy_is_rejected_instead_of_moving_the_callout():

--- a/tests/test_issue_563_placement_intent.py
+++ b/tests/test_issue_563_placement_intent.py
@@ -354,7 +354,7 @@ def test_compose_reserves_every_supported_measured_corridor_family():
 
 
 def test_front_and_plan_horizontal_corridors_reuse_the_same_depth():
-    def depth(routes):
+    def depth(routes, *, side="left", n_steps=0):
         sheet = Sheet(Box(80, 50, 30)).authored_dimensions()
         for index, (axis, view) in enumerate(routes):
             sheet.measured_dimension(
@@ -365,13 +365,92 @@ def test_front_and_plan_horizontal_corridors_reuse_the_same_depth():
                 ref_bbox=(-5, -5, 0, 5, 5, 10),
                 ref_pts=[(0, 0, 0), (0, 0, 10)],
                 view=view,
-                side="left",
+                side=side,
             )
-        return _footprint_from_boxes(_compose_anno_boxes(sheet.model(), n_steps=0)).left
+        footprint = _footprint_from_boxes(_compose_anno_boxes(sheet.model(), n_steps=n_steps))
+        return getattr(footprint, side)
 
     front = [("Z", "front")] * 5
     plan = [("Y", "plan")] * 5
     assert depth(front + plan) == max(depth(front), depth(plan))
+    # The automatic height/step ladder occupies the front view's vertical range too. A
+    # plan-right stack reuses that horizontal depth instead of adding to it.
+    right_baseline = depth([], side="right", n_steps=5)
+    plan_right = depth(plan, side="right", n_steps=0)
+    assert depth(plan, side="right", n_steps=5) == max(right_baseline, plan_right)
+
+
+@pytest.mark.parametrize(
+    ("kind", "axis", "view", "side", "ref_bbox", "ref_pts"),
+    [
+        ("linear", "X", "front", "above", (-10, -2, -2, 10, 2, 2), [(-10, 0, 0), (10, 0, 0)]),
+        ("linear", "X", "front", "below", (-10, -2, -2, 10, 2, 2), [(-10, 0, 0), (10, 0, 0)]),
+        ("linear", "Z", "front", "left", (-2, -2, -10, 2, 2, 10), [(0, 0, -10), (0, 0, 10)]),
+        ("linear", "Z", "front", "right", (-2, -2, -10, 2, 2, 10), [(0, 0, -10), (0, 0, 10)]),
+        ("linear", "Y", "side", "above", (-2, -10, -2, 2, 10, 2), [(0, -10, 0), (0, 10, 0)]),
+        ("linear", "Y", "side", "below", (-2, -10, -2, 2, 10, 2), [(0, -10, 0), (0, 10, 0)]),
+        ("linear", "Y", "plan", "left", (-2, -10, -2, 2, 10, 2), [(0, -10, 0), (0, 10, 0)]),
+        ("linear", "Y", "plan", "right", (-2, -10, -2, 2, 10, 2), [(0, -10, 0), (0, 10, 0)]),
+        ("diameter", "X", "side", "above", (-2, -10, -10, 2, 10, 10), [(0, -10, 0), (0, 10, 0)]),
+        ("diameter", "X", "side", "below", (-2, -10, -10, 2, 10, 10), [(0, -10, 0), (0, 10, 0)]),
+        ("diameter", "Y", "front", "above", (-10, -2, -10, 10, 2, 10), [(-10, 0, 0), (10, 0, 0)]),
+        ("diameter", "Y", "front", "below", (-10, -2, -10, 10, 2, 10), [(-10, 0, 0), (10, 0, 0)]),
+        ("diameter", "Z", "plan", "above", (-10, -10, -2, 10, 10, 2), [(-10, 0, 0), (10, 0, 0)]),
+        ("diameter", "Z", "plan", "below", (-10, -10, -2, 10, 10, 2), [(-10, 0, 0), (10, 0, 0)]),
+    ],
+)
+def test_every_explicit_measured_corridor_stays_outside_scaled_view(
+    kind, axis, view, side, ref_bbox, ref_pts
+):
+    sheet = Sheet(Box(40, 40, 40), page="A3", scale=2).authored_dimensions()
+    sheet.measured_dimension(
+        kind=kind,
+        value=20,
+        label="ø20" if kind == "diameter" else "20",
+        dominant_axis=axis,
+        ref_bbox=ref_bbox,
+        ref_pts=ref_pts,
+        view=view,
+        side=side,
+    )
+    drawing = sheet.build()
+    assert drawing.scale == 2
+    annotation = next(
+        annotation for name, annotation in drawing.iter_annotations() if name.startswith("pmi_")
+    )
+    vx0, vy0, vx1, vy1 = drawing.view_bounds(view)
+    lx0, ly0, lx1, ly1 = annotation.label_bbox
+    outside = {
+        "left": lx1 <= vx0,
+        "right": lx0 >= vx1,
+        "above": ly0 >= vy1,
+        "below": ly1 <= vy0,
+    }
+    assert outside[side], (drawing.view_bounds(view), annotation.label_bbox)
+    # A centred symmetric solid gives a direct transform invariant: the projected world
+    # origin and the rendered silhouette centre must agree at non-1:1 scale.
+    px, py, _ = drawing.at(view, 0, 0, 0)
+    assert px == pytest.approx((vx0 + vx1) / 2)
+    assert py == pytest.approx((vy0 + vy1) / 2)
+    assert not [issue for issue in drawing.lint() if issue.severity != "info"]
+
+
+def test_plan_right_corridor_does_not_force_feasible_a4_scale_reduction():
+    sheet = Sheet(Box(40, 50, 20), page="A4").authored_dimensions()
+    sheet.measured_dimension(
+        kind="linear",
+        value=25,
+        label="25",
+        dominant_axis="Y",
+        ref_bbox=(-2, -12.5, -2, 2, 12.5, 2),
+        ref_pts=[(0, -12.5, 0), (0, 12.5, 0)],
+        view="plan",
+        side="right",
+    )
+    drawing = sheet.build()
+    assert drawing.scale == 1
+    assert drawing.get_annotation("pmi_y_0").label_bbox[0] >= drawing.view_bounds("plan")[2]
+    assert not [issue for issue in drawing.lint() if issue.severity != "info"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_issue_563_placement_intent.py
+++ b/tests/test_issue_563_placement_intent.py
@@ -12,6 +12,7 @@ from draftwright import Sheet
 from draftwright.compose import _compose_anno_boxes, _footprint_from_boxes
 from draftwright.model import DimensionParameterId
 from draftwright.model.compiled import compile_dimensions
+from draftwright.model.ir import authored_dimension_target_view
 from draftwright.model.planner import plan_dimensions
 from draftwright.sheet_emit import emit_sheet_script
 
@@ -236,6 +237,26 @@ def test_no_measured_override_keeps_existing_geometric_derivation():
     assert annotation._dw_spec.side == "right"
 
 
+@pytest.mark.parametrize(
+    ("kind", "axis", "view", "side", "expected"),
+    [
+        ("linear", "?", "detail_a", None, "detail_a"),
+        ("linear", "Z", None, None, None),
+        ("diameter", "X", None, "above", "side"),
+        ("diameter", "Y", None, "above", "front"),
+        ("diameter", "Z", None, "above", "plan"),
+        ("diameter", "?", None, "above", None),
+        ("linear", "X", None, "above", "front"),
+        ("linear", "Z", None, "left", "front"),
+        ("linear", "Y", None, "above", "side"),
+        ("linear", "Y", None, "right", "plan"),
+        ("linear", "?", None, "right", None),
+    ],
+)
+def test_measured_target_view_resolution_is_total(kind, axis, view, side, expected):
+    assert authored_dimension_target_view(kind, axis, view, side) == expected
+
+
 def test_view_only_measured_override_preserves_the_derived_side():
     def build(view):
         sheet = Sheet(Box(60, 40, 20), page="A3").authored_dimensions()
@@ -251,6 +272,51 @@ def test_view_only_measured_override_preserves_the_derived_side():
         return sheet.build().get_annotation("pmi_z_0")._dw_spec.side
 
     assert build(None) == build("front") == "left"
+
+
+@pytest.mark.parametrize(
+    ("view", "ref_bbox", "expected_side"),
+    [
+        ("side", (-2, -10, 20, 2, 10, 30), "above"),
+        ("side", (-2, -10, -30, 2, 10, -20), "below"),
+        ("plan", (20, -10, -2, 30, 10, 2), "right"),
+        ("plan", (-30, -10, -2, -20, 10, 2), "left"),
+    ],
+)
+def test_y_view_only_override_preserves_its_geometry_derived_side(view, ref_bbox, expected_side):
+    sheet = Sheet(Box(80, 80, 80), page="A3").authored_dimensions()
+    sheet.measured_dimension(
+        kind="linear",
+        value=20,
+        label="20",
+        dominant_axis="Y",
+        ref_bbox=ref_bbox,
+        ref_pts=[(0, -10, 0), (0, 10, 0)],
+        view=view,
+    )
+
+    drawing = sheet.build()
+    assert drawing.get_annotation("pmi_y_0")._dw_spec.side == expected_side
+    assert not [issue for issue in drawing.lint() if issue.severity != "info"]
+
+
+def test_y_override_reports_degenerate_reference_geometry():
+    sheet = Sheet(Box(80, 80, 80), page="A3").authored_dimensions()
+    sheet.measured_dimension(
+        kind="linear",
+        value=1,
+        label="1",
+        dominant_axis="Y",
+        ref_bbox=(-2, 0, -2, 2, 0, 2),
+        ref_pts=[(0, 0, 0), (0, 0, 0)],
+        view="side",
+    )
+
+    drawing = sheet.build()
+    assert "pmi_y_0" not in drawing.annotations()
+    assert [(issue.severity, issue.code) for issue in drawing.lint()] == [
+        ("warning", "authored_dim_degenerate")
+    ]
 
 
 def test_front_above_measured_intent_participates_in_view_composition():
@@ -351,6 +417,15 @@ def test_compose_reserves_every_supported_measured_corridor_family():
     assert footprint.fv_top > 0 and footprint.fv_bottom > 0
     assert footprint.pv_authored_top > 0 and footprint.pv_bottom > 0
     assert footprint.sv_top > 0 and footprint.sv_bottom > 0
+
+
+def test_compose_ignores_an_unresolved_defensive_target(monkeypatch):
+    import draftwright.compose as compose
+
+    sheet = _measured_sheet(view="front", side="left")
+    monkeypatch.setattr(compose, "authored_dimension_target_view", lambda *_args: None)
+
+    assert _compose_anno_boxes(sheet.model(), n_steps=0)
 
 
 def test_front_and_plan_horizontal_corridors_reuse_the_same_depth():
@@ -496,6 +571,36 @@ def test_invalid_referential_strip_and_compound_conflict_fail_clearly():
     conflict.dimension(blind, "bore.depth", view="plan", side="right")
     with pytest.raises(ValueError, match="conflicting placement intent"):
         plan_dimensions(conflict.model())
+
+
+def test_repeat_parameter_placement_conflict_and_envelope_side_fail_clearly():
+    repeated = Sheet(Box(40, 40, 10)).authored_dimensions()
+    hole = repeated.hole(diameter=4, at=(0, 0, 0), axis="z")
+    repeated.dimension(hole, "bore.diameter", view="plan", side="left")
+    repeated.dimension(hole, "bore.diameter", view="plan", side="right")
+    with pytest.raises(ValueError, match="conflicting placement intent"):
+        plan_dimensions(repeated.model())
+
+    envelope_sheet = Sheet.from_part(Box(40, 20, 10)).take_over(
+        dimensions="authored",
+        principal_views="automatic",
+        derived_views="automatic",
+    )
+    envelope = next(feature for feature in envelope_sheet.features if feature.kind == "envelope")
+    envelope_sheet.dimension(envelope, "width.length", view="front", side="above")
+    with pytest.raises(ValueError, match="supported sides for this renderer: none"):
+        plan_dimensions(envelope_sheet.model())
+
+
+def test_legacy_build123d_scaling_uses_the_factor_only_signature(monkeypatch):
+    import draftwright._geometry as geometry
+
+    class LegacyShape:
+        def scale(self, factor):
+            return ("scaled", factor)
+
+    monkeypatch.setattr(geometry, "_SCALE_SUPPORTS_ABOUT", False)
+    assert geometry._scale_world(LegacyShape(), 2) == ("scaled", 2)
 
 
 def test_location_unknown_side_unavailable_view_and_missing_planned_view_fail_clearly():

--- a/tests/test_issue_563_placement_intent.py
+++ b/tests/test_issue_563_placement_intent.py
@@ -1,0 +1,268 @@
+"""#563 — authored dimensions select a semantic view/strip, never page coordinates."""
+
+from __future__ import annotations
+
+import warnings
+from typing import cast
+
+import pytest
+from build123d import Align, Box, Cylinder, Pos
+
+from draftwright import Sheet
+from draftwright.model import DimensionParameterId
+from draftwright.model.compiled import compile_dimensions
+from draftwright.model.planner import plan_dimensions
+from draftwright.sheet_emit import emit_sheet_script
+
+
+def _opposite_face_taps():
+    """A GRM-02-shaped pair: coaxial M2/M4 blind operations from opposite faces."""
+    return (
+        Box(40, 40, 20, align=(Align.CENTER, Align.CENTER, Align.CENTER))
+        - Pos(0, 0, 4) * Cylinder(1, 6)
+        - Pos(0, 0, -10) * Cylinder(2, 6)
+    )
+
+
+def _authored_taps() -> Sheet:
+    sheet = Sheet.from_part(_opposite_face_taps(), page="A3", scale=2).take_over(
+        dimensions="authored",
+        principal_views="automatic",
+        derived_views="automatic",
+    )
+    holes = sorted(
+        (feature for feature in sheet.features if feature.kind == "hole"),
+        key=lambda feature: feature.diameter,
+    )
+    for feature, side, thread in zip(
+        holes,
+        ("left", "right"),
+        ("M2x0.4", "M4x0.7"),
+        strict=True,
+    ):
+        handle = sheet.of(feature).thread(thread)
+        for parameter_id in handle.dimension_ids():
+            if parameter_id == "location":
+                sheet.dimension(handle, cast(DimensionParameterId, parameter_id))
+            else:
+                sheet.dimension(
+                    handle,
+                    cast(DimensionParameterId, parameter_id),
+                    view="plan",
+                    side=side,
+                )
+    envelope = next(feature for feature in sheet.features if feature.kind == "envelope")
+    for parameter in envelope.parameters():
+        sheet.dimension(envelope, cast(DimensionParameterId, parameter.parameter_id))
+    return sheet
+
+
+def test_referential_intent_survives_ir_planner_compiler_and_places_opposite_sides():
+    sheet = _authored_taps()
+    requests = [
+        request
+        for request in sheet.model().authored_dimensions
+        if request.feature.kind == "hole" and request.role != "location"
+    ]
+    assert {(request.view, request.side) for request in requests} == {
+        ("plan", "left"),
+        ("plan", "right"),
+    }
+
+    planned = [group for group in plan_dimensions(sheet.model()) if group.feature.kind == "hole"]
+    assert {(group.view, group.side) for group in planned} == {
+        ("plan", "left"),
+        ("plan", "right"),
+    }
+    compiled = [
+        group for group in compile_dimensions(sheet.model()).groups if group.feature_kind == "hole"
+    ]
+    assert {(group.view, group.side) for group in compiled} == {
+        ("plan", "left"),
+        ("plan", "right"),
+    }
+
+    drawing = sheet.build()
+    plan_left, _, plan_right, _ = drawing.view_bounds("plan")
+    callouts = {
+        annotation.label: annotation
+        for name, annotation in drawing.iter_annotations()
+        if name.startswith("hc_plan")
+    }
+    assert callouts["⌀2 ↧ 6 M2x0.4"].elbow[0] < plan_left
+    assert callouts["⌀4 ↧ 3 M4x0.7"].elbow[0] > plan_right
+    assert not [issue for issue in drawing.lint() if issue.severity != "info"]
+
+
+def test_referential_placement_round_trips_through_generated_sheet_code():
+    sheet = _authored_taps()
+    source = emit_sheet_script(
+        sheet.model(),
+        "part",
+        "grm02",
+        title="GRM-02",
+        number="GRM-02",
+        view_constraints=sheet.view_constraints,
+    )
+    assert 'view="plan", side="left"' in source
+    assert 'view="plan", side="right"' in source
+
+    namespace = {"part": _opposite_face_taps()}
+    body = source.replace("\npart\n", "\n", 1)
+    exec(  # noqa: S102 - generated public Sheet code is the round-trip under test
+        compile(body[: body.index("drawing = sheet.build()")], "<issue-563>", "exec"),
+        namespace,
+    )
+    regenerated = namespace["sheet"]
+    policies = {
+        (request.feature.diameter, request.view, request.side)
+        for request in regenerated.model().authored_dimensions
+        if request.feature.kind == "hole" and request.role != "location"
+    }
+    assert policies == {(2.0, "plan", "left"), (4.0, "plan", "right")}
+
+
+def test_augmenting_referential_intent_is_preserved_when_the_emitter_mirrors_it():
+    sheet = Sheet(Box(40, 40, 10))
+    hole = sheet.hole(diameter=4, at=(0, 0, 0), axis="z")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        sheet.auto_dimensions()
+        sheet.add_dimension(hole, "bore.diameter", view="plan", side="left")
+
+    source = emit_sheet_script(sheet.model(), "part", "augment", title="P", number="N")
+    assert 'sheet.dimension(hole1, "bore.diameter", view="plan", side="left")' in source
+
+
+def _measured_sheet(*, view=None, side=None) -> Sheet:
+    sheet = Sheet(Box(40, 20, 10)).authored_dimensions()
+    sheet.measured_dimension(
+        kind="linear",
+        value=10,
+        label="10",
+        dominant_axis="Z",
+        ref_bbox=(-10, -5, 0, 10, 5, 10),
+        ref_pts=[(0, 0, 0), (0, 0, 10)],
+        view=view,
+        side=side,
+    )
+    return sheet
+
+
+def test_measured_dimension_uses_requested_corridor_and_round_trips():
+    sheet = _measured_sheet(view="front", side="left")
+    drawing = sheet.build()
+    annotation = drawing.get_annotation("pmi_z_0")
+    assert annotation._dw_spec.side == "left"
+    assert not [issue for issue in drawing.lint() if issue.severity != "info"]
+
+    source = emit_sheet_script(sheet.model(), "part", "measured", title="P", number="N")
+    assert "view='front'" in source and "side='left'" in source
+    namespace = {"part": Box(40, 20, 10)}
+    exec(  # noqa: S102 - generated public Sheet code is the round-trip under test
+        compile(source[: source.index("drawing = sheet.build()")], "<issue-563-pmi>", "exec"),
+        namespace,
+    )
+    record = next(
+        feature
+        for feature in namespace["sheet"].model().features
+        if feature.kind == "authored_dimension"
+    )
+    assert (record.view, record.side) == ("front", "left")
+
+
+def test_no_measured_override_keeps_existing_geometric_derivation():
+    annotation = _measured_sheet().build().get_annotation("pmi_z_0")
+    assert annotation._dw_spec.side == "right"
+
+
+def test_y_and_diameter_measured_intents_use_their_supported_exact_corridors():
+    y_sheet = Sheet(Box(40, 20, 10), page="A3").authored_dimensions()
+    y_sheet.measured_dimension(
+        kind="linear",
+        value=20,
+        label="20",
+        dominant_axis="Y",
+        ref_bbox=(-10, -10, 2, 10, 10, 8),
+        ref_pts=[(0, -10, 5), (0, 10, 5)],
+        view="side",
+        side="above",
+    )
+    y_drawing = y_sheet.build()
+    assert y_drawing.get_annotation("pmi_y_0")._dw_spec.side == "above"
+    assert not [issue for issue in y_drawing.lint() if issue.severity != "info"]
+
+    diameter_sheet = Sheet(Box(40, 40, 10), page="A3").authored_dimensions()
+    diameter_sheet.measured_dimension(
+        kind="diameter",
+        value=10,
+        label="ø10",
+        dominant_axis="Z",
+        ref_bbox=(-5, -5, 0, 5, 5, 10),
+        ref_pts=[(-5, 0, 5), (5, 0, 5)],
+        view="plan",
+        side="above",
+    )
+    diameter_drawing = diameter_sheet.build()
+    assert diameter_drawing.get_annotation("pmi_d_0")._dw_spec.side == "above"
+    assert not [issue for issue in diameter_drawing.lint() if issue.severity != "info"]
+
+
+@pytest.mark.parametrize(
+    ("view", "side", "message"),
+    [
+        ("iso", "below", "view must be one of"),
+        ("front", "above", "cannot render linear/Z"),
+    ],
+)
+def test_invalid_measured_placement_fails_clearly(view, side, message):
+    with pytest.raises(ValueError, match=message):
+        _measured_sheet(view=view, side=side)
+
+
+def test_invalid_referential_strip_and_compound_conflict_fail_clearly():
+    bad_side = Sheet(Box(40, 40, 10)).authored_dimensions()
+    hole = bad_side.hole(diameter=4, at=(0, 0, 0), axis="z")
+    bad_side.dimension(hole, "bore.diameter", view="plan", side="above")
+    with pytest.raises(ValueError, match="supported sides"):
+        plan_dimensions(bad_side.model())
+
+    conflict = Sheet(Box(40, 40, 10)).authored_dimensions()
+    blind = conflict.hole(diameter=4, at=(0, 0, 0), axis="z").depth(5)
+    conflict.dimension(blind, "bore.diameter", view="plan", side="left")
+    conflict.dimension(blind, "bore.depth", view="plan", side="right")
+    with pytest.raises(ValueError, match="conflicting placement intent"):
+        plan_dimensions(conflict.model())
+
+
+def test_location_unknown_side_unavailable_view_and_missing_planned_view_fail_clearly():
+    invalid_side = Sheet(Box(40, 40, 10)).authored_dimensions()
+    with pytest.raises(ValueError, match="side must be one of"):
+        invalid_side.measured_dimension(
+            kind="linear",
+            value=10,
+            label="10",
+            dominant_axis="Z",
+            ref_bbox=(-5, -5, 0, 5, 5, 10),
+            ref_pts=[(0, 0, 0), (0, 0, 10)],
+            view="front",
+            side="inside",
+        )
+
+    location_sheet = Sheet(Box(40, 40, 10)).authored_dimensions()
+    located = location_sheet.hole(diameter=4, at=(5, 5, 0), axis="z")
+    location_sheet.dimension(located, "location", view="plan", side="left")
+    with pytest.raises(ValueError, match="unavailable for location dimensions"):
+        location_sheet.model()
+
+    bad_view = Sheet(Box(40, 40, 10)).authored_dimensions()
+    bore = bad_view.hole(diameter=4, at=(0, 0, 0), axis="z")
+    bad_view.dimension(bore, "bore.diameter", view="front")
+    with pytest.raises(ValueError, match="cannot render in 'front'"):
+        plan_dimensions(bad_view.model())
+
+    missing_view = Sheet(Box(40, 40, 10)).authored_dimensions()
+    bore = missing_view.hole(diameter=4, at=(0, 0, 0), axis="z")
+    missing_view.dimension(bore, "bore.diameter", view="plan")
+    with pytest.raises(ValueError, match="not in the planned views"):
+        plan_dimensions(missing_view.model(), planned_views=("front",))

--- a/tests/test_issue_563_placement_intent.py
+++ b/tests/test_issue_563_placement_intent.py
@@ -6,7 +6,7 @@ import warnings
 from typing import cast
 
 import pytest
-from build123d import Align, Box, Cylinder, Pos
+from build123d import Align, Box, Cylinder, Pos, Rot
 
 from draftwright import Sheet
 from draftwright.model import DimensionParameterId
@@ -134,6 +134,65 @@ def test_augmenting_referential_intent_is_preserved_when_the_emitter_mirrors_it(
     assert 'sheet.dimension(hole1, "bore.diameter", view="plan", side="left")' in source
 
 
+def test_independent_envelope_dimensions_honour_distinct_view_overrides():
+    sheet = Sheet.from_part(Box(40, 20, 10), page="A3").take_over(
+        dimensions="authored",
+        principal_views="automatic",
+        derived_views="automatic",
+    )
+    envelope = next(feature for feature in sheet.features if feature.kind == "envelope")
+    sheet.dimension(envelope, "width.length", view="front")
+    sheet.dimension(envelope, "depth.length", view="side")
+
+    planned = next(group for group in plan_dimensions(sheet.model()) if group.feature is envelope)
+    assert {(pd.param.parameter_id, pd.view) for pd in planned.dims if not pd.suppressed} == {
+        ("width.length", "front"),
+        ("depth.length", "side"),
+    }
+    compiled = next(
+        group
+        for group in compile_dimensions(sheet.model()).groups
+        if group.feature_kind == "envelope"
+    )
+    assert {(pd.parameter_id, pd.view) for pd in compiled.dims} == {
+        ("width.length", "front"),
+        ("depth.length", "side"),
+    }
+
+    drawing = sheet.build()
+    assert drawing.view_of("m_env_width") == "front"
+    assert drawing.view_of("m_env_depth") == "side"
+    assert not [issue for issue in drawing.lint() if issue.severity != "info"]
+
+
+def test_augmenting_envelope_view_policy_builds_without_moving_its_siblings():
+    sheet = Sheet.from_part(Box(40, 20, 10), page="A3")
+    envelope = next(feature for feature in sheet.features if feature.kind == "envelope")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        sheet.auto_dimensions()
+        sheet.add_dimension(envelope, "width.length", view="front")
+
+    drawing = sheet.build()
+    assert drawing.view_of("m_env_width") == "front"
+    assert drawing.view_of("m_env_depth") == "side"
+
+
+def test_referential_override_vetoes_an_automatic_view_reduction():
+    part = Rot(0, 90, 0) * Cylinder(10, 40)
+    sheet = Sheet.from_part(part, page="A3").take_over(
+        dimensions="authored",
+        principal_views="automatic",
+        derived_views="automatic",
+    )
+    envelope = next(feature for feature in sheet.features if feature.kind == "envelope")
+    sheet.dimension(envelope, "width.length", view="plan")
+
+    drawing = sheet.build()
+    assert "plan" in drawing.views
+    assert drawing.view_decision["status"] == "retained_for_requirements"
+
+
 def _measured_sheet(*, view=None, side=None) -> Sheet:
     sheet = Sheet(Box(40, 20, 10)).authored_dimensions()
     sheet.measured_dimension(
@@ -174,6 +233,40 @@ def test_measured_dimension_uses_requested_corridor_and_round_trips():
 def test_no_measured_override_keeps_existing_geometric_derivation():
     annotation = _measured_sheet().build().get_annotation("pmi_z_0")
     assert annotation._dw_spec.side == "right"
+
+
+def test_view_only_measured_override_preserves_the_derived_side():
+    def build(view):
+        sheet = Sheet(Box(60, 40, 20), page="A3").authored_dimensions()
+        sheet.measured_dimension(
+            kind="linear",
+            value=10,
+            label="10",
+            dominant_axis="Z",
+            ref_bbox=(-25, -2, 0, -15, 2, 10),
+            ref_pts=[(-20, 0, 0), (-20, 0, 10)],
+            view=view,
+        )
+        return sheet.build().get_annotation("pmi_z_0")._dw_spec.side
+
+    assert build(None) == build("front") == "left"
+
+
+def test_front_above_measured_intent_participates_in_view_composition():
+    sheet = Sheet(Box(60, 40, 20), page="A3").authored_dimensions()
+    sheet.measured_dimension(
+        kind="linear",
+        value=40,
+        label="40",
+        dominant_axis="X",
+        ref_bbox=(-20, -2, 4, 20, 2, 8),
+        ref_pts=[(-20, 0, 6), (20, 0, 6)],
+        view="front",
+        side="above",
+    )
+    drawing = sheet.build()
+    assert drawing.get_annotation("pmi_x_0")._dw_spec.side == "above"
+    assert not [issue for issue in drawing.lint() if issue.code == "pmi_dropped"]
 
 
 def test_y_and_diameter_measured_intents_use_their_supported_exact_corridors():
@@ -264,5 +357,36 @@ def test_location_unknown_side_unavailable_view_and_missing_planned_view_fail_cl
     missing_view = Sheet(Box(40, 40, 10)).authored_dimensions()
     bore = missing_view.hole(diameter=4, at=(0, 0, 0), axis="z")
     missing_view.dimension(bore, "bore.diameter", view="plan")
-    with pytest.raises(ValueError, match="not in the planned views"):
+    with pytest.raises(ValueError, match="cannot be shown"):
         plan_dimensions(missing_view.model(), planned_views=("front",))
+
+    measured_missing = Sheet(Box(40, 20, 10)).authored_dimensions().authored_views()
+    measured_missing.view("front")
+    measured_missing.measured_dimension(
+        kind="diameter",
+        value=10,
+        label="ø10",
+        dominant_axis="Z",
+        ref_bbox=(-5, -5, 0, 5, 5, 10),
+        ref_pts=[(-5, 0, 5), (5, 0, 5)],
+        view="plan",
+        side="above",
+    )
+    with pytest.raises(ValueError, match="cannot be shown"):
+        measured_missing.build()
+
+
+def test_pattern_pitch_placement_policy_is_rejected_instead_of_moving_the_callout():
+    sheet = Sheet(Box(40, 20, 10)).authored_dimensions()
+    sheet.hole(diameter=4, at=(-10, 0, 0), axis="z")
+    pattern = sheet.pattern(
+        sheet.features[-1],
+        kind="linear",
+        count=3,
+        pitch=10,
+        direction=(1, 0, 0),
+        at=(-10, 0, 0),
+    )
+    sheet.dimension(pattern, "pitch.length", view="plan", side="left")
+    with pytest.raises(ValueError, match="unavailable.*pattern pitch"):
+        plan_dimensions(sheet.model())

--- a/tests/test_issue_563_placement_intent.py
+++ b/tests/test_issue_563_placement_intent.py
@@ -302,6 +302,24 @@ def test_y_and_diameter_measured_intents_use_their_supported_exact_corridors():
     assert not [issue for issue in diameter_drawing.lint() if issue.severity != "info"]
 
 
+@pytest.mark.parametrize("side", ["left", "right"])
+def test_y_plan_measured_intents_participate_in_horizontal_composition(side):
+    sheet = Sheet(Box(40, 20, 10), page="A3").authored_dimensions()
+    sheet.measured_dimension(
+        kind="linear",
+        value=20,
+        label="20",
+        dominant_axis="Y",
+        ref_bbox=(-2, -10, 2, 2, 10, 8),
+        ref_pts=[(0, -10, 5), (0, 10, 5)],
+        view="plan",
+        side=side,
+    )
+    drawing = sheet.build()
+    assert drawing.get_annotation("pmi_y_0")._dw_spec.side == side
+    assert not [issue for issue in drawing.lint() if issue.severity != "info"]
+
+
 @pytest.mark.parametrize(
     ("view", "side", "message"),
     [

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -298,6 +298,16 @@ def test_record_pmi_drop_emits_a_pmi_escalation():
     _record_pmi_drop(ctx2, object(), "Y", "12.0", SimpleNamespace(pmi_kind="linear"))
     assert ctx2.escalations[0].view == "side"
 
+    ctx_explicit = PlacementContext(registry=AnnotationRegistry())
+    _record_pmi_drop(
+        ctx_explicit,
+        object(),
+        "Y",
+        "12.0",
+        SimpleNamespace(pmi_kind="linear", view="plan", side="right"),
+    )
+    assert ctx_explicit.escalations[0].view == "plan"
+
     # A bore diameter/radius uses a DIFFERENT view table (the view where the bore
     # appears as a circle) from linear dims — conflating the two mislabelled every
     # dropped bore diameter/radius (caught by review, #351 PR-4a).


### PR DESCRIPTION
## Summary

- add optional `view=` and `side=` placement intent to referential and measured Sheet dimensions
- preserve policy through IR, planning, compilation, generated Sheet code, build, export, and lint
- validate unsupported combinations and absent required views before placement
- compose requested corridor capacity before packing while retaining the ordinary shared solve
- keep projected geometry, coordinate maps, and detail views aligned across build123d 0.9, 0.10, and 0.11 at non-1:1 scales
- demonstrate opposite-side coaxial M2/M4 Gramel-style callouts

Part of #1353.
Closes #563.

## Verification

- `scripts/pr-check --full`
  - 5,076 passed, 5 skipped, 2 expected xfailed
  - 95.21% total coverage; 100% changed-line coverage
  - formatting, Ruff, mypy, and docs passed
- public projection/detail smoke builds passed on build123d 0.9.1, 0.10.0, and 0.11.1
- all supported explicit linear, diameter, and radius corridors passed at scales 0.5 and 2 for centred and translated solids
- PDF/SVG export retained searchable/selectable semantic text

## Independent review

Three independent final reviews of exact commit `20863ba5b9d6ac21e0d151adaa8b3504fb9f65dc` reported zero blockers, majors, or minors. Two reported no nits; one reported a non-blocking defensive-test assertion nit. Only nits remain.

## ADR audit

- ADR 0004: requested corridor footprints enter compose-before-pack; shared front/plan depths use the correct max/sum algebra
- ADR 0014: view/side only filters ordinary solver candidates; no raw page-coordinate placement
- ADR 0015: intent flows Sheet → IR → planner → compiler → renderer through the existing waist
- ADR 0016: per-dimension policy and identity survive compilation; invalid/conflicting policy fails explicitly
- ADR 0018: explicit and side-implied view requirements prevent invalid view reduction or omission
- ADR 0019: labels and placed/dropped outcomes remain compiler-owned and visible

No recognizer was added or changed; no upstream recognizer issue is required.
