### PR TITLE
Adopt provider-owned local recognition frames

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,9 @@ Compact map, bottom to top:
   `_geometry.py` (page-plane maths + the ADR 0014 Amdt 3 material field; the DAG's
   bottom leaf), `fonts.py` (pinned IBM Plex, ADR 0006), `fits.py` (ISO 286),
   `intents.py` (deferred-edit low IR), `recognition_cache.py` (ADR 0017 one-result
-  lifecycle), `_warnings.py`, `_pmi_part21.py`, and the `linting/` subpackage
+  lifecycle), `recognition_frame.py` (ADR 0020 caller-space source ↔ provider-owned local
+  recognition boundary),
+  `_warnings.py`, `_pmi_part21.py`, and the `linting/` subpackage
   (draftwright owns lint, ADR 0007).
 - **`_core.py`** — shared primitives: the `Analysis` namespace, dim/format helpers,
   page/slot/margin constants.

--- a/docs/adr/0020-provider-owned-local-frame-for-automatic-recognition.md
+++ b/docs/adr/0020-provider-owned-local-frame-for-automatic-recognition.md
@@ -1,0 +1,171 @@
+# ADR 0020 — Provider-owned local frame for automatic recognition
+
+- **Status:** Accepted for explicit opt-in rollout; legacy automatic recognition remains the
+  default until the supported platform matrix and representative real-part canaries approve a
+  default transition.
+- **Date:** 2026-08-30
+- **Deciders:** Paul Fremantle (pzfreo)
+
+## Context
+
+Recognition records contain positions, axes, spans, face/body ownership, and finite geometric
+evidence. Historically those facts used the caller's STEP/world coordinates. Translating a part
+does not change their meaning, but an arbitrary rotation changes which principal-axis vocabulary
+the recognisers can use and can therefore change detection, view planning, and the finished
+drawing.
+
+`b123d-recognisers` 0.4.6 provides the immutable public
+`build_framed_recognition_result(part)` contract. A successful result carries:
+
+- the inferred `PartFrame`;
+- the exact topology-preserving local working solid used by the provider; and
+- the aggregate `RecognitionResult` expressed against that solid.
+
+It may instead return a typed `RefusedPartFrame`. The older
+`build_recognition_result(part)` API is unchanged.
+
+Adopting only the local records would mix them with caller-space bounding boxes and projection
+geometry. Reconstructing the provider's normalization in Draftwright would create a second frame
+authority and could not guarantee topology/provenance identity. Transforming every record back to
+world coordinates is also not representable by the current principal-axis IR: an arbitrary
+world-space direction is not one of the IR's `x`/`y`/`z` axes.
+
+## Decision
+
+### 1. Automatic framed recognition compiles one coherent local unit
+
+`recognition_frame.adapt_recognition` is the only Draftwright-owned selection boundary. On a
+successful framed run, the provider's exact `part` and `result` remain paired. Bounding-box
+analysis, classification, record-to-IR conversion, planning, projection, rendering, and physical
+lint all use that working solid and its local coordinates.
+
+No downstream stage recreates the transform, applies it record by record, or combines local
+records with the caller-space solid. The provider owns frame inference and topology-preserving
+normalization; Draftwright owns the consumer decision and every drafting policy after the
+recognition-to-IR adapter.
+
+### 2. The caller solid and working solid have distinct public meanings
+
+For a framed automatic build:
+
+- `Drawing.part` is the caller-space source body;
+- `Drawing.working_part` is the exact local solid compiled and projected;
+- `Drawing.recognition_frame` is the caller-to-working `PartFrame`; and
+- `Drawing.recognition_frame_decision` states `framed`, `legacy_fallback`, `legacy`, or
+  `declared`, including gauge and refusal reason where applicable.
+
+Keeping both solids prevents a public source-coordinate property from silently changing meaning
+while making the geometry used by the compiler inspectable. `working_part` is read-only. Scale
+retry/repack analyses reuse the same solid, aggregate, frame, and decision rather than running a
+second recognition universe (ADR 0017).
+
+### 3. Declaration remains caller-coordinate authority
+
+Supplying `model=` and every `Sheet` build remain in the caller's coordinates and perform no
+automatic recognition during rendering (ADR 0011). `detect_part_model` and `Sheet.from_part`
+retain their legacy caller-coordinate contract: returning a naked local `PartModel` without its
+paired working solid and frame would make it unsafe to pass back to a declared build.
+
+A caller that deliberately wants to re-declare framed output may use
+`build_drawing(..., framed_recognition=True)`, then pass both `drawing.working_part` and
+`drawing.model()` to a declared build. That coordinate pairing is explicit.
+
+### 4. AP242 geometry crosses the boundary once
+
+AP242 nominal values and source identities are requirements and remain unchanged. Geometry used
+to correlate those requirements—reference points, axis-aligned support bounds, principal-axis
+hints, and finite cylindrical references—is mapped once from source coordinates into the working
+frame before PMI lowering. Bounds are transformed through all eight corners; directions do not
+receive the frame translation; finite cylinders are rebuilt from transformed endpoints.
+
+The source extraction report remains a source census. Only the records passed into the local IR
+lowering step are reframed.
+
+### 5. Gauge and refusal behavior are explicit
+
+`FULL`, `ORTHOGONAL`, and `AXIAL` successful frames use the same paired-solid contract and are
+covered by fixtures. `AXIAL` establishes a stable gauge for a rotational part, but Draftwright
+does not interpret its arbitrary roll as authored material direction or manufacturing intent.
+
+A typed `RefusedPartFrame` takes exactly one documented legacy aggregate run and records
+`legacy_fallback` plus the provider reason. It does not pretend the caller axes are an inferred
+part frame. The explicit comparison/default route records `legacy`.
+
+### 6. Rollout is opt-in
+
+`build_drawing(..., framed_recognition=True)` and the equivalent `make_drawing` argument opt into
+the framed route. The default stays on legacy automatic recognition for this decision's first
+delivery.
+
+This is not a permanent preference for world coordinates. Initial default-on testing showed that
+provider normalization can legitimately permute even an unrotated part's principal axes. That
+changes view selection, arrangement, ladders, and layout snapshots across the existing corpus.
+Rigid-motion parity fixtures prove the new route's internal invariance, but they do not by
+themselves approve every legacy-to-framed transition. Default promotion requires the supported
+Python/platform matrix and representative real-part canaries to enumerate and review those
+transitions. The old route remains available during that rollout, as issue #1357 requires.
+
+### 7. Frame-induced axis permutations must preserve requirements
+
+An ordinary Z-normal hole pattern can become X- or Y-normal in the working frame. Such a pattern
+still has two perpendicular location requirements. The compiler therefore treats off-axis
+patterns like the corresponding off-axis hole path: it compiles bounding-box-referenced location
+components under the stable `location_pattern.location` identity, and the shared renderer places
+only those approved entries. This extends compiler vocabulary; it does not hand-place dimensions
+or bypass the collect-then-solve placement architecture (ADRs 0014 and 0016).
+
+Feature/audit keys canonicalize rounded signed zero so kernel noise cannot make two rigidly
+equivalent local builds appear semantically different.
+
+## Consequences
+
+- Rigid translation and rotation can be tested against finished requirements and outcomes in one
+  stable local coordinate system.
+- Face/body provenance survives because Draftwright consumes the provider's exact normalized
+  topology instead of reconstructing a lookalike solid.
+- Public source geometry remains available without being used accidentally by local lint or
+  projection.
+- A successful opt-in build may choose different principal views from the legacy build; that is a
+  rollout transition to review, not a promise of byte-identical output (ADRs 0004 and 0012).
+- The framed aggregate is requested without pre-classifying in source coordinates. Draftwright
+  classifies from the returned local cylinder inventory and gates its IR consumers there. This
+  preserves one aggregate run and avoids using arbitrary caller axes to decide package inventory.
+- A new provider fact/API is not required for this decision. The exact local solid added by
+  b123d-recognisers PR #292 and released in 0.4.6 is the necessary seam.
+
+## Rejected alternatives
+
+- **Transform local records back into caller coordinates.** The principal-axis IR cannot express
+  arbitrary world-space directions without a larger architecture change.
+- **Normalize the solid independently in Draftwright.** That creates two authorities and loses
+  the provider's topology/provenance guarantee.
+- **Return frame-local IR from `detect_part_model`.** A `PartModel` alone cannot prove which solid
+  shares its coordinates; `Sheet.from_part` would then compile it against the wrong geometry.
+- **Enable framed recognition by default immediately.** The focused invariance evidence is not a
+  disposition for every corpus-wide view/layout transition.
+- **Treat refusal as success in caller axes.** That erases the diagnostic distinction between a
+  proved frame and no frame.
+
+## Verification
+
+`tests/test_issue_1357_framed_recognition.py` guards successful gauges, typed refusal, the legacy
+default, source/working separation, rigid-motion requirement and finished-build parity,
+off-axis-pattern locations, compound topology ownership, AP242 transforms, declared-build
+coordinates, and audit-key stability. `tests/test_part_model.py` retains the one-aggregate-per-run
+guard. `tests/test_declared_recognition_gate.py` retains the declared no-recognition rule.
+`tests/test_import_boundaries.py` keeps the adapter at the leaf rank.
+
+## Relationship to prior decisions
+
+- **ADR 0011:** preserved; declarations and `Sheet` stay in caller coordinates.
+- **ADR 0013:** preserved; normalization remains geometry-package policy and Draftwright adapts
+  public records into its own IR.
+- **ADR 0015:** refined at the recognition input: the detected compiler unit is now
+  working-solid plus aggregate, still converging on the same `PartModel` waist.
+- **ADR 0017:** preserved; one immutable aggregate is shared by automatic model construction and
+  critique. Framed selection does not create a second run.
+- **ADR 0018:** preserved; view planning reads the resulting requirement-bearing IR and does not
+  infer a frame itself.
+- **ADRs 0014/0016:** preserved; new off-axis pattern dimensions are compiler-approved candidates,
+  never raw-coordinate placements.
+

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,6 +36,7 @@ architecture** table; open retired or superseded records only for design history
 | [0017](0017-recognition-inventory-correspondence-and-measurement-provenance.md) | One recognition result per run; correspondence is evidence-gated | Produce one external immutable recognition result held by Draftwright's per-run cache; require vertical-slice evidence before generalising correspondence, identity, requirements, outcomes, or reconciliation. | Accepted; external cache ownership clarified, extensions gated by #1018 | `test_external_recognition_boundary.py`, `test_recognition_manifest.py`, `test_declared_recognition_gate.py` |
 | [0018](0018-requirement-driven-view-planning-and-editable-sheet-layout.md) | Requirement-driven view planning and editable sheet layout | Use one `ViewSpec` vocabulary and planner with distinct authored `ViewConstraints` and immutable `ResolvedViewPlan`; jointly validate views, typography, convention, scale, paper and layout against requirement survival. Supersedes ADR 0004's fixed-topology assumption while retaining compose-then-pack. | Accepted 2026-08-16; partially implemented (`ViewSpec`, `ResolvedViewPlan`, `ViewCoverage`, arrangement choice and requirement gate); tracked by #1130/#1259-#1262 | Required guards are listed in the ADR |
 | [0019](0019-display-complete-labels-and-dimension-outcomes.md) | Display-complete labels and a dimension-outcome ledger | The compiled plan carries the full label text (tolerance and collapse wording included) so renderers render and never compose; dimension outcomes reconcile at one seam on both build routes; ladder rungs get per-mark identity. Finishes the ADR 0016 Amdt 1 boundary; supersedes Amdt 6's enforcement mechanism. | Proposed | `test_issue_1215_no_approved_tolerance_is_dropped.py` reduces to plan-equality when implemented |
+| [0020](0020-provider-owned-local-frame-for-automatic-recognition.md) | Provider-owned local frame for automatic recognition | Keep the provider's exact local working solid and aggregate together behind one Draftwright adapter; retain source geometry as provenance, keep declarations in caller coordinates, and roll the framed route out explicitly before any default transition. | Accepted for explicit opt-in rollout | `test_issue_1357_framed_recognition.py`, `test_part_model.py`, `test_declared_recognition_gate.py`, `test_import_boundaries.py` |
 
 ## Historical records
 
@@ -52,6 +53,6 @@ architecture** table; open retired or superseded records only for design history
 - Layout and placement: 0004 → 0014 → 0012 → 0018.
 - Declared intent and the editable surface: 0001 → 0011 → 0012 → 0016 → 0018 → 0019.
 - Quality and correction: 0002, with provenance from 0010.
-- Recognition correspondence and completeness: 0007 → 0013 → 0015 → 0017.
+- Recognition correspondence, frames, and completeness: 0007 → 0013 → 0015 → 0017 → 0020.
 
 Tracking issue: #745.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,8 @@ keep that table, this document, and `CLAUDE.md`'s compact map in step. The
 
 The dependency graph is a DAG (the #138 / ADR 0005 split is complete). Bottom to
 top: leaf modules (`layout.py`, `registry.py`, `fonts.py`, `_geometry.py`,
-`fits.py`, `intents.py`, `recognition_cache.py`, and the `linting/` subpackage) →
+`fits.py`, `intents.py`, `recognition_cache.py`, `recognition_frame.py`, and the `linting/`
+subpackage) →
 `_core.py` → stage modules (`export.py`,
 `repair.py`, `projection.py`, `compose.py`, `analysis.py`, `drawing.py`, the
 `model/` IR subpackage, the `annotations/` subpackage) → `builder.py` → the
@@ -201,6 +202,10 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
 - **`recognition_cache.py`** — Draftwright's ADR 0017 one-result lifecycle owner. It calls
   external `build_recognition_result(part)` at most once for a build/lazy-critique run; the
   package owns recognition, while Draftwright owns when the result is computed and reused.
+- **`recognition_frame.py`** — the ADR 0020 / #1357 consumer boundary for framed recognition. It binds
+  the provider's topology-preserving local working solid to the aggregate produced from that
+  exact solid, retains the caller-space source and `PartFrame` as provenance, and owns the
+  explicit legacy/refusal fallback decision.
 - **`recogniser_contract.py`** — the fail-closed cross-repository capability join. It consumes
   only the installed `b123d-recognisers` public manifest, then validates Draftwright-owned IR,
   `Sheet`, generated-code, drawing, completeness, and documentation declarations. It is rank 7
@@ -545,6 +550,14 @@ policy) live in `CLAUDE.md`. This is the per-ADR status trail; each ADR's
   off-centre slots plus N:1 slot patterns. Each new semantic guard needs the mutation that
   breaks its claimed contract; a green suite alone is not evidence that the guard is
   load-bearing.
+
+- **0020** — **Accepted for explicit opt-in rollout** (#1357): automatic framed builds pair
+  the provider's exact local working solid with its one aggregate behind
+  `recognition_frame.adapt_recognition`. `Drawing.part` retains caller-space provenance;
+  `Drawing.working_part` supplies IR, projection and physical lint. `PartFrame` plus an
+  explicit decision records successful gauges and typed legacy fallbacks. Declared/Sheet
+  builds and the public default retain caller coordinates until platform and representative
+  real-part evidence reviews the legacy-to-framed view/layout transitions.
 
 - **0019** — **Proposed**: **display-complete labels and a dimension-outcome ledger** —
   finishing the 0016 Amdt 1 boundary after epic #1215/#1216's ten review rounds showed its

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -228,7 +228,7 @@ profile warning only for that occurrence, so an unrelated unrecognised profile r
 
 ## Passage compatibility boundary
 
-The installed `b123d-recognisers==0.4.5` release contains the `passages` family introduced
+The installed `b123d-recognisers==0.4.6` release contains the `passages` family introduced
 in 0.2.6. Version 0.4.0 makes `SectionPassage` the authoritative physical output and retains
 schema-v1 `Passage` as its compatibility projection. Draftwright declares all six public and nested
 record schemas exhaustively but deliberately keeps the family `unsupported`, with the drafting
@@ -246,10 +246,23 @@ The 0.4 contract is explicit:
 - rich split-junction passages can supersede a Slot claim, moving physical ownership to the
   unsupported Passage family through `SLOT_SUPERSEDED_BY_PASSAGE`.
 
-The exact 0.4.5 pin, manifest-v2 validator and explicit unsupported inventories make that limitation
+The exact 0.4.6 pin, manifest-v2 validator and explicit unsupported inventories make that limitation
 fail-visible rather than silently treating rich passages as supported. Draftwright deliberately
 does not claim that a regular-polygon `HEX … A/F THRU` callout covers the complete line/arc section
 schema. Each authoritative `RecognitionResult.section_passages` occurrence therefore emits
 `passage_requirement_unsupported` at warning severity and contributes an `unsupported` requirement
 to the completeness component. The accepted-only legacy `.passages` projection contributes neither
 a second issue nor a second requirement. Issue #1245 records this consumer decision.
+
+## Step families introduced in recognisers 0.4.6
+
+The 0.4.6 provider manifest adds `circular-blind-steps`, `paired-ramp-steps`, and
+`through-steps`. Their typed records expose physical axes, locations, run lengths, and the relevant
+section or angle; no provider API change is currently required. Those facts do not by themselves
+choose Draftwright's manufacturing requirement, semantic view, or dimension grammar.
+
+Draftwright therefore declares all three families unsupported at the IR, Sheet, generated-code,
+and drawing-consumer boundaries, creates no inferred feature or annotation, and keeps their
+completeness state explicitly `deferred`. Their aggregate inventories remain classified as
+undecided physical families rather than being hidden among non-requirement substrate. Issue #1382
+owns the reviewed downstream disposition for all three families.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "build123d>=0.9.0,<0.11 ; python_full_version < '3.13'",
     "build123d>=0.11,<0.12 ; python_full_version >= '3.13'",
     "build123d-drafting-helpers>=0.14.2",
-    "b123d-recognisers==0.4.5",
+    "b123d-recognisers==0.4.6",
     "numpy>=1.24",
     # PNG raster export (SVG→PDF→PNG). Both permissively licensed (Pillow HPND; pypdfium2
     # Apache-2.0 wrapping Google PDFium BSD-3) and ship pre-built wheels with NO native system

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -1189,6 +1189,16 @@ class Analysis:
     # from the effective mode so the ignored-PMI diagnostic can distinguish that default from
     # an explicit opt-out without widening the three-mode renderer contract (#623).
     pmi_defaulted: bool
+    #: Caller-space solids-only body. Automatic framed detection may compile a normalized local
+    #: ``part``; this retains the public/source coordinate authority without mixing it into
+    #: local IR, projection, or lint. None preserves compatibility for hand-built Analysis.
+    source_part: Shape | None = None
+    #: Provider-owned mapping from ``source_part`` coordinates to the automatic build's local
+    #: working ``part``. None for declared, legacy, refused, and hand-built analyses.
+    recognition_frame: object | None = None
+    #: JSON-friendly framed/legacy/refusal decision. Kept beside the frame so callers never
+    #: infer a fallback from its absence.
+    recognition_frame_decision: object | None = None
     # Standing ISO 7200 title-block fields (#766) — defaulted, so they sit after the
     # non-default fields above. Defaults preserve the prior output: revision "A", the rest
     # blank (the TitleBlock helper's own defaults).

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -22,6 +22,7 @@ from b123d_recognisers import (
     TurnedProfile,
     TurnedStep,
     analyse_cylinders,
+    build_framed_recognition_result,
     build_recognition_result,
     full_cylinders,
 )
@@ -55,6 +56,7 @@ from draftwright.compose import (
 from draftwright.model import build_part_model
 from draftwright.model.ir import Datum, PartModel, StepFeature, StepLevelFeature
 from draftwright.model.planner import plan_dimensions
+from draftwright.recognition_frame import adapt_recognition
 from draftwright.view_plan import ViewConstraints, arrangement_of
 
 _log = logging.getLogger(__name__)
@@ -491,11 +493,13 @@ class _GeomClass:
     is_rotational: bool
 
 
-def _classify_geometry(part, x_size, y_size, z_size, cx, cy, cz) -> _GeomClass:
+def _classify_geometry(
+    part, x_size, y_size, z_size, cx, cy, cz, *, cylinders=None
+) -> _GeomClass:
     """Analyse *part*'s cylinders and classify its OD / rotational orientation (#590 split of
     :func:`_analyse`). Partial (fillet) faces are excluded — they would pollute the OD, the bore
     leaders, and the rotational test alike (#81)."""
-    z_cyls, cross_cyls = analyse_cylinders(part)
+    z_cyls, cross_cyls = analyse_cylinders(part) if cylinders is None else cylinders
     full_z = full_cylinders(z_cyls)
     z_diams = dedup_diams(full_z)
     cross_diams = dedup_diams(full_cylinders(cross_cyls))
@@ -645,6 +649,7 @@ def _analyse(
     _views: tuple[str, ...] | None = None,
     _include_iso: bool = True,
     _view_constraints=None,
+    _framed_recognition: bool = False,
 ) -> Analysis:
     """Load STEP or use a build123d Shape, analyse geometry, compute layout.
 
@@ -656,11 +661,17 @@ def _analyse(
     # placement both reserve room for the border. Computed up front so the choose_scale inside
     # step-count convergence sees it too.
     margin = _content_margin(frame)
+    recognition: RecognitionResult | None
+    recognition_frame: object | None
+    recognition_frame_decision: object
     if _reuse is not None:
         # Explicit-scale fallback changes only page-space layout. Reuse the immutable geometry,
         # STEP/PMI census, classification, and recognition waist from the requested trial rather
         # than importing and recognising the same part up to fifteen more times (#1146).
         part = _reuse.part
+        source_part = _reuse.source_part if _reuse.source_part is not None else part
+        recognition_frame = _reuse.recognition_frame
+        recognition_frame_decision = _reuse.recognition_frame_decision
         src = str(_reuse.step_file)
         pmi_defaulted = _reuse.pmi_defaulted
         pmi_mode = _reuse.pmi_mode
@@ -683,6 +694,7 @@ def _analyse(
             part = _import_step(step_file)
             src = str(step_file)
         part = _solids_body(part, src)
+        source_part = part
 
         pmi_defaulted = pmi is None
         pmi_mode = "off" if pmi_defaulted else pmi
@@ -703,6 +715,37 @@ def _analyse(
                 _log.warning("PMI extraction failed: %s", exc)
                 pmi_report = PmiExtractionReport(error=f"{type(exc).__name__}: {exc}")
 
+        # ADR 0011: a declaration keeps the caller's coordinate authority and performs no
+        # recognition. Automatic detection instead consumes the provider's exact normalized
+        # working solid and result as ONE coordinate pair (#1357). The source body above is
+        # retained separately; no downstream stage is allowed to combine it with local facts.
+        layout_model = _coerce_layout_model(model, part, decorations)
+        recognition = None
+        recognition_frame = None
+        recognition_frame_decision = {
+            "status": "declared",
+            "gauge": None,
+            "refusal_reason": None,
+        }
+        if layout_model is None and _framed_recognition:
+            adapted = adapt_recognition(
+                part,
+                # Classification is derived below in the returned local coordinates. The
+                # provider's False/default aggregate is deliberately complete; Draftwright's
+                # own is_rotational fact gates the IR families that consume it (ADR 0017 §4).
+                rotational=False,
+                framed_builder=build_framed_recognition_result,
+                legacy_builder=build_recognition_result,
+            )
+            part = adapted.part
+            recognition = adapted.result
+            recognition_frame = adapted.frame
+            recognition_frame_decision = adapted.decision
+            if adapted.frame is not None and pmi_records:
+                from draftwright.pmi import reframe_pmi_records
+
+                pmi_records = reframe_pmi_records(pmi_records, adapted.frame)
+
         bb = part.bounding_box()
         x_size = bb.max.X - bb.min.X
         y_size = bb.max.Y - bb.min.Y
@@ -714,10 +757,33 @@ def _analyse(
 
         _log.info("Loaded %s  bbox: %.2f × %.2f × %.2f mm", src, x_size, y_size, z_size)
 
-        _gc = _classify_geometry(part, x_size, y_size, z_size, cx, cy, cz)
+        _gc = _classify_geometry(
+            part,
+            x_size,
+            y_size,
+            z_size,
+            cx,
+            cy,
+            cz,
+            cylinders=recognition.cylinders if recognition is not None else None,
+        )
         z_cyls, cross_cyls = _gc.z_cyls, _gc.cross_cyls
         z_diams, cross_diams = _gc.z_diams, _gc.cross_diams
         od_diam, od_axis, is_rotational = _gc.od_diam, _gc.od_axis, _gc.is_rotational
+        if layout_model is None and not _framed_recognition:
+            # Compatibility/default route: preserve the exact pre-#1357 ordering and
+            # classification-gated aggregate. The framed path must earn promotion through
+            # platform/canary evidence; opting in above is the separately reviewable rollout.
+            adapted = adapt_recognition(
+                part,
+                rotational=is_rotational,
+                framed=False,
+                cylinders=(z_cyls, cross_cyls),
+                framed_builder=build_framed_recognition_result,
+                legacy_builder=build_recognition_result,
+            )
+            recognition = adapted.result
+            recognition_frame_decision = adapted.decision
 
     # Step Z-levels feed both the step-height ladder and the page-sizing step
     # count. For a vertical (Z-axis) turned part, take them from the unified
@@ -730,8 +796,8 @@ def _analyse(
     # ADR 0011 / ADR 0017 §6: a declared model skips detection (#1022).  The gate has to sit
     # here, ABOVE the aggregate, which is why `_coerce_layout_model` moved up from its old
     # place below — it is pure (IR in, IR out) and reads nothing this block computes.
-    layout_model = _coerce_layout_model(model, part, decorations)
-    recognition: RecognitionResult | None
+    if _reuse is not None:
+        layout_model = _coerce_layout_model(model, part, decorations)
     _turned: TurnedProfile | None
     step_zs: list[float]
     if _reuse is not None:
@@ -747,9 +813,9 @@ def _analyse(
         _turned = _declared_turned_profile(layout_model)
         step_zs = _declared_step_zs(layout_model, _turned, bb)
     else:
-        recognition = build_recognition_result(
-            part, cylinders=(z_cyls, cross_cyls), rotational=is_rotational
-        )
+        # Filled above by the one framed adapter before local bbox/classification. A successful
+        # framed run, or the adapter's explicit legacy fallback, always supplies an aggregate.
+        assert recognition is not None
         _turned = TurnedProfile.from_steps(list(recognition.turned_steps))
         # The aggregate's own rule (#578 review; hoisted there by #1022, shared with critique
         # by #1025). Both callers deriving this separately let lint project over a different
@@ -1023,6 +1089,9 @@ def _analyse(
         planned_iso_scale=planned_iso_scale,
         view_constraints=_view_constraints,
         part=part,
+        source_part=source_part,
+        recognition_frame=recognition_frame,
+        recognition_frame_decision=recognition_frame_decision,
         recognition=recognition,
         bb=bb,
         x_size=x_size,

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -674,6 +674,7 @@ class _OffHole(NamedTuple):
 
     axis: str
     location: tuple
+    feature: HoleFeature | PatternFeature
     approved: dict
 
 
@@ -705,14 +706,17 @@ def _approved_off_axis_holes(plan) -> list[_OffHole]:
         # Derived, not spelled: the role is a CONTRACT between the compiler that mints it
         # and this filter that reads it. A literal here is a second owner — renaming the
         # declaration would make every side-hole position dim vanish (#966).
-        if entry.role != HoleFeature.LOCATION_OFF_AXIS_STEM:
+        if entry.axis == "z" or entry.role not in {
+            HoleFeature.LOCATION_OFF_AXIS_STEM,
+            PatternFeature.LOCATION_STEM,
+        }:
             continue
         assert entry.span is not None  # off-axis entries always carry datum → member
         member = entry.span[1]
         key = (entry.ref, member)
         hole = holes.get(key)
         if hole is None:
-            hole = holes[key] = _OffHole(entry.axis, member, {})
+            hole = holes[key] = _OffHole(entry.axis, member, resolve_feature(entry.ref), {})
         hole.approved[entry.discriminator] = entry
     return list(holes.values())
 
@@ -819,12 +823,11 @@ def _off_axis_queue(
         )
 
 
-def _off_axis_owner(ctx, hole_locs):
+def _off_axis_owner(holes):
     # The IR hole feature owning a side-drilled location dim, or None when the dim's
     # offset is shared by >1 distinct feature (unowned, so drop can't over-strip a
     # sibling — mirrors the #398c shared-coordinate rule). Promoted (#638).
-    feats = {ctx.feature_of_hole_at(loc) for loc in hole_locs}
-    feats.discard(None)
+    feats = {hole.feature for hole in holes}
     return next(iter(feats)) if len(feats) == 1 else None
 
 
@@ -843,7 +846,7 @@ def _locate_across(dwg, ctx, a: Analysis, off):
     seen_y: set = set()
     cands = []
     order_y: dict = {}
-    loc_by_name: dict = {}  # dim name -> contributing hole locations (for provenance)
+    loc_by_name: dict = {}  # dim name -> contributing holes/patterns (for provenance)
     mids_by_name: dict = {}
     coverage_by_name: dict = {}
     plan_alternates: dict = {}
@@ -856,7 +859,7 @@ def _locate_across(dwg, ctx, a: Analysis, off):
         if yo * a.SCALE < 1.0:
             continue
         name = f"dim_loc_side_y{round(yo * 100)}"
-        loc_by_name.setdefault(name, []).append(h.location)
+        loc_by_name.setdefault(name, []).append(h)
         mids_by_name.setdefault(name, []).append(entry.id)
         coverage_by_name.setdefault(name, []).append(_hole_location_coverage_fact(entry))
         order_y[name] = yo
@@ -894,7 +897,7 @@ def _locate_across(dwg, ctx, a: Analysis, off):
                     )
                 ),
             )
-    feats = {nm: _off_axis_owner(ctx, locs) for nm, locs in loc_by_name.items()}
+    feats = {nm: _off_axis_owner(holes) for nm, holes in loc_by_name.items()}
     measurements = {name: tuple(ids) for name, ids in mids_by_name.items()}
 
     def _fallback(name):
@@ -979,7 +982,7 @@ def _locate_along_planar(dwg, ctx, a: Analysis, off):
         if xo * a.SCALE < 1.0:
             continue
         name = f"dim_loc_front_x{round(xo * 100)}"
-        x_loc_by_name.setdefault(name, []).append(h.location)
+        x_loc_by_name.setdefault(name, []).append(h)
         x_mids_by_name.setdefault(name, []).append(entry.id)
         x_coverage_by_name.setdefault(name, []).append(_hole_location_coverage_fact(entry))
         order_x[name] = xo
@@ -997,7 +1000,7 @@ def _locate_along_planar(dwg, ctx, a: Analysis, off):
                     ),
                 )
             )
-    x_feats = {nm: _off_axis_owner(ctx, locs) for nm, locs in x_loc_by_name.items()}
+    x_feats = {nm: _off_axis_owner(holes) for nm, holes in x_loc_by_name.items()}
     x_measurements = {name: tuple(ids) for name, ids in x_mids_by_name.items()}
     _off_axis_queue(
         dwg,
@@ -1035,7 +1038,7 @@ def _locate_along_z(dwg, ctx, a: Analysis, off):
     for h in off:
         entry = h.approved.get("z")
         if entry is not None and round(entry.value, 2) * a.SCALE >= 1.0:
-            z_locs.setdefault(round(entry.value, 2), []).append(h.location)
+            z_locs.setdefault(round(entry.value, 2), []).append(h)
             z_mids.setdefault(round(entry.value, 2), []).append(entry.id)
             z_coverage.setdefault(round(entry.value, 2), []).append(
                 _hole_location_coverage_fact(entry)
@@ -1050,7 +1053,7 @@ def _locate_along_z(dwg, ctx, a: Analysis, off):
             continue
         seen_z.add(zo)
         hz = h.location[2]
-        owner = _off_axis_owner(ctx, z_locs[zo])
+        owner = _off_axis_owner(z_locs[zo])
 
         def _zc(view, p_lo, p_hi, edge, _zo=zo, _lbl=entry.value_text):
             return (
@@ -1211,6 +1214,8 @@ def _locate_off_axis_holes(dwg, ctx, a: Analysis, *, which, plan):
         # prevents ``a.is_rotational``. Treat either classification as a valid
         # turning axis so the centreline, not redundant half-envelope offsets,
         # locates the bore (#881).
+        if isinstance(h.feature, PatternFeature):
+            return False
         turning_axis = a.od_axis if a.is_rotational else getattr(a.prof, "axis", None)
         if turning_axis is None or h.axis != turning_axis:
             return False
@@ -1388,42 +1393,18 @@ def _add_grid_pitch_dims(
     drop_code=None,
 ):
     """Both pitch dimensions of a rectangular grid — one along each lattice axis,
-    each labelled ``(n-1)× pitch`` (#92).  The two axes are recovered as the two
-    shortest near-orthogonal inter-hole page vectors (the recogniser's own
-    basis); this is used only to pick the dimension endpoints and the per-axis
-    count, not to re-recognise the grid (recognition stays upstream). *members* are
-    the grid's member locations; *nominals* is ``(row_pitch, col_pitch)``."""
-    pts = [to_page(m) for m in members]
-    diffs = []
-    for ia in range(len(pts)):
-        for ib in range(len(pts)):
-            if ia == ib:
-                continue
-            dx, dy = pts[ib][0] - pts[ia][0], pts[ib][1] - pts[ia][1]
-            length = math.hypot(dx, dy)
-            if length > 1e-6:
-                diffs.append((length, dx, dy))
-    if not diffs:
-        return
-    diffs.sort()
-    l1, ax, ay = diffs[0]
-    u1 = (ax / l1, ay / l1)
-    basis2 = next(
-        (
-            (length, dx, dy)
-            for length, dx, dy in diffs
-            if abs((dx * u1[0] + dy * u1[1]) / length) < 0.2
-        ),
-        None,
-    )
-    if basis2 is None:
-        return
-    l2, bx, by = basis2
-    u2 = (bx / l2, by / l2)
+    each labelled ``(n-1)× pitch`` (#92). The recognised frame supplies the axes; this is
+    used only to pick dimension endpoints and per-axis counts, not to re-recognise the grid
+    (recognition stays upstream). *members* are the grid's member locations; *nominals* is
+    ``(row_pitch, col_pitch)``.
 
-    # The two pitch values are not identities: on a square-pitch grid they are equal. Map
-    # recovered page axes to the IR's row/column lattice basis instead. `angle` names the
-    # column direction in the plane_axes frame; the perpendicular direction is the row.
+    The axes come from the recognised pattern frame, not from a shortest-pair search over
+    member coordinates.  Equal lattice edges are intentionally interchangeable geometry;
+    using their last few floating-point bits as a tie-break made the chosen edge (and hence
+    placement success) change when b123d-recognisers 0.4.6 rounded otherwise identical
+    member coordinates (#1357).  The IR already owns the row/column basis, so use it.
+    """
+    pts = [to_page(m) for m in members]
     actual_feature = resolve_feature(feature)
     by_discriminator = {
         entry.discriminator: entry
@@ -1433,14 +1414,37 @@ def _add_grid_pitch_dims(
     pu, pv = plane_axes(actual_feature.frame.axis)
     angle = math.radians(actual_feature.angle or 0.0)
     column_world = tuple(math.cos(angle) * pu[k] + math.sin(angle) * pv[k] for k in range(3))
+    row_world = tuple(-math.sin(angle) * pu[k] + math.cos(angle) * pv[k] for k in range(3))
     origin = actual_feature.frame.origin
     page_origin = to_page(origin)
-    page_column = to_page(tuple(origin[k] + column_world[k] for k in range(3)))
-    dx, dy = page_column[0] - page_origin[0], page_column[1] - page_origin[1]
-    norm = math.hypot(dx, dy)
-    column_page = (dx / norm, dy / norm)
 
-    def _axis_dim(u, pitch_page, sub):
+    def _page_axis(world, discriminator):
+        pitch = by_discriminator.get(discriminator)
+        if pitch is None:
+            return None
+        endpoint = to_page(tuple(origin[k] + world[k] for k in range(3)))
+        dx, dy = endpoint[0] - page_origin[0], endpoint[1] - page_origin[1]
+        unit_scale = math.hypot(dx, dy)
+        if unit_scale <= 1e-9:
+            return None
+        return ((dx / unit_scale, dy / unit_scale), abs(pitch.value) * unit_scale, pitch)
+
+    axes = [
+        axis
+        for axis in (
+            _page_axis(column_world, "col"),
+            _page_axis(row_world, "row"),
+        )
+        if axis is not None
+    ]
+    if len(axes) != 2:
+        return
+    # Keep the historical short-axis-first annotation order while making equal-pitch grids
+    # deterministic by semantic discriminator instead of member order.
+    axes.sort(key=lambda axis: (round(axis[1], 9), axis[2].discriminator or ""))
+    min_pitch_page = min(axis[1] for axis in axes)
+
+    def _axis_dim(u, pitch_page, pitch, sub):
         perp = (-u[1], u[0])
 
         def along(idx):
@@ -1449,19 +1453,32 @@ def _add_grid_pitch_dims(
         def across(idx):
             return pts[idx][0] * perp[0] + pts[idx][1] * perp[1]
 
-        lo = min(range(len(pts)), key=along)
-        # Keep the dimension on ONE lattice line: of the holes sharing lo's
-        # perpendicular coordinate, take the far one along u. Picking the global
-        # max-projection hole instead lands on the opposite diagonal corner and
-        # draws the pitch dim diagonally across the grid (#92).
+        # Keep the dimension on ONE lattice line. Pick the OUTER line on the same page side
+        # the pitch placer prefers, rather than whichever equal edge happened to contain the
+        # lexicographically smallest floating-point difference. Besides being deterministic,
+        # this minimises extension-line reach and leaves the opposite lattice dimension room.
+        if view == "side":
+            anchor = min(range(len(pts)), key=lambda idx: (across(idx), along(idx)))
+        else:
+            preferred = (-0.3, 1.0) if view == "plan" else (-0.3, -1.0)
+            toward_positive = perp[0] * preferred[0] + perp[1] * preferred[1] >= 0.0
+            extremum = max if toward_positive else min
+            anchor = extremum(
+                range(len(pts)),
+                key=lambda idx: (across(idx), along(idx)),
+            )
+        anchor_across = across(anchor)
+        # Of the holes sharing the selected line's perpendicular coordinate, take both
+        # extremes along u. Picking the global max-projection hole instead lands on the
+        # opposite diagonal corner and draws the pitch dim diagonally across the grid (#92).
         # Tolerance must be below the PERPENDICULAR lattice-line spacing — which
         # is the *other* axis' pitch, so use the smaller of the two pitches.
         # (pitch_page * 0.25 fails on a high-aspect grid: for the long axis the
         # perpendicular lines are only the short pitch apart, and a quarter of
         # the long pitch can exceed that, merging two lines → diagonal again.)
-        lo_across = across(lo)
-        line_tol = min(l1, l2) * 0.25
-        line = [idx for idx in range(len(pts)) if abs(across(idx) - lo_across) < line_tol]
+        line_tol = min_pitch_page * 0.25
+        line = [idx for idx in range(len(pts)) if abs(across(idx) - anchor_across) < line_tol]
+        lo = min(line, key=along)
         hi = max(line, key=along)
         # The holes this dim actually spans, in the order it spans them. `members[lo:hi+1]`
         # is a slice of the IR's member order, which on a grid walks the lattice in neither
@@ -1471,10 +1488,6 @@ def _add_grid_pitch_dims(
         spanned = [members[idx] for idx in sorted(line, key=along)]
         span = along(hi) - along(lo)
         n = round(span / pitch_page) + 1
-        discriminator = (
-            "col" if abs(u[0] * column_page[0] + u[1] * column_page[1]) > 0.7 else "row"
-        )
-        pitch = by_discriminator[discriminator]
         _place_pitch_dim(
             dwg,
             a,
@@ -1491,8 +1504,8 @@ def _add_grid_pitch_dims(
             ctx=ctx,
         )
 
-    _axis_dim(u1, l1, 0)
-    _axis_dim(u2, l2, 1)
+    for sub, (unit, pitch_page, pitch) in enumerate(axes):
+        _axis_dim(unit, pitch_page, pitch, sub)
 
 
 def _pitch_text(pitch, members, draft, *, ctx) -> str:

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -445,7 +445,13 @@ def detect_part_model(part, *, pmi="off") -> PartModel:
     seed path behind :meth:`draftwright.Sheet.from_part`, so pure feature inspection no longer
     pays for a full drawing (nor its layout/rendering failure modes)."""
     a = _analyse(
-        part, title="", number="", tolerance="ISO 2768-m", drawn_by="", out="model", pmi=pmi
+        part,
+        title="",
+        number="",
+        tolerance="ISO 2768-m",
+        drawn_by="",
+        out="model",
+        pmi=pmi,
     )
     # `_analyse` already detected and stored the model, so calling `build_model(a)`
     # unconditionally re-ran every detector `build_part_model` doesn't take by injection —
@@ -491,7 +497,8 @@ def _assemble(
         dist=dist,
         centroid=(a.cx, a.cy, a.cz),
         out=out,
-        part=a.part,
+        part=a.source_part if a.source_part is not None else a.part,
+        working_part=a.part,
         cyls=a.cyls,
         assembly=assembly,
         reproducible=reproducible,
@@ -1092,6 +1099,7 @@ def _build_drawing_once(
     projection: str | None = None,
     zones: bool = False,
     reproducible: bool = False,
+    framed_recognition: bool = False,
     _analysis_base=None,
     _analysis_sink: Callable[[Analysis], None] | None = None,
     _critique_recognition=None,
@@ -1141,6 +1149,14 @@ def _build_drawing_once(
             because it is not free: settling the element order costs roughly a third
             of DXF export time again (one bounding box and one edge walk per part),
             while the metadata pinning it also turns on is ~1 ms.
+        framed_recognition: opt into provider-owned part-relative recognition for an
+            automatically detected build. On success the returned drawing keeps the caller
+            solid as :attr:`Drawing.part`, compiles and projects the exact normalized solid as
+            :attr:`Drawing.working_part`, and exposes the mapping and JSON-friendly decision as
+            ``recognition_frame`` / ``recognition_frame_decision``. A typed provider refusal
+            takes an explicit legacy fallback. The default remains ``False`` while the framed
+            route completes platform and representative-part rollout evidence. Supplying
+            ``model=`` remains a declared caller-coordinate build and performs no recognition.
         model: a caller-supplied IR (ADR 0011) — a :class:`PartModel`, or a sequence
             of :class:`Feature`\\ s (declared with :func:`draftwright.model.hole`,
             ``boss``, ``step``, … from the objects you built). When given, **feature
@@ -1214,6 +1230,7 @@ def _build_drawing_once(
             _views=views,
             _include_iso=_include_iso,
             _view_constraints=_view_constraints,
+            _framed_recognition=framed_recognition,
         )
 
     a = analyse(reuse=_analysis_base, views=_views)
@@ -1745,6 +1762,7 @@ def build_drawing(
     zones: bool = False,
     scale_policy: Literal["strict", "fallback", "permissive"] = "fallback",
     reproducible: bool = False,
+    framed_recognition: bool = False,
     _post_build: Callable[[Drawing], Drawing] | None = None,
     _required_tables=(),
     _views: tuple[str, ...] | None = None,
@@ -1793,6 +1811,7 @@ def build_drawing(
         projection=projection,
         zones=zones,
         reproducible=reproducible,
+        framed_recognition=framed_recognition,
         _required_tables=_required_tables,
         _include_iso=_include_iso,
         _view_constraints=_view_constraints,
@@ -2633,6 +2652,7 @@ def make_drawing(
     zones: bool = False,
     scale_policy: Literal["strict", "fallback", "permissive"] = "fallback",
     reproducible: bool = False,
+    framed_recognition: bool = False,
 ) -> tuple[str, str]:
     """Generate a 4-view technical drawing from a STEP file or build123d object.
 
@@ -2661,6 +2681,10 @@ def make_drawing(
         reproducible: make repeated exports from the returned drawing byte-identical
             on the same Draftwright version. Off by default because canonical DXF
             ordering has a measurable export-time cost.
+        framed_recognition: opt into part-relative automatic recognition. The returned
+            drawing retains caller-space ``part`` plus the provider-owned local
+            ``working_part`` and frame decision. Default ``False`` during evidence-gated
+            rollout; declared ``model=`` builds remain in caller coordinates.
 
     Returns:
         Tuple of ``(svg_path, dxf_path)`` for the generated files.
@@ -2697,6 +2721,7 @@ def make_drawing(
         projection=projection,
         zones=zones,
         reproducible=reproducible,
+        framed_recognition=framed_recognition,
         scale_policy=scale_policy,
     ).export(formats=("svg", "dxf"))
     assert isinstance(_paths, dict)  # formats=... always returns the {format: path} dict

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -373,9 +373,16 @@ def feature_key(f) -> str | None:
     axis = getattr(frame, "axis", "")
     if origin is None:
         return f"{kind}/{axis}" if axis else kind
-    x, y, z = (float(v) for v in (origin[0], origin[1], origin[2]))
+    # Python preserves the sign of a rounded negative epsilon (``-0.000``). Rigidly equivalent
+    # framed builds can acquire opposite kernel-noise signs, so canonicalise zero after the
+    # ledger's documented 3-decimal rounding before serialising identity (#1357).
+    def clean(value) -> float:
+        rounded = round(float(value), 3)
+        return 0.0 if rounded == 0 else rounded
+
+    x, y, z = (clean(v) for v in (origin[0], origin[1], origin[2]))
     sizes = [
-        f"{name}={float(v):.3f}"
+        f"{name}={clean(v):.3f}"
         for name in _KEY_SCALARS
         if isinstance(v := getattr(f, name, None), (int, float))
     ]
@@ -532,7 +539,10 @@ class Drawing:
         centroid: unscaled centroid ``(x, y, z)``.
         views: ``{name: (visible_compound, hidden_compound_or_None)}``.
         items: ordered list of annotation objects (mutable).
-        part: the source solid, when known — enables the feature-coverage lint.
+        part: the caller-space source solid, when known.
+        working_part: the solid in the coordinate system used by the IR, projected views, and
+            physical lint. Defaults to ``part``; automatic framed builds retain their
+            normalized working solid here without changing ``part`` or public Sheet coordinates.
         assembly: feature-coverage severity control — ``None`` auto-detects a
             multi-solid part as an assembly (per-part bores at ``info``),
             ``True``/``False`` forces it (#69).
@@ -559,6 +569,7 @@ class Drawing:
         centroid,
         out,
         part=None,
+        working_part=None,
         cyls=None,
         assembly=None,
         reproducible=False,
@@ -610,6 +621,7 @@ class Drawing:
             "detail": "the section pass has not run",
         }
         self.part = part
+        self._working_part = part if working_part is None else working_part
         self._cyl_cache = cyls
         # None → the coverage lint auto-detects a multi-solid part as an
         # assembly; True/False forces assembly/strict severity (#69).
@@ -668,6 +680,33 @@ class Drawing:
         prevent. Editing means converting it into constraints explicitly and resolving again.
         """
         return self._build.view_plan
+
+    @property
+    def working_part(self):
+        """The solid compiled/projected by this drawing (read-only).
+
+        On automatic framed builds this is provider-normalized local geometry. ``part`` remains
+        the caller-space source; declared and legacy builds use the same solid for both.
+        """
+
+        return self._working_part
+
+    @property
+    def recognition_frame(self):
+        """Caller-space → working-space frame, or ``None`` when no frame was adopted."""
+
+        return getattr(self._build.analysis, "recognition_frame", None)
+
+    @property
+    def recognition_frame_decision(self):
+        """JSON-friendly framed/legacy/refusal outcome for this build."""
+
+        decision = getattr(self._build.analysis, "recognition_frame_decision", None)
+        return decision or {
+            "status": "not_evaluated",
+            "gauge": None,
+            "refusal_reason": None,
+        }
 
     @property
     def registry(self):
@@ -3314,7 +3353,8 @@ class Drawing:
             view_material_fields=self.material_fields(),
             _aggregation=aggregation,
         )
-        if self.part is not None and physical:
+        working_part = self._working_part
+        if working_part is not None and physical:
             # Reuse the single feature inventory from the build (#244) when present,
             # so lint does not re-detect holes/patterns/turned-steps; fall back to
             # detecting when there is no analysis (a manually-built Drawing, or lint
@@ -3341,7 +3381,7 @@ class Drawing:
                 # empty because nothing looked — not because the part has none. Feeding that
                 # emptiness to coverage would report every real hole as uncovered, so critique
                 # recognises here instead: once per drawing, owned by BuildState.
-                rec = self._build.ensure_recognition(self.part)
+                rec = self._build.ensure_recognition(working_part)
                 cyls = rec.cylinders
                 holes = list(rec.holes)
                 patterns = list(rec.hole_patterns)
@@ -3360,16 +3400,16 @@ class Drawing:
                 prof_kw = {"prof": a.prof}
             else:
                 if self._cyl_cache is None:
-                    self._cyl_cache = analyse_cylinders(self.part)
+                    self._cyl_cache = analyse_cylinders(working_part)
                 cyls = self._cyl_cache
                 holes = patterns = bosses = None
                 pads = pockets = recognition = None
                 prof_kw = {}
             if recognition is None:
-                recognition = self._build.ensure_recognition(self.part)
+                recognition = self._build.ensure_recognition(working_part)
             profiled_bores = list(recognition.double_d_bores)
             issues += lint_feature_coverage(
-                self.part,
+                working_part,
                 self.items,
                 cyls=cyls,
                 exclude=self._coverage.dropped_diams,
@@ -3379,7 +3419,7 @@ class Drawing:
                 registry=self._registry,
             )
             issues += lint_axial_coverage(
-                self.part,
+                working_part,
                 self,
                 assembly=self.assembly,
                 recognition=recognition,
@@ -3400,14 +3440,14 @@ class Drawing:
             # specifically for a prismatic boss's independent projection height.
             if model is not None and (a is None or (not a.is_rotational and a.prof is None)):
                 issues += lint_boss_height_coverage(
-                    self.part,
+                    working_part,
                     self,
                     getattr(model, "features", ()),
                     assembly=self.assembly,
                     omissions=self._build.omissions,
                 )
             issues += lint_location_coverage(
-                self.part,
+                working_part,
                 self,
                 cyls=cyls,
                 assembly=self.assembly,
@@ -3416,7 +3456,7 @@ class Drawing:
                 profiled_bores=profiled_bores,
             )
             issues += lint_prismatic_coverage(
-                self.part,
+                working_part,
                 self,
                 assembly=self.assembly,
                 pads=pads,
@@ -3430,26 +3470,26 @@ class Drawing:
             issues += lint_angled_step_coverage(recognition)
             resolved_assembly = self.assembly
             if resolved_assembly is None:
-                resolved_assembly = len(self.part.solids()) > 1
+                resolved_assembly = len(working_part.solids()) > 1
             profile_cache = self._build.principal_profile_cache
             if (
                 profile_cache is None
-                or profile_cache[0] is not self.part
+                or profile_cache[0] is not working_part
                 or profile_cache[1] != resolved_assembly
             ):
                 profile_issues = tuple(
                     lint_principal_profile_coverage(
-                        self.part,
+                        working_part,
                         assembly=resolved_assembly,
                         prismatic_pockets=recognition.prismatic_pockets,
                         section_passages=recognition.section_passages,
                     )
                 )
-                profile_cache = (self.part, resolved_assembly, profile_issues)
+                profile_cache = (working_part, resolved_assembly, profile_issues)
                 self._build.principal_profile_cache = profile_cache
             issues += list(profile_cache[2])
             issues += lint_profiled_bore_coverage(
-                self.part,
+                working_part,
                 self.items,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
@@ -3459,7 +3499,7 @@ class Drawing:
                 assembly=self.assembly,
             )
             issues += lint_flat_coverage(
-                self.part,
+                working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
                 registry=self._registry,
@@ -3467,7 +3507,7 @@ class Drawing:
                 assembly=self.assembly,
             )
             issues += lint_groove_coverage(
-                self.part,
+                working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
                 registry=self._registry,
@@ -3475,7 +3515,7 @@ class Drawing:
                 assembly=self.assembly,
             )
             issues += lint_slot_coverage(
-                self.part,
+                working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
                 registry=self._registry,
@@ -3483,7 +3523,7 @@ class Drawing:
                 assembly=self.assembly,
             )
             issues += lint_hole_coverage(
-                self.part,
+                working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
                 registry=self._registry,
@@ -3491,7 +3531,7 @@ class Drawing:
                 assembly=self.assembly,
             )
             issues += lint_channel_coverage(
-                self.part,
+                working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
                 registry=self._registry,
@@ -3499,7 +3539,7 @@ class Drawing:
                 assembly=self.assembly,
             )
             issues += lint_polygonal_stock_coverage(
-                self.part,
+                working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
                 registry=self._registry,
@@ -3507,7 +3547,7 @@ class Drawing:
                 assembly=self.assembly,
             )
             issues += lint_pocket_coverage(
-                self.part,
+                working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
                 registry=self._registry,
@@ -3515,7 +3555,7 @@ class Drawing:
                 assembly=self.assembly,
             )
             issues += lint_pocket_pattern_coverage(
-                self.part,
+                working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
                 registry=self._registry,

--- a/src/draftwright/inspection_contract.py
+++ b/src/draftwright/inspection_contract.py
@@ -16,7 +16,7 @@ from b123d_recognisers.inspection import inspection_api_manifest
 CONSUMER_INSPECTION_FORMAT = "draftwright-inspection-api"
 CONSUMER_INSPECTION_FORMAT_VERSION = 1
 SUPPORTED_INSPECTION_API_MAJOR = 1
-SUPPORTED_RECOGNISER_VERSION = "0.4.5"
+SUPPORTED_RECOGNISER_VERSION = "0.4.6"
 _DISTRIBUTION = "b123d-recognisers"
 _PROVIDER_FORMAT = "b123d-recognisers-inspection-api"
 _NAMESPACE = "b123d_recognisers.inspection"

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -148,7 +148,11 @@ _NON_REQUIREMENT_INVENTORIES = frozenset(
 #: merging them would let an undecided family look settled (#1244). Passage, PrismaticPocket and
 #: AngledStep left this register when #1245/#1246/#1247 gave every authoritative occurrence an
 #: unsupported outcome.
-_UNDECIDED_INVENTORIES: dict[str, str] = {}
+_UNDECIDED_INVENTORIES: dict[str, str] = {
+    "circular_blind_steps": "https://github.com/pzfreo/draftwright/issues/1382",
+    "paired_ramp_steps": "https://github.com/pzfreo/draftwright/issues/1382",
+    "through_steps": "https://github.com/pzfreo/draftwright/issues/1382",
+}
 
 _AUDITED_FAMILIES = (
     "angled_steps",

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -1288,36 +1288,59 @@ def _compile_off_axis_hole_locations(
     for f in model.features:
         # Eligibility comes from `location_datum`, not a second orientation rule here —
         # that is the duplication this whole class of defect keeps coming from (#925).
-        if not isinstance(f, HoleFeature) or location_datum(f) != "bbox":
+        if not isinstance(f, HoleFeature | PatternFeature) or location_datum(f) != "bbox":
             continue
-        # An X-drilled hole is located across Y; a Y-drilled one across X. Both carry a
-        # height. (Pattern members are their own `PatternFeature`, so patterned holes are
-        # excluded by construction — as `_ir_off_axis_holes` documents.)
+        # An X-normal hole/pattern is located across Y; a Y-normal one across X. Both carry
+        # a height. Framed recognition can rotate the ordinary Z-normal pattern case onto
+        # either principal axis, so treating PatternFeature as unlocatable would discard a
+        # physical requirement solely because the input was rigidly moved (#1357).
         measured = ("y" if f.frame.axis == "x" else "x", "z")
         omitted = authored_location_omitted(model, f)
-        for member in f.members or (f.frame.origin,):
+        references: tuple[Point, ...]
+        if isinstance(f, PatternFeature):
+            if f.pattern == "bolt_circle" or not f.members:
+                references = (f.frame.origin,)
+            else:
+                transverse = tuple(axis for axis in "xyz" if axis != f.frame.axis)
+                references = (
+                    min(
+                        f.members,
+                        key=lambda member: sum(
+                            (
+                                member["xyz".index(axis)]
+                                - float(getattr(bb.min, axis.upper()))
+                            )
+                            ** 2
+                            for axis in transverse
+                        ),
+                    ),
+                )
+            role = f.LOCATION_STEM
+        else:
+            references = f.members or (f.frame.origin,)
+            role = f.LOCATION_OFF_AXIS_STEM
+        for member in references:
             for meas in measured:
                 index = "xyz".index(meas)
                 datum = float(getattr(bb.min, meas.upper()))
                 value = abs(member[index] - datum)
+                parameter = f"{role}.location" if isinstance(f, PatternFeature) else f"{role}.{meas}"
                 if omitted:
                     omissions.append(
-                        Omission(
-                            f, f"{f.LOCATION_OFF_AXIS_STEM}.{meas}", value, _AUTHORED_OMISSION
-                        )
+                        Omission(f, parameter, value, _AUTHORED_OMISSION)
                     )
                     continue
                 start = list(member)
                 start[index] = datum
                 approved.append(
                     ApprovedDimension(
-                        id=_dim_id(f, f"{f.LOCATION_OFF_AXIS_STEM}.{meas}"),
+                        id=_dim_id(f, parameter),
                         value_text=_fmt(value),
                         value=value,
                         span=((start[0], start[1], start[2]), member),
                         ref=FeatureRef(f),
                         kind="length",
-                        role=f.LOCATION_OFF_AXIS_STEM,  # the feature owns its name (#966)
+                        role=role,  # the feature owns its name (#966)
                         discriminator=meas,
                         axis=f.frame.axis,
                     )

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -24,6 +24,7 @@ from b123d_recognisers import (
     BossRecord,
     Chamfer,
     Channel,
+    CircularBlindStep,
     CounterSink,
     DoubleDBore,
     FaceLevel,
@@ -33,6 +34,7 @@ from b123d_recognisers import (
     HoleRecord,
     HoleSpec,
     LinearArray,
+    PairedRampStep,
     Passage,
     Plate,
     Pocket,
@@ -50,6 +52,7 @@ from b123d_recognisers import (
     SlotArray,
     SlotGrid,
     StepShoulder,
+    ThroughStep,
     TurnedProfile,
     TurnedStep,
     has_multi_axis_plates,
@@ -736,6 +739,18 @@ _UNCONSUMED_RECORDS: dict[type, str] = {
         "an aggregate-reconciled polygonal blind recess not owned by `Pocket`; its arbitrary "
         "section has no truthful general Draftwright dimension grammar, so every occurrence has "
         "an explicit unsupported completeness outcome (#1246)"
+    ),
+    CircularBlindStep: (
+        "a physical step family added in recognisers 0.4.6; Draftwright has not yet reviewed "
+        "its feature, view, dimension, or completeness semantics (#1382)"
+    ),
+    PairedRampStep: (
+        "a physical step family added in recognisers 0.4.6; Draftwright has not yet reviewed "
+        "its feature, view, dimension, or completeness semantics (#1382)"
+    ),
+    ThroughStep: (
+        "a physical step family added in recognisers 0.4.6; Draftwright has not yet reviewed "
+        "its feature, view, dimension, or completeness semantics (#1382)"
     ),
 }
 

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -740,11 +740,12 @@ def location_datum(feature) -> str | None:
         return "datum_xy"  # every orientation: its two in-plane coordinates
     if isinstance(feature, HoleFeature):
         return "datum_xy" if feature.frame.axis == "z" else "bbox"
-    # Patterns, pocket/slot-patterns and pads: the plan-X / side-Y ladder only, so Z-normal
-    # only. A fall-through, not another `isinstance` + `return None`: membership above is by
-    # exact type, so those four are all that can reach here and the extra arm was
-    # unreachable — dead code that read as defensive and showed up as the one uncovered
-    # line in the patch.
+    # A framed automatic build may make a physical hole-pattern plane X/Y-normal. It is the
+    # same locatable requirement as a Z-normal pattern, compiled from the working bbox and
+    # rendered in the end-on principal view just like an off-axis singleton hole (#1357).
+    if isinstance(feature, PatternFeature):
+        return "datum_xy" if feature.frame.axis == "z" else "bbox"
+    # Pocket/slot-patterns and pads: the plan-X / side-Y ladder only, so Z-normal only.
     return "datum_xy" if feature.frame.axis == "z" else None
 
 

--- a/src/draftwright/pmi.py
+++ b/src/draftwright/pmi.py
@@ -239,6 +239,89 @@ class PmiRecord:
     cylindrical_refs: tuple[CylindricalReference, ...] = ()
 
 
+def _frame_direction(direction, frame) -> tuple[float, float, float]:
+    """Rotate a caller-space direction into *frame* without applying its origin."""
+
+    return tuple(
+        sum(float(direction[index]) * float(axis[index]) for index in range(3))
+        for axis in (frame.x, frame.y, frame.z)
+    )  # type: ignore[return-value]
+
+
+def _frame_axis(axis: str, frame) -> str:
+    if axis.upper() not in {"X", "Y", "Z"}:
+        return "?" if axis else ""
+    unit = tuple(1.0 if index == "XYZ".index(axis.upper()) else 0.0 for index in range(3))
+    local = _frame_direction(unit, frame)
+    dominant = max(range(3), key=lambda index: abs(local[index]))
+    if abs(abs(local[dominant]) - 1.0) > 1e-6 or any(
+        abs(local[index]) > 1e-6 for index in range(3) if index != dominant
+    ):
+        return "?"
+    return "XYZ"[dominant]
+
+
+def _frame_bbox(bbox, frame) -> tuple[float, float, float, float, float, float] | None:
+    if bbox is None:
+        return None
+    corners = tuple(
+        frame.to_local((bbox[ix], bbox[iy], bbox[iz]))
+        for ix in (0, 3)
+        for iy in (1, 4)
+        for iz in (2, 5)
+    )
+    return tuple(
+        min(point[index] for point in corners) for index in range(3)
+    ) + tuple(max(point[index] for point in corners) for index in range(3))
+
+
+def _frame_cylinder(reference: CylindricalReference, frame) -> CylindricalReference:
+    start = tuple(
+        reference.axis_origin[index]
+        + reference.axial_interval[0] * reference.axis_direction[index]
+        for index in range(3)
+    )
+    finish = tuple(
+        reference.axis_origin[index]
+        + reference.axial_interval[1] * reference.axis_direction[index]
+        for index in range(3)
+    )
+    local_start = frame.to_local(start)
+    local_finish = frame.to_local(finish)
+    direction = tuple(local_finish[index] - local_start[index] for index in range(3))
+    length = math.sqrt(sum(component * component for component in direction))
+    return CylindricalReference.canonical(
+        axis_point=local_start,
+        axis_direction=direction,
+        radius=reference.radius,
+        local_interval=(0.0, length),
+        sense=reference.sense,
+    )
+
+
+def reframe_pmi_records(records, frame) -> list[PmiRecord]:
+    """Map AP242 geometry facts from caller space into the framed working solid.
+
+    This is the only source→working coordinate conversion in Draftwright. Numeric requirement
+    values and source identities are unchanged; points, support bounds, axes, and finite-cylinder
+    provenance move together so PMI lowering never correlates caller-space facts with local IR.
+    """
+
+    return [
+        replace(
+            record,
+            ref_pts=tuple(frame.to_local(point) for point in record.ref_pts),
+            ref_bbox=_frame_bbox(record.ref_bbox, frame),
+            dominant_axis=_frame_axis(record.dominant_axis, frame),
+            reference_axis=_frame_axis(record.reference_axis, frame),
+            cylindrical_refs=tuple(
+                _frame_cylinder(reference, frame) for reference in record.cylindrical_refs
+            ),
+        )
+        for record in records
+    ]
+
+
 PmiExtractionOutcome = Literal[
     "extracted", "partially_extracted", "presentation_only", "not_extracted"
 ]

--- a/src/draftwright/recogniser_contract.py
+++ b/src/draftwright/recogniser_contract.py
@@ -270,7 +270,7 @@ def _geometry_only_declaration() -> dict[str, Any]:
 #: have a live decision issue, while a settled unsupported boundary must carry an explicit
 #: outcome such as Passage completeness below. ``pending_family_declarations`` reports anything
 #: absent from BOTH this map and ``_FAMILIES``, so the next new family fails closed exactly as
-#: these three did (#1244).
+#: the first three did (#1244), and the 0.4.6 step families do now (#1382).
 _UNSUPPORTED: dict[str, tuple[tuple[str, ...], str, str]] = {
     "passages": (
         (
@@ -304,6 +304,30 @@ _UNSUPPORTED: dict[str, tuple[tuple[str, ...], str, str]] = {
         "AngledStep, but its angle, legs and run length do not themselves decide which drawing "
         "requirements or section/detail view are required. Draftwright therefore reports every "
         "occurrence as an unsupported completeness requirement.",
+    ),
+    "circular-blind-steps": (
+        ("CircularBlindStep",),
+        "https://github.com/pzfreo/draftwright/issues/1382",
+        "The provider proves a quarter-cylindrical blind corner step and supplies its radius, "
+        "run and oriented section. Draftwright has not yet reviewed which feature, view and "
+        "dimension grammar truthfully expresses that manufacturing requirement, so every "
+        "consumer boundary remains unsupported and completeness remains explicitly deferred.",
+    ),
+    "paired-ramp-steps": (
+        ("PairedRampStep",),
+        "https://github.com/pzfreo/draftwright/issues/1382",
+        "The provider proves a mirror-symmetric two-sided ramp and supplies its angle, run and "
+        "ridge anchor. Draftwright has not yet reviewed which feature, view and dimension "
+        "grammar truthfully expresses that manufacturing requirement, so every consumer "
+        "boundary remains unsupported and completeness remains explicitly deferred.",
+    ),
+    "through-steps": (
+        ("ThroughStep",),
+        "https://github.com/pzfreo/draftwright/issues/1382",
+        "The provider proves a principal-axis rectangular through step and supplies its run, "
+        "anchor and open section. Draftwright has not yet reviewed which feature, view and "
+        "dimension grammar truthfully expresses that manufacturing requirement, so every "
+        "consumer boundary remains unsupported and completeness remains explicitly deferred.",
     ),
 }
 

--- a/src/draftwright/recognition_frame.py
+++ b/src/draftwright/recognition_frame.py
@@ -1,0 +1,103 @@
+"""Draftwright's owned framed-recognition boundary (#1357).
+
+The external package owns frame inference and topology-preserving normalisation. Draftwright
+owns the consumer decision: automatic detection compiles the returned local working solid and
+its aggregate together, while retaining the caller-space solid and frame as provenance. A
+typed frame refusal takes the documented legacy path; no downstream stage is allowed to combine
+local records with caller-space geometry or independently recreate the provider's transform.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal
+
+from b123d_recognisers import (
+    FramedRecognitionResult,
+    PartFrame,
+    RecognitionResult,
+    RefusedPartFrame,
+    build_framed_recognition_result,
+    build_recognition_result,
+)
+from build123d import Shape
+
+RecognitionFrameStatus = Literal["framed", "legacy_fallback", "legacy"]
+
+
+@dataclass(frozen=True)
+class AdaptedRecognition:
+    """One coherent shape/result pair plus caller-space provenance.
+
+    ``part`` and ``result`` are always expressed in the same coordinate system. ``source_part``
+    is never transformed. ``frame`` maps source coordinates to ``part`` coordinates when the
+    framed route succeeds and is ``None`` on either legacy route.
+    """
+
+    source_part: Shape
+    part: Shape
+    result: RecognitionResult
+    frame: PartFrame | None
+    status: RecognitionFrameStatus
+    refusal_reason: str | None = None
+
+    @property
+    def decision(self) -> dict[str, object]:
+        """JSON-friendly account of which coordinate contract was selected."""
+
+        return {
+            "status": self.status,
+            "gauge": self.frame.gauge.value if self.frame is not None else None,
+            "refusal_reason": self.refusal_reason,
+        }
+
+
+def adapt_recognition(
+    part: Shape,
+    *,
+    rotational: bool = False,
+    framed: bool = True,
+    cylinders=None,
+    framed_builder: Callable[..., FramedRecognitionResult | RefusedPartFrame] = (
+        build_framed_recognition_result
+    ),
+    legacy_builder: Callable[..., RecognitionResult] = build_recognition_result,
+) -> AdaptedRecognition:
+    """Recognise *part* through the one sanctioned frame/IR boundary.
+
+    ``framed=False`` deliberately retains the old route for rollout comparison. A provider
+    refusal also falls back to that route, but records the closed refusal reason rather than
+    silently treating the caller axes as an inferred part frame.
+    """
+
+    legacy_kwargs = {"rotational": rotational}
+    if cylinders is not None:
+        legacy_kwargs["cylinders"] = cylinders
+
+    if not framed:
+        return AdaptedRecognition(
+            source_part=part,
+            part=part,
+            result=legacy_builder(part, **legacy_kwargs),
+            frame=None,
+            status="legacy",
+        )
+
+    outcome = framed_builder(part, rotational=rotational)
+    if isinstance(outcome, RefusedPartFrame):
+        return AdaptedRecognition(
+            source_part=part,
+            part=part,
+            result=legacy_builder(part, **legacy_kwargs),
+            frame=None,
+            status="legacy_fallback",
+            refusal_reason=outcome.reason.value,
+        )
+    return AdaptedRecognition(
+        source_part=part,
+        part=outcome.part,
+        result=outcome.result,
+        frame=outcome.frame,
+        status="framed",
+    )

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -548,23 +548,17 @@ class TestAPositionIsADimension:
     @pytest.mark.parametrize(
         "roles", [("location",), ("bore.diameter", "location")], ids=["alone", "with-bore"]
     )
-    def test_an_off_axis_pattern_location_is_refused_not_accepted_and_lost(self, axis, roles):
-        """Eligibility must match what a compiler will actually produce.
+    def test_an_off_axis_pattern_location_is_compiled_and_drawn(self, axis, roles):
+        """Rigid framing must not turn a locatable pattern into a blank declaration.
 
-        `_LOCATION_ROLE` said every pattern is locatable; `plan_locations` planned only
-        Z-normal ones and the bbox compiler handled only holes, so an X/Y pattern fell
-        between them — `dimension(pattern, "location")` was ACCEPTED and produced nothing,
-        with no diagnostic. That is precisely the blank-drawing failure
-        `_check_authored_targets` exists to prevent (#925 review).
+        The ordinary Z-normal pattern can become X- or Y-normal in the provider-owned local
+        frame. Its datum then changes from the plan ladder to the working solid's bounding
+        box, but the physical position requirement does not disappear (#1357). The compiler
+        approves the two perpendicular components under one stable pattern-location identity;
+        the renderer consumes those approvals like the equivalent side-drilled-hole path.
 
-        The engine has never drawn an off-axis pattern position (the off-axis pass excluded
-        patterns by construction), so the honest fix is for the vocabulary to say so rather
-        than for the compiler to invent output. `location_datum` is now the single answer
-        that `plan_locations`, the bbox compiler and this check all read.
-
-        The `with-bore` case is the one that survived the first fix: the target check asked
-        whether the FEATURE matched anything, so a valid `bore.diameter` entry vouched for
-        the invalid `location` beside it.
+        The `with-bore` case also proves that a valid diameter request neither vouches for nor
+        suppresses the separate location request.
         """
         from draftwright.model.ir import Frame, HoleFeature, PatternFeature, RequestedDimension
 
@@ -578,12 +572,21 @@ class TestAPositionIsADimension:
             pitch=15,
             direction=(0, 1, 0),
         )
-        with pytest.raises(ValueError, match="draws no position"):
-            build_drawing(
-                Box(100, 60, 20),
-                model=[pattern],
-                authored=tuple(RequestedDimension(pattern, r) for r in roles),
-            )
+        drawing = build_drawing(
+            Box(100, 60, 20),
+            model=[pattern],
+            authored=tuple(RequestedDimension(pattern, r) for r in roles),
+        )
+        locations = compile_dimensions(drawing.model()).locations
+
+        assert len(locations) == 2
+        assert {entry.id.parameter for entry in locations} == {"location_pattern.location"}
+        assert {entry.discriminator for entry in locations} == (
+            {"y", "z"} if axis == "x" else {"x", "z"}
+        )
+        assert len(
+            [name for name, _ in drawing.iter_annotations() if name.startswith("dim_loc_")]
+        ) == 2
 
     def test_a_Z_normal_pattern_location_still_works(self):
         """The false-positive half: narrowing eligibility must not cost the case that works."""

--- a/tests/test_declared_recognition_gate.py
+++ b/tests/test_declared_recognition_gate.py
@@ -501,8 +501,8 @@ def test_one_ladder_rule_serves_sizing_and_critique():
     part they coincide and this would assert nothing.
     """
     part = _turned_shaft_with_blind_bore()
-    rec = build_recognition_result(part)
     bb = part.bounding_box()
+    rec = build_recognition_result(part)
 
     ladder = rec.step_ladder_for_z_span(bb.min.Z, bb.max.Z)
     raw_level_zs = [level.z for level in rec.step_levels]
@@ -544,7 +544,6 @@ def test_sizing_and_critique_adapt_the_part_bounds_to_the_scalar_ladder_boundary
 ):
     """Both production callers pass only the independently measured Z envelope."""
     part = Pos(0, 0, 17) * _turned_shaft_with_blind_bore()
-    bb = part.bounding_box()
     calls: list[tuple[float, float]] = []
     original = RecognitionResult.step_ladder_for_z_span
 
@@ -554,12 +553,15 @@ def test_sizing_and_critique_adapt_the_part_bounds_to_the_scalar_ladder_boundary
 
     monkeypatch.setattr(RecognitionResult, "step_ladder_for_z_span", recording_projection)
 
-    drawing = build_drawing(part)
+    drawing = build_drawing(part, framed_recognition=True)
     sizing_calls = list(calls)
     calls.clear()
     drawing.lint()
     critique_calls = list(calls)
 
+    # Automatic detection compiles the provider's local working solid. Its scalar ladder and
+    # critique must use THAT solid's bounds, not the caller-space source bounds (#1357).
+    bb = drawing.working_part.bounding_box()
     expected = (bb.min.Z, bb.max.Z)
     assert sizing_calls and all(call == expected for call in sizing_calls)
     assert critique_calls and all(call == expected for call in critique_calls)

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -73,6 +73,8 @@ _LAYERS: dict[str, int] = {
     "intents": 0,
     "recognition": 0,
     "recognition_cache": 0,
+    # Provider-local working solid + aggregate, caller-space provenance (#1357).
+    "recognition_frame": 0,
     "score": 0,  # census over recognition/ only — a leaf beside the recognisers (#704)
     # audit: diffs two FINISHED drawings through their public reads (#996). A leaf by
     # construction — it imports nothing from the engine, so the thing it measures can never

--- a/tests/test_inspection_contract.py
+++ b/tests/test_inspection_contract.py
@@ -26,7 +26,7 @@ def _manifest() -> dict:
 def test_installed_pypi_wheel_satisfies_the_inspection_contract() -> None:
     distribution = importlib.metadata.distribution("b123d-recognisers")
 
-    assert distribution.version == "0.4.5"
+    assert distribution.version == "0.4.6"
     assert distribution.read_text("direct_url.json") is None
     assert Path(inspect.getfile(inspection)).resolve().is_relative_to(ROOT / ".venv")
     validate_inspection_contract()
@@ -43,7 +43,7 @@ def test_consumer_declaration_is_an_isolated_value() -> None:
     ("path", "replacement"),
     [
         (("format_version",), 2),
-        (("package", "version"), "0.4.6"),
+        (("package", "version"), "0.4.5"),
         (("api", "major"), 2),
         (("api", "namespace"), "b123d_recognisers.experimental_geometry"),
     ],

--- a/tests/test_issue_1130_view_planning_evidence.py
+++ b/tests/test_issue_1130_view_planning_evidence.py
@@ -162,8 +162,9 @@ class TestTheFixedTopologyForcesTheSheet:
         ran `_scale_blockers` and the automatic path did not.
 
         The blockers are real, not an artefact of the stricter path: the automatic drawing
-        still carries `slot_dim_dropped` and `hole_requirement_missing`, so it IS the
-        incomplete drawing the explicit gate exists to prevent.
+        still carries `slot_dim_dropped`, so it IS the incomplete drawing the explicit gate
+        exists to prevent. The former off-axis pattern-location loss was fixed by #1357;
+        retaining it here would make an improvement invalidate the scale-gate evidence.
 
         ADR 0018's evidence list requires: "A forced small sheet/large scale that drops a
         requirement is rejected, not accepted with a warning-only incomplete drawing." The
@@ -180,7 +181,7 @@ class TestTheFixedTopologyForcesTheSheet:
             "the automatic path is reporting success again — #1250 has regressed"
         )
         dropped = {issue.code for issue in automatic.lint()}
-        assert {"slot_dim_dropped", "hole_requirement_missing"} <= dropped, (
+        assert "slot_dim_dropped" in dropped, (
             f"the automatic drawing no longer loses requirements, so there is nothing "
             f"inconsistent about accepting it: {sorted(dropped)}"
         )

--- a/tests/test_issue_1143_hole_completeness.py
+++ b/tests/test_issue_1143_hole_completeness.py
@@ -1735,7 +1735,7 @@ def test_distinct_exact_and_projected_owners_remain_valid():
     assert not [item for item in outcomes if item.state == "unverifiable"]
 
 
-def test_off_axis_pattern_keeps_absolute_location_requirements_fail_closed():
+def test_off_axis_pattern_places_both_absolute_location_requirements():
     drawing = build_drawing(_off_axis_linear_pattern(), page="A3")
     outcomes = {item.parameter_id: item.state for item in _outcomes(drawing)}
 
@@ -1744,12 +1744,12 @@ def test_off_axis_pattern_keeps_absolute_location_requirements_fail_closed():
         "bore.through": "placed",
         "grouping.count": "placed",
         "pitch.length": "placed",
-        "location_pattern.location.y": "missing",
-        "location_pattern.location.z": "missing",
+        "location_pattern.location.y": "placed",
+        "location_pattern.location.z": "placed",
     }
     completeness = _completeness(drawing)
     assert completeness["requirements"] == 6
-    assert completeness["audited_score"] == pytest.approx(4 / 6)
+    assert completeness["audited_score"] == pytest.approx(1.0)
 
 
 def test_compound_countersink_callout_accounts_for_every_printed_measurement():

--- a/tests/test_issue_1357_framed_recognition.py
+++ b/tests/test_issue_1357_framed_recognition.py
@@ -1,0 +1,337 @@
+"""#1357: framed recognition is one explicit source→working compiler boundary."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+from b123d_recognisers import (
+    FrameGauge,
+    FrameRefusalReason,
+    PartFrame,
+    RefusedPartFrame,
+    build_recognition_result,
+)
+from build123d import Align, Box, Compound, Cylinder, Pos, Rot, Sphere
+
+from draftwright import build_drawing
+from draftwright.audit import diff_builds
+from draftwright.model import CylindricalReference
+from draftwright.pmi import PmiRecord, reframe_pmi_records
+from draftwright.recognition_frame import adapt_recognition
+
+_C = (Align.CENTER, Align.CENTER, Align.CENTER)
+
+
+def _orthogonal_part():
+    return Box(60, 40, 20, align=_C) - Pos(10, 5, 0) * Cylinder(4, 30, align=_C)
+
+
+def _full_part():
+    return (
+        Box(80, 55, 20, align=_C)
+        - Pos(17, 8, 0) * Cylinder(4, 30, align=_C)
+        - Pos(-22, -11, 4) * Box(10, 8, 8, align=_C)
+    )
+
+
+def _pattern_part():
+    part = Box(80, 80, 10)
+    for x, y in ((25, 25), (-25, 25), (25, -25), (-25, -25)):
+        part -= Pos(x, y, 0) * Cylinder(3, 20)
+    return part
+
+
+def _requirements(drawing):
+    """Coordinate-noise-insensitive physical requirement projection of the public IR."""
+
+    rows = []
+    for feature in drawing.model().features:
+        rows.append(
+            (
+                feature.kind,
+                feature.frame.axis,
+                tuple(
+                    sorted(
+                        (
+                            parameter.parameter_id,
+                            round(float(parameter.value), 6),
+                            parameter.role,
+                        )
+                        for parameter in feature.parameters()
+                    )
+                ),
+            )
+        )
+    return sorted(rows)
+
+
+@pytest.mark.parametrize(
+    ("part", "gauge"),
+    [
+        pytest.param(_full_part(), FrameGauge.FULL, id="full"),
+        pytest.param(_orthogonal_part(), FrameGauge.ORTHOGONAL, id="orthogonal"),
+        pytest.param(Cylinder(10, 40, align=_C), FrameGauge.AXIAL, id="axial"),
+    ],
+)
+def test_every_successful_gauge_binds_one_local_shape_and_result(part, gauge):
+    adapted = adapt_recognition(part)
+
+    assert adapted.status == "framed"
+    assert adapted.source_part is part
+    assert adapted.part is not part
+    assert adapted.frame is not None and adapted.frame.gauge is gauge
+    assert adapted.result.cylinders == build_recognition_result(adapted.part).cylinders
+    assert adapted.decision == {
+        "status": "framed",
+        "gauge": gauge.value,
+        "refusal_reason": None,
+    }
+
+
+def test_refusal_is_explicit_and_falls_back_once_to_legacy():
+    calls = []
+    legacy_result = build_recognition_result(Sphere(10))
+
+    def refuse(part, *, rotational=False):
+        calls.append(("framed", part, rotational))
+        return RefusedPartFrame(FrameRefusalReason.NO_ANALYTIC_DIRECTION)
+
+    def legacy(part, *, rotational=False):
+        calls.append(("legacy", part, rotational))
+        return legacy_result
+
+    source = Sphere(10)
+    adapted = adapt_recognition(source, framed_builder=refuse, legacy_builder=legacy)
+
+    assert [(kind, rotational) for kind, _part, rotational in calls] == [
+        ("framed", False),
+        ("legacy", False),
+    ]
+    assert adapted.part is source and adapted.source_part is source
+    assert adapted.result is legacy_result and adapted.frame is None
+    assert adapted.decision == {
+        "status": "legacy_fallback",
+        "gauge": None,
+        "refusal_reason": "no-analytic-direction",
+    }
+
+
+def test_legacy_route_remains_available_without_frame_inference():
+    calls = []
+    legacy_result = build_recognition_result(Box(4, 5, 6))
+
+    def framed(*args, **kwargs):  # pragma: no cover - must remain unreachable
+        calls.append("framed")
+        raise AssertionError("legacy comparison route inferred a frame")
+
+    def legacy(part, *, rotational=False):
+        calls.append((part, rotational))
+        return legacy_result
+
+    source = Box(4, 5, 6)
+    adapted = adapt_recognition(
+        source,
+        framed=False,
+        framed_builder=framed,
+        legacy_builder=legacy,
+    )
+
+    assert calls == [(source, False)]
+    assert adapted.status == "legacy" and adapted.part is source and adapted.frame is None
+
+
+def test_public_default_retains_legacy_coordinates_and_never_calls_framed_builder(monkeypatch):
+    source = Pos(23, -17, 9) * _orthogonal_part()
+
+    def forbidden(*args, **kwargs):  # pragma: no cover - must remain unreachable
+        raise AssertionError("default automatic build inferred a part frame")
+
+    monkeypatch.setattr("draftwright.analysis.build_framed_recognition_result", forbidden)
+    drawing = build_drawing(source, auto_dims=False)
+
+    assert drawing.recognition_frame_decision == {
+        "status": "legacy",
+        "gauge": None,
+        "refusal_reason": None,
+    }
+    assert drawing.recognition_frame is None
+    assert drawing.part is drawing.working_part
+
+
+def test_drawing_exposes_distinct_caller_source_and_local_working_part():
+    source = Pos(123, -47, 91) * Rot(17, 31, 23) * _full_part()
+    drawing = build_drawing(source, auto_dims=False, framed_recognition=True)
+
+    assert drawing.recognition_frame_decision["status"] == "framed"
+    assert drawing.recognition_frame is not None
+    # The public value is the caller-space BODY. A one-solid Part wrapper is deliberately
+    # normalised to its Solid, so topology and placement — not Python wrapper identity — are
+    # the contract.
+    assert drawing.part.wrapped.IsPartner(source.solids()[0].wrapped)
+    public_bbox = drawing.part.bounding_box()
+    caller_bbox = source.bounding_box()
+    assert tuple(public_bbox.min) == pytest.approx(tuple(caller_bbox.min))
+    assert tuple(public_bbox.max) == pytest.approx(tuple(caller_bbox.max))
+    assert drawing.part is not drawing.working_part
+    working_bbox = drawing.working_part.bounding_box()
+    source_bbox = drawing.part.bounding_box()
+    assert (tuple(working_bbox.min), tuple(working_bbox.max)) != (
+        tuple(source_bbox.min),
+        tuple(source_bbox.max),
+    )
+
+
+@pytest.mark.parametrize(
+    "part",
+    [_full_part(), _orthogonal_part(), _pattern_part(), Cylinder(10, 40, align=_C)],
+    ids=("full", "orthogonal", "pattern", "axial"),
+)
+def test_rigid_motion_preserves_requirements_finished_sheet_and_lint(part):
+    baseline = build_drawing(part, framed_recognition=True)
+    moved = build_drawing(
+        Pos(123, -47, 91) * Rot(17, 31, 23) * part,
+        framed_recognition=True,
+    )
+
+    assert baseline.recognition_frame_decision == moved.recognition_frame_decision
+    assert _requirements(baseline) == _requirements(moved)
+    assert baseline.annotations() == moved.annotations()
+    assert diff_builds(baseline, moved) == {
+        "dimensions_lost": {},
+        "dimensions_gained": {},
+        "dimensions_changed": {},
+        "measurements_substituted": {},
+        "suppressions_gained": [],
+        "suppressions_lost": [],
+        "candidate_explanations": {},
+    }
+    assert [(issue.severity, issue.code) for issue in baseline.lint()] == [
+        (issue.severity, issue.code) for issue in moved.lint()
+    ]
+
+
+def test_framed_off_axis_pattern_keeps_both_location_requirements_and_clean_lint():
+    drawing = build_drawing(_pattern_part(), framed_recognition=True)
+    pattern = next(feature for feature in drawing.model().features if feature.kind == "pattern")
+    location_ids = {
+        key["parameter_id"]
+        for name, _annotation in drawing.iter_annotations()
+        for key in drawing.measurement_keys(name)
+        if key["feature"].startswith("pattern") and key["parameter_id"].startswith("location")
+    }
+
+    assert pattern.frame.axis in {"x", "y"}, "fixture stopped exercising framed off-axis output"
+    assert location_ids == {"location_pattern.location"}
+    assert drawing.lint() == []
+
+
+def test_compound_ownership_and_face_topology_survive_provider_normalisation():
+    left = Pos(-35, 0, 0) * (
+        Box(30, 24, 12, align=_C) - Pos(0, 0, 4) * Box(12, 8, 8, align=_C)
+    )
+    right = Pos(35, 8, 4) * (
+        Box(24, 18, 10, align=_C) - Pos(0, 0, 3) * Box(8, 6, 6, align=_C)
+    )
+    source = Compound([left, right])
+    adapted = adapt_recognition(source)
+
+    assert len(source.solids()) == len(adapted.part.solids()) == 2
+    assert len(adapted.result.pockets) == 2
+    assert len({pocket.body_key for pocket in adapted.result.pockets}) == 2
+    # TopLoc normalisation changes placement, not the underlying TShapes: a face-backed
+    # association can therefore be reconciled against the exact working solid from #292.
+    assert all(
+        any(source_face.wrapped.IsPartner(local_face.wrapped) for local_face in adapted.part.faces())
+        for source_face in source.faces()
+    )
+
+
+def test_ap242_geometry_and_finite_cylinder_provenance_move_through_one_adapter():
+    frame = PartFrame(
+        origin=(10.0, 20.0, 30.0),
+        x=(0.0, 1.0, 0.0),
+        y=(0.0, 0.0, 1.0),
+        z=(1.0, 0.0, 0.0),
+        gauge=FrameGauge.FULL,
+    )
+    cylinder = CylindricalReference.canonical(
+        axis_point=(10.0, 22.0, 33.0),
+        axis_direction=(1.0, 0.0, 0.0),
+        radius=4.0,
+        local_interval=(0.0, 4.0),
+        sense="internal",
+    )
+    record = PmiRecord(
+        kind="diameter",
+        type_code=2,
+        value=8.0,
+        ref_pts=((10.0, 22.0, 33.0), (14.0, 22.0, 33.0)),
+        ref_bbox=(10.0, 20.0, 30.0, 14.0, 25.0, 36.0),
+        dominant_axis="X",
+        reference_axis="Y",
+        cylindrical_refs=(cylinder,),
+        source_id="dimension:1",
+    )
+
+    local = reframe_pmi_records([record], frame)[0]
+
+    assert local.value == record.value and local.source_id == record.source_id
+    assert local.ref_pts == ((2.0, 3.0, 0.0), (2.0, 3.0, 4.0))
+    assert local.ref_bbox == (0.0, 0.0, 0.0, 5.0, 6.0, 4.0)
+    assert local.dominant_axis == "Z" and local.reference_axis == "X"
+    assert len(local.cylindrical_refs) == 1
+    local_cylinder = local.cylindrical_refs[0]
+    assert local_cylinder.principal_axis == "Z"
+    assert local_cylinder.midpoint == pytest.approx((2.0, 3.0, 2.0))
+    assert local_cylinder.radius == cylinder.radius and local_cylinder.sense == cylinder.sense
+
+
+def test_detected_model_can_be_declared_again_in_the_same_working_coordinates(monkeypatch):
+    automatic = build_drawing(_full_part(), framed_recognition=True)
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("declared rendering performed recognition")
+
+    monkeypatch.setattr("draftwright.analysis.build_framed_recognition_result", forbidden)
+    declared = build_drawing(automatic.working_part, model=automatic.model())
+
+    assert declared.recognition_frame_decision["status"] == "declared"
+    assert declared.recognition_frame is None
+    assert _requirements(declared) == _requirements(automatic)
+    assert declared.annotations() == automatic.annotations()
+
+
+def test_sheet_declared_surface_stays_in_caller_coordinates(monkeypatch):
+    from draftwright import Sheet
+
+    source = Pos(23, -17, 9) * _orthogonal_part()
+
+    def forbidden(*args, **kwargs):  # pragma: no cover - must remain unreachable
+        raise AssertionError("Sheet declaration inferred a part frame")
+
+    monkeypatch.setattr("draftwright.analysis.build_framed_recognition_result", forbidden)
+    drawing = Sheet.from_part(source).build()
+
+    assert drawing.recognition_frame_decision["status"] == "declared"
+    assert drawing.recognition_frame is None
+    assert drawing.part is drawing.working_part
+    assert tuple(drawing.working_part.bounding_box().min) == pytest.approx(
+        tuple(source.bounding_box().min)
+    )
+
+
+def test_feature_key_canonicalises_framed_negative_zero():
+    from draftwright.drawing import feature_key
+
+    feature = next(
+        f
+        for f in build_drawing(
+            Cylinder(10, 40, align=_C), framed_recognition=True
+        ).model().features
+        if f.kind == "envelope"
+    )
+    negative = replace(feature, frame=replace(feature.frame, origin=(0.0, 0.0, -1e-12)))
+    positive = replace(feature, frame=replace(feature.frame, origin=(0.0, 0.0, 1e-12)))
+
+    assert feature_key(negative) == feature_key(positive)

--- a/tests/test_location_vocabulary.py
+++ b/tests/test_location_vocabulary.py
@@ -9,7 +9,7 @@ tests pin the declaration as the one source, fail-closed.
 import dataclasses
 
 import pytest
-from build123d import Box, Cylinder, Pos
+from build123d import Align, Box, Cylinder, Pos
 
 from draftwright.model.planner import _LOCATABLE, location_datum, location_role
 
@@ -200,7 +200,11 @@ def test_a_subclass_is_not_silently_locatable(feature):
         pytest.param(
             "hole",
             "HoleFeature",
-            lambda: Box(80, 60, 10) - Pos(20, 10, 0) * Cylinder(4, 20),
+            # Framed recognition owns the working axes. This asymmetric tall body resolves a
+            # FULL frame whose physical bore is local-Z; a conventional thin source plate is
+            # deliberately local-X and exercises the off-axis compiler instead (#1357).
+            lambda: Box(20, 50, 80, align=(Align.CENTER,) * 3)
+            - Pos(8, 12, 0) * Cylinder(3, 120, align=(Align.CENTER,) * 3),
             id="hole-z",
         ),
         pytest.param(
@@ -347,25 +351,42 @@ def test_the_on_axis_bore_skip_reads_the_declaration_on_both_surfaces():
     and a stronger one than asking the analysis whether the part is rotational.
     """
     from draftwright import build_drawing
-    from draftwright.model import HoleFeature
+    from draftwright.model import Datum, Frame, HoleFeature, PartModel
     from draftwright.model.compiled import compile_dimensions
 
     part = Cylinder(20, 40) - Cylinder(6, 60)
+    bb = part.bounding_box()
+    centre = bb.center()
+    hole = HoleFeature(
+        Frame((centre.X, centre.Y, centre.Z), "z"),
+        diameter=12,
+        depth=40,
+        through=True,
+    )
+    model = PartModel(
+        bb,
+        "z",
+        [hole],
+        [Datum("datum_xy", "point", (bb.min.X, bb.min.Y, bb.min.Z))],
+    )
     original = HoleFeature.LOCATION_STEM
     try:
         HoleFeature.LOCATION_STEM = "location_canary"
-        auto = build_drawing(part)
+        # A declared model retains caller-space Z. Framed automatic detection of the same
+        # axial body intentionally compiles local-X, so it cannot exercise the locate() Z
+        # surface this regression guards (#1357).
+        auto = build_drawing(part, model=model)
         auto_ids = {
             key["parameter_id"]
             for n, _a in auto.iter_annotations()
             for key in auto.measurement_keys(n)
             if key["feature"].startswith("hole")
         }
-        dwg = build_drawing(part, auto_dims=False)
-        model = dwg.model()
-        hole = next(f for f in model.features if isinstance(f, HoleFeature))
-        approved = [loc.id.parameter for loc in compile_dimensions(model).locations]
-        names = dwg.locate(hole)
+        dwg = build_drawing(part, model=model, auto_dims=False)
+        built_model = dwg.model()
+        built_hole = next(f for f in built_model.features if isinstance(f, HoleFeature))
+        approved = [loc.id.parameter for loc in compile_dimensions(built_model).locations]
+        names = dwg.locate(built_hole)
     finally:
         HoleFeature.LOCATION_STEM = original
 
@@ -384,7 +405,7 @@ def test_the_on_axis_bore_skip_reads_the_declaration_on_both_surfaces():
     )
 
 
-def test_location_role_answers_for_an_eligible_feature_and_none_for_an_ineligible_one():
+def test_location_role_answers_for_principal_axis_holes_and_patterns():
     """Both directions, unlike the first cut — which was named "...answers none where no
     location is planned" and then asserted the opposite on a feature that IS locatable,
     ending with `assert model is not None`, which cannot fail after ordinary construction."""
@@ -396,5 +417,5 @@ def test_location_role_answers_for_an_eligible_feature_and_none_for_an_ineligibl
 
     member = HoleFeature(Frame((0.0, 0.0, 0.0), "x"), 6.0, depth=None, through=True)
     off_axis = PatternFeature(Frame((0.0, 0.0, 0.0), "x"), "linear", 3, member)
-    assert location_datum(off_axis) is None, "an off-axis pattern has never been drawn"
-    assert location_role(off_axis) is None, "so the vocabulary must not accept it"
+    assert location_datum(off_axis) == "bbox"
+    assert location_role(off_axis) == "location_pattern"

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -9407,7 +9407,7 @@ class TestTurnedDiameters:
                 distance = math.hypot(cx - (ax + t * vx), cy - (ay + t * vy))
                 assert distance > radius
 
-    def test_issue_881_y_axis_steps_render_without_half_envelope_locations(self):
+    def test_issue_881_y_axis_steps_keep_pattern_locations_but_not_bore_locations(self):
         dwg = build_drawing(self._issue_881_y_step_flange())
 
         steps = [f for f in dwg.model().features if f.kind == "step"]
@@ -9438,13 +9438,15 @@ class TestTurnedDiameters:
             expected = 4 if dwg.get_annotation(name).label == "4× 2" else 1
             assert len(dwg.measurement_keys(name)) == expected
 
-        # The central Y-axis bore shares the detected turned-profile axis. Its
-        # centreline locates it; generic minimum-edge offsets would redundantly
-        # show half the 46 mm envelope in both X and Z (#881).
+        # The central Y-axis bore shares the detected turned-profile axis. Its centreline
+        # locates it, so generic minimum-edge offsets remain suppressed (#881). The bolt
+        # pattern is a distinct physical feature: its relative pitch/count do not state its
+        # absolute centre, and #1357 now places both of those formerly missing requirements.
         assert dwg.view_of("centerline_side") == "side"
         assert dwg.view_of("centerline_plan") == "plan"
-        assert not any(n.startswith("dim_loc_front_") for n in dwg.annotations())
-        assert not any(n.startswith("dim_loc_side_") for n in dwg.annotations())
+        locations = [n for n in dwg.annotations() if n.startswith("dim_loc_")]
+        assert {dwg.view_of(n) for n in locations} == {"front", "side"}
+        assert {dwg.registry.feature_of(n).kind for n in locations} == {"pattern"}
 
         codes = {issue.code for issue in dwg.lint()}
         assert "feature_not_dimensioned" not in codes
@@ -9663,9 +9665,9 @@ class TestTurnedDiameters:
 
         Retargeted onto the Sheet script by #940. This fixture also carries what
         `test_issue_881_generated_script_emits_y_step_intents` used to assert about the
-        imperative script's TEXT: that suite's executable half — side/plan centrelines, no
-        front/side location dims, the step-length chain on the side view — is folded in
-        below, since the source-text half described a file that no longer exists.
+        imperative script's TEXT: that suite's executable half — side/plan centrelines,
+        pattern-owned front/side location dims, the step-length chain on the side view — is
+        folded in below, since the source-text half described a file that no longer exists.
         """
         part = self._issue_881_y_step_flange()
         assert not any(f.kind == "envelope" for f in build_drawing(part).model().features), (
@@ -9686,10 +9688,9 @@ class TestTurnedDiameters:
         assert (
             auto.get_annotation("dim_height").label == replayed.get_annotation("dim_height").label
         )
-        # The off-axis four-hole pattern has relative pitch/count but no absolute X/Z
-        # location dimensions. The hole-family ledger added by #1143 reports those two
-        # physical requirements honestly on both paths; reconstruction must preserve the
-        # same critique as well as the same annotation set.
+        # The off-axis four-hole pattern's relative pitch/count do not state its absolute X/Z
+        # position. #1357 now places those dimensions on both paths; reconstruction must
+        # preserve the same clean hole ledger as well as the same annotation set.
         # The `leader_crosses_silhouette` entry is the #798 bolt-circle cut described in
         # test_issue_881_...; it appears on BOTH paths, which is what this test is
         # actually about — the replay reproduces the same critique, defects included.
@@ -9700,7 +9701,6 @@ class TestTurnedDiameters:
             auto.lint_summary()["by_code"]
             == replayed.lint_summary()["by_code"]
             == {
-                "hole_requirement_missing": 2,
                 "leader_crosses_silhouette": 1,
             }
         )
@@ -9708,7 +9708,9 @@ class TestTurnedDiameters:
         # ── from #881: the Y-step furniture lands in the right views on the replay ──
         assert replayed.view_of("centerline_side") == "side"
         assert replayed.view_of("centerline_plan") == "plan"
-        assert not any(n.startswith(("dim_loc_front_", "dim_loc_side_")) for n in replay)
+        locations = [n for n in replay if n.startswith("dim_loc_")]
+        assert {replayed.view_of(n) for n in locations} == {"front", "side"}
+        assert {replayed.registry.feature_of(n).kind for n in locations} == {"pattern"}
         assert {replayed.view_of(n) for n in replay if n.startswith("m_steplen")} == {"side"}
 
     @pytest.mark.parametrize(("axis_z", "rotation"), [(0.0, 90), (17.0, 90), (-11.0, -90)])

--- a/tests/test_part_model.py
+++ b/tests/test_part_model.py
@@ -298,7 +298,8 @@ def test_feature_detection_runs_once_per_build(monkeypatch):
     """ADR 0008 Amendment 5 / #244 — one aggregate inventory per build.
 
     The recogniser package owns its internal family orchestration; Draftwright's contract is
-    the single public ``build_recognition_result`` call whose result every consumer reuses.
+    the single public ``build_framed_recognition_result`` call whose result every consumer
+    reuses together with its exact local working solid (#1357).
     """
     from build123d import Cylinder, Pos, Rotation
 
@@ -306,17 +307,20 @@ def test_feature_detection_runs_once_per_build(monkeypatch):
     from draftwright import build_drawing
 
     calls = 0
-    original = amod.build_recognition_result
+    original = amod.build_framed_recognition_result
 
     def wrap(*args, **kwargs):
         nonlocal calls
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(amod, "build_recognition_result", wrap)
+    monkeypatch.setattr(amod, "build_framed_recognition_result", wrap)
 
     # A turned X shaft exercises the detected path, including a repack when required.
-    build_drawing(Rotation(0, 90, 0) * (Cylinder(15, 30) + Pos(0, 0, 30) * Cylinder(8, 30)))
+    build_drawing(
+        Rotation(0, 90, 0) * (Cylinder(15, 30) + Pos(0, 0, 30) * Cylinder(8, 30)),
+        framed_recognition=True,
+    )
     assert calls == 1
 
 

--- a/tests/test_private_test_attr_reads.py
+++ b/tests/test_private_test_attr_reads.py
@@ -92,6 +92,7 @@ _DRAWING_PRIVATES: frozenset[str] = frozenset(
         "_view_edge_cache",
         "_write_dxf",
         "_write_svg",
+        "_working_part",
     }
 )
 

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -119,16 +119,16 @@ def test_installed_package_contract_validates_without_a_sibling_checkout() -> No
     _validate()
     package = recognition.capability_manifest(format_version=2)
     declaration = consumer_capability_declaration()
-    # 25 since 0.2.6 added angled-steps, passages and prismatic-pockets (#1244). A literal,
+    # 28 since 0.4.6 added three step families (#1382). A literal,
     # not a length comparison against the package: the point is that BOTH sides changed
     # together, so an upgrade that declared nothing would leave this at 22 and fail.
-    assert len(package["families"]) == len(declaration["families"]) == 25
+    assert len(package["families"]) == len(declaration["families"]) == 28
 
 
 def test_rich_passage_contract_has_an_explicit_unsupported_completeness_outcome() -> None:
     """Pin the 0.4 physical record and compatibility projection to one decision."""
 
-    assert INSTALLED_PACKAGE_VERSION == "0.4.5"
+    assert INSTALLED_PACKAGE_VERSION == "0.4.6"
     installed = tuple(int(component) for component in INSTALLED_PACKAGE_VERSION.split("."))
     assert (0, 4, 0) <= installed < (0, 5, 0)
     package = _families(recognition.capability_manifest())
@@ -143,6 +143,7 @@ def test_rich_passage_contract_has_an_explicit_unsupported_completeness_outcome(
         record for record in passage_package["records"] if record["name"] == "Passage"
     )
     assert passage_record["name"] == "Passage"
+
     assert passage_record["role"] == "projection"
     assert passage_record["schema_version"] == 1
     assert passage_record["aggregate_membership"] == ["RecognitionResult.passages"]
@@ -300,6 +301,36 @@ def test_rich_passage_contract_has_an_explicit_unsupported_completeness_outcome(
             "version": importlib.metadata.version("draftwright"),
         },
     ]
+
+
+@pytest.mark.parametrize(
+    ("family_id", "record_name", "inventory"),
+    [
+        ("circular-blind-steps", "CircularBlindStep", "circular_blind_steps"),
+        ("paired-ramp-steps", "PairedRampStep", "paired_ramp_steps"),
+        ("through-steps", "ThroughStep", "through_steps"),
+    ],
+)
+def test_046_step_families_are_explicit_downstream_decisions(
+    family_id: str, record_name: str, inventory: str
+) -> None:
+    """The dependency bump cannot silently turn new physical families into substrate."""
+
+    package = _families(recognition.capability_manifest())[family_id]
+    consumer = _families(consumer_capability_declaration())[family_id]
+
+    assert package["introduced_in"] == "0.4.6"
+    assert package["census_output"] == f"RecognitionResult.{inventory}"
+    assert [record["name"] for record in package["records"]] == [record_name]
+    assert consumer["record_schemas"] == {record_name: [1]}
+    assert consumer["tracking"] == "https://github.com/pzfreo/draftwright/issues/1382"
+    assert consumer["disposition"] == "unsupported"
+    assert {
+        consumer[boundary]["state"]
+        for boundary in ("ir_adapter", "dsl_declaration", "generated_code", "drawing_consumer")
+    } == {"unsupported"}
+    assert consumer["completeness"]["state"] == "deferred"
+    assert family_id not in pending_family_declarations()
 
 
 def test_holes_completeness_is_supported_by_the_independent_observed_corpus() -> None:

--- a/tests/test_recognition_manifest.py
+++ b/tests/test_recognition_manifest.py
@@ -27,6 +27,7 @@ from b123d_recognisers import (
     recognise_bosses,
     recognise_chamfers,
     recognise_channels,
+    recognise_circular_blind_steps,
     recognise_countersinks,
     recognise_double_d_bores,
     recognise_fillets,
@@ -34,6 +35,7 @@ from b123d_recognisers import (
     recognise_grooves,
     recognise_hole_patterns,
     recognise_holes,
+    recognise_paired_ramp_steps,
     recognise_passages,
     recognise_plates,
     recognise_pocket_patterns,
@@ -47,6 +49,7 @@ from b123d_recognisers import (
     recognise_section_passages,
     recognise_slot_patterns,
     recognise_slots,
+    recognise_through_steps,
     recognise_turned_steps,
     step_level_records,
 )
@@ -59,8 +62,10 @@ from build123d import (
     Cone,
     Cylinder,
     Plane,
+    Polygon,
     Pos,
     RegularPolygon,
+    Rot,
     extrude,
     import_step,
 )
@@ -216,11 +221,31 @@ def _hexagonal_pocket_plate():
     return plate - Pos(-30, 0, 0) * tool.part - Pos(30, 0, 4) * Box(30, 24, 20)
 
 
+def _rectangular_through_step():
+    """A rectangular full-depth shoulder owned by the 0.4.6 through-step family."""
+    return Box(40, 30, 20) - Pos(15, 10, 0) * Box(20, 20, 30)
+
+
+def _paired_ramp_step():
+    """A paired triangular ramp subtraction owned by the 0.4.6 ramp-step family."""
+    profile = Polygon((0, -8), (0, 8), (-10, 0))
+    cutter = Pos(20, 20, 0) * extrude(Plane.XZ * profile, 25)
+    return Box(40, 40, 30) - cutter
+
+
+def _circular_blind_step():
+    """A side-entering stopped cylinder owned by the 0.4.6 circular-step family."""
+    return Box(40, 30, 20) - Pos(7.5, 15, 10) * Rot(0, 90, 0) * Cylinder(4, 25)
+
+
 _ORACLE_FIXTURES = [
     ("bolt circle with countersinks", _bolt_circle_with_countersinks),
     ("angled blind step", _angled_blind_step),
     ("hexagonal passage", _hexagonal_passage_plate),
     ("hexagonal pocket", _hexagonal_pocket_plate),
+    ("rectangular through step", _rectangular_through_step),
+    ("paired ramp step", _paired_ramp_step),
+    ("circular blind step", _circular_blind_step),
     ("slot grid", _slot_grid_plate),
     ("pocket grid", _pocket_grid_plate),
     ("stepped shaft", _stepped_shaft),
@@ -338,7 +363,10 @@ def test_no_deferred_family_is_reachable_from_the_orchestration():
 #: aggregate now recognises their conical/toroidal turned forms (#1254/#1281).
 _CLASSIFICATION_GATED = (
     "recognise_angled_steps",
+    "recognise_circular_blind_steps",
+    "recognise_paired_ramp_steps",
     "recognise_plates",
+    "recognise_through_steps",
 )
 
 
@@ -468,6 +496,11 @@ def _expected_inventory(part, *, rotational: bool = False) -> dict:
         # still hold what its recognisers produced: an inventory nobody converts is exactly where
         # an empty tuple would go unnoticed (#1244).
         "angled_steps": tuple(recognise_angled_steps(part)) if not rotational else (),
+        "circular_blind_steps": (
+            tuple(recognise_circular_blind_steps(part)) if not rotational else ()
+        ),
+        "paired_ramp_steps": tuple(recognise_paired_ramp_steps(part)) if not rotational else (),
+        "through_steps": tuple(recognise_through_steps(part)) if not rotational else (),
         "passages": tuple(recognise_passages(part)),
         "section_passages": tuple(recognise_section_passages(part)),
         "prismatic_pockets": tuple(recognise_prismatic_pockets(part)),
@@ -488,7 +521,9 @@ def _expected_inventory(part, *, rotational: bool = False) -> dict:
 #: For these the assertion is SUBSET, not equality: the aggregate may drop a candidate to
 #: another family, and may never invent one. Equality is still demanded everywhere else, so the
 #: "ran it and stored ()" failure this test exists for is still caught for every other field.
-_RECONCILED_FIELDS = frozenset({"chamfers", "passages", "prismatic_pockets", "section_passages"})
+_RECONCILED_FIELDS = frozenset(
+    {"chamfers", "fillets", "passages", "prismatic_pockets", "section_passages"}
+)
 
 
 def test_the_aggregate_carries_what_its_recognisers_returned():

--- a/uv.lock
+++ b/uv.lock
@@ -85,15 +85,15 @@ wheels = [
 
 [[package]]
 name = "b123d-recognisers"
-version = "0.4.5"
+version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/14/07/b8b0e4256dda31097220b350363605736b74579a2b01a253d7ff842a719b/b123d_recognisers-0.4.5.tar.gz", hash = "sha256:3412f2a2701825e441c320360484ed2a8243b5ff9a9cebd4142813c8da196e32", size = 1097659, upload-time = "2026-08-28T18:27:08.657Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/c7/ad6be406531a243bd416017c75659d455a6cb0f2f49202c354f0b7d8bbca/b123d_recognisers-0.4.6.tar.gz", hash = "sha256:ea4a0ca46eb97017594636d95b638ad19bea448f7d05a12428f7d33cd1071341", size = 2063844, upload-time = "2026-08-29T21:52:11.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/13/c88a4959c86c18f855e9edd893e66ace23dc2b95342611f7dbed90a562e8/b123d_recognisers-0.4.5-py3-none-any.whl", hash = "sha256:3c170a5123cc09566100eed797eab783fe1a3c5de45f2c723094b566204ce16a", size = 351440, upload-time = "2026-08-28T18:27:07.374Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/88/c74b9e350c833746987b3f53189a1fb33e0dc6dea98190f14000852d8061/b123d_recognisers-0.4.6-py3-none-any.whl", hash = "sha256:55dfff8510fc4c5aaf5f3783ec1e78ac82e4db152f6935b3e5dd2563fc5f2568", size = 375023, upload-time = "2026-08-29T21:52:09.945Z" },
 ]
 
 [[package]]
@@ -746,7 +746,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "antlr4-python3-runtime", specifier = "<4.10" },
-    { name = "b123d-recognisers", specifier = "==0.4.5" },
+    { name = "b123d-recognisers", specifier = "==0.4.6" },
     { name = "build123d", marker = "python_full_version < '3.13'", specifier = ">=0.9.0,<0.11" },
     { name = "build123d", marker = "python_full_version >= '3.13'", specifier = ">=0.11,<0.12" },
     { name = "build123d-drafting-helpers", specifier = ">=0.14.2" },


### PR DESCRIPTION
## Summary

- adopt b123d-recognisers 0.4.6 and bind its exact local working solid to its aggregate behind one Draftwright adapter
- add an explicit opt-in framed-recognition route while preserving legacy defaults and caller-coordinate declared/Sheet builds
- transform AP242 correlation geometry once at the source-to-working boundary
- preserve off-axis pattern location requirements after frame-induced axis permutations
- declare the three new 0.4.6 step inventories unsupported/deferred pending downstream semantics in #1382
- make rectangular-grid pitch placement deterministic from the recognised lattice basis rather than floating-point member tie breaks

## ADR audit

- adds accepted ADR 0020 for the explicit opt-in rollout
- preserves ADR 0011 declaration authority and no-recognition gate
- preserves ADR 0013 provider-owned normalisation boundary
- preserves ADR 0015 convergence on one PartModel compiler waist
- preserves ADR 0017 one aggregate per run and reuse across scale retries
- preserves ADRs 0014/0016 by compiling off-axis pattern locations as placement candidates, never raw coordinates
- preserves ADR 0018 requirement-driven view planning in working coordinates

## Verification

- `uv run ruff check .`
- `uv run mypy src`
- `uv run pytest tests/ -n auto --dist loadscope --durations=25`
  - 5,355 passed, 5 skipped, 2 xfailed

Closes #1357