### PR TITLE
Make recognised passages fail visibly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@
 
 ### Changed
 
+- Recognised prismatic passages now fail visibly instead of disappearing into an unscored
+  inventory. Each authoritative `SectionPassage` produces an actionable warning and an
+  `unsupported` completeness outcome; the legacy `Passage` compatibility projection is never
+  double-counted. Draftwright retains the family-level unsupported disposition rather than
+  claiming a regular-polygon callout represents the provider's complete line/arc schema (#1245).
+
 - Declared Double-D bore, countersink, chamfer, fillet, and groove geometry reads now use the
   stable `b123d_recognisers.inspection` namespace from the exact 0.4.5 wheel. A separate
   Draftwright-owned format-1 contract fails closed on changes to the consumed signatures, result

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -80,9 +80,10 @@ The installed `b123d-recognisers==0.4.5` release contains the `passages` family 
 in 0.2.6. Version 0.4.0 makes `SectionPassage` the authoritative physical output and retains
 schema-v1 `Passage` as its compatibility projection. Draftwright declares all six public and nested
 record schemas exhaustively but deliberately keeps the family `unsupported`, with the drafting
-decision tracked by issue #1245. This is a truthful consumer disposition: both aggregate
-inventories are visible and explicitly unscored, while Draftwright does not invent an IR feature,
-DSL declaration, generated code, drawing annotation, or completeness requirement for them.
+decision recorded by issue #1245. This is a truthful consumer disposition: both aggregate
+inventories remain visible, but only authoritative `section_passages` contributes an explicitly
+`unsupported` completeness requirement. Draftwright does not invent an IR feature, DSL
+declaration, generated code, or drawing annotation for either inventory.
 
 The 0.4 contract is explicit:
 
@@ -94,5 +95,9 @@ The 0.4 contract is explicit:
   unsupported Passage family through `SLOT_SUPERSEDED_BY_PASSAGE`.
 
 The exact 0.4.5 pin, manifest-v2 validator and explicit unsupported inventories make that limitation
-fail-visible rather than silently treating rich passages as supported. Issue #1245 still owns the
-decision about what newly Passage-owned occurrences draw and how they participate in completeness.
+fail-visible rather than silently treating rich passages as supported. Draftwright deliberately
+does not claim that a regular-polygon `HEX … A/F THRU` callout covers the complete line/arc section
+schema. Each authoritative `RecognitionResult.section_passages` occurrence therefore emits
+`passage_requirement_unsupported` at warning severity and contributes an `unsupported` requirement
+to the completeness component. The accepted-only legacy `.passages` projection contributes neither
+a second issue nor a second requirement. Issue #1245 records this consumer decision.

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -101,6 +101,7 @@ from draftwright.linting import (
     lint_flat_coverage,
     lint_hole_coverage,
     lint_location_coverage,
+    lint_passage_coverage,
     lint_pmi_extraction,
     lint_pmi_ignored,
     lint_pmi_lowering,
@@ -172,6 +173,7 @@ _GEOMETRY_AWARE_CODES = frozenset(
         "feature_not_located",
         "feature_no_centermark",
         "pad_footprint_not_defined",
+        "passage_requirement_unsupported",
         "pocket_not_located",
         "unrecognised_defining_geometry",
         "pmi_not_lowered",
@@ -3409,6 +3411,7 @@ class Drawing:
                 features=getattr(model, "features", ()) if model is not None else (),
                 recognition=recognition,
             )
+            issues += lint_passage_coverage(recognition)
             resolved_assembly = self.assembly
             if resolved_assembly is None:
                 resolved_assembly = len(self.part.solids()) > 1
@@ -3422,6 +3425,7 @@ class Drawing:
                     lint_principal_profile_coverage(
                         self.part,
                         assembly=resolved_assembly,
+                        section_passages=recognition.section_passages,
                     )
                 )
                 profile_cache = (self.part, resolved_assembly, profile_issues)

--- a/src/draftwright/linting/__init__.py
+++ b/src/draftwright/linting/__init__.py
@@ -37,6 +37,7 @@ from draftwright.linting.flat_coverage import lint_flat_coverage
 from draftwright.linting.gear_coverage import lint_declared_gear_coverage
 from draftwright.linting.hole_coverage import lint_hole_coverage
 from draftwright.linting.issues import LintIssue
+from draftwright.linting.passage_coverage import lint_passage_coverage
 from draftwright.linting.pmi_coverage import (
     lint_pmi_extraction,
     lint_pmi_ignored,
@@ -71,6 +72,7 @@ __all__ = [
     "lint_declared_gear_coverage",
     "lint_slot_coverage",
     "lint_location_coverage",
+    "lint_passage_coverage",
     "lint_pmi_ignored",
     "lint_pmi_extraction",
     "lint_pmi_lowering",

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -606,20 +606,109 @@ def _pair_covers(
     )
 
 
+def _passage_matches_principal_wire(
+    passage,
+    wire,
+    axis: str,
+    plane_axes: tuple[str, str],
+    at: float,
+    tol: float,
+) -> bool:
+    """Whether *wire* is an endpoint of this authoritative Passage record.
+
+    Matching the endpoint geometry, rather than merely noticing that the part has some
+    Passage, lets the specific Passage diagnostic replace the generic profile diagnostic
+    without hiding an unrelated unsupported opening on the same part.
+    """
+
+    try:
+        frame = passage.frame
+        run = tuple(float(value) for value in frame.run)
+        axis_i = "xyz".index(axis)
+        if abs(abs(run[axis_i]) - 1.0) > tol or any(
+            abs(value) > tol for i, value in enumerate(run) if i != axis_i
+        ):
+            return False
+        matching_run = next(
+            (
+                float(run_at)
+                for run_at in passage.run_interval
+                if abs(float(frame.origin[axis_i]) + run[axis_i] * float(run_at) - at)
+                <= max(8 * tol, 1e-3)
+            ),
+            None,
+        )
+        if matching_run is None:
+            return False
+        boundary = tuple(passage.section.boundary)
+        vertices = tuple(wire.vertices())
+        edges = tuple(wire.edges())
+        if len(boundary) != len(vertices) or not boundary:
+            return False
+        if any(edge.geom_type not in (GeomType.LINE, GeomType.CIRCLE) for edge in edges):
+            return False
+        expected_arcs = sum(abs(float(vertex.bulge)) > tol for vertex in boundary)
+        actual_arcs = sum(edge.geom_type == GeomType.CIRCLE for edge in edges)
+        if expected_arcs != actual_arcs:
+            return False
+
+        expected: list[tuple[float, float]] = []
+        for vertex in boundary:
+            section_u, section_v = (float(value) for value in vertex.point)
+            world = tuple(
+                float(frame.origin[i])
+                + run[i] * matching_run
+                + float(frame.u[i]) * section_u
+                + float(frame.v[i]) * section_v
+                for i in range(3)
+            )
+            expected.append(
+                (
+                    world["xyz".index(plane_axes[0])],
+                    world["xyz".index(plane_axes[1])],
+                )
+            )
+        actual = [
+            tuple(float(getattr(vertex, name.upper())) for name in plane_axes)
+            for vertex in vertices
+        ]
+    except (AttributeError, TypeError, ValueError):
+        return False
+
+    match_tol = max(8 * tol, 1e-3)
+    unmatched = list(actual)
+    for point in expected:
+        match = next(
+            (
+                i
+                for i, candidate in enumerate(unmatched)
+                if all(abs(a - b) <= match_tol for a, b in zip(point, candidate, strict=True))
+            ),
+            None,
+        )
+        if match is None:
+            return False
+        unmatched.pop(match)
+    return not unmatched
+
+
 def _supported_inner_profile(
     wire,
     plane_axes: tuple[str, str],
     tol: float,
     *,
     axis: str | None = None,
+    at: float | None = None,
     double_d_bores=(),
+    section_passages=(),
     profile=_UNSET,
 ) -> bool:
-    """Whether an inner boundary loop has a profile the current IR can describe.
+    """Whether an inner boundary loop has a specific semantic owner.
 
     Circular holes, axis-aligned rectangles, true obrounds and proven double-D bores are the
-    supported principal opening vocabulary. The double-D correspondence is delegated to its
-    recogniser's profile reader, so critique cannot accept a shape the IR then omits.
+    supported principal opening vocabulary. An authoritative SectionPassage is also accounted
+    for, but remains unsupported and is reported by ``lint_passage_coverage``. The explicit
+    endpoint match prevents that specific diagnostic from silencing an unrelated profile.
     """
     edges = list(wire.edges())
     if not edges:
@@ -627,6 +716,15 @@ def _supported_inner_profile(
     types = [edge.geom_type for edge in edges]
     wbb = wire.bounding_box()
     ext = {axis: float(getattr(wbb.size, axis.upper())) for axis in plane_axes}
+    if (
+        axis is not None
+        and at is not None
+        and any(
+            _passage_matches_principal_wire(passage, wire, axis, plane_axes, at, tol)
+            for passage in section_passages
+        )
+    ):
+        return True
     profile = double_d_profile(wire, plane_axes, tol=tol) if profile is _UNSET else profile
     if profile is not None and axis is not None:
         axis_i = "xyz".index(axis)
@@ -808,7 +906,7 @@ def _supported_inner_profile(
     return arcs_match(expected, pi * radius / 2.0)
 
 
-def _has_unsupported_principal_inner_profile(part, bbox) -> bool:
+def _has_unsupported_principal_inner_profile(part, bbox, *, section_passages=()) -> bool:
     """Does a principal extremal face prove an internal profile outside the IR vocabulary?"""
     part_extent = (float(bbox.size.X), float(bbox.size.Y), float(bbox.size.Z))
     tol = max(1e-5, max(part_extent) * 1e-5)
@@ -821,7 +919,7 @@ def _has_unsupported_principal_inner_profile(part, bbox) -> bool:
         axis, plane_axes, at = boundary
         for wire in face.inner_wires():
             profile = double_d_profile(wire, plane_axes, tol=tol)
-            wires.append((axis, plane_axes, wire, profile))
+            wires.append((axis, plane_axes, at, wire, profile))
             if profile is not None:
                 openings.append((axis, at, profile, wire))
     double_d_bores = double_d_bores_from_openings(openings, bbox, part=part, tol=tol)
@@ -831,10 +929,12 @@ def _has_unsupported_principal_inner_profile(part, bbox) -> bool:
             plane_axes,
             tol,
             axis=axis,
+            at=at,
             double_d_bores=double_d_bores,
+            section_passages=section_passages,
             profile=profile,
         )
-        for axis, plane_axes, wire, profile in wires
+        for axis, plane_axes, at, wire, profile in wires
     )
 
 
@@ -897,19 +997,26 @@ def _radial_outer_arc_count(part, bbox) -> int | None:
     return best
 
 
-def lint_principal_profile_coverage(part, *, assembly=None) -> list:
+def lint_principal_profile_coverage(part, *, assembly=None, section_passages=()) -> list:
     """Report principal inner or outer profiles outside the current feature vocabulary.
 
     The scan owns its physical extent: there is deliberately no caller-supplied bounding box
     that could narrow the answer. The double-D correspondence is the recogniser's shared pure
-    correspondence proof over openings collected during this scan; lint accepts no foreign
-    aggregate nor reruns a public recogniser. :class:`Drawing` caches the returned issues
-    against the source part identity so repeated lint does not rescan the B-rep.
+    correspondence proof over openings collected during this scan; lint reruns no public
+    recogniser. ``section_passages`` is the explicit projection of the drawing's cached
+    authoritative result used only to replace a matched generic profile finding with the
+    specific unsupported-Passage finding. :class:`Drawing` caches the returned issues against
+    the source part identity so repeated lint does not rescan the B-rep.
     """
     solids = list(part.solids())
     sources = solids if len(solids) > 1 else [part]
     unsupported_inner = any(
-        _has_unsupported_principal_inner_profile(solid, solid.bounding_box()) for solid in sources
+        _has_unsupported_principal_inner_profile(
+            solid,
+            solid.bounding_box(),
+            section_passages=section_passages,
+        )
+        for solid in sources
     )
     radial_arc_count = max(
         (

--- a/src/draftwright/linting/passage_coverage.py
+++ b/src/draftwright/linting/passage_coverage.py
@@ -1,0 +1,38 @@
+"""Explicit completeness disposition for recognised prismatic passages (#1245)."""
+
+from __future__ import annotations
+
+from draftwright.linting.issues import LintIssue
+
+
+def lint_passage_coverage(recognition) -> list[LintIssue]:
+    """Report every authoritative Passage occurrence as unsupported.
+
+    ``RecognitionResult.section_passages`` is the package's counted physical authority.
+    The legacy ``.passages`` inventory is only a compatibility projection and must not be
+    reported a second time.  A Passage remains outside the Draftwright IR until one drawing
+    contract can truthfully represent the provider's complete line/arc section vocabulary.
+    """
+
+    passages = tuple(getattr(recognition, "section_passages", ()))
+    total = len(passages)
+    issues: list[LintIssue] = []
+    for ordinal, passage in enumerate(passages, start=1):
+        side_count = len(passage.section.boundary)
+        qualifier = f"{side_count}-edge " if side_count else ""
+        issues.append(
+            LintIssue(
+                severity="warning",
+                code="passage_requirement_unsupported",
+                message=(
+                    f"recognised {qualifier}prismatic through-opening "
+                    f"({ordinal} of {total}) is not represented by Draftwright dimensions; "
+                    "review and define its manufacturing section outside automatic drawing "
+                    "approval"
+                ),
+            )
+        )
+    return issues
+
+
+__all__ = ["lint_passage_coverage"]

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -13,9 +13,9 @@ them into another blessed scalar:
   pair observations from one annotation and failure mechanism;
 - restraint fails closed until measurement provenance can classify every annotation.
 
-Completeness is deliberately marked partial.  Only the feature families with a semantic
-``*_outcomes`` ledger participate today; warning counts and declared IR are never substituted
-for the missing physical denominator.
+Completeness is deliberately marked partial. Only feature families with a semantic
+``*_outcomes`` ledger or an explicitly audited unsupported outcome participate today; warning
+counts and declared IR are never substituted for the missing physical denominator.
 
 Its scalar is therefore named ``audited_score``, not ``score``.  A part reaches 1.0 whenever
 every requirement recognition *did* identify was placed or explicitly satisfied by structured
@@ -46,6 +46,7 @@ _OUTCOME_STATES = (
     "dropped",
     "missing",
     "unverifiable",
+    "unsupported",
 )
 
 # Structural diagnostics that describe whether the composed sheet remains readable. Placement
@@ -107,6 +108,9 @@ _RECOGNISED_REQUIREMENT_FAMILIES = {
     "turned_steps": "turned_steps",
     "chamfers": "chamfers",
     "fillets": "fillets",
+    # The rich aggregate is the sole physical Passage authority. The legacy
+    # ``passages`` projection is classified below as non-requirement compatibility data.
+    "section_passages": "passages",
 }
 
 # Inventories that are deliberately NOT requirement families: the substrates would list the
@@ -120,7 +124,16 @@ _RECOGNISED_REQUIREMENT_FAMILIES = {
 #: raw geometry, classification flags, evidence aggregated into another feature. Permanent by
 #: design, not pending a decision.
 _NON_REQUIREMENT_INVENTORIES = frozenset(
-    {"countersinks", "cylinders", "plates", "risers", "rotational", "step_levels"}
+    {
+        "countersinks",
+        "cylinders",
+        # Accepted-only compatibility projection of authoritative ``section_passages``.
+        "passages",
+        "plates",
+        "risers",
+        "rotational",
+        "step_levels",
+    }
 )
 
 #: Inventories the installed package proves and this consumer has not decided about, each with
@@ -129,12 +142,11 @@ _NON_REQUIREMENT_INVENTORIES = frozenset(
 #: merging them would let an undecided family look settled (#1244).
 #:
 #: The effect on the score is deliberate and worth stating: a drawing that omits a recognised
-#: passage, prismatic pocket or angled step scores complete today. That is a blind spot — the
-#: register is what stops it being a silent one, and closing each issue closes the gap.
+#: prismatic pocket or angled step scores complete today. That is a blind spot — the register is
+#: what stops it being a silent one, and closing each issue closes the gap. Passage left this
+#: register when #1245 gave every authoritative occurrence an unsupported outcome.
 _UNDECIDED_INVENTORIES: dict[str, str] = {
     "angled_steps": "https://github.com/pzfreo/draftwright/issues/1247",
-    "passages": "https://github.com/pzfreo/draftwright/issues/1245",
-    "section_passages": "https://github.com/pzfreo/draftwright/issues/1245",
     "prismatic_pockets": "https://github.com/pzfreo/draftwright/issues/1246",
 }
 
@@ -143,6 +155,7 @@ _AUDITED_FAMILIES = (
     "flats",
     "hole_patterns",
     "holes",
+    "passages",
     "polygonal_stock",
     "slot_patterns",
     "slots",
@@ -284,6 +297,7 @@ _UNSCORED_CODES = frozenset(
         "pmi_present_but_ignored",
         "step_dim_withheld",
         "pattern_pitch_tolerance_withheld",
+        "passage_requirement_unsupported",
         "pocket_not_located",
         "step_position_coincident_with_datum",
         # Neither confirmed nor refuted: the annotation renders no readable text, or the
@@ -585,6 +599,13 @@ def _completeness_component(recognition, features, registry, omissions, issues) 
             counts[outcome.state] += requirement_count
             family_count += requirement_count
         by_family[family] = family_count
+    # A recognised Passage is dimension-relevant physical evidence with an explicit
+    # unsupported outcome. Count only the authoritative rich inventory; the accepted-only
+    # legacy projection may contain the same occurrences and is never a second requirement.
+    passage_count = len(getattr(recognition, "section_passages", ()))
+    if passage_count:
+        counts["unsupported"] += passage_count
+        by_family["passages"] = passage_count
     requirements = sum(counts.values())
     recognised = {
         family

--- a/src/draftwright/recogniser_contract.py
+++ b/src/draftwright/recogniser_contract.py
@@ -208,10 +208,11 @@ def _geometry_only_declaration() -> dict[str, Any]:
     }
 
 
-#: Families the installed package proves and Draftwright has taken NO position on yet, each with
-#: the issue where that position is being decided. Not a parking bay: a family sits here only
-#: while a decision is genuinely open, and `pending_family_declarations` still reports anything
-#: absent from BOTH this map and `_FAMILIES`, so the next new family fails closed exactly as
+#: Families the installed package proves but Draftwright does not fully support, each with the
+#: issue recording its consumer disposition. Not a parking bay: an undecided family must still
+#: have a live decision issue, while a settled unsupported boundary must carry an explicit
+#: outcome such as Passage completeness below. ``pending_family_declarations`` reports anything
+#: absent from BOTH this map and ``_FAMILIES``, so the next new family fails closed exactly as
 #: these three did (#1244).
 _UNSUPPORTED: dict[str, tuple[tuple[str, ...], str, str]] = {
     "passages": (
@@ -224,9 +225,10 @@ _UNSUPPORTED: dict[str, tuple[tuple[str, ...], str, str]] = {
             "SectionPassage",
         ),
         "https://github.com/pzfreo/draftwright/issues/1245",
-        "A prismatic through-opening — the internal counterpart to polygonal stock. Whether it "
-        "becomes an IR kind or refines `hole`, and what a passage draws (across-flats + THRU, or "
-        "a section), are drafting decisions this consumer has not made.",
+        "A prismatic through-opening — the internal counterpart to polygonal stock. The rich "
+        "record permits arbitrary line/arc sections, so treating its regular-polygon subset as "
+        "a supported IR feature or HEX callout would overstate the drawing contract. Draftwright "
+        "therefore reports every occurrence as an unsupported completeness requirement.",
     ),
     "prismatic-pockets": (
         ("PrismaticPocket",),
@@ -247,16 +249,30 @@ _UNSUPPORTED: dict[str, tuple[tuple[str, ...], str, str]] = {
 
 
 def _unsupported_declaration(family_id: str) -> dict[str, Any]:
-    """A family the package proves and this consumer has not decided about.
+    """A family the package proves and this consumer does not fully support.
 
-    Every boundary is `unsupported` with the same rationale, and `completeness` is `deferred`
-    with the tracking issue — so the inventory is visible (`RecognitionResult` carries it, the
-    manifest joins) while nothing scores it. That is the honest position: scoring a family whose
-    drafting meaning is undecided would either invent a requirement or, for `prismatic-pockets`,
-    count one physical recess twice.
+    Drafting boundaries remain ``unsupported``. Completeness stays ``deferred`` while its meaning
+    is undecided, except where a reviewed consumer decision defines an explicit unsupported
+    outcome. That distinction keeps the inventory visible without inventing drafting semantics or,
+    for ``prismatic-pockets``, counting one physical recess twice.
     """
     records, tracking, rationale = _UNSUPPORTED[family_id]
     unsupported = {"state": "unsupported", "rationale": rationale}
+    completeness = (
+        {
+            "state": "unsupported",
+            "rationale": (
+                "Every authoritative SectionPassage occurrence produces a warning and an "
+                "unsupported completeness outcome; no drafting requirement is invented."
+            ),
+        }
+        if family_id == "passages"
+        else {
+            "state": "deferred",
+            "rationale": rationale,
+            "tracking": tracking,
+        }
+    )
     return {
         "id": family_id,
         "record_schemas": _record_schema_versions(family_id, records),
@@ -267,11 +283,7 @@ def _unsupported_declaration(family_id: str) -> dict[str, Any]:
         "dsl_declaration": copy.deepcopy(unsupported),
         "generated_code": copy.deepcopy(unsupported),
         "drawing_consumer": copy.deepcopy(unsupported),
-        "completeness": {
-            "state": "deferred",
-            "rationale": rationale,
-            "tracking": tracking,
-        },
+        "completeness": completeness,
         "documentation": {
             "state": "supported",
             "evidence": ["docs/reference/recogniser-capabilities.md"],
@@ -295,7 +307,20 @@ def consumer_capability_declaration() -> dict[str, Any]:
             "manifest_format": 2,
         },
         "families": families,
-        "transitions": [],
+        "transitions": [
+            {
+                "boundary": "completeness",
+                "compatibility_evidence": [
+                    "tests/test_issue_1245_passage_disposition.py",
+                    "tests/test_recogniser_capabilities.py",
+                ],
+                "family": "passages",
+                "from": "deferred",
+                "release_notes": "CHANGELOG.md",
+                "to": "unsupported",
+                "version": distribution_version("draftwright"),
+            }
+        ],
     }
 
 

--- a/tests/test_issue_1058_wheel_profile.py
+++ b/tests/test_issue_1058_wheel_profile.py
@@ -592,7 +592,7 @@ def test_edge_types_alone_do_not_certify_a_supported_profile(part):
     issues = [
         issue
         for issue in build_drawing(part).lint()
-        if issue.code == "unrecognised_defining_geometry"
+        if issue.code in {"passage_requirement_unsupported", "unrecognised_defining_geometry"}
     ]
     assert len(issues) == 1
 

--- a/tests/test_issue_1245_passage_disposition.py
+++ b/tests/test_issue_1245_passage_disposition.py
@@ -1,0 +1,178 @@
+"""#1245: recognised passages fail visibly without invented drafting semantics."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+from b123d_recognisers import build_recognition_result
+from b123d_recognisers.profiled_bores import principal_boundary_plane
+from build123d import Box, GeomType, Pos, RegularPolygon, extrude
+
+from draftwright import build_drawing
+from draftwright.linting.coverage import _passage_matches_principal_wire
+from draftwright.linting.passage_coverage import lint_passage_coverage
+from draftwright.linting.quality import quality_components
+from draftwright.registry import AnnotationRegistry
+
+
+def _hex_passage_part():
+    cutter = extrude(RegularPolygon(6, 6), amount=12, both=True)
+    return Box(40, 40, 10) - cutter
+
+
+def _matched_mouth(part, passage):
+    bbox = part.bounding_box()
+    tol = max(1e-5, max(float(bbox.size.X), float(bbox.size.Y), float(bbox.size.Z)) * 1e-5)
+    for face in part.faces():
+        boundary = principal_boundary_plane(face, bbox)
+        if boundary is None:
+            continue
+        axis, plane_axes, at = boundary
+        for wire in face.inner_wires():
+            if _passage_matches_principal_wire(passage, wire, axis, plane_axes, at, tol):
+                return wire, axis, plane_axes, at, tol
+    raise AssertionError("fixture has no principal mouth matching its Passage record")
+
+
+def test_a_recognised_passage_is_specific_actionable_and_non_info() -> None:
+    part = _hex_passage_part()
+    recognition = build_recognition_result(part)
+    drawing = build_drawing(part)
+
+    assert len(recognition.section_passages) == 1
+    assert len(recognition.passages) == 1, "precondition: legacy projection exists"
+    issues = drawing.lint()
+
+    assert [issue.code for issue in issues] == ["passage_requirement_unsupported"]
+    assert issues[0].severity == "warning"
+    assert "recognised 6-edge prismatic through-opening (1 of 1)" in issues[0].message
+    assert "outside automatic drawing approval" in issues[0].message
+    summary = drawing.lint_summary()
+    assert summary["warnings"] == summary["geometry_issues"] == 1
+    assert summary["quality"]["completeness"]["unrecognised_geometry_reports"] == 0
+
+
+def test_a_passage_does_not_hide_an_unrelated_unsupported_inner_profile() -> None:
+    through = Pos(-10, 0, 0) * extrude(RegularPolygon(3, 6), amount=12, both=True)
+    blind = Pos(10, 0, 2) * extrude(RegularPolygon(3, 5), amount=4)
+    part = Box(40, 40, 10) - through - blind
+    recognition = build_recognition_result(part)
+
+    assert len(recognition.section_passages) == 1
+    codes = [issue.code for issue in build_drawing(part).lint()]
+    assert codes.count("passage_requirement_unsupported") == 1
+    assert codes.count("unrecognised_defining_geometry") == 1
+
+
+@pytest.mark.parametrize(
+    "case",
+    (
+        "non_principal_run",
+        "no_endpoint_on_face",
+        "boundary_cardinality",
+        "unsupported_edge",
+        "arc_cardinality",
+        "malformed_record",
+        "vertex_mismatch",
+    ),
+)
+def test_passage_profile_correlation_fails_closed(case: str) -> None:
+    part = _hex_passage_part()
+    passage = build_recognition_result(part).section_passages[0]
+    wire, axis, plane_axes, at, tol = _matched_mouth(part, passage)
+    candidate = passage
+    candidate_wire = wire
+
+    if case == "non_principal_run":
+        candidate = SimpleNamespace(
+            frame=SimpleNamespace(
+                origin=passage.frame.origin,
+                run=(0.1, 0.0, 1.0),
+                u=passage.frame.u,
+                v=passage.frame.v,
+            ),
+            run_interval=passage.run_interval,
+            section=passage.section,
+        )
+    elif case == "no_endpoint_on_face":
+        candidate = SimpleNamespace(
+            frame=passage.frame,
+            run_interval=(100.0, 110.0),
+            section=passage.section,
+        )
+    elif case == "boundary_cardinality":
+        candidate = SimpleNamespace(
+            frame=passage.frame,
+            run_interval=passage.run_interval,
+            section=SimpleNamespace(boundary=passage.section.boundary[:-1]),
+        )
+    elif case == "unsupported_edge":
+        candidate_wire = SimpleNamespace(
+            vertices=wire.vertices,
+            edges=lambda: (
+                [SimpleNamespace(geom_type=GeomType.ELLIPSE)] * len(passage.section.boundary)
+            ),
+        )
+    elif case == "arc_cardinality":
+        boundary = list(passage.section.boundary)
+        boundary[0] = SimpleNamespace(point=boundary[0].point, bulge=1.0)
+        candidate = SimpleNamespace(
+            frame=passage.frame,
+            run_interval=passage.run_interval,
+            section=SimpleNamespace(boundary=boundary),
+        )
+    elif case == "malformed_record":
+        candidate = object()
+    elif case == "vertex_mismatch":
+        boundary = list(passage.section.boundary)
+        boundary[0] = SimpleNamespace(point=(100.0, 100.0), bulge=boundary[0].bulge)
+        candidate = SimpleNamespace(
+            frame=passage.frame,
+            run_interval=passage.run_interval,
+            section=SimpleNamespace(boundary=boundary),
+        )
+
+    assert not _passage_matches_principal_wire(
+        candidate,
+        candidate_wire,
+        axis,
+        plane_axes,
+        at,
+        tol,
+    )
+
+
+def test_a_passage_is_an_explicit_unsupported_completeness_outcome() -> None:
+    completeness = build_drawing(_hex_passage_part()).lint_summary()["quality"]["completeness"]
+
+    assert completeness["available"] is True
+    assert completeness["audited_score"] == 0.0
+    assert completeness["requirements"] == 1
+    assert completeness["unsupported"] == 1
+    assert completeness["by_family"]["passages"] == 1
+    assert "passages" not in completeness["unscored_recognized_families"]
+
+
+def test_only_the_authoritative_rich_inventory_contributes_a_requirement() -> None:
+    recognition = build_recognition_result(_hex_passage_part())
+    assert recognition.section_passages and recognition.passages
+    legacy_only = replace(recognition, section_passages=())
+
+    assert lint_passage_coverage(legacy_only) == []
+
+    completeness = quality_components(
+        recognition=legacy_only,
+        features=(),
+        registry=AnnotationRegistry(),
+        omissions=(),
+        issues=(),
+        error_penalty=0.15,
+        warning_penalty=0.05,
+        has_asserted_content=False,
+    )["completeness"]
+
+    assert completeness["requirements"] == 0
+    assert completeness["unsupported"] == 0
+    assert completeness["by_family"].get("passages", 0) == 0

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -125,7 +125,7 @@ def test_installed_package_contract_validates_without_a_sibling_checkout() -> No
     assert len(package["families"]) == len(declaration["families"]) == 25
 
 
-def test_rich_passage_contract_is_truthfully_deferred_with_its_projection() -> None:
+def test_rich_passage_contract_has_an_explicit_unsupported_completeness_outcome() -> None:
     """Pin the 0.4 physical record and compatibility projection to one decision."""
 
     assert INSTALLED_PACKAGE_VERSION == "0.4.5"
@@ -137,6 +137,7 @@ def test_rich_passage_contract_is_truthfully_deferred_with_its_projection() -> N
     passage_consumer = declaration["passages"]
 
     assert passage_package["introduced_in"] == "0.2.6"
+    assert passage_package["census_output"] == "RecognitionResult.section_passages"
     assert len(passage_package["records"]) == 6
     passage_record = next(
         record for record in passage_package["records"] if record["name"] == "Passage"
@@ -145,6 +146,11 @@ def test_rich_passage_contract_is_truthfully_deferred_with_its_projection() -> N
     assert passage_record["role"] == "projection"
     assert passage_record["schema_version"] == 1
     assert passage_record["aggregate_membership"] == ["RecognitionResult.passages"]
+    section_record = next(
+        record for record in passage_package["records"] if record["name"] == "SectionPassage"
+    )
+    assert section_record["role"] == "output"
+    assert section_record["aggregate_membership"] == ["RecognitionResult.section_passages"]
     assert passage_consumer["record_schemas"] == {
         "Passage": [1],
         "PassageEnds": [1],
@@ -164,12 +170,32 @@ def test_rich_passage_contract_is_truthfully_deferred_with_its_projection() -> N
             "drawing_consumer",
         )
     } == {"unsupported"}
-    assert passage_consumer["completeness"]["state"] == "deferred"
+    assert passage_consumer["completeness"] == {
+        "state": "unsupported",
+        "rationale": (
+            "Every authoritative SectionPassage occurrence produces a warning and an "
+            "unsupported completeness outcome; no drafting requirement is invented."
+        ),
+    }
     assert passage_consumer["documentation"] == {
         "state": "supported",
         "evidence": ["docs/reference/recogniser-capabilities.md"],
     }
     assert "passages" not in pending_family_declarations()
+    assert consumer_capability_declaration()["transitions"] == [
+        {
+            "boundary": "completeness",
+            "compatibility_evidence": [
+                "tests/test_issue_1245_passage_disposition.py",
+                "tests/test_recogniser_capabilities.py",
+            ],
+            "family": "passages",
+            "from": "deferred",
+            "release_notes": "CHANGELOG.md",
+            "to": "unsupported",
+            "version": importlib.metadata.version("draftwright"),
+        }
+    ]
 
 
 def test_runtime_adapter_inventory_is_derived_independently_and_exhaustive() -> None:


### PR DESCRIPTION
## Outcome

Closes #1245.

Draftwright now treats every authoritative `RecognitionResult.section_passages` occurrence as an explicit unsupported drawing requirement instead of allowing it to disappear into an unscored inventory.

- emits one actionable `passage_requirement_unsupported` warning per physical Passage
- replaces the generic unsupported-profile warning only when its endpoint geometry correlates to that Passage, while preserving generic findings for unrelated profiles
- records each occurrence as `unsupported` in completeness and as a structured geometry issue
- never double-counts the legacy accepted-only `.passages` projection
- keeps the family unsupported instead of claiming a regular-polygon callout covers the provider's arbitrary line/arc section schema
- records the deferred → unsupported capability transition and documents the decision

No recogniser or recogniser API change is required.

## Verification

- `scripts/pr-check --static`
- `uv run pytest tests/ -n auto --dist loadscope --durations=25`
  - 5,173 passed, 5 skipped, 2 xfailed
- fail-closed correlation branches covered for malformed axes/endpoints, boundary and arc cardinality, unsupported edges, malformed records, and vertex mismatch

## ADR review

- ADR 0011: no partial IR kind is introduced without a declaration and generated-code round trip
- ADR 0013: geometry proof remains provider-owned; drafting disposition remains consumer-owned
- ADR 0015: lint reads the cached authoritative aggregate and does not rescan recognition
- ADR 0016: recognised intent neither vanishes silently nor becomes an invented drafting claim
- ADR 0017: `section_passages` is the sole physical authority and completeness is independent of annotation-plan success
- ADR 0004/0014: no raw annotation or placement path is introduced
