### PR TITLE
Handle unsupported prismatic pockets explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,11 @@
 
 ### Changed
 
+- Aggregate-reconciled `PrismaticPocket` occurrences now fail visibly instead of
+  remaining an unscored inventory. Each produces an actionable warning and one `unsupported`
+  completeness outcome, without repeating the provider's cross-family reconciliation or
+  inventing width/length, across-flats, IR, Sheet, generated-code, or annotation semantics (#1246).
+
 - Recognised prismatic passages now fail visibly instead of disappearing into an unscored
   inventory. Each authoritative `SectionPassage` produces an actionable warning and an
   `unsupported` completeness outcome; the legacy `Passage` compatibility projection is never

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -74,6 +74,24 @@ pass.
 reference: it remains geometry-only critique evidence for a separately authored gear declaration,
 with no inferred gear feature added to fill the table.
 
+## Prismatic-pocket boundary
+
+The installed aggregate reconciles the two pocket inventories before Draftwright sees them. A
+candidate reported by both direct recognisers yields to the supported `Pocket` record;
+`RecognitionResult.prismatic_pockets` therefore contains occurrences not owned by `Pocket`.
+Draftwright consumes that aggregate policy and does not repeat provider reconciliation. This is an
+ownership statement, not a shape classification: for example, a rotated four-sided recess can
+remain a `PrismaticPocket` when the axis-paired `Pocket` recogniser does not accept it.
+
+The remaining `PrismaticPocket.section` may be any planar polygon. The rectangular pocket grammar
+`W × L × D DEEP` is false for a triangle, while an across-flats callout applies only to selected
+regular polygons and cannot represent the general record. Draftwright therefore retains the family
+disposition as `unsupported`: it creates no inferred IR feature, Sheet declaration, generated code,
+or drawing annotation. Each aggregate occurrence instead emits
+`prismatic_pocket_requirement_unsupported` at warning severity and contributes one `unsupported`
+completeness requirement. Exact mouth-to-section correlation replaces the generic unsupported-
+profile warning only for that occurrence, so an unrelated unrecognised profile remains visible.
+
 ## Passage compatibility boundary
 
 The installed `b123d-recognisers==0.4.5` release contains the `passages` family introduced

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -109,6 +109,7 @@ from draftwright.linting import (
     lint_polygonal_stock_coverage,
     lint_principal_profile_coverage,
     lint_prismatic_coverage,
+    lint_prismatic_pocket_coverage,
     lint_profiled_bore_coverage,
     lint_slot_coverage,
     pmi_stage_summary,
@@ -174,6 +175,7 @@ _GEOMETRY_AWARE_CODES = frozenset(
         "feature_no_centermark",
         "pad_footprint_not_defined",
         "passage_requirement_unsupported",
+        "prismatic_pocket_requirement_unsupported",
         "pocket_not_located",
         "unrecognised_defining_geometry",
         "pmi_not_lowered",
@@ -3412,6 +3414,7 @@ class Drawing:
                 recognition=recognition,
             )
             issues += lint_passage_coverage(recognition)
+            issues += lint_prismatic_pocket_coverage(recognition)
             resolved_assembly = self.assembly
             if resolved_assembly is None:
                 resolved_assembly = len(self.part.solids()) > 1
@@ -3425,6 +3428,7 @@ class Drawing:
                     lint_principal_profile_coverage(
                         self.part,
                         assembly=resolved_assembly,
+                        prismatic_pockets=recognition.prismatic_pockets,
                         section_passages=recognition.section_passages,
                     )
                 )

--- a/src/draftwright/linting/__init__.py
+++ b/src/draftwright/linting/__init__.py
@@ -46,6 +46,7 @@ from draftwright.linting.pmi_coverage import (
     pmi_stage_summary,
 )
 from draftwright.linting.polygonal_stock_coverage import lint_polygonal_stock_coverage
+from draftwright.linting.prismatic_pocket_coverage import lint_prismatic_pocket_coverage
 from draftwright.linting.profiled_bore_coverage import lint_profiled_bore_coverage
 from draftwright.linting.slot_coverage import lint_slot_coverage
 from draftwright.linting.structural import is_dimension_like, lint_drawing
@@ -61,6 +62,7 @@ __all__ = [
     "verify_measurement_claims",
     "lint_hole_coverage",
     "lint_polygonal_stock_coverage",
+    "lint_prismatic_pocket_coverage",
     "_suggest_fix",
     "lint_axial_coverage",
     "lint_boss_height_coverage",

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -692,6 +692,67 @@ def _passage_matches_principal_wire(
     return not unmatched
 
 
+def _prismatic_pocket_matches_principal_wire(
+    pocket,
+    wire,
+    axis: str,
+    plane_axes: tuple[str, str],
+    at: float,
+    tol: float,
+) -> bool:
+    """Whether *wire* is the open mouth of *pocket* on this principal face.
+
+    ``PrismaticPocket.section`` is expressed in the two non-depth axes, in axis order.  The
+    aggregate has already removed candidates also owned by ``Pocket``; this correlation
+    only replaces the generic unsupported-profile report for the exact surviving polygonal
+    recess.  It does not perform cross-family reconciliation itself.
+    """
+
+    try:
+        if pocket.axis != axis:
+            return False
+        axis_i = "xyz".index(axis)
+        open_sign = int(pocket.open_sign)
+        if open_sign not in (-1, 1):
+            return False
+        mouth = float(pocket.at[axis_i]) + open_sign * float(pocket.depth) / 2
+        match_tol = max(8 * tol, 1e-3)
+        if abs(mouth - at) > match_tol:
+            return False
+        section = tuple(tuple(float(value) for value in point) for point in pocket.section)
+        vertices = tuple(wire.vertices())
+        edges = tuple(wire.edges())
+        if (
+            not section
+            or int(pocket.sides) != len(section)
+            or len(section) != len(vertices)
+            or len(edges) != len(section)
+            or any(edge.geom_type != GeomType.LINE for edge in edges)
+        ):
+            return False
+        actual = [
+            tuple(float(getattr(vertex, name.upper())) for name in plane_axes)
+            for vertex in vertices
+        ]
+    except (AttributeError, TypeError, ValueError):
+        return False
+
+    unmatched = list(actual)
+    for point in section:
+        match = next(
+            (
+                i
+                for i, candidate in enumerate(unmatched)
+                if all(abs(a - b) <= match_tol for a, b in zip(point, candidate, strict=True))
+            ),
+            None,
+        )
+        if match is None:
+            return False
+        unmatched.pop(match)
+    return not unmatched
+
+
 def _supported_inner_profile(
     wire,
     plane_axes: tuple[str, str],
@@ -700,15 +761,17 @@ def _supported_inner_profile(
     axis: str | None = None,
     at: float | None = None,
     double_d_bores=(),
+    prismatic_pockets=(),
     section_passages=(),
     profile=_UNSET,
 ) -> bool:
     """Whether an inner boundary loop has a specific semantic owner.
 
     Circular holes, axis-aligned rectangles, true obrounds and proven double-D bores are the
-    supported principal opening vocabulary. An authoritative SectionPassage is also accounted
-    for, but remains unsupported and is reported by ``lint_passage_coverage``. The explicit
-    endpoint match prevents that specific diagnostic from silencing an unrelated profile.
+    supported principal opening vocabulary. Authoritative SectionPassage and aggregate-
+    reconciled PrismaticPocket occurrences are also accounted for, but remain unsupported and
+    are reported by their specific coverage checks. Exact boundary matching prevents either
+    diagnostic from silencing an unrelated profile.
     """
     edges = list(wire.edges())
     if not edges:
@@ -716,6 +779,15 @@ def _supported_inner_profile(
     types = [edge.geom_type for edge in edges]
     wbb = wire.bounding_box()
     ext = {axis: float(getattr(wbb.size, axis.upper())) for axis in plane_axes}
+    if (
+        axis is not None
+        and at is not None
+        and any(
+            _prismatic_pocket_matches_principal_wire(pocket, wire, axis, plane_axes, at, tol)
+            for pocket in prismatic_pockets
+        )
+    ):
+        return True
     if (
         axis is not None
         and at is not None
@@ -906,7 +978,13 @@ def _supported_inner_profile(
     return arcs_match(expected, pi * radius / 2.0)
 
 
-def _has_unsupported_principal_inner_profile(part, bbox, *, section_passages=()) -> bool:
+def _has_unsupported_principal_inner_profile(
+    part,
+    bbox,
+    *,
+    prismatic_pockets=(),
+    section_passages=(),
+) -> bool:
     """Does a principal extremal face prove an internal profile outside the IR vocabulary?"""
     part_extent = (float(bbox.size.X), float(bbox.size.Y), float(bbox.size.Z))
     tol = max(1e-5, max(part_extent) * 1e-5)
@@ -931,6 +1009,7 @@ def _has_unsupported_principal_inner_profile(part, bbox, *, section_passages=())
             axis=axis,
             at=at,
             double_d_bores=double_d_bores,
+            prismatic_pockets=prismatic_pockets,
             section_passages=section_passages,
             profile=profile,
         )
@@ -997,16 +1076,22 @@ def _radial_outer_arc_count(part, bbox) -> int | None:
     return best
 
 
-def lint_principal_profile_coverage(part, *, assembly=None, section_passages=()) -> list:
+def lint_principal_profile_coverage(
+    part,
+    *,
+    assembly=None,
+    prismatic_pockets=(),
+    section_passages=(),
+) -> list:
     """Report principal inner or outer profiles outside the current feature vocabulary.
 
     The scan owns its physical extent: there is deliberately no caller-supplied bounding box
     that could narrow the answer. The double-D correspondence is the recogniser's shared pure
     correspondence proof over openings collected during this scan; lint reruns no public
-    recogniser. ``section_passages`` is the explicit projection of the drawing's cached
-    authoritative result used only to replace a matched generic profile finding with the
-    specific unsupported-Passage finding. :class:`Drawing` caches the returned issues against
-    the source part identity so repeated lint does not rescan the B-rep.
+    recogniser. ``section_passages`` and ``prismatic_pockets`` are explicit projections of the
+    drawing's cached authoritative result used only to replace a matched generic profile finding
+    with the corresponding specific unsupported-family finding. :class:`Drawing` caches the
+    returned issues against the source part identity so repeated lint does not rescan the B-rep.
     """
     solids = list(part.solids())
     sources = solids if len(solids) > 1 else [part]
@@ -1014,6 +1099,7 @@ def lint_principal_profile_coverage(part, *, assembly=None, section_passages=())
         _has_unsupported_principal_inner_profile(
             solid,
             solid.bounding_box(),
+            prismatic_pockets=prismatic_pockets,
             section_passages=section_passages,
         )
         for solid in sources

--- a/src/draftwright/linting/prismatic_pocket_coverage.py
+++ b/src/draftwright/linting/prismatic_pocket_coverage.py
@@ -1,0 +1,38 @@
+"""Explicit completeness disposition for recognised prismatic pockets (#1246)."""
+
+from __future__ import annotations
+
+from draftwright.linting.issues import LintIssue
+
+
+def lint_prismatic_pocket_coverage(recognition) -> list[LintIssue]:
+    """Report every aggregate-reconciled PrismaticPocket occurrence as unsupported.
+
+    The aggregate has already removed candidates also owned by ``Pocket``.  Each remaining record
+    is therefore one physical recess not superseded by that family, counted once.  Its
+    arbitrary polygonal section has no general Draftwright dimension grammar yet, so reporting
+    it is truthful while converting it to width/length or regular-polygon A/F would not be.
+    """
+
+    pockets = tuple(getattr(recognition, "prismatic_pockets", ()))
+    total = len(pockets)
+    issues: list[LintIssue] = []
+    for ordinal, pocket in enumerate(pockets, start=1):
+        side_count = int(getattr(pocket, "sides", 0))
+        qualifier = f"{side_count}-sided " if side_count else "polygonal "
+        depth = float(getattr(pocket, "depth", 0.0))
+        issues.append(
+            LintIssue(
+                severity="warning",
+                code="prismatic_pocket_requirement_unsupported",
+                message=(
+                    f"recognised {qualifier}blind prismatic recess {depth:g} mm deep "
+                    f"({ordinal} of {total}) is not represented by Draftwright dimensions; "
+                    "review and define its section and depth outside automatic drawing approval"
+                ),
+            )
+        )
+    return issues
+
+
+__all__ = ["lint_prismatic_pocket_coverage"]

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -102,6 +102,7 @@ _RECOGNISED_REQUIREMENT_FAMILIES = {
     "grooves": "grooves",
     "flats": "flats",
     "pockets": "pockets",
+    "prismatic_pockets": "prismatic_pockets",
     "pocket_patterns": "pocket_patterns",
     "pads": "pads",
     "repeating_radial_profiles": "repeating_radial_profiles",
@@ -142,12 +143,11 @@ _NON_REQUIREMENT_INVENTORIES = frozenset(
 #: merging them would let an undecided family look settled (#1244).
 #:
 #: The effect on the score is deliberate and worth stating: a drawing that omits a recognised
-#: prismatic pocket or angled step scores complete today. That is a blind spot — the register is
-#: what stops it being a silent one, and closing each issue closes the gap. Passage left this
-#: register when #1245 gave every authoritative occurrence an unsupported outcome.
+#: angled step scores complete today. That is a blind spot — the register is what stops it being
+#: a silent one, and closing the issue closes the gap. Passage and PrismaticPocket left this
+#: register when #1245/#1246 gave every authoritative occurrence an unsupported outcome.
 _UNDECIDED_INVENTORIES: dict[str, str] = {
     "angled_steps": "https://github.com/pzfreo/draftwright/issues/1247",
-    "prismatic_pockets": "https://github.com/pzfreo/draftwright/issues/1246",
 }
 
 _AUDITED_FAMILIES = (
@@ -157,6 +157,7 @@ _AUDITED_FAMILIES = (
     "holes",
     "passages",
     "polygonal_stock",
+    "prismatic_pockets",
     "slot_patterns",
     "slots",
 )
@@ -298,6 +299,7 @@ _UNSCORED_CODES = frozenset(
         "step_dim_withheld",
         "pattern_pitch_tolerance_withheld",
         "passage_requirement_unsupported",
+        "prismatic_pocket_requirement_unsupported",
         "pocket_not_located",
         "step_position_coincident_with_datum",
         # Neither confirmed nor refuted: the annotation renders no readable text, or the
@@ -599,13 +601,18 @@ def _completeness_component(recognition, features, registry, omissions, issues) 
             counts[outcome.state] += requirement_count
             family_count += requirement_count
         by_family[family] = family_count
-    # A recognised Passage is dimension-relevant physical evidence with an explicit
-    # unsupported outcome. Count only the authoritative rich inventory; the accepted-only
-    # legacy projection may contain the same occurrences and is never a second requirement.
-    passage_count = len(getattr(recognition, "section_passages", ()))
-    if passage_count:
-        counts["unsupported"] += passage_count
-        by_family["passages"] = passage_count
+    # These recognised physical occurrences have reviewed, explicit unsupported outcomes.  The
+    # Passage count uses only its authoritative rich inventory; the legacy projection is never a
+    # second requirement. PrismaticPocket uses the aggregate-reconciled inventory, after
+    # candidates also claimed by Pocket have yielded to that family.
+    for family, inventory in (
+        ("passages", "section_passages"),
+        ("prismatic_pockets", "prismatic_pockets"),
+    ):
+        unsupported_count = len(getattr(recognition, inventory, ()))
+        if unsupported_count:
+            counts["unsupported"] += unsupported_count
+            by_family[family] = unsupported_count
     requirements = sum(counts.values())
     recognised = {
         family

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -708,29 +708,32 @@ _ORCHESTRATED_RECORDS: dict[type, str] = {
 }
 
 
-# Tier 4 — records the installed package proves and this consumer has NOT decided about. Not
-# "orchestrated": these are not nested sub-records or aggregated evidence, they are families
-# whose drafting meaning is an open question, declared `unsupported` in
-# `recogniser_contract._UNSUPPORTED` against the issue deciding each. Kept as its own tier so the
-# partition below stays honest — folding them into tier 3 would claim a design reason that does
-# not exist, and would hide them the day one is decided (#1244).
+# Tier 4 — records the installed package proves and this consumer deliberately does NOT convert.
+# Not "orchestrated": these are records from unsupported feature families, rather than nested
+# sub-records or aggregate substrate. Authoritative outputs remain dimension-relevant physical
+# evidence; accepted-only projections are identified individually below. Some dispositions remain
+# undecided and others are reviewed unsupported outcomes. Each is declared in
+# `recogniser_contract._UNSUPPORTED` against the issue recording that disposition. Kept as its own
+# tier so neither unsupported evidence nor its compatibility records disappear into substrate
+# merely because neither has an IR converter (#1244).
 _UNCONSUMED_RECORDS: dict[type, str] = {
     AngledStep: (
         "a step's slanted wall, split out of `chamfers` by 0.2.5 to stop it being reported as a "
         "chamfer; whether draftwright dimensions it is open (#1247)"
     ),
     Passage: (
-        "the compatibility projection of a prismatic through-opening; whether it is an IR kind "
-        "or refines `hole`, and what it draws, is open (#1245)"
+        "the accepted-only compatibility projection of authoritative SectionPassage; it is not "
+        "a second physical requirement and has no converter (#1245)"
     ),
     SectionPassage: (
-        "the authoritative physical prismatic-opening evidence introduced in 0.4.0; its IR kind, "
-        "section rendering and completeness semantics remain open (#1245)"
+        "the authoritative physical prismatic-opening evidence introduced in 0.4.0; its complete "
+        "line/arc section has no truthful general drafting grammar, so every occurrence has an "
+        "explicit unsupported completeness outcome (#1245)"
     ),
     PrismaticPocket: (
-        "a non-rectangular blind recess that OVERLAPS the supported `pockets` family — measured, "
-        "both recognisers claim a rectangular recess — so IR ownership must be settled before a "
-        "converter exists (#1246)"
+        "an aggregate-reconciled polygonal blind recess not owned by `Pocket`; its arbitrary "
+        "section has no truthful general Draftwright dimension grammar, so every occurrence has "
+        "an explicit unsupported completeness outcome (#1246)"
     ),
 }
 

--- a/src/draftwright/recogniser_contract.py
+++ b/src/draftwright/recogniser_contract.py
@@ -233,10 +233,11 @@ _UNSUPPORTED: dict[str, tuple[tuple[str, ...], str, str]] = {
     "prismatic-pockets": (
         ("PrismaticPocket",),
         "https://github.com/pzfreo/draftwright/issues/1246",
-        "Overlaps the supported `pockets` family: measured on a plate with one hexagonal and one "
-        "rectangular recess, `recognise_prismatic_pockets` claims BOTH and `recognise_pockets` "
-        "claims the rectangular one as well. Wiring it to a converter would double-count every "
-        "rectangular pocket in completeness, so ownership must be decided at the IR first.",
+        "The aggregate removes candidates also owned by the supported `pockets` family, so each "
+        "remaining PrismaticPocket is a distinct recess not superseded by Pocket. Its section may "
+        "be any planar polygon: width/length is false for triangles and a regular-polygon A/F "
+        "callout is incomplete in the general case. Draftwright therefore reports every "
+        "surviving occurrence as an unsupported completeness requirement.",
     ),
     "angled-steps": (
         ("AngledStep",),
@@ -253,20 +254,26 @@ def _unsupported_declaration(family_id: str) -> dict[str, Any]:
 
     Drafting boundaries remain ``unsupported``. Completeness stays ``deferred`` while its meaning
     is undecided, except where a reviewed consumer decision defines an explicit unsupported
-    outcome. That distinction keeps the inventory visible without inventing drafting semantics or,
-    for ``prismatic-pockets``, counting one physical recess twice.
+    outcome. That distinction keeps the inventory visible without inventing drafting semantics.
     """
     records, tracking, rationale = _UNSUPPORTED[family_id]
     unsupported = {"state": "unsupported", "rationale": rationale}
+    unsupported_completeness = {
+        "passages": (
+            "Every authoritative SectionPassage occurrence produces a warning and an "
+            "unsupported completeness outcome; no drafting requirement is invented."
+        ),
+        "prismatic-pockets": (
+            "Every aggregate-reconciled PrismaticPocket occurrence produces a warning and an "
+            "unsupported completeness outcome; no polygonal drafting grammar is invented."
+        ),
+    }
     completeness = (
         {
             "state": "unsupported",
-            "rationale": (
-                "Every authoritative SectionPassage occurrence produces a warning and an "
-                "unsupported completeness outcome; no drafting requirement is invented."
-            ),
+            "rationale": unsupported_completeness[family_id],
         }
-        if family_id == "passages"
+        if family_id in unsupported_completeness
         else {
             "state": "deferred",
             "rationale": rationale,
@@ -319,7 +326,19 @@ def consumer_capability_declaration() -> dict[str, Any]:
                 "release_notes": "CHANGELOG.md",
                 "to": "unsupported",
                 "version": distribution_version("draftwright"),
-            }
+            },
+            {
+                "boundary": "completeness",
+                "compatibility_evidence": [
+                    "tests/test_issue_1246_prismatic_pocket_disposition.py",
+                    "tests/test_recogniser_capabilities.py",
+                ],
+                "family": "prismatic-pockets",
+                "from": "deferred",
+                "release_notes": "CHANGELOG.md",
+                "to": "unsupported",
+                "version": distribution_version("draftwright"),
+            },
         ],
     }
 

--- a/tests/test_detect_registry.py
+++ b/tests/test_detect_registry.py
@@ -131,13 +131,13 @@ def test_orchestrated_records_document_their_residual_reason():
         assert isinstance(reason, str) and reason.strip(), f"{rec_type.__name__} needs a reason"
 
 
-def test_unconsumed_records_name_the_issue_deciding_them():
-    """Tier 4 is a WAITING ROOM, not a bin: each entry cites the issue that will empty it.
+def test_unconsumed_records_name_the_issue_recording_their_disposition():
+    """Tier 4 is an explicit consumer boundary, not a bin: every entry cites its decision.
 
-    Tier 3 entries have design reasons that will not change; these are open questions, and the
-    difference has to survive in the register or the two collapse into "we do not convert this"
-    (#1244). The issue reference is the thing that expires — when it closes, the record either
-    moves to a converter or its reason has to be rewritten as a permanent one.
+    Tier 3 entries are non-requirement substrate. Tier 4 entries belong to unsupported families:
+    an open issue may still decide their meaning, or a closed issue may record a reviewed
+    unsupported outcome. That distinction has to survive in the register or both tiers collapse
+    into an unexplained "we do not convert this" (#1244).
     """
     import re
 

--- a/tests/test_issue_1245_passage_disposition.py
+++ b/tests/test_issue_1245_passage_disposition.py
@@ -8,7 +8,7 @@ from types import SimpleNamespace
 import pytest
 from b123d_recognisers import build_recognition_result
 from b123d_recognisers.profiled_bores import principal_boundary_plane
-from build123d import Box, GeomType, Pos, RegularPolygon, extrude
+from build123d import Box, Ellipse, GeomType, Pos, RegularPolygon, extrude
 
 from draftwright import build_drawing
 from draftwright.linting.coverage import _passage_matches_principal_wire
@@ -56,7 +56,7 @@ def test_a_recognised_passage_is_specific_actionable_and_non_info() -> None:
 
 def test_a_passage_does_not_hide_an_unrelated_unsupported_inner_profile() -> None:
     through = Pos(-10, 0, 0) * extrude(RegularPolygon(3, 6), amount=12, both=True)
-    blind = Pos(10, 0, 2) * extrude(RegularPolygon(3, 5), amount=4)
+    blind = Pos(10, 0, 2) * extrude(Ellipse(5, 3), amount=4)
     part = Box(40, 40, 10) - through - blind
     recognition = build_recognition_result(part)
 

--- a/tests/test_issue_1246_prismatic_pocket_disposition.py
+++ b/tests/test_issue_1246_prismatic_pocket_disposition.py
@@ -1,0 +1,188 @@
+"""#1246: recognised prismatic pockets fail visibly without false dimensions."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+from b123d_recognisers import (
+    build_recognition_result,
+    recognise_pockets,
+    recognise_prismatic_pockets,
+)
+from b123d_recognisers.profiled_bores import principal_boundary_plane
+from build123d import (
+    Box,
+    BuildPart,
+    BuildSketch,
+    Ellipse,
+    GeomType,
+    Plane,
+    Pos,
+    RegularPolygon,
+    Rot,
+    extrude,
+)
+
+from draftwright import build_drawing
+from draftwright.linting.coverage import _prismatic_pocket_matches_principal_wire
+from draftwright.linting.prismatic_pocket_coverage import lint_prismatic_pocket_coverage
+
+
+def _blind_tool(profile) -> object:
+    with BuildPart() as tool:
+        with BuildSketch(Plane.XY.offset(4)):
+            profile()
+        extrude(amount=20)
+    return tool.part
+
+
+def _hexagonal_pocket_part(*, rectangular: bool = False, ellipse: bool = False):
+    part = Box(120, 80, 20)
+    part -= Pos(-30 if rectangular or ellipse else 0, 0, 0) * _blind_tool(
+        lambda: RegularPolygon(12, 6)
+    )
+    if rectangular:
+        part -= Pos(30, 0, 4) * Box(30, 24, 20)
+    if ellipse:
+        part -= Pos(30, 0, 0) * _blind_tool(lambda: Ellipse(8, 5))
+    return part
+
+
+def _matched_mouth(part, pocket):
+    bbox = part.bounding_box()
+    tol = max(1e-5, max(float(bbox.size.X), float(bbox.size.Y), float(bbox.size.Z)) * 1e-5)
+    for face in part.faces():
+        boundary = principal_boundary_plane(face, bbox)
+        if boundary is None:
+            continue
+        axis, plane_axes, at = boundary
+        for wire in face.inner_wires():
+            if _prismatic_pocket_matches_principal_wire(pocket, wire, axis, plane_axes, at, tol):
+                return wire, axis, plane_axes, at, tol
+    raise AssertionError("fixture has no principal mouth matching its PrismaticPocket record")
+
+
+def test_a_prismatic_pocket_is_specific_actionable_and_non_info() -> None:
+    part = _hexagonal_pocket_part()
+    recognition = build_recognition_result(part)
+
+    assert len(recognition.prismatic_pockets) == 1
+    assert recognition.pockets == ()
+    drawing = build_drawing(part)
+    issues = drawing.lint()
+
+    assert [issue.code for issue in issues] == ["prismatic_pocket_requirement_unsupported"]
+    assert issues[0].severity == "warning"
+    assert "recognised 6-sided blind prismatic recess 6 mm deep (1 of 1)" in issues[0].message
+    assert "outside automatic drawing approval" in issues[0].message
+    summary = drawing.lint_summary()
+    assert summary["warnings"] == summary["geometry_issues"] == 1
+    assert summary["quality"]["completeness"]["unrecognised_geometry_reports"] == 0
+
+
+def test_a_prismatic_pocket_does_not_hide_an_unrelated_unsupported_profile() -> None:
+    part = _hexagonal_pocket_part(ellipse=True)
+    recognition = build_recognition_result(part)
+
+    assert len(recognition.prismatic_pockets) == 1
+    codes = [issue.code for issue in build_drawing(part).lint()]
+    assert codes.count("prismatic_pocket_requirement_unsupported") == 1
+    assert codes.count("unrecognised_defining_geometry") == 1
+
+
+@pytest.mark.parametrize(
+    "case",
+    (
+        "wrong_axis",
+        "wrong_mouth",
+        "invalid_open_sign",
+        "side_count",
+        "unsupported_edge",
+        "malformed_record",
+        "vertex_mismatch",
+    ),
+)
+def test_prismatic_pocket_profile_correlation_fails_closed(case: str) -> None:
+    part = _hexagonal_pocket_part()
+    pocket = build_recognition_result(part).prismatic_pockets[0]
+    wire, axis, plane_axes, at, tol = _matched_mouth(part, pocket)
+    candidate = pocket
+    candidate_wire = wire
+
+    if case == "wrong_axis":
+        candidate = replace(pocket, axis="x")
+    elif case == "wrong_mouth":
+        moved = list(pocket.at)
+        moved["xyz".index(axis)] += 10
+        candidate = replace(pocket, at=tuple(moved))
+    elif case == "invalid_open_sign":
+        candidate = replace(pocket, open_sign=0)
+    elif case == "side_count":
+        candidate = replace(pocket, sides=pocket.sides + 1)
+    elif case == "unsupported_edge":
+        candidate_wire = SimpleNamespace(
+            vertices=wire.vertices,
+            edges=lambda: [SimpleNamespace(geom_type=GeomType.ELLIPSE)] * len(pocket.section),
+        )
+    elif case == "malformed_record":
+        candidate = object()
+    elif case == "vertex_mismatch":
+        section = list(pocket.section)
+        section[0] = (100.0, 100.0)
+        candidate = replace(pocket, section=tuple(section))
+
+    assert not _prismatic_pocket_matches_principal_wire(
+        candidate,
+        candidate_wire,
+        axis,
+        plane_axes,
+        at,
+        tol,
+    )
+
+
+def test_a_prismatic_pocket_is_an_explicit_unsupported_completeness_outcome() -> None:
+    completeness = build_drawing(_hexagonal_pocket_part()).lint_summary()["quality"][
+        "completeness"
+    ]
+
+    assert completeness["available"] is True
+    assert completeness["audited_score"] == 0.0
+    assert completeness["requirements"] == 1
+    assert completeness["unsupported"] == 1
+    assert completeness["by_family"]["prismatic_pockets"] == 1
+    assert "prismatic_pockets" not in completeness["unscored_recognized_families"]
+
+
+def test_aggregate_reconciliation_counts_the_rectangular_recess_only_as_pocket() -> None:
+    part = _hexagonal_pocket_part(rectangular=True)
+
+    assert len(recognise_prismatic_pockets(part)) == 2, "direct calls precede reconciliation"
+    assert len(recognise_pockets(part)) == 1
+    recognition = build_recognition_result(part)
+    assert len(recognition.prismatic_pockets) == 1
+    assert len(recognition.pockets) == 1
+
+    issues = lint_prismatic_pocket_coverage(recognition)
+    assert len(issues) == 1
+    completeness = build_drawing(part).lint_summary()["quality"]["completeness"]
+    assert completeness["requirements"] == completeness["unsupported"] == 1
+    assert completeness["by_family"]["prismatic_pockets"] == 1
+
+
+def test_a_four_sided_survivor_is_unsupported_not_misclassified_as_non_rectangular() -> None:
+    part = Box(80, 80, 20) - Pos(0, 0, 4) * Rot(0, 0, 30) * Box(30, 24, 20)
+
+    recognition = build_recognition_result(part)
+    assert recognition.pockets == ()
+    assert len(recognition.prismatic_pockets) == 1
+    assert recognition.prismatic_pockets[0].sides == 4
+
+    drawing = build_drawing(part)
+    codes = [issue.code for issue in drawing.lint()]
+    assert codes.count("prismatic_pocket_requirement_unsupported") == 1
+    assert "unrecognised_defining_geometry" not in codes
+    completeness = drawing.lint_summary()["quality"]["completeness"]
+    assert completeness["requirements"] == completeness["unsupported"] == 1

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -194,8 +194,60 @@ def test_rich_passage_contract_has_an_explicit_unsupported_completeness_outcome(
             "release_notes": "CHANGELOG.md",
             "to": "unsupported",
             "version": importlib.metadata.version("draftwright"),
-        }
+        },
+        {
+            "boundary": "completeness",
+            "compatibility_evidence": [
+                "tests/test_issue_1246_prismatic_pocket_disposition.py",
+                "tests/test_recogniser_capabilities.py",
+            ],
+            "family": "prismatic-pockets",
+            "from": "deferred",
+            "release_notes": "CHANGELOG.md",
+            "to": "unsupported",
+            "version": importlib.metadata.version("draftwright"),
+        },
     ]
+
+
+def test_prismatic_pocket_contract_has_an_explicit_unsupported_completeness_outcome() -> None:
+    """Pin aggregate ownership and the arbitrary-polygon boundary to one decision."""
+
+    package = _families(recognition.capability_manifest())["prismatic-pockets"]
+    consumer = _families(consumer_capability_declaration())["prismatic-pockets"]
+
+    assert package["introduced_in"] == "0.2.6"
+    assert package["census_output"] == "RecognitionResult.prismatic_pockets"
+    assert len(package["records"]) == 1
+    record = package["records"][0]
+    assert record["name"] == "PrismaticPocket"
+    assert record["role"] == "output"
+    assert record["schema_version"] == 1
+    assert record["aggregate_membership"] == ["RecognitionResult.prismatic_pockets"]
+    assert consumer["record_schemas"] == {"PrismaticPocket": [1]}
+    assert consumer["disposition"] == "unsupported"
+    assert consumer["tracking"] == "https://github.com/pzfreo/draftwright/issues/1246"
+    assert {
+        consumer[name]["state"]
+        for name in (
+            "ir_adapter",
+            "dsl_declaration",
+            "generated_code",
+            "drawing_consumer",
+        )
+    } == {"unsupported"}
+    assert consumer["completeness"] == {
+        "state": "unsupported",
+        "rationale": (
+            "Every aggregate-reconciled PrismaticPocket occurrence produces a warning and an "
+            "unsupported completeness outcome; no polygonal drafting grammar is invented."
+        ),
+    }
+    assert consumer["documentation"] == {
+        "state": "supported",
+        "evidence": ["docs/reference/recogniser-capabilities.md"],
+    }
+    assert "prismatic-pockets" not in pending_family_declarations()
 
 
 def test_runtime_adapter_inventory_is_derived_independently_and_exhaustive() -> None:


### PR DESCRIPTION
## Summary
- give aggregate-reconciled PrismaticPocket occurrences an explicit unsupported drawing and completeness disposition
- replace only the correlated generic profile warning while preserving unrelated unrecognised geometry
- document the aggregate ownership boundary, including legitimate four-sided survivors, without inventing IR, Sheet DSL, generated-code, or rendering semantics

## Verification
- `scripts/pr-check --full`: 5,186 passed, 5 skipped, 2 xfailed
- 95.26% total coverage and 100% changed-line coverage
- independent Google-style review: zero findings and zero nits at exact head
- independent ADR review: clean against ADRs 0004, 0011, 0012, 0014, and 0015 at exact head
- no upstream recogniser or API change required

Closes #1246