### PR TITLE
Adopt b123d-recognisers 0.4.6 safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,9 +92,15 @@
   claiming a regular-polygon callout represents the provider's complete line/arc schema (#1245).
 
 - Declared Double-D bore, countersink, chamfer, fillet, and groove geometry reads now use the
-  stable `b123d_recognisers.inspection` namespace from the exact 0.4.5 wheel. A separate
+  stable `b123d_recognisers.inspection` namespace from the exact 0.4.6 wheel. A separate
   Draftwright-owned format-1 contract fails closed on changes to the consumed signatures, result
   schemas, units, bevel rejection reasons, or cylindrical surface layout (#1362).
+
+- Updated the exact `b123d-recognisers` production lock to 0.4.6. Circular blind, paired ramp,
+  and through-step inventories are now carried from the one aggregate and surfaced as unscored
+  completeness evidence pending #1382 semantics. Rectangular-grid pitch placement also uses a
+  deterministic outer witness line across plan, front, and side views despite the release's
+  coordinate-rounding differences.
 
 - `annotation_overlap` now reports the whole defect when the same pair also draws
   line-work through one of the two labels: the message names the crosser, the label

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -2,7 +2,8 @@
 
 - **Status:** Accepted; narrowed after phase 1 (Amendment 1, 2026-08-05), with
   external-package/cache ownership clarified by Amendment 2 (2026-08-15) and turned
-  edge-treatment applicability widened by Amendment 3 (2026-08-22)
+  edge-treatment applicability widened by Amendment 3 (2026-08-22), and the 0.4.6
+  prismatic step inventories incorporated by Amendment 4 (2026-08-30)
 - **Date:** 2026-08-03
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -111,6 +112,20 @@ record it may rotate the physical circumferential anchor about the nearest exter
 axis from the shared substrate onto the selected profile plane, preserving its axial station
 and radius.
 
+## Amendment 4 — 0.4.6 adds three prismatic-only step inventories
+
+`b123d-recognisers` 0.4.6 adds circular blind steps, paired ramp steps, and through steps to
+the aggregate. Like plates and angled prismatic steps, those inventories are inapplicable to a
+turned build and remain gated inside the one orchestration. A prismatic aggregate therefore
+runs 28 public families once each; a turned aggregate runs 23, with five prismatic-only
+families gated out by design.
+
+Ownership does not imply invented drafting semantics. Draftwright consumes the three new
+immutable inventories from the shared result and exposes any non-empty inventory as explicitly
+unscored completeness evidence. Their record-to-IR, declaration, annotation, and completeness
+outcomes remain evidence-gated under #1382. This preserves the one-inventory contract while
+preventing a newly recognised family from masquerading as a complete drawing.
+
 ## Accepted Contract
 
 ### 1. One orchestration owns the recognition universe
@@ -129,7 +144,8 @@ reason code and, where applicable, the issue that removes its constraint.
 
 Owning a family is distinct from always running it. Applicability gates live inside the one
 orchestration. Since Amendment 3, chamfers and fillets run for both prismatic and turned
-solids; plates and angled prismatic steps remain gated away from turned parts.
+solids; plates, angled prismatic steps, circular blind steps, paired ramp steps, and through
+steps remain gated away from turned parts.
 
 ### 2. Consumers reuse the result; they do not rescan per concern
 
@@ -200,8 +216,8 @@ critique because it logs its diagnostics. Therefore the observable call contract
 
 | path | recognition calls |
 |---|---|
-| automatic prismatic build | 25 families, once each |
-| automatic turned build | 23 families; two prismatic-only families gated out by design |
+| automatic prismatic build | 28 families, once each |
+| automatic turned build | 23 families; five prismatic-only families gated out by design |
 | declared build/render | zero |
 | first physical critique/export of a declared drawing | at most one aggregate |
 | subsequent lint of the same drawing | zero additional calls |

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -527,15 +527,17 @@ policy) live in `CLAUDE.md`. This is the per-ADR status trail; each ADR's
   their classification gate *into* the orchestration — the distinction that made it possible
   being that **owning a family and always running it are different things**. In
   b123d-recognisers 0.2.9 chamfers and fillets became unconditional because the package now
-  recognises their conical/toroidal turned forms; plates and angled prismatic steps remain
-  classification-gated (#1254/#1281).
+  recognises their conical/toroidal turned forms. In 0.4.6, plates and the four prismatic step
+  families (angled, circular blind, paired ramp, and through) remain classification-gated
+  (#1254/#1281/#1382).
   **`DEFERRED` is now empty** — every public `recognise_*` family is owned by the one
   orchestration. The mechanism stays fail-closed (a new family must still be classified, and
   every `Deferral` member survives for a future one); what went was each deferral, as its
-  stated constraint stopped being true. Measured per family after 0.2.9: a prismatic build
-  runs 25 once each, a turned build 23 (the remaining prismatic-only families excluded), a
-  declared build/render **zero**. Physical critique or export may then obtain one cached
-  aggregate.
+  stated constraint stopped being true. Measured per family with 0.4.6: a prismatic build runs
+  28 once each, a turned build 23 (the five prismatic-only families excluded), and a declared
+  build/render **zero**. Physical critique or export may then obtain one cached aggregate. The
+  three 0.4.6 step inventories are owned by that aggregate but remain explicitly unscored in
+  Draftwright completeness until #1382 supplies evidence-backed consumer semantics.
   The accepted contract stops there. `BuildState` proves result-to-build provenance; it does
   **not** yet provide recognition-record→IR-feature→requirement correspondence. The original
   four-type identity taxonomy, shared requirements module, general outcome ledger,

--- a/docs/geometry-facade-spike.md
+++ b/docs/geometry-facade-spike.md
@@ -4,7 +4,7 @@ Draftwright's selected F7 workflow was the existing `fillet(face)` declaration. 
 spike replaced Draftwright's direct `BRepAdaptor_Surface` read and recogniser-specific
 `fillet_anchor` call with graph-independent face inspection. That experiment graduated into
 `b123d_recognisers.inspection` in recognisers 0.4.4; Draftwright adopts its completed format-1
-contract from the immutable 0.4.5 wheel (#1362).
+contract from the immutable 0.4.6 wheel (#1362).
 
 The result is semantically successful: the same principal axis, radius and on-round anchor are
 produced; planar faces refuse with the existing user-facing error; existing declared/detected

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -228,7 +228,7 @@ profile warning only for that occurrence, so an unrelated unrecognised profile r
 
 ## Passage compatibility boundary
 
-The installed `b123d-recognisers==0.4.5` release contains the `passages` family introduced
+The installed `b123d-recognisers==0.4.6` release contains the `passages` family introduced
 in 0.2.6. Version 0.4.0 makes `SectionPassage` the authoritative physical output and retains
 schema-v1 `Passage` as its compatibility projection. Draftwright declares all six public and nested
 record schemas exhaustively but deliberately keeps the family `unsupported`, with the drafting
@@ -246,10 +246,24 @@ The 0.4 contract is explicit:
 - rich split-junction passages can supersede a Slot claim, moving physical ownership to the
   unsupported Passage family through `SLOT_SUPERSEDED_BY_PASSAGE`.
 
-The exact 0.4.5 pin, manifest-v2 validator and explicit unsupported inventories make that limitation
+The exact 0.4.6 pin, manifest-v2 validator and explicit unsupported inventories make that limitation
 fail-visible rather than silently treating rich passages as supported. Draftwright deliberately
 does not claim that a regular-polygon `HEX … A/F THRU` callout covers the complete line/arc section
 schema. Each authoritative `RecognitionResult.section_passages` occurrence therefore emits
 `passage_requirement_unsupported` at warning severity and contributes an `unsupported` requirement
 to the completeness component. The accepted-only legacy `.passages` projection contributes neither
 a second issue nor a second requirement. Issue #1245 records this consumer decision.
+
+## Step families introduced in recognisers 0.4.6
+
+The 0.4.6 provider manifest adds `circular-blind-steps`, `paired-ramp-steps`, and
+`through-steps`. Their typed records expose physical axes, locations, run lengths, and the relevant
+section or angle. Those facts do not by themselves choose Draftwright's manufacturing requirement,
+semantic view, or dimension grammar.
+
+Draftwright therefore declares all three families unsupported at the IR, Sheet, generated-code,
+and drawing-consumer boundaries, creates no inferred feature or annotation, and keeps their
+completeness state explicitly `deferred`. A non-empty inventory is reported in
+`quality.completeness.unscored_recognized_families`, so the completeness component cannot
+misrepresent it as a clean zero-requirement inventory. Issue #1382 owns the reviewed downstream
+disposition for all three families.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "build123d>=0.9.0,<0.11 ; python_full_version < '3.13'",
     "build123d>=0.11,<0.12 ; python_full_version >= '3.13'",
     "build123d-drafting-helpers>=0.14.2",
-    "b123d-recognisers==0.4.5",
+    "b123d-recognisers==0.4.6",
     "numpy>=1.24",
     # PNG raster export (SVG→PDF→PNG). Both permissively licensed (Pillow HPND; pypdfium2
     # Apache-2.0 wrapping Google PDFium BSD-3) and ship pre-built wheels with NO native system

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -1405,7 +1405,13 @@ def _add_grid_pitch_dims(
                 diffs.append((length, dx, dy))
     if not diffs:
         return
-    diffs.sort()
+    # Equal lattice edges are interchangeable geometry. b123d-recognisers 0.4.6 rounds member
+    # coordinates more consistently, which changed their last few floating-point bits and made
+    # the raw tuple sort select a different physical row. That row is later used as the placement
+    # witness, so a numerically meaningless tie could drop the second pitch dimension. Quantise
+    # only the ordering key (never the measured vector) at a scale far below drafting precision;
+    # stable sort then retains the recogniser's deterministic member order for equal edges.
+    diffs.sort(key=lambda vector: tuple(round(component, 6) for component in vector))
     l1, ax, ay = diffs[0]
     u1 = (ax / l1, ay / l1)
     basis2 = next(
@@ -1449,19 +1455,45 @@ def _add_grid_pitch_dims(
         def across(idx):
             return pts[idx][0] * perp[0] + pts[idx][1] * perp[1]
 
-        lo = min(range(len(pts)), key=along)
-        # Keep the dimension on ONE lattice line: of the holes sharing lo's
-        # perpendicular coordinate, take the far one along u. Picking the global
-        # max-projection hole instead lands on the opposite diagonal corner and
-        # draws the pitch dim diagonally across the grid (#92).
+        # Keep the dimension on ONE lattice line. In plan/front, choose the OUTER line on
+        # the same page side `_place_pitch_dim` prefers. The former `min(..., key=along)`
+        # leaves the perpendicular tie to sub-ulp coordinate noise; 0.4.6 consequently chose
+        # a central short-axis row that occupied the only clear corridor for the long pitch.
+        # Side-view placement uses the same nearest-part-side policy as `_place_pitch_dim`.
+        if view == "side":
+            corner_across = [
+                a.proj.side_x(y) * perp[0] + a.proj.side_z(z) * perp[1]
+                for y in (a.bb.min.Y, a.bb.max.Y)
+                for z in (a.bb.min.Z, a.bb.max.Z)
+            ]
+            point_across = [across(idx) for idx in range(len(pts))]
+            positive_reach = max(corner_across) - max(point_across)
+            negative_reach = min(point_across) - min(corner_across)
+            extremum = max if positive_reach <= negative_reach else min
+            anchor = extremum(
+                range(len(pts)),
+                key=lambda idx: (across(idx), along(idx)),
+            )
+        else:
+            preferred = (-0.3, 1.0) if view == "plan" else (-0.3, -1.0)
+            toward_positive = perp[0] * preferred[0] + perp[1] * preferred[1] >= 0.0
+            extremum = max if toward_positive else min
+            anchor = extremum(
+                range(len(pts)),
+                key=lambda idx: (across(idx), along(idx)),
+            )
+        # Of the holes sharing the selected perpendicular coordinate, take both extremes
+        # along u. Picking the global max-projection hole instead lands on the opposite
+        # diagonal corner and draws the pitch dim diagonally across the grid (#92).
         # Tolerance must be below the PERPENDICULAR lattice-line spacing — which
         # is the *other* axis' pitch, so use the smaller of the two pitches.
         # (pitch_page * 0.25 fails on a high-aspect grid: for the long axis the
         # perpendicular lines are only the short pitch apart, and a quarter of
         # the long pitch can exceed that, merging two lines → diagonal again.)
-        lo_across = across(lo)
+        lo_across = across(anchor)
         line_tol = min(l1, l2) * 0.25
         line = [idx for idx in range(len(pts)) if abs(across(idx) - lo_across) < line_tol]
+        lo = min(line, key=along)
         hi = max(line, key=along)
         # The holes this dim actually spans, in the order it spans them. `members[lo:hi+1]`
         # is a slice of the IR's member order, which on a grid walks the lattice in neither

--- a/src/draftwright/inspection_contract.py
+++ b/src/draftwright/inspection_contract.py
@@ -16,7 +16,7 @@ from b123d_recognisers.inspection import inspection_api_manifest
 CONSUMER_INSPECTION_FORMAT = "draftwright-inspection-api"
 CONSUMER_INSPECTION_FORMAT_VERSION = 1
 SUPPORTED_INSPECTION_API_MAJOR = 1
-SUPPORTED_RECOGNISER_VERSION = "0.4.5"
+SUPPORTED_RECOGNISER_VERSION = "0.4.6"
 _DISTRIBUTION = "b123d-recognisers"
 _PROVIDER_FORMAT = "b123d-recognisers-inspection-api"
 _NAMESPACE = "b123d_recognisers.inspection"

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -148,7 +148,11 @@ _NON_REQUIREMENT_INVENTORIES = frozenset(
 #: merging them would let an undecided family look settled (#1244). Passage, PrismaticPocket and
 #: AngledStep left this register when #1245/#1246/#1247 gave every authoritative occurrence an
 #: unsupported outcome.
-_UNDECIDED_INVENTORIES: dict[str, str] = {}
+_UNDECIDED_INVENTORIES: dict[str, str] = {
+    "circular_blind_steps": "https://github.com/pzfreo/draftwright/issues/1382",
+    "paired_ramp_steps": "https://github.com/pzfreo/draftwright/issues/1382",
+    "through_steps": "https://github.com/pzfreo/draftwright/issues/1382",
+}
 
 _AUDITED_FAMILIES = (
     "angled_steps",
@@ -634,7 +638,14 @@ def _completeness_component(recognition, features, registry, omissions, issues) 
         for attribute, family in _RECOGNISED_REQUIREMENT_FAMILIES.items()
         if getattr(recognition, attribute, ())
     }
-    unaudited = sorted(recognised - set(_AUDITED_FAMILIES))
+    # Undecided physical inventories have no requirement grammar yet, so they cannot enter
+    # the denominator. They must nevertheless remain visible at runtime: classifying them only
+    # in a static exhaustiveness register would let a real occurrence produce a clean-looking
+    # zero-requirement drawing (#1382).
+    undecided = {
+        inventory for inventory in _UNDECIDED_INVENTORIES if getattr(recognition, inventory, ())
+    }
+    unaudited = sorted((recognised - set(_AUDITED_FAMILIES)) | undecided)
     covered = counts["placed"] + counts["satisfied_by_structured_note"]
     audited_score = covered / requirements if requirements else None
     if requirements:

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -24,6 +24,7 @@ from b123d_recognisers import (
     BossRecord,
     Chamfer,
     Channel,
+    CircularBlindStep,
     CounterSink,
     DoubleDBore,
     FaceLevel,
@@ -33,6 +34,7 @@ from b123d_recognisers import (
     HoleRecord,
     HoleSpec,
     LinearArray,
+    PairedRampStep,
     Passage,
     Plate,
     Pocket,
@@ -50,6 +52,7 @@ from b123d_recognisers import (
     SlotArray,
     SlotGrid,
     StepShoulder,
+    ThroughStep,
     TurnedProfile,
     TurnedStep,
     has_multi_axis_plates,
@@ -736,6 +739,18 @@ _UNCONSUMED_RECORDS: dict[type, str] = {
         "an aggregate-reconciled polygonal blind recess not owned by `Pocket`; its arbitrary "
         "section has no truthful general Draftwright dimension grammar, so every occurrence has "
         "an explicit unsupported completeness outcome (#1246)"
+    ),
+    CircularBlindStep: (
+        "a physical step family added in recognisers 0.4.6; Draftwright has not yet reviewed "
+        "its feature, view, dimension, or completeness semantics (#1382)"
+    ),
+    PairedRampStep: (
+        "a physical step family added in recognisers 0.4.6; Draftwright has not yet reviewed "
+        "its feature, view, dimension, or completeness semantics (#1382)"
+    ),
+    ThroughStep: (
+        "a physical step family added in recognisers 0.4.6; Draftwright has not yet reviewed "
+        "its feature, view, dimension, or completeness semantics (#1382)"
     ),
 }
 

--- a/src/draftwright/recogniser_contract.py
+++ b/src/draftwright/recogniser_contract.py
@@ -270,7 +270,7 @@ def _geometry_only_declaration() -> dict[str, Any]:
 #: have a live decision issue, while a settled unsupported boundary must carry an explicit
 #: outcome such as Passage completeness below. ``pending_family_declarations`` reports anything
 #: absent from BOTH this map and ``_FAMILIES``, so the next new family fails closed exactly as
-#: these three did (#1244).
+#: the first three did (#1244), and the 0.4.6 step families do now (#1382).
 _UNSUPPORTED: dict[str, tuple[tuple[str, ...], str, str]] = {
     "passages": (
         (
@@ -304,6 +304,30 @@ _UNSUPPORTED: dict[str, tuple[tuple[str, ...], str, str]] = {
         "AngledStep, but its angle, legs and run length do not themselves decide which drawing "
         "requirements or section/detail view are required. Draftwright therefore reports every "
         "occurrence as an unsupported completeness requirement.",
+    ),
+    "circular-blind-steps": (
+        ("CircularBlindStep",),
+        "https://github.com/pzfreo/draftwright/issues/1382",
+        "The provider proves a quarter-cylindrical blind corner step and supplies its radius, "
+        "run and oriented section. Draftwright has not yet reviewed which feature, view and "
+        "dimension grammar truthfully expresses that manufacturing requirement, so every "
+        "consumer boundary remains unsupported and completeness remains explicitly deferred.",
+    ),
+    "paired-ramp-steps": (
+        ("PairedRampStep",),
+        "https://github.com/pzfreo/draftwright/issues/1382",
+        "The provider proves a mirror-symmetric two-sided ramp and supplies its angle, run and "
+        "ridge anchor. Draftwright has not yet reviewed which feature, view and dimension "
+        "grammar truthfully expresses that manufacturing requirement, so every consumer "
+        "boundary remains unsupported and completeness remains explicitly deferred.",
+    ),
+    "through-steps": (
+        ("ThroughStep",),
+        "https://github.com/pzfreo/draftwright/issues/1382",
+        "The provider proves a principal-axis rectangular through step and supplies its run, "
+        "anchor and open section. Draftwright has not yet reviewed which feature, view and "
+        "dimension grammar truthfully expresses that manufacturing requirement, so every "
+        "consumer boundary remains unsupported and completeness remains explicitly deferred.",
     ),
 }
 

--- a/tests/test_inspection_contract.py
+++ b/tests/test_inspection_contract.py
@@ -26,7 +26,7 @@ def _manifest() -> dict:
 def test_installed_pypi_wheel_satisfies_the_inspection_contract() -> None:
     distribution = importlib.metadata.distribution("b123d-recognisers")
 
-    assert distribution.version == "0.4.5"
+    assert distribution.version == "0.4.6"
     assert distribution.read_text("direct_url.json") is None
     assert Path(inspect.getfile(inspection)).resolve().is_relative_to(ROOT / ".venv")
     validate_inspection_contract()
@@ -43,7 +43,7 @@ def test_consumer_declaration_is_an_isolated_value() -> None:
     ("path", "replacement"),
     [
         (("format_version",), 2),
-        (("package", "version"), "0.4.6"),
+        (("package", "version"), "0.4.5"),
         (("api", "major"), 2),
         (("api", "namespace"), "b123d_recognisers.experimental_geometry"),
     ],

--- a/tests/test_issue_1382_046_step_inventory.py
+++ b/tests/test_issue_1382_046_step_inventory.py
@@ -1,0 +1,76 @@
+"""#1382: recognisers 0.4.6 step families stay visible pending a semantic decision."""
+
+from __future__ import annotations
+
+import pytest
+from b123d_recognisers import build_recognition_result
+from build123d import Box, Compound, Cylinder, Plane, Polygon, Pos, Rot, extrude
+
+from draftwright import build_drawing
+
+
+def _through_step():
+    return Box(40, 30, 20) - Pos(15, 10, 0) * Box(20, 20, 30)
+
+
+def _paired_ramp_step():
+    profile = Polygon((0, -8), (0, 8), (-10, 0))
+    cutter = Pos(20, 20, 0) * extrude(Plane.XZ * profile, 25)
+    return Box(40, 40, 30) - cutter
+
+
+def _circular_blind_step():
+    return Box(40, 30, 20) - Pos(7.5, 15, 10) * Rot(0, 90, 0) * Cylinder(4, 25)
+
+
+@pytest.mark.parametrize(
+    ("inventory", "part_factory"),
+    [
+        ("circular_blind_steps", _circular_blind_step),
+        ("paired_ramp_steps", _paired_ramp_step),
+        ("through_steps", _through_step),
+    ],
+)
+def test_each_046_step_inventory_is_visible_in_runtime_completeness(inventory, part_factory):
+    """Static registration is insufficient: a real occurrence must reach public quality data."""
+
+    part = part_factory()
+    recognition = build_recognition_result(part)
+    assert getattr(recognition, inventory), "fixture stopped exercising its provider family"
+
+    completeness = build_drawing(part).lint_summary()["quality"]["completeness"]
+
+    assert completeness["unscored_recognized_families"] == [inventory]
+    assert completeness["requirements"] == 0
+    assert completeness["available"] is False
+    assert completeness["audited_score"] is None
+    assert completeness["unsupported"] == 0
+    assert inventory not in completeness["by_family"], (
+        "undecided evidence is visible but must not invent a requirement denominator"
+    )
+
+
+def test_absent_046_step_families_do_not_pollute_an_ordinary_part():
+    completeness = build_drawing(Box(30, 20, 10)).lint_summary()["quality"]["completeness"]
+
+    assert not {
+        "circular_blind_steps",
+        "paired_ramp_steps",
+        "through_steps",
+    } & set(completeness["unscored_recognized_families"])
+
+
+def test_undecided_evidence_stays_visible_beside_a_perfect_audited_family():
+    pocket = Box(80, 60, 20) - Pos(20, 0, 5) * Box(20, 10, 12)
+    mixed = Compound([Pos(-70, 0, 0) * _through_step(), Pos(70, 0, 0) * pocket])
+
+    completeness = build_drawing(mixed).lint_summary()["quality"]["completeness"]
+
+    assert completeness["unscored_recognized_families"] == ["through_steps"]
+    assert completeness["requirements"] == 5
+    assert completeness["placed"] == 5
+    assert completeness["audited_score"] == 1.0
+    assert completeness["reason"] == (
+        "audited_score covers recognized requirements in audited families only; it is "
+        "not evidence that the drawing is complete"
+    )

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -16,7 +16,7 @@ from b123d_recognisers import (
     recognise_pockets,
     recognise_slots,
 )
-from build123d import Align, Axis, Box, Compound, Cylinder, Edge, Pos, Rotation, export_step
+from build123d import Align, Axis, Box, Compound, Cylinder, Edge, Pos, Rot, Rotation, export_step
 from build123d_drafting import HoleCallout, Leader, ViewCoordinates, view_axes
 
 from draftwright import Drawing, build_drawing, make_drawing
@@ -3161,6 +3161,28 @@ class TestHolePatternCallouts:
             assert abs(span - expected) < 1.0, (
                 f"{n} ({dim.label!r}) endpoint span {span:.1f} ≠ {expected:.1f} — drawn diagonally"
             )
+
+    @pytest.mark.timeout(120)
+    def test_x_axis_rect_grid_keeps_both_pitches_in_the_side_view(self):
+        """0.4.6 coordinate rounding must not select an interior side-view witness row."""
+
+        ang = math.radians(25)
+        ca, sa = math.cos(ang), math.sin(ang)
+        centre = (Align.CENTER, Align.CENTER, Align.CENTER)
+        part = Box(12, 220, 120, align=centre)
+        cutter = Rot(0, 90, 0) * Cylinder(4, 20, align=centre)
+        for r in range(2):
+            for c in range(5):
+                y, z = (c - 2) * 45, (r - 0.5) * 10
+                part -= Pos(0, y * ca - z * sa, y * sa + z * ca) * cutter
+
+        dwg = build_drawing(part)
+        pitch = [name for name in dwg.annotations() if name.startswith("dim_pitch_")]
+
+        assert len(pitch) == 2, f"expected two side-grid pitch dims, got {pitch}"
+        assert {dwg.view_of(name) for name in pitch} == {"side"}
+        assert {dwg.get_annotation(name).label for name in pitch} == {"1× 10", "4× 45"}
+        assert "hole_pattern_dim_dropped" not in {issue.code for issue in dwg.lint()}
 
     @pytest.mark.timeout(120)
     def test_rect_grid_coverage_lint_quiet(self):

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -119,16 +119,16 @@ def test_installed_package_contract_validates_without_a_sibling_checkout() -> No
     _validate()
     package = recognition.capability_manifest(format_version=2)
     declaration = consumer_capability_declaration()
-    # 25 since 0.2.6 added angled-steps, passages and prismatic-pockets (#1244). A literal,
+    # 28 since 0.4.6 added three step families (#1382). A literal,
     # not a length comparison against the package: the point is that BOTH sides changed
-    # together, so an upgrade that declared nothing would leave this at 22 and fail.
-    assert len(package["families"]) == len(declaration["families"]) == 25
+    # together, so an upgrade that declared nothing would leave this at 25 and fail.
+    assert len(package["families"]) == len(declaration["families"]) == 28
 
 
 def test_rich_passage_contract_has_an_explicit_unsupported_completeness_outcome() -> None:
     """Pin the 0.4 physical record and compatibility projection to one decision."""
 
-    assert INSTALLED_PACKAGE_VERSION == "0.4.5"
+    assert INSTALLED_PACKAGE_VERSION == "0.4.6"
     installed = tuple(int(component) for component in INSTALLED_PACKAGE_VERSION.split("."))
     assert (0, 4, 0) <= installed < (0, 5, 0)
     package = _families(recognition.capability_manifest())
@@ -300,6 +300,36 @@ def test_rich_passage_contract_has_an_explicit_unsupported_completeness_outcome(
             "version": importlib.metadata.version("draftwright"),
         },
     ]
+
+
+@pytest.mark.parametrize(
+    ("family_id", "record_name", "inventory"),
+    [
+        ("circular-blind-steps", "CircularBlindStep", "circular_blind_steps"),
+        ("paired-ramp-steps", "PairedRampStep", "paired_ramp_steps"),
+        ("through-steps", "ThroughStep", "through_steps"),
+    ],
+)
+def test_046_step_families_are_explicit_downstream_decisions(
+    family_id: str, record_name: str, inventory: str
+) -> None:
+    """The dependency bump cannot silently turn new physical families into substrate."""
+
+    package = _families(recognition.capability_manifest())[family_id]
+    consumer = _families(consumer_capability_declaration())[family_id]
+
+    assert package["introduced_in"] == "0.4.6"
+    assert package["census_output"] == f"RecognitionResult.{inventory}"
+    assert [record["name"] for record in package["records"]] == [record_name]
+    assert consumer["record_schemas"] == {record_name: [1]}
+    assert consumer["tracking"] == "https://github.com/pzfreo/draftwright/issues/1382"
+    assert consumer["disposition"] == "unsupported"
+    assert {
+        consumer[boundary]["state"]
+        for boundary in ("ir_adapter", "dsl_declaration", "generated_code", "drawing_consumer")
+    } == {"unsupported"}
+    assert consumer["completeness"]["state"] == "deferred"
+    assert family_id not in pending_family_declarations()
 
 
 def test_holes_completeness_is_supported_by_the_independent_observed_corpus() -> None:

--- a/tests/test_recognition_manifest.py
+++ b/tests/test_recognition_manifest.py
@@ -27,6 +27,7 @@ from b123d_recognisers import (
     recognise_bosses,
     recognise_chamfers,
     recognise_channels,
+    recognise_circular_blind_steps,
     recognise_countersinks,
     recognise_double_d_bores,
     recognise_fillets,
@@ -34,6 +35,7 @@ from b123d_recognisers import (
     recognise_grooves,
     recognise_hole_patterns,
     recognise_holes,
+    recognise_paired_ramp_steps,
     recognise_passages,
     recognise_plates,
     recognise_pocket_patterns,
@@ -47,6 +49,7 @@ from b123d_recognisers import (
     recognise_section_passages,
     recognise_slot_patterns,
     recognise_slots,
+    recognise_through_steps,
     recognise_turned_steps,
     step_level_records,
 )
@@ -59,8 +62,10 @@ from build123d import (
     Cone,
     Cylinder,
     Plane,
+    Polygon,
     Pos,
     RegularPolygon,
+    Rot,
     extrude,
     import_step,
 )
@@ -216,11 +221,31 @@ def _hexagonal_pocket_plate():
     return plate - Pos(-30, 0, 0) * tool.part - Pos(30, 0, 4) * Box(30, 24, 20)
 
 
+def _rectangular_through_step():
+    """A rectangular full-depth shoulder owned by the 0.4.6 through-step family."""
+    return Box(40, 30, 20) - Pos(15, 10, 0) * Box(20, 20, 30)
+
+
+def _paired_ramp_step():
+    """A paired triangular ramp subtraction owned by the 0.4.6 ramp-step family."""
+    profile = Polygon((0, -8), (0, 8), (-10, 0))
+    cutter = Pos(20, 20, 0) * extrude(Plane.XZ * profile, 25)
+    return Box(40, 40, 30) - cutter
+
+
+def _circular_blind_step():
+    """A side-entering stopped cylinder owned by the 0.4.6 circular-step family."""
+    return Box(40, 30, 20) - Pos(7.5, 15, 10) * Rot(0, 90, 0) * Cylinder(4, 25)
+
+
 _ORACLE_FIXTURES = [
     ("bolt circle with countersinks", _bolt_circle_with_countersinks),
     ("angled blind step", _angled_blind_step),
     ("hexagonal passage", _hexagonal_passage_plate),
     ("hexagonal pocket", _hexagonal_pocket_plate),
+    ("rectangular through step", _rectangular_through_step),
+    ("paired ramp step", _paired_ramp_step),
+    ("circular blind step", _circular_blind_step),
     ("slot grid", _slot_grid_plate),
     ("pocket grid", _pocket_grid_plate),
     ("stepped shaft", _stepped_shaft),
@@ -338,7 +363,10 @@ def test_no_deferred_family_is_reachable_from_the_orchestration():
 #: aggregate now recognises their conical/toroidal turned forms (#1254/#1281).
 _CLASSIFICATION_GATED = (
     "recognise_angled_steps",
+    "recognise_circular_blind_steps",
+    "recognise_paired_ramp_steps",
     "recognise_plates",
+    "recognise_through_steps",
 )
 
 
@@ -463,11 +491,16 @@ def _expected_inventory(part, *, rotational: bool = False) -> dict:
             if not rotational and not recognise_turned_steps(part, cyls=cyls)
             else ()
         ),
-        # Recognised and carried, but never converted to inferred IR. Their capability-contract
-        # dispositions are explicit unsupported outcomes (#1245/#1246/#1247). The aggregate must
-        # still hold what its recognisers produced: an inventory nobody converts is exactly where
-        # an empty tuple would go unnoticed (#1244).
+        # Recognised and carried, but never converted to inferred IR. The first family has a
+        # reviewed unsupported outcome (#1247); the 0.4.6 families remain explicitly deferred
+        # under #1382. The aggregate must still hold what its recognisers produced: an inventory
+        # nobody converts is exactly where an empty tuple would go unnoticed (#1244).
         "angled_steps": tuple(recognise_angled_steps(part)) if not rotational else (),
+        "circular_blind_steps": (
+            tuple(recognise_circular_blind_steps(part)) if not rotational else ()
+        ),
+        "paired_ramp_steps": tuple(recognise_paired_ramp_steps(part)) if not rotational else (),
+        "through_steps": tuple(recognise_through_steps(part)) if not rotational else (),
         "passages": tuple(recognise_passages(part)),
         "section_passages": tuple(recognise_section_passages(part)),
         "prismatic_pockets": tuple(recognise_prismatic_pockets(part)),
@@ -482,13 +515,30 @@ def _expected_inventory(part, *, rotational: bool = False) -> dict:
 #:
 #: A four-wall passage yields to the more directly dimensioned `Slot`;
 #: `_reconcile.prismatic_pockets_that_are_not_pockets` keeps the `Pocket`; and
-#: `_reconcile.chamfers_that_are_not_angled_steps` drops a chamfer whose face a step owns —
-#: which is why `chamfers` is here too, latent until a fixture carries an angled step (#1244).
+#: `_reconcile.chamfers_that_are_not_angled_steps` drops a chamfer whose face a step owns; and
+#: circular blind steps supersede the fillet that otherwise describes their cylindrical corner.
+#: Those last two ownership rules are why ``chamfers`` and ``fillets`` are here (#1244/#1382).
 #:
 #: For these the assertion is SUBSET, not equality: the aggregate may drop a candidate to
 #: another family, and may never invent one. Equality is still demanded everywhere else, so the
 #: "ran it and stored ()" failure this test exists for is still caught for every other field.
-_RECONCILED_FIELDS = frozenset({"chamfers", "passages", "prismatic_pockets", "section_passages"})
+_RECONCILED_FIELDS = frozenset(
+    {"chamfers", "fillets", "passages", "prismatic_pockets", "section_passages"}
+)
+
+
+def test_circular_blind_step_owns_the_corner_instead_of_a_second_fillet():
+    """The 0.4.6 family is deferred, but its aggregate ownership is already authoritative."""
+
+    part = _circular_blind_step()
+    direct_fillets = recognise_fillets(part)
+    direct_steps = recognise_circular_blind_steps(part)
+    result = build_recognition_result(part)
+
+    assert len(direct_fillets) == 1, "fixture no longer exercises the reconciliation loser"
+    assert len(direct_steps) == 1, "fixture no longer exercises the new physical owner"
+    assert result.circular_blind_steps == tuple(direct_steps)
+    assert result.fillets == ()
 
 
 def test_the_aggregate_carries_what_its_recognisers_returned():

--- a/uv.lock
+++ b/uv.lock
@@ -85,15 +85,15 @@ wheels = [
 
 [[package]]
 name = "b123d-recognisers"
-version = "0.4.5"
+version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/14/07/b8b0e4256dda31097220b350363605736b74579a2b01a253d7ff842a719b/b123d_recognisers-0.4.5.tar.gz", hash = "sha256:3412f2a2701825e441c320360484ed2a8243b5ff9a9cebd4142813c8da196e32", size = 1097659, upload-time = "2026-08-28T18:27:08.657Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c0/c7/ad6be406531a243bd416017c75659d455a6cb0f2f49202c354f0b7d8bbca/b123d_recognisers-0.4.6.tar.gz", hash = "sha256:ea4a0ca46eb97017594636d95b638ad19bea448f7d05a12428f7d33cd1071341", size = 2063844, upload-time = "2026-08-29T21:52:11.202Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/13/c88a4959c86c18f855e9edd893e66ace23dc2b95342611f7dbed90a562e8/b123d_recognisers-0.4.5-py3-none-any.whl", hash = "sha256:3c170a5123cc09566100eed797eab783fe1a3c5de45f2c723094b566204ce16a", size = 351440, upload-time = "2026-08-28T18:27:07.374Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/88/c74b9e350c833746987b3f53189a1fb33e0dc6dea98190f14000852d8061/b123d_recognisers-0.4.6-py3-none-any.whl", hash = "sha256:55dfff8510fc4c5aaf5f3783ec1e78ac82e4db152f6935b3e5dd2563fc5f2568", size = 375023, upload-time = "2026-08-29T21:52:09.945Z" },
 ]
 
 [[package]]
@@ -746,7 +746,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "antlr4-python3-runtime", specifier = "<4.10" },
-    { name = "b123d-recognisers", specifier = "==0.4.5" },
+    { name = "b123d-recognisers", specifier = "==0.4.6" },
     { name = "build123d", marker = "python_full_version < '3.13'", specifier = ">=0.9.0,<0.11" },
     { name = "build123d", marker = "python_full_version >= '3.13'", specifier = ">=0.11,<0.12" },
     { name = "build123d-drafting-helpers", specifier = ">=0.14.2" },


### PR DESCRIPTION
## Summary

- pin b123d-recognisers 0.4.6 and update the exact inspection/capability contracts
- classify the three new step families as explicit unsupported record-to-IR decisions while deferring their completeness semantics to #1382
- expose every non-empty undecided inventory in public runtime completeness data without inventing requirements
- preserve both rectangular-grid pitch dimensions despite 0.4.6 coordinate rounding by making equal-edge and outward-row selection deterministic in plan, front, and side views

This deliberately does **not** adopt framed recognition. That remains #1357 and is blocked on pzfreo/b123d-recognisers#328 after the closed review of #1383.

## ADR audit

- ADR 0013: consumes only released public provider contracts; no recogniser internals
- ADR 0017 (including Amendment 4): keeps one aggregate, exhaustively accounts for every new result field/family, and preserves classification-gated orchestration
- ADR 0015: keeps physical completeness independent of the approved plan; undecided evidence is visible without inventing a requirement denominator
- ADRs 0004/0014: the grid change selects a natural outer lattice witness for the existing placement candidate; it adds no raw placement coordinates or second solve

## Verification

- `scripts/pr-check --static`
- focused contract/manifest/quality/pattern suite: 110 passed
- `uv run pytest -q`: 5,345 passed, 5 skipped, 50 deselected, 2 xfailed

Refs #1382
Refs #1357
