### PR TITLE
Adopt the stable recogniser inspection API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@
 
 ### Changed
 
+- Declared Double-D bore, countersink, chamfer, fillet, and groove geometry reads now use the
+  stable `b123d_recognisers.inspection` namespace from the exact 0.4.5 wheel. A separate
+  Draftwright-owned format-1 contract fails closed on changes to the consumed signatures, result
+  schemas, units, bevel rejection reasons, or cylindrical surface layout (#1362).
+
 - `annotation_overlap` now reports the whole defect when the same pair also draws
   line-work through one of the two labels: the message names the crosser, the label
   crossed and the millimetres, and replaces the "use `label_offset_x`" remedy, which

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,8 @@ Compact map, bottom to top:
   `_build_profile.py` (developer-only pytest/runner profiling support),
   `evaluation/` (the versioned STEP-analysis benchmark — production code must never
   depend on benchmark expectations or scores), `recogniser_contract.py` (the
-  fail-closed cross-repository capability join).
+  fail-closed cross-repository capability join), and `inspection_contract.py` (the
+  separate fail-closed declared-geometry inspection join).
 - `score.py` / `recognition/` — temporary identity-preserving re-exports of
   `b123d_recognisers`; removal scheduled for 0.6.0.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -206,6 +206,10 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   `Sheet`, generated-code, drawing, completeness, and documentation declarations. It is rank 7
   because validation dynamically resolves implementation references across every lower layer;
   package geometry policy never imports or owns this consumer overlay.
+- **`inspection_contract.py`** — the separate fail-closed join for declared-feature geometry
+  reads. It validates inspection manifest format 1/API major 1, the exact installed recogniser
+  release, and only the stable `b123d_recognisers.inspection` symbols and value schemas consumed
+  by `model/declare.py`. It deliberately does not declare recognition-family semantics.
 - **`model/`** — the ADR 0015 IR waist: `ir.py` (the `Feature`/`DimParameter`/
   `Datum`/`PartModel` types — the one inventory), `detect.py` (detectors →
   `Feature` objects, adapting `b123d_recognisers` records), `planner.py`

--- a/docs/geometry-facade-spike.md
+++ b/docs/geometry-facade-spike.md
@@ -1,23 +1,27 @@
 # Geometry facade spike: Draftwright finding
 
 Draftwright's selected F7 workflow was the existing `fillet(face)` declaration. The completed
-spike replaces Draftwright's direct `BRepAdaptor_Surface` read and recogniser-specific
-`fillet_anchor` call with the graph-independent
-`b123d_recognisers.experimental_geometry.inspect_face`.
+spike replaced Draftwright's direct `BRepAdaptor_Surface` read and recogniser-specific
+`fillet_anchor` call with graph-independent face inspection. That experiment graduated into
+`b123d_recognisers.inspection` in recognisers 0.4.4; Draftwright adopts its completed format-1
+contract from the immutable 0.4.5 wheel (#1362).
 
 The result is semantically successful: the same principal axis, radius and on-round anchor are
 produced; planar faces refuse with the existing user-facing error; existing declared/detected
-fillet and drawing tests pass; and Draftwright imports no underscore-private recogniser module.
+fillet and drawing tests pass; and Draftwright imports no experimental, family-specific, or
+underscore-private recogniser module for declared geometry reads.
 
 The architectural result is a deliberate **no-go on publishing the graph yet**, and a **go on API
-review for face inspection**. Draftwright imports exactly `AnalyticSurface` and `inspect_face`; no
-graph, run-local reference, adjacency, smooth region or blend-selection type crosses the package
-boundary. The result contains the closed surface fact and an optional on-face anchor.
+review for face inspection**. The published inspection surface now also owns the four other
+declared-feature reads (Double-D bore, countersink, chamfer, and groove). No graph, run-local
+reference, adjacency, smooth region or blend-selection type crosses the package boundary. The
+fillet result contains the closed surface fact and an optional on-face anchor.
 
 `GeometryGraph` should be published only after another concrete out-of-tree workflow independently
 requires adjacency or selected blend provenance. Correspondence, snapshots, body matching,
 registries and recognition ownership remain out of scope.
 
-Executable evidence lives in `tests/test_geometry_graph_spike.py`; the package-side design,
+Executable evidence lives in `tests/test_geometry_graph_spike.py` and
+`tests/test_inspection_contract.py`; the package-side design,
 benchmarks and complete recommendation live in `docs/f7-geometry-facade-spike.md` in the paired
 `b123d-recognisers` spike checkout.

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -11,6 +11,15 @@ completeness treatment, and documentation. A stage is either `supported`, `defer
 other CAD consumers apply different policy without making Draftwright policy part of the geometry
 library.
 
+Declared-feature geometry reads use a different public boundary. The installed package's
+inspection manifest format 1 is joined to the separate Draftwright-owned declaration in
+`draftwright.inspection_contract`. That contract admits inspection API major 1 and exactly the
+consumed `b123d_recognisers.inspection` symbol schemas: the five geometry readers, their public
+result/error types, the cylindrical surface parameter layout, bevel rejection reasons, and the
+semantic names and units of the Double-D tuple. It also checks the exact installed package
+version. Recognition-family policy does not leak into this smaller measurement contract, and an
+additive inspection symbol does not pretend to be a new recogniser family.
+
 ## What failures mean
 
 Validation fails closed and names the family and boundary whenever possible:
@@ -67,7 +76,7 @@ with no inferred gear feature added to fill the table.
 
 ## Passage compatibility boundary
 
-The installed `b123d-recognisers==0.4.2` release contains the `passages` family introduced
+The installed `b123d-recognisers==0.4.5` release contains the `passages` family introduced
 in 0.2.6. Version 0.4.0 makes `SectionPassage` the authoritative physical output and retains
 schema-v1 `Passage` as its compatibility projection. Draftwright declares all six public and nested
 record schemas exhaustively but deliberately keeps the family `unsupported`, with the drafting
@@ -84,6 +93,6 @@ The 0.4 contract is explicit:
 - rich split-junction passages can supersede a Slot claim, moving physical ownership to the
   unsupported Passage family through `SLOT_SUPERSEDED_BY_PASSAGE`.
 
-The exact 0.4.2 pin, manifest-v2 validator and explicit unsupported inventories make that limitation
+The exact 0.4.5 pin, manifest-v2 validator and explicit unsupported inventories make that limitation
 fail-visible rather than silently treating rich passages as supported. Issue #1245 still owns the
 decision about what newly Passage-owned occurrences draw and how they participate in completeness.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "build123d>=0.9.0,<0.11 ; python_full_version < '3.13'",
     "build123d>=0.11,<0.12 ; python_full_version >= '3.13'",
     "build123d-drafting-helpers>=0.14.2",
-    "b123d-recognisers==0.4.2",
+    "b123d-recognisers==0.4.5",
     "numpy>=1.24",
     # PNG raster export (SVG→PDF→PNG). Both permissively licensed (Pillow HPND; pypdfium2
     # Apache-2.0 wrapping Google PDFium BSD-3) and ship pre-built wheels with NO native system

--- a/src/draftwright/inspection_contract.py
+++ b/src/draftwright/inspection_contract.py
@@ -1,0 +1,243 @@
+"""Fail-closed contract for Draftwright's declared-feature geometry reads.
+
+Recognition-family adoption is governed by :mod:`draftwright.recogniser_contract`.  This
+separate join covers the smaller, stable inspection API used when a caller declares a feature
+from build123d geometry and Draftwright must measure it.
+"""
+
+from __future__ import annotations
+
+import copy
+from importlib.metadata import version as distribution_version
+from typing import Any
+
+from b123d_recognisers.inspection import inspection_api_manifest
+
+CONSUMER_INSPECTION_FORMAT = "draftwright-inspection-api"
+CONSUMER_INSPECTION_FORMAT_VERSION = 1
+SUPPORTED_INSPECTION_API_MAJOR = 1
+SUPPORTED_RECOGNISER_VERSION = "0.4.5"
+_DISTRIBUTION = "b123d-recognisers"
+_PROVIDER_FORMAT = "b123d-recognisers-inspection-api"
+_NAMESPACE = "b123d_recognisers.inspection"
+
+
+class InspectionContractError(RuntimeError):
+    """The installed inspection API cannot safely serve Draftwright's declared reads."""
+
+
+_CYLINDER_PARAMETERS = [
+    {"name": "axis_point_x", "unit": "model-length"},
+    {"name": "axis_point_y", "unit": "model-length"},
+    {"name": "axis_point_z", "unit": "model-length"},
+    {"name": "axis_x", "unit": "unitless"},
+    {"name": "axis_y", "unit": "unitless"},
+    {"name": "axis_z", "unit": "unitless"},
+    {"name": "radius", "unit": "model-length"},
+]
+
+_REQUIRED_SYMBOLS: dict[str, dict[str, Any]] = {
+    "AnalyticSurface": {
+        "kind": "dataclass",
+        "qualified_name": f"{_NAMESPACE}.AnalyticSurface",
+        "contract": {
+            "fields": [
+                {"name": "kind", "type": "SurfaceKind"},
+                {"name": "provenance", "type": "SurfaceProvenance"},
+                {"name": "orientation", "type": "OrientationCapability"},
+                {"name": "parameters", "type": "tuple[float,...]"},
+                {"name": "requested_tolerance", "type": "float"},
+                {"name": "kernel_reported_gap", "type": "float"},
+            ],
+            "frozen": True,
+            "slots": True,
+        },
+    },
+    "BevelReject": {
+        "kind": "exception",
+        "qualified_name": f"{_NAMESPACE}.BevelReject",
+        "contract": {
+            "attributes": [
+                {
+                    "name": "reason",
+                    "type": "str",
+                    "values": ["nonplanar", "degenerate", "aligned", "compound"],
+                }
+            ],
+            "base": "ValueError",
+        },
+    },
+    "FaceInspection": {
+        "kind": "dataclass",
+        "qualified_name": f"{_NAMESPACE}.FaceInspection",
+        "contract": {
+            "fields": [
+                {"name": "surface", "type": "AnalyticSurface|RefusedSurface"},
+                {"name": "anchor", "type": "tuple[float,float,float]|null"},
+            ],
+            "frozen": True,
+            "slots": True,
+        },
+    },
+    "SurfaceKind": {
+        "kind": "enum",
+        "qualified_name": f"{_NAMESPACE}.SurfaceKind",
+        "contract": {
+            "members": [
+                {"name": "PLANE", "value": "plane"},
+                {"name": "CYLINDER", "value": "cylinder"},
+                {"name": "CONE", "value": "cone"},
+                {"name": "SPHERE", "value": "sphere"},
+            ]
+        },
+    },
+    "classify_bevel": {
+        "kind": "function",
+        "qualified_name": f"{_NAMESPACE}.classify_bevel",
+        "contract": {
+            "signature": (
+                "(face: 'FaceLike') -> 'tuple[int, Vector3, dict[int, tuple[float, float]], "
+                "float, float]'"
+            )
+        },
+    },
+    "cone_rims": {
+        "kind": "function",
+        "qualified_name": f"{_NAMESPACE}.cone_rims",
+        "contract": {
+            "signature": "(face: 'FaceLike') -> 'tuple[EdgeLike, EdgeLike, float] | None'"
+        },
+    },
+    "floor_face_anchor": {
+        "kind": "function",
+        "qualified_name": f"{_NAMESPACE}.floor_face_anchor",
+        "contract": {"signature": "(face: 'FaceLike') -> 'tuple[float, float, float]'"},
+    },
+    "inspect_face": {
+        "kind": "function",
+        "qualified_name": f"{_NAMESPACE}.inspect_face",
+        "contract": {"signature": "(face: 'FaceLike') -> 'FaceInspection'"},
+    },
+    "read_double_d_tool": {
+        "kind": "function",
+        "qualified_name": f"{_NAMESPACE}.read_double_d_tool",
+        "contract": {
+            "signature": (
+                "(obj: 'Part', *, tol: 'float' = 1e-05) -> "
+                "'tuple[str, float, float, Vector3, float, Vector3]'"
+            ),
+            "returns": {
+                "kind": "tuple",
+                "members": [
+                    {"name": "axis", "type": "str", "unit": None, "values": ["x", "y", "z"]},
+                    {
+                        "name": "major_diameter",
+                        "type": "float",
+                        "unit": "model-length",
+                        "values": None,
+                    },
+                    {
+                        "name": "across_flats",
+                        "type": "float",
+                        "unit": "model-length",
+                        "values": None,
+                    },
+                    {
+                        "name": "origin",
+                        "type": "tuple[float,float,float]",
+                        "unit": "model-length",
+                        "values": None,
+                    },
+                    {
+                        "name": "depth",
+                        "type": "float",
+                        "unit": "model-length",
+                        "values": None,
+                    },
+                    {
+                        "name": "profile_direction",
+                        "type": "tuple[float,float,float]",
+                        "unit": "unitless",
+                        "values": None,
+                    },
+                ],
+            },
+        },
+    },
+}
+
+
+def consumer_inspection_declaration() -> dict[str, Any]:
+    """Return an isolated declaration of the inspection contract Draftwright consumes."""
+    return {
+        "format": CONSUMER_INSPECTION_FORMAT,
+        "format_version": CONSUMER_INSPECTION_FORMAT_VERSION,
+        "consumer": {"name": "draftwright"},
+        "package": {"name": _DISTRIBUTION, "version": SUPPORTED_RECOGNISER_VERSION},
+        "api": {
+            "format": _PROVIDER_FORMAT,
+            "format_version": 1,
+            "major": SUPPORTED_INSPECTION_API_MAJOR,
+            "namespace": _NAMESPACE,
+            "surface_parameters": {"cylinder": copy.deepcopy(_CYLINDER_PARAMETERS)},
+            "symbols": copy.deepcopy(_REQUIRED_SYMBOLS),
+        },
+    }
+
+
+def _require_equal(label: str, actual: object, expected: object) -> None:
+    if actual != expected:
+        raise InspectionContractError(f"{label} mismatch: expected {expected!r}, got {actual!r}")
+
+
+def validate_inspection_contract(
+    package_manifest: dict[str, Any] | None = None,
+    declaration: dict[str, Any] | None = None,
+) -> None:
+    """Validate the installed provider against Draftwright's exact consumed subset."""
+    expected_declaration = consumer_inspection_declaration()
+    consumer = expected_declaration if declaration is None else declaration
+    _require_equal("consumer inspection declaration", consumer, expected_declaration)
+
+    installed_version = distribution_version(_DISTRIBUTION)
+    _require_equal("installed package version", installed_version, SUPPORTED_RECOGNISER_VERSION)
+
+    package = inspection_api_manifest() if package_manifest is None else package_manifest
+    _require_equal("provider format", package.get("format"), _PROVIDER_FORMAT)
+    _require_equal("provider format version", package.get("format_version"), 1)
+    _require_equal("provider package", package.get("package"), consumer["package"])
+
+    api = package.get("api")
+    if not isinstance(api, dict):
+        raise InspectionContractError("provider api must be an object")
+    _require_equal("inspection API major", api.get("major"), SUPPORTED_INSPECTION_API_MAJOR)
+    _require_equal("inspection namespace", api.get("namespace"), _NAMESPACE)
+
+    parameters = api.get("surface_parameters")
+    if not isinstance(parameters, dict):
+        raise InspectionContractError("provider surface_parameters must be an object")
+    _require_equal("cylinder parameter contract", parameters.get("cylinder"), _CYLINDER_PARAMETERS)
+
+    symbols = api.get("symbols")
+    if not isinstance(symbols, list):
+        raise InspectionContractError("provider symbols must be a list")
+    named_symbols: dict[str, dict[str, Any]] = {}
+    for symbol in symbols:
+        if not isinstance(symbol, dict) or not isinstance(symbol.get("name"), str):
+            raise InspectionContractError("every provider symbol must be a named object")
+        name = symbol["name"]
+        if name in named_symbols:
+            raise InspectionContractError(f"provider symbol {name!r} is duplicated")
+        named_symbols[name] = symbol
+
+    required = consumer["api"]["symbols"]
+    for name, expected in required.items():
+        if name not in named_symbols:
+            raise InspectionContractError(f"required inspection symbol {name!r} is missing")
+        actual = named_symbols[name]
+        consumed = {
+            "kind": actual.get("kind"),
+            "qualified_name": actual.get("qualified_name"),
+            "contract": actual.get("contract"),
+        }
+        _require_equal(f"inspection symbol {name!r}", consumed, expected)

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -301,7 +301,7 @@ def double_d_bore(
     with exactly that boundary; arbitrary line/arc profiles and blind profiles fail closed.
     """
     if obj is not None:
-        from b123d_recognisers.profiled_bores import read_double_d_tool
+        from b123d_recognisers.inspection import read_double_d_tool
 
         r_axis, r_major, r_af, r_at, r_depth, r_direction = read_double_d_tool(obj)
         axis = r_axis if axis is None else axis
@@ -340,9 +340,9 @@ def read_countersink(cone) -> tuple[float, float]:
     """``(major_diameter, included_angle°)`` of a countersink **cone** tool — the larger rim ⌀
     and the full cone angle, read off its conical **face** (not a removed edge, #576 lesson).
     The cone geometry is the recogniser's own
-    :func:`~b123d_recognisers.countersinks.cone_rims` (#704), so a declared
+    :func:`~b123d_recognisers.inspection.cone_rims` (#704), so a declared
     countersink reads identically to a detected one by construction."""
-    from b123d_recognisers import cone_rims
+    from b123d_recognisers.inspection import cone_rims
     from build123d import GeomType
 
     faces = cone.faces().filter_by(GeomType.CONE)
@@ -534,10 +534,10 @@ def _read_chamfer_face(face) -> tuple[str, float, float, Point]:
     """Read a chamfer off its **oblique planar bevel face**: the axis (the edge the chamfer
     runs along), the two legs (the face's in-plane extents), and a point **on the bevel** (the
     face centre — not the removed sharp corner). The classification + leg geometry is the
-    recogniser's own :func:`~b123d_recognisers.chamfers.classify_bevel` (#704), so a
+    recogniser's own :func:`~b123d_recognisers.inspection.classify_bevel` (#704), so a
     declared chamfer reads identically to a detected one by construction; only the
     user-facing error messages live here."""
-    from b123d_recognisers import BevelReject, classify_bevel
+    from b123d_recognisers.inspection import BevelReject, classify_bevel
 
     try:
         edge_i, _nv, _span, hi, lo = classify_bevel(face)
@@ -621,11 +621,11 @@ def _read_fillet_face(face) -> tuple[str, float, Point]:
     along), the radius (the cylinder radius), and a point **on the round** (mid angular/axial of
     the trimmed face — the ``R`` leader's tip). Agrees with the recogniser (recognition/fillets.py)
     in the two in-plane (placement) coordinates; the along-edge coordinate is view depth."""
-    from b123d_recognisers.experimental_geometry import AnalyticSurface, inspect_face
+    from b123d_recognisers.inspection import AnalyticSurface, SurfaceKind, inspect_face
 
     inspection = inspect_face(face)
     surface = inspection.surface
-    if not isinstance(surface, AnalyticSurface) or surface.kind.value != "cylinder":
+    if not isinstance(surface, AnalyticSurface) or surface.kind is not SurfaceKind.CYLINDER:
         raise ValueError(
             "fillet(face=...) needs a cylindrical blend face (the round); an edge or flat "
             "face is not a fillet — declare with axis=, radius=, at= instead"
@@ -772,7 +772,7 @@ def _read_groove_face(face) -> tuple[str, float, float, Point]:
     span = ((bb.min.X, bb.max.X), (bb.min.Y, bb.max.Y), (bb.min.Z, bb.max.Z))[axis_i]
     # The leader tip is the recogniser's own floor_face_anchor (#704), so a declared
     # groove anchors identically to a detected one by construction.
-    from b123d_recognisers import floor_face_anchor
+    from b123d_recognisers.inspection import floor_face_anchor
 
     c = floor_face_anchor(face)
     return (

--- a/tests/test_geometry_graph_spike.py
+++ b/tests/test_geometry_graph_spike.py
@@ -1,4 +1,4 @@
-"""Bounded Draftwright consumer evidence for the provisional F7 facade."""
+"""Bounded Draftwright consumer evidence for the stable inspection facade."""
 
 from __future__ import annotations
 
@@ -12,9 +12,19 @@ from build123d import fillet as bd_fillet
 from draftwright.model.declare import fillet
 
 ROOT = Path(__file__).parents[1]
+INSPECTION_ROSTER = {
+    "AnalyticSurface",
+    "BevelReject",
+    "SurfaceKind",
+    "classify_bevel",
+    "cone_rims",
+    "floor_face_anchor",
+    "inspect_face",
+    "read_double_d_tool",
+}
 
 
-def test_declared_fillet_uses_the_facade_without_private_recogniser_imports() -> None:
+def test_declared_geometry_reads_use_only_the_stable_inspection_facade() -> None:
     source = (ROOT / "src/draftwright/model/declare.py").read_text()
     tree = ast.parse(source)
     recogniser_imports = {
@@ -25,16 +35,20 @@ def test_declared_fillet_uses_the_facade_without_private_recogniser_imports() ->
         and node.module.startswith("b123d_recognisers")
     }
 
-    assert "b123d_recognisers.experimental_geometry" in recogniser_imports
+    assert "b123d_recognisers.inspection" in recogniser_imports
     assert all(not name.startswith("b123d_recognisers._") for name in recogniser_imports)
-    imported_names = {
-        alias.name
+    roster_imports = {
+        (node.module, alias.name)
         for node in ast.walk(tree)
         if isinstance(node, ast.ImportFrom)
-        and node.module == "b123d_recognisers.experimental_geometry"
+        and node.module is not None
+        and node.module.startswith("b123d_recognisers")
         for alias in node.names
+        if alias.name in INSPECTION_ROSTER
     }
-    assert imported_names == {"AnalyticSurface", "inspect_face"}
+    assert roster_imports == {("b123d_recognisers.inspection", name) for name in INSPECTION_ROSTER}
+    assert "experimental_geometry" not in source
+    assert "profiled_bores" not in source
     assert "GeometryGraph" not in source
 
 

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -107,6 +107,9 @@ _LAYERS: dict[str, int] = {
     # Cross-repository CI contract: dynamically resolves declared implementations at every
     # lower layer, so it deliberately sits above the whole engine beside the user surfaces.
     "recogniser_contract": 7,
+    # Separate cross-repository inspection contract. It currently imports no engine module,
+    # but remains a top-layer consumer policy boundary rather than an engine dependency.
+    "inspection_contract": 7,
     # Versioned, independently-authored recognition benchmark. It may validate through the
     # cross-repository contract, but the drawing engine must never depend on its evaluator.
     "evaluation": 7,

--- a/tests/test_inspection_contract.py
+++ b/tests/test_inspection_contract.py
@@ -1,0 +1,158 @@
+"""Independent checks for Draftwright's stable declared-geometry inspection join."""
+
+from __future__ import annotations
+
+import copy
+import importlib.metadata
+import inspect
+from pathlib import Path
+
+import b123d_recognisers.inspection as inspection
+import pytest
+
+from draftwright.inspection_contract import (
+    InspectionContractError,
+    consumer_inspection_declaration,
+    validate_inspection_contract,
+)
+
+ROOT = Path(__file__).parents[1]
+
+
+def _manifest() -> dict:
+    return inspection.inspection_api_manifest()
+
+
+def test_installed_pypi_wheel_satisfies_the_inspection_contract() -> None:
+    distribution = importlib.metadata.distribution("b123d-recognisers")
+
+    assert distribution.version == "0.4.5"
+    assert distribution.read_text("direct_url.json") is None
+    assert Path(inspect.getfile(inspection)).resolve().is_relative_to(ROOT / ".venv")
+    validate_inspection_contract()
+
+
+def test_consumer_declaration_is_an_isolated_value() -> None:
+    first = consumer_inspection_declaration()
+    first["api"]["symbols"]["inspect_face"]["contract"]["signature"] = "changed"
+
+    assert consumer_inspection_declaration() != first
+
+
+@pytest.mark.parametrize(
+    ("path", "replacement"),
+    [
+        (("format_version",), 2),
+        (("package", "version"), "0.4.6"),
+        (("api", "major"), 2),
+        (("api", "namespace"), "b123d_recognisers.experimental_geometry"),
+    ],
+)
+def test_provider_identity_and_version_mutations_fail_closed(
+    path: tuple[str, ...], replacement: object
+) -> None:
+    package = copy.deepcopy(_manifest())
+    target = package
+    for component in path[:-1]:
+        target = target[component]
+    target[path[-1]] = replacement
+
+    with pytest.raises(InspectionContractError, match="mismatch"):
+        validate_inspection_contract(package)
+
+
+def test_cylinder_parameter_layout_mutation_fails_closed() -> None:
+    package = copy.deepcopy(_manifest())
+    package["api"]["surface_parameters"]["cylinder"][-1]["unit"] = "unitless"
+
+    with pytest.raises(InspectionContractError, match="cylinder parameter contract"):
+        validate_inspection_contract(package)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda package: package.update(api=None), "api must be an object"),
+        (
+            lambda package: package["api"].update(surface_parameters=None),
+            "surface_parameters must be an object",
+        ),
+        (lambda package: package["api"].update(symbols=None), "symbols must be a list"),
+        (
+            lambda package: package["api"].update(symbols=[{"kind": "function"}]),
+            "symbol must be a named object",
+        ),
+    ],
+)
+def test_malformed_provider_containers_fail_closed(mutate, message: str) -> None:
+    package = copy.deepcopy(_manifest())
+    mutate(package)
+
+    with pytest.raises(InspectionContractError, match=message):
+        validate_inspection_contract(package)
+
+
+@pytest.mark.parametrize("symbol", ["inspect_face", "classify_bevel", "read_double_d_tool"])
+def test_required_signature_mutation_fails_closed(symbol: str) -> None:
+    package = copy.deepcopy(_manifest())
+    entry = next(item for item in package["api"]["symbols"] if item["name"] == symbol)
+    entry["contract"]["signature"] = "(*args)"
+
+    with pytest.raises(InspectionContractError, match=repr(symbol)):
+        validate_inspection_contract(package)
+
+
+def test_bevel_rejection_reason_mutation_fails_closed() -> None:
+    package = copy.deepcopy(_manifest())
+    entry = next(item for item in package["api"]["symbols"] if item["name"] == "BevelReject")
+    entry["contract"]["attributes"][0]["values"].remove("compound")
+
+    with pytest.raises(InspectionContractError, match="BevelReject"):
+        validate_inspection_contract(package)
+
+
+def test_double_d_tuple_semantics_mutation_fails_closed() -> None:
+    package = copy.deepcopy(_manifest())
+    entry = next(
+        item for item in package["api"]["symbols"] if item["name"] == "read_double_d_tool"
+    )
+    entry["contract"]["returns"]["members"][3]["unit"] = "unitless"
+
+    with pytest.raises(InspectionContractError, match="read_double_d_tool"):
+        validate_inspection_contract(package)
+
+
+def test_missing_or_duplicate_required_symbol_fails_closed() -> None:
+    missing = copy.deepcopy(_manifest())
+    missing["api"]["symbols"] = [
+        item for item in missing["api"]["symbols"] if item["name"] != "cone_rims"
+    ]
+    duplicate = copy.deepcopy(_manifest())
+    duplicate["api"]["symbols"].append(copy.deepcopy(duplicate["api"]["symbols"][0]))
+
+    with pytest.raises(InspectionContractError, match="cone_rims.*missing"):
+        validate_inspection_contract(missing)
+    with pytest.raises(InspectionContractError, match="duplicated"):
+        validate_inspection_contract(duplicate)
+
+
+def test_additive_provider_symbol_does_not_break_the_consumed_subset() -> None:
+    package = copy.deepcopy(_manifest())
+    package["api"]["symbols"].append(
+        {
+            "name": "future_inspection",
+            "kind": "function",
+            "qualified_name": "b123d_recognisers.inspection.future_inspection",
+            "contract": {"signature": "() -> None"},
+        }
+    )
+
+    validate_inspection_contract(package)
+
+
+def test_consumer_declaration_mutation_fails_closed() -> None:
+    declaration = consumer_inspection_declaration()
+    declaration["api"]["symbols"]["SurfaceKind"]["contract"]["members"].pop()
+
+    with pytest.raises(InspectionContractError, match="consumer inspection declaration"):
+        validate_inspection_contract(declaration=declaration)

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -128,7 +128,7 @@ def test_installed_package_contract_validates_without_a_sibling_checkout() -> No
 def test_rich_passage_contract_is_truthfully_deferred_with_its_projection() -> None:
     """Pin the 0.4 physical record and compatibility projection to one decision."""
 
-    assert INSTALLED_PACKAGE_VERSION == "0.4.2"
+    assert INSTALLED_PACKAGE_VERSION == "0.4.5"
     installed = tuple(int(component) for component in INSTALLED_PACKAGE_VERSION.split("."))
     assert (0, 4, 0) <= installed < (0, 5, 0)
     package = _families(recognition.capability_manifest())

--- a/uv.lock
+++ b/uv.lock
@@ -85,15 +85,15 @@ wheels = [
 
 [[package]]
 name = "b123d-recognisers"
-version = "0.4.2"
+version = "0.4.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/1c/968350d87c664dfcc967066e4fa8fbcf0af077c7f63db71cfcb9b294d309/b123d_recognisers-0.4.2.tar.gz", hash = "sha256:7ca7827804fe0ae3e9767daaf571805b730dda7abf4d0b51e013ad2829c04ef3", size = 1013615, upload-time = "2026-08-27T10:03:01.431Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/14/07/b8b0e4256dda31097220b350363605736b74579a2b01a253d7ff842a719b/b123d_recognisers-0.4.5.tar.gz", hash = "sha256:3412f2a2701825e441c320360484ed2a8243b5ff9a9cebd4142813c8da196e32", size = 1097659, upload-time = "2026-08-28T18:27:08.657Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/45/8d3deb343ce714a9c0f1eef76027cdd52a6e718373c71a13b7f0db494c09/b123d_recognisers-0.4.2-py3-none-any.whl", hash = "sha256:ac306d0451e23574792c4f8a6b2d9273784775a8d99aaf976684ee8eafe97401", size = 333103, upload-time = "2026-08-27T10:02:59.783Z" },
+    { url = "https://files.pythonhosted.org/packages/40/13/c88a4959c86c18f855e9edd893e66ace23dc2b95342611f7dbed90a562e8/b123d_recognisers-0.4.5-py3-none-any.whl", hash = "sha256:3c170a5123cc09566100eed797eab783fe1a3c5de45f2c723094b566204ce16a", size = 351440, upload-time = "2026-08-28T18:27:07.374Z" },
 ]
 
 [[package]]
@@ -746,7 +746,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "antlr4-python3-runtime", specifier = "<4.10" },
-    { name = "b123d-recognisers", specifier = "==0.4.2" },
+    { name = "b123d-recognisers", specifier = "==0.4.5" },
     { name = "build123d", marker = "python_full_version < '3.13'", specifier = ">=0.9.0,<0.11" },
     { name = "build123d", marker = "python_full_version >= '3.13'", specifier = ">=0.11,<0.12" },
     { name = "build123d-drafting-helpers", specifier = ">=0.14.2" },


### PR DESCRIPTION
## Symptom and evidence

- User-visible problem: declared Double-D bore, countersink, chamfer, fillet, and groove reads depended on experimental, root, or family compatibility paths rather than one supported inspection boundary.
- Fixture/reproducer: the installed-wheel, inspection-contract, declared-feature, and structural import suites exercise the immutable 0.4.5 wheel and all five reads.
- Before/after result: Draftwright is pinned to `b123d-recognisers==0.4.5`; the declared reads now come exclusively from `b123d_recognisers.inspection` with unchanged behavior.
- Mutation that makes the guard fail: changing a required signature/schema, cylinder parameter, bevel reason, Double-D member meaning/unit, package/API identity, or protected import module fails the new contract or AST guards.

## Contract and scope

- Smallest contract this change tests: inspection manifest format 1/API major 1 and the exact stable symbol/value subset consumed by declared-feature geometry measurement.
- Relevant ADRs: 0005 and 0007 for ownership/layering; 0011, 0013, and 0015 for declared geometry, the external package contract, and the single IR/compiler waist.
- Explicitly deferred: GeometryGraph, adjacency, correspondence, new recognition families, record adapters, and any layout/rendering/completeness change.

## Validation

- [x] `scripts/pr-check --quick`
- [x] `scripts/pr-check` before final review: 5,162 passed, 5 skipped, 2 expected xfailed; 95.26% total coverage and 100% changed-line coverage
- [x] The named mutations are exercised explicitly by fail-closed compatibility tests
- [x] Declared paths were checked; automatic and generated recognition semantics are unchanged and the full suite passes
- [x] Recognition and repeated-lint behavior are unchanged; no recognition/cache path was modified
- [x] Two independent exact-head reviews report zero blocker, major, minor, or nit findings

## Stop check

- [x] No two consecutive review rounds invalidated the same core association strategy
- [x] The provider prerequisite was split upstream as b123d-recognisers #286/#287 and released immutably in 0.4.5

## Architecture review

The new inspection contract is separate from the recogniser-family capability join. `model/declare.py` remains the ADR 0011 declared front door into the same IR; recognition, caching, planning, placement, layout, rendering, and completeness are untouched. No raw annotation coordinates were introduced.

No new or updated recogniser is required. The previously identified provider contract gap was raised upstream as #286 and delivered by #287 in 0.4.5; no further upstream issue is needed.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/pzfreo/draftwright/blob/main/CLA.md) and agree to it. If I am contributing on behalf of an organisation, I am authorised to agree on its behalf.

Closes #1362