### PR TITLE
Support recognised rectangular through steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,17 @@
   exact IR conversion, explicit `Sheet.paired_ramp_step(...)` declaration, generated-code
   round trip, end-view solver-placed `2× angle × run RUN` leader, independent angle/run
   tolerances and authored suppression, and a two-requirement fail-closed completeness ledger.
-  Circular blind and rectangular through steps remain separately visible pending their own
-  #1382 semantic decisions (#1382).
+  Circular blind steps remain separately visible pending their own #1382 semantic decision
+  (#1382).
+
+- Rectangular through steps recognised by `b123d-recognisers` now lower without rescanning to
+  an explicit-only IR/Sheet feature. Automatic and explicit lowering support every principal
+  axis; an X/Y occurrence stays with the established face-level and shoulder/plate grammar only
+  when that grammar proves both exact leg intervals, avoiding both silent loss and duplicate
+  dimensions. The two
+  orthogonal open-section legs are independently addressable, tolerance-aware, solver-placed in
+  the end view, preserved by generated code and scored by a fail-closed two-requirement
+  completeness ledger. The through extent stays owned by the envelope (#1382).
 
 - Hole completeness is now supported by a versioned, independently authored STEP corpus rather
   than a Draftwright-derived census. Detection, parameter fidelity and downstream usefulness stay

--- a/docs/adr/0015-part-drawing-compiler-as-built.md
+++ b/docs/adr/0015-part-drawing-compiler-as-built.md
@@ -126,6 +126,7 @@ by #754 (Amendment 2): those labels are now planner-fed.
 | flats ({across} A/F leader, #726) | `from_model.render_flats` | `plan_dimensions` |
 | grooves ({width} WIDE × ø{diameter} leader, #727) | `from_model.render_grooves` | `plan_dimensions` |
 | paired ramps (2× angle × run compound leader, #1382) | `from_model.render_paired_ramp_steps` | `plan_dimensions` |
+| rectangular through steps (two open-section leg dimensions, #1382) | `from_model.render_through_steps` | `plan_dimensions` |
 | pockets (W × L × D DEEP leader, #728) | `from_model.render_pockets` | `plan_dimensions` |
 | plates (thickness linear dim, #729) | `from_model.render_plates` | `plan_dimensions` |
 | slots (width/length linear dims, #730; the datum position dim stays model-derived — it is drawing state, not a feature parameter) | `from_model.render_slots` | `plan_dimensions` |

--- a/docs/adr/0016-declared-dimensioning-intent.md
+++ b/docs/adr/0016-declared-dimensioning-intent.md
@@ -123,7 +123,7 @@ so this inventory cannot drift from the code:
 
 | Contract | Meaning | Renderers |
 |---|---|---|
-| `plan` | approved entries only — inside the rule | `render_height_ladder`, `render_step_positions`, `render_plates`, `render_chamfers`, `render_fillets`, `render_flats`, `render_grooves`, `render_paired_ramp_steps`, `render_boss_diameters`, `render_polygonal_bosses`, `render_boss_heights`, `render_envelope`, `render_pockets`, `render_pocket_patterns`, `render_slot_patterns`, `render_diameters`, `render_rotational`, `render_step_lengths`, `render_locations`, `render_slots` (+ the prismatic detail redraw) |
+| `plan` | approved entries only — inside the rule | `render_height_ladder`, `render_step_positions`, `render_plates`, `render_chamfers`, `render_fillets`, `render_flats`, `render_grooves`, `render_paired_ramp_steps`, `render_through_steps`, `render_boss_diameters`, `render_polygonal_bosses`, `render_boss_heights`, `render_envelope`, `render_pockets`, `render_pocket_patterns`, `render_slot_patterns`, `render_diameters`, `render_rotational`, `render_step_lengths`, `render_locations`, `render_slots` (+ the prismatic detail redraw) |
 | `groups` | advisory `suppressed` | *(empty — the guard fails if anything reappears)* |
 | `model` | author-supplied text, not a generated measurement | `render_gdt`, `render_pmi` |
 

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -121,11 +121,23 @@ runs 28 public families once each; a turned aggregate runs 23, with five prismat
 families gated out by design.
 
 Ownership does not imply invented drafting semantics. Draftwright consumes the three new
-immutable inventories from the shared result. Paired ramps now have an evidence-gated record-to-IR,
-declaration, generated-code, annotation, and two-requirement completeness path under #1382.
-Circular blind and through steps remain explicitly unscored until their separate #1382 decisions.
+immutable inventories from the shared result. Paired ramps and through steps now have
+evidence-gated record-to-IR, declaration, generated-code, annotation, and two-requirement
+completeness paths under #1382. Circular blind steps remain explicitly unscored until their
+separate #1382 decision.
 This preserves the one-inventory contract while preventing an undecided newly recognised family
 from masquerading as a complete drawing.
+
+Consumer ordering remains a drafting-policy decision. Automatic through-step lowering supports
+every principal run axis. For X/Y runs, face levels plus shoulders/plates retain ownership only
+when their coordinate intervals (including an envelope-defined complement) prove both physical
+legs. That complete alternate projection is `inapplicable`; axis or family presence alone is not
+evidence, and the alternate owner's exact measurement identities must themselves be placed or
+structurally satisfied. Its authored suppression, placement drop, or missing ink remains visible
+as that outcome instead of becoming `inapplicable`. A partially covered occurrence instead lowers
+as the aggregate owner and removes exact matching legacy fragments. The explicit Sheet declaration
+permits the same local two-leg grammar on every principal axis. This is a pure projection of the
+shared aggregate, not a second recognition scan.
 
 ## Accepted Contract
 

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -233,8 +233,32 @@ carries both compiler measurement identities. An authored set may retain either 
 without resurrecting the omitted one, and tolerances remain attached to their own numeric value.
 The completeness ledger follows each requirement independently to placed, structured-note,
 suppressed, dropped, missing or unverifiable outcomes; duplicate source/IR correspondence fails
-closed rather than choosing by order. Circular blind steps and rectangular through steps remain
-separate undecided families under #1382.
+closed rather than choosing by order. Circular blind steps remain a separate undecided family
+under #1382.
+
+## Through-step completeness evidence
+
+The `through-steps` family is supported from the public `ThroughStep` record. Exact principal
+axis, removed-prism midpoint, through length and the complete three-point open section identify
+one occurrence. Automatic lowering supports every principal run axis. An X/Y-run occurrence is
+left with the established face-level plus shoulder/plate grammar only when that grammar proves
+both exact physical leg intervals (including an envelope-defined complementary interval); a
+partially covered occurrence instead lowers as one aggregate and replaces its exact matching
+legacy fragments. Explicit `Sheet.through_step(...)` declarations choose the same local two-leg
+grammar on any principal axis. Both paths preserve their correspondence facts in generated Sheet
+code without a second geometry scan.
+
+The two orthogonal section legs become independently addressable
+`through_step_leg.length.<axis>` requirements. The through length remains structural because the
+part envelope already states that extent; printing it again would double-dimension the part.
+Both legs are solver-placed in the axis end view, outside the missing corner, and carry their own
+compiler identities and tolerances. The fail-closed ledger follows each selected leg through
+placed, structured-note, suppressed, dropped, missing or unverifiable outcomes; duplicate or
+mutated source/IR correspondence is never paired by order. A coordinate-proven complete legacy
+projection is `inapplicable` only while its exact alternate measurement identities are actually
+placed or structurally satisfied. Authored omission and placement failure remain `suppressed` or
+`dropped`; missing alternate ink remains `missing`. Axis or family presence alone can never claim
+an outcome. Circular blind steps remain the only undecided 0.4.6 step family under #1382.
 
 Remaining supported-family completeness work is tracked by family group rather than the closed
 shared design issue: #1370 retains countersinks and Double-D bores; #1371 covers
@@ -314,11 +338,12 @@ The 0.4.6 provider manifest adds `circular-blind-steps`, `paired-ramp-steps`, an
 section or angle. Those facts do not by themselves choose Draftwright's manufacturing requirement,
 semantic view, or dimension grammar, so each family receives a separate reviewed disposition.
 
-Paired ramps now have the complete supported path described above: explicit IR and Sheet surfaces,
-generated-code parity, one solver-placed compound leader, and independently scored angle/run
-requirements. Circular blind and rectangular through steps remain unsupported at the IR, Sheet,
-generated-code, and drawing-consumer boundaries with completeness explicitly `deferred`. A
-non-empty inventory for either undecided family is reported in
+Paired ramps and rectangular through steps now have the complete supported paths described
+above. Through-step automatic ownership supports every principal run axis while retaining an
+X/Y occurrence's existing Z-up grammar only when both physical legs and their actual outcomes
+are proved; the explicit Sheet surface likewise supports all principal axes. Circular blind
+steps remain unsupported at the IR, Sheet, generated-code, and drawing-consumer boundaries with
+completeness explicitly `deferred`. A non-empty circular-blind-step inventory is reported in
 `quality.completeness.unscored_recognized_families`, so the completeness component cannot
-misrepresent it as a clean zero-requirement inventory. Issue #1382 retains their reviewed
+misrepresent it as a clean zero-requirement inventory. Issue #1382 retains its reviewed
 downstream disposition.

--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -163,8 +163,8 @@ sheet.dimension(tapped_hole, "bore.diameter", view="plan", side="left")
 
 ## Multi-parameter handle
 
-Paired-ramp steps use a multi-parameter handle because the angle and run remain separately
-addressable even though the drawing normally combines them on one leader:
+Paired-ramp and through steps use a multi-parameter handle because their requirements remain
+separately addressable:
 
 ```python
 ramp = sheet.paired_ramp_step(
@@ -176,11 +176,28 @@ ramp = sheet.paired_ramp_step(
 sheet.authored_dimensions()
 sheet.dimension(ramp, "ramp_angle.angle")
 sheet.dimension(ramp, "ramp_run.length")
+
+step = sheet.through_step(
+    axis="z",
+    length=20,
+    at=(12.5, 7.5, 0),
+    section=((5, 15), (5, 0), (20, 0)),
+)
+sheet.dimension(step, "through_step_leg.length.x")
+sheet.dimension(step, "through_step_leg.length.y")
 ```
 
-The declaration is explicit-only. A detached face or cutter does not prove that two ramps form
-one mirror-symmetric, open-to-terminal material-removal feature. Placement remains solver-owned;
-the engine selects the end-on view and positions the compound leader.
+Both declarations are explicit-only. A detached face or cutter cannot prove the aggregate
+material-removal topology. Placement remains solver-owned; the engine selects the end-on view
+and positions the compound leader or linear section dimensions.
+
+An explicit through-step may use any principal run axis, and automatic detection supports the
+same three axes. Where an X/Y-run record's two exact physical intervals are already proved by the
+face-level plus shoulder/plate grammar and the envelope, that established grammar remains the
+owner. If even one leg is not proved, the aggregate local-leg grammar owns the occurrence and its
+exact matching lower-level fragments are removed, so one physical requirement reaches the sheet
+once. Completeness follows the chosen legacy dimensions too: their authored omission, placement
+drop, or missing ink is not hidden by the ownership choice.
 
 ::: draftwright.sheet._Params
     options:

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -925,6 +925,8 @@ class DetailRequest:
                       narrow profile strip when enlarging the full radial extent
                       would not fit on the sheet.
         kind:         short label for logging.
+        measurement_ids/measurement_spans: exact compiler-owned requirements the detail
+                      is recovering. Empty for purely geometric/authored details.
     """
 
     axis: str
@@ -951,6 +953,8 @@ class DetailRequest:
     #: dimension. Automatic recovery details retain the historical "no dimension, no view" gate.
     keep_without_annotations: bool = False
     source: object | None = None
+    measurement_ids: tuple = ()
+    measurement_spans: tuple = ()
 
 
 @dataclass(frozen=True)

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -827,6 +827,7 @@ def _analyse(
             chamfers=list(recognition.chamfers) if recognition else None,
             fillets=list(recognition.fillets) if recognition else None,
             paired_ramp_steps=list(recognition.paired_ramp_steps) if recognition else None,
+            through_steps=list(recognition.through_steps) if recognition else None,
             plates=list(recognition.plates) if recognition else None,
             flats=list(recognition.flats) if recognition else None,
             pockets=pockets,

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -2375,6 +2375,8 @@ class PlacementContext:
         message,
         *,
         measurement=None,
+        measurement_span=None,
+        measurement_spans=(),
         hole_requirements=(),
         source=None,
         outcome_stage=None,
@@ -2388,6 +2390,11 @@ class PlacementContext:
             ids = tuple(item for item in measurement if item is not None)
         else:
             ids = (measurement,)
+        spans = (
+            tuple(measurement_spans)
+            if measurement_spans
+            else ((measurement_span,) if measurement_span is not None else ())
+        )
         if isinstance(source, (list, tuple)):
             source_ids = tuple(str(item) for item in source if item)
         else:
@@ -2401,6 +2408,7 @@ class PlacementContext:
                 hole_requirement_ids=tuple(hole_requirements),
                 source_ids=source_ids,
                 outcome_stage=outcome_stage,
+                measurement_spans=spans,
             )
         )
 

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -2439,6 +2439,159 @@ def _paired_ramp_label(angle, run, draft) -> str:
     return " × ".join(parts)
 
 
+def render_through_steps(dwg, plan, a, *, ctx, only=None) -> int:
+    """Render both defining legs of each rectangular through step (#1382).
+
+    The provider supplies the canonical open section, so the renderer needs no geometry
+    inference: each approved leg span becomes one linear dimension in the end-on view.  The
+    missing rectangle's direction signs select the natural outside corridor; the shared
+    corridor solve owns the final coordinate, then a post-drain opposite-side retry gets one
+    final solver-owned chance before an explicit unavoidable drop is recorded.
+    """
+    draft = dwg.draft
+    tier = draft.font_size + 2 * draft.pad_around_text
+    zones_for_view = {"front": a.fv_zones, "side": a.sv_zones, "plan": a.pv_zones}
+    opposite = {"above": "below", "below": "above", "left": "right", "right": "left"}
+    count = 0
+    for index, group in enumerate(plan.of_kind("through_step")):
+        if only is not None and group.ref not in only:
+            continue
+        facts = group.facts
+        view = group.view
+        if view is None or dwg.view_bounds(view) is None:
+            continue
+        outside = dict(facts.outside_directions)
+        for approved in group.dims:
+            if approved.role != "through_step_leg" or approved.span is None:
+                continue
+            start = dwg.at(view, *approved.span[0])
+            end = dwg.at(view, *approved.span[1])
+            changed_axis = approved.discriminator
+            if changed_axis not in "xyz":
+                continue
+            perpendicular = next(axis for axis in "xyz" if axis not in (facts.axis, changed_axis))
+            probe_world = [
+                (a + b) / 2 for a, b in zip(approved.span[0], approved.span[1], strict=True)
+            ]
+            probe_world["xyz".index(perpendicular)] += outside[perpendicular]
+            exterior = dwg.at(view, *probe_world)
+            dx, dy = end[0] - start[0], end[1] - start[1]
+            if abs(dx) >= abs(dy):
+                side = "above" if exterior[1] > (start[1] + end[1]) / 2 else "below"
+                stack = "y"
+                edge = (start[1] + end[1]) / 2
+                pa, pb = (start[0], edge, 0), (end[0], edge, 0)
+            else:
+                side = "right" if exterior[0] > (start[0] + end[0]) / 2 else "left"
+                stack = "x"
+                edge = (start[0] + end[0]) / 2
+                pa, pb = (edge, start[1], 0), (edge, end[1], 0)
+            zones = zones_for_view[view]
+            strip = getattr(zones, side)
+            alternate_side = opposite[side]
+            alternate_strip = getattr(zones, alternate_side)
+            if strip is None:
+                side, strip = alternate_side, alternate_strip
+                alternate_side, alternate_strip = opposite[side], None
+            label = approved.value_text + _tol_suffix(approved.tolerance, draft)
+            discriminator = approved.discriminator or "leg"
+            name = f"dim_through_step_{facts.axis}{index}_{discriminator}"
+
+            def _build(pos, pa=pa, pb=pb, side=side, edge=edge, label=label):
+                return _dim(pa, pb, side, pos - edge, draft, label=label)
+
+            def _foot(pos, pa=pa, pb=pb, side=side, edge=edge, label=label):
+                return dim_footprint(pa, pb, side, pos - edge, draft, label)
+
+            def _drop(
+                dropped_name,
+                *,
+                value=approved.value,
+                view=view,
+                side=side,
+                alternate_side=alternate_side,
+                alternate_strip=alternate_strip,
+                pa=pa,
+                pb=pb,
+                edge=edge,
+                label=label,
+                stack=stack,
+                feature=group.ref,
+                measurement=approved.id,
+            ):
+                def _retry() -> None:
+                    if alternate_strip is not None:
+
+                        def _alternate_build(position):
+                            return _dim(
+                                pa,
+                                pb,
+                                alternate_side,
+                                position - edge,
+                                draft,
+                                label=label,
+                            )
+
+                        def _alternate_foot(position):
+                            return dim_footprint(
+                                pa,
+                                pb,
+                                alternate_side,
+                                position - edge,
+                                draft,
+                                label,
+                            )
+
+                        left = place_strip_candidates(
+                            dwg,
+                            alternate_strip,
+                            view,
+                            stack,
+                            [(dropped_name, _alternate_build)],
+                            tier,
+                            ctx=ctx,
+                            force=True,
+                            features={dropped_name: feature},
+                            measurements={dropped_name: measurement},
+                            footprints={dropped_name: _alternate_foot},
+                            trace=ctx.trace,
+                            trace_label=f"through_step_{alternate_side}_fallthrough",
+                        )
+                        if not left:
+                            return
+                    ctx.record_issue(
+                        "warning",
+                        "through_step_dim_dropped",
+                        f"through-step leg {_fmt(value)} not dimensioned "
+                        f"({view} {side}/{alternate_side}-strips full)",
+                        measurement=measurement,
+                    )
+
+                ctx.post_drain.append(_retry)
+
+            register_corridor(
+                ctx,
+                (view, side),
+                strip,
+                view,
+                stack,
+                tier,
+                CorridorCandidate(
+                    name=name,
+                    build=_build,
+                    order=(_SIZE_SUBCHAIN, index, discriminator, name),
+                    on_place=lambda _name: None,
+                    on_drop=_drop,
+                    force=True,
+                    feature=group.ref,
+                    measurement=approved.id,
+                    footprint=_foot,
+                ),
+            )
+            count += 1
+    return count
+
+
 def render_paired_ramp_steps(dwg, plan, a, *, ctx, only=None) -> int:
     """Render each recognised paired-ramp step as one solver-placed compound leader.
 
@@ -3268,13 +3421,27 @@ def render_plates(dwg, plan, a, *, ctx) -> int:
             alt = None
         name = f"dim_plate_{axis}{i}"
 
-        def _build(pos, pa=pa, pb=pb, side=side, edge=edge, lbl=lbl):
-            return _dim(pa, pb, side, pos - edge, draft, label=lbl)
+        def _build_plate(
+            pos, pa=pa, pb=pb, side=side, edge=edge, lbl=lbl, measurement_span=pd.span
+        ):
+            dim = _dim(pa, pb, side, pos - edge, draft, label=lbl)
+            dim._dw_measurement_span = measurement_span
+            return dim
 
         def _foot(pos, pa=pa, pb=pb, side=side, edge=edge, lbl=lbl):
             return dim_footprint(pa, pb, side, pos - edge, draft, lbl)
 
-        def _drop(nm, val=val, lbl=lbl, view=view, stack=stack, alt=alt, feat=g.ref, mid=pd.id):  # noqa: B008
+        def _drop(
+            nm,
+            val=val,
+            lbl=lbl,
+            view=view,
+            stack=stack,
+            alt=alt,
+            feat=g.ref,
+            mid=pd.id,
+            measurement_span=pd.span,
+        ):  # noqa: B008
             # Opposite-strip fallthrough (mirrors the GD&T #481 pattern), DEFERRED to
             # ctx.post_drain so it runs after EVERY corridor has drained (#684 review):
             # a mid-drain carve could occupy a corner a later sibling's force candidate
@@ -3283,7 +3450,15 @@ def render_plates(dwg, plan, a, *, ctx) -> int:
             # loop's variable and these retries run post-drain, so reading it live would
             # record the LAST plate's identity on every one of them (#1002).
             def _retry(
-                nm=nm, val=val, lbl=lbl, view=view, stack=stack, alt=alt, feat=feat, mid=mid
+                nm=nm,
+                val=val,
+                lbl=lbl,
+                view=view,
+                stack=stack,
+                alt=alt,
+                feat=feat,
+                mid=mid,
+                measurement_span=measurement_span,
             ):
                 for view2, side2, strip2, axis2, qa, qb, edge2 in alt or ():
                     if strip2 is None:
@@ -3298,6 +3473,7 @@ def render_plates(dwg, plan, a, *, ctx) -> int:
                         # contract as the corridor's validation fallback). A miss
                         # tries the next alternate.
                         dim = _dim(qa, qb, side2, pos - edge2, draft, label=lbl)
+                        dim._dw_measurement_span = measurement_span
                         real = _geom_box(dim)
                         page = (_MARGIN, _MARGIN, a.PAGE_W - _MARGIN, a.PAGE_H - _MARGIN)
                         if real is None or (
@@ -3316,6 +3492,8 @@ def render_plates(dwg, plan, a, *, ctx) -> int:
                     "warning",
                     "plate_thickness_dropped",
                     f"plate thickness {_fmt(val)} not dimensioned ({view} {stack}-strip full)",
+                    measurement=mid,
+                    measurement_span=measurement_span,
                 )
 
             # Queued retries run in registration order (deterministic; plates sort by
@@ -3338,7 +3516,7 @@ def render_plates(dwg, plan, a, *, ctx) -> int:
             tier,
             CorridorCandidate(
                 name=name,
-                build=_build,
+                build=_build_plate,
                 order=(_SIZE_SUBCHAIN, i, name),
                 on_place=lambda nm: None,
                 on_drop=_drop,
@@ -3491,8 +3669,21 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
         build,
         footprint=None,
         measurement=None,
+        measurement_span=None,
     ):
-        def _report(nm, _view=view, _strip=strip, _above=above_strip, _mid=measurement):
+        def _tagged_build(pos, _build=build, _span=measurement_span):
+            dim = _build(pos)
+            dim._dw_measurement_span = _span
+            return dim
+
+        def _report(
+            nm,
+            _view=view,
+            _strip=strip,
+            _above=above_strip,
+            _mid=measurement,
+            _span=measurement_span,
+        ):
             # An overall extent is the one dimension every drawing must carry, and until
             # #1216 review r9 its drop was the only one in the engine that reported NOTHING:
             # `on_drop` was `lambda _nm: None`, so a starved strip removed the width from the
@@ -3528,9 +3719,23 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
                 occupants = strip_occupants(dwg, side_strip, _view, "y") if side_strip else []
                 if occupants:
                     msg = f"{msg[:-1]}; {side_name} occupied by: {', '.join(occupants)})"
-            ctx.record_issue("error", "overall_dim_withheld", msg, measurement=_mid)
+            ctx.record_issue(
+                "error",
+                "overall_dim_withheld",
+                msg,
+                measurement=_mid,
+                measurement_span=_span,
+            )
 
-        def _drop(nm, _view=view, _above=above_strip, _mid=measurement, _xs=xs, _label=label):
+        def _drop(
+            nm,
+            _view=view,
+            _above=above_strip,
+            _mid=measurement,
+            _xs=xs,
+            _label=label,
+            _span=measurement_span,
+        ):
             # Opposite-strip fallthrough (#1236). A feature leader placed before the drain —
             # a polygonal boss's A/F callout on CTC-01, slot width dims on CTC-04 — can span
             # the whole below corridor, and no corridor-side fix reaches it: the leader is not
@@ -3549,6 +3754,19 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
                 bounds = dwg.view_bounds(_view)
                 if _above is not None and bounds is not None:
                     lift = bounds[3] + _WITNESS_LIFT_MM
+
+                    def _fallback_build(pos, _l=lift):
+                        dim = _dim(
+                            (_xs[0], _l, 0),
+                            (_xs[1], _l, 0),
+                            "above",
+                            pos - _l,
+                            dwg.draft,
+                            label=_label,
+                        )
+                        dim._dw_measurement_span = _span
+                        return dim
+
                     if not place_strip_candidates(
                         dwg,
                         _above,
@@ -3557,14 +3775,7 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
                         [
                             (
                                 nm,
-                                lambda pos, _l=lift: _dim(
-                                    (_xs[0], _l, 0),
-                                    (_xs[1], _l, 0),
-                                    "above",
-                                    pos - _l,
-                                    dwg.draft,
-                                    label=_label,
-                                ),
+                                _fallback_build,
                             )
                         ],
                         tier,
@@ -3587,7 +3798,7 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
             tier,
             CorridorCandidate(
                 name=name,
-                build=build,
+                build=_tagged_build,
                 order=(_OVERALL_SUBCHAIN, distance, name),
                 on_place=lambda _nm: None,
                 on_drop=_drop,
@@ -3626,6 +3837,7 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
                 f"overall {role} cannot be shown: no planned view lays the {axis} axis "
                 f"out horizontally (planned: {tuple(dwg.views)})",
                 measurement=extent.id,
+                measurement_span=extent.span,
             )
             continue
         index = "xyz".index(axis)
@@ -3667,6 +3879,7 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
                 dim_footprint((_p1[0], _w, 0), (_p2[0], _w, 0), "below", _w - pos, dwg.draft, _v)
             ),
             measurement=extent.id,
+            measurement_span=extent.span,
         )
         n += 1
     return n
@@ -4354,6 +4567,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                 # rule the turned-step collapse follows (#28 / P2a). The plain rungs below each
                 # state their own measurement and do carry it (#1234 review r5).
                 None,
+                rep.span,
             )
         )
     elif rungs:
@@ -4393,8 +4607,10 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                 # satisfied by any other absence-shaped code in the same build — which is
                 # exactly what the first cut of that guard did (#1216 review r9, F2).
                 measurement=[rung.id for rung in withheld if rung.id is not None],
+                measurement_spans=[rung.span for rung in withheld if rung.id is not None],
             )
         if n_close:
+            crowded = tuple(rung for rung in rungs if rung.span[1][2] not in kept_level_set)
             # When detail recovery is enabled the enlarged view owns the omitted rungs.
             # Report the source-view drop only when no recovery was requested; a failed
             # detail records ``detail_unplaceable`` instead.
@@ -4404,6 +4620,9 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                     "step_dim_dropped",
                     f"{n_close} step height(s) too closely spaced to dimension at this scale "
                     "(use a detail view)",
+                    measurement=[rung.id for rung in crowded if rung.id is not None],
+                    measurement_spans=[rung.span for rung in crowded if rung.id is not None],
+                    outcome_stage="placement",
                 )
             # First-class escalation alongside the lint code (ADR 0009 Amdt 1, #351 PR-4b) —
             # `_request_prismatic_detail` (sections.py) consumes this instead of recomputing
@@ -4414,7 +4633,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                     view="front",
                     feature=step,
                     reason="illegible",
-                    targets=tuple(rung for rung in rungs if rung.span[1][2] not in kept_level_set),
+                    targets=crowded,
                 )
             )
         kept = [r for r in rungs if r.span[1][2] in kept_level_set]
@@ -4434,6 +4653,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                     rung.id,
                     None,  # no `N×` prefix: the label states the span itself
                     rung.tolerance,
+                    rung.span,
                 )
             )
 
@@ -4450,6 +4670,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                 height.id,
                 None,  # no `N×` prefix
                 height.tolerance,
+                height.span,
             )
         )
 
@@ -4466,7 +4687,18 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
 
     names = [c[0] for c in chain]
     solved: dict[str, float] = {}
-    for k, (name, zbase, ztop, label, _tsize, drop_msg, mid, per_unit, _rt) in enumerate(chain):
+    for k, (
+        name,
+        zbase,
+        ztop,
+        label,
+        _tsize,
+        drop_msg,
+        mid,
+        per_unit,
+        _rt,
+        measurement_span,
+    ) in enumerate(chain):
 
         def _build(
             pos,
@@ -4477,6 +4709,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
             k=k,
             per_unit=per_unit,
             _tol=_tolerances.get(name),
+            measurement_span=measurement_span,
         ):
             base = edge2
             for pn in reversed(names[:k]):  # nearest already-built predecessor's line
@@ -4498,6 +4731,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                 # conventions here and the string cannot tell them apart: this one is ONE
                 # step, while a hole pitch spans the whole run. Same seam as `_dw_scale`.
                 dim._dw_label_value = per_unit
+            dim._dw_measurement_span = measurement_span
             return dim
 
         # The footprint measures the RENDERED string, so it carries the same suffix the
@@ -4524,12 +4758,25 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                 (base, zbase, 0), (base, ztop, 0), "right", pos - base, draft, label
             )
 
-        def _drop(nm, drop_msg=drop_msg, name=name):
+        def _drop(
+            nm,
+            drop_msg=drop_msg,
+            name=name,
+            measurement=mid,
+            measurement_span=measurement_span,
+        ):
             solved.pop(name, None)
             # Name what filled the strip (#736): the #733 diagnosis becomes a glance at the
             # lint message.
             msg = full_strip_message(drop_msg, dwg, strip, "front", "x")
-            ctx.record_issue("error", "placement_unsatisfiable", msg)
+            ctx.record_issue(
+                "error",
+                "placement_unsatisfiable",
+                msg,
+                measurement=measurement,
+                measurement_span=measurement_span,
+                outcome_stage="placement",
+            )
 
         register_corridor(
             ctx,
@@ -4572,8 +4819,8 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
         # by another route, and it dropped the tolerance (#1234 review r6).
         label = rung.final_label + _tol_suffix(rung.tolerance, draft)
 
-        def _build_left(pos, zbase=zbase, ztop=ztop, label=label):
-            return _dim(
+        def _build_left(pos, zbase=zbase, ztop=ztop, label=label, measurement_span=rung.span):
+            dim = _dim(
                 (left_edge, zbase, 0),
                 (left_edge, ztop, 0),
                 "left",
@@ -4581,8 +4828,10 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                 draft,
                 label=label,
             )
+            dim._dw_measurement_span = measurement_span
+            return dim
 
-        def _drop_left(nm):
+        def _drop_left(nm, measurement=rung.id, measurement_span=rung.span):
             msg = full_strip_message(
                 "short step-height dimension dropped (front-view left strip full)",
                 dwg,
@@ -4590,7 +4839,14 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                 "front",
                 "x",
             )
-            ctx.record_issue("error", "placement_unsatisfiable", msg)
+            ctx.record_issue(
+                "error",
+                "placement_unsatisfiable",
+                msg,
+                measurement=measurement,
+                measurement_span=measurement_span,
+                outcome_stage="placement",
+            )
 
         register_corridor(
             ctx,
@@ -4693,8 +4949,16 @@ def render_step_positions(dwg, plan, frame, *, ctx) -> int:
         # tolerance like any other (#1234 review r6).
         shoulder_label = rung.final_label + _tol_suffix(rung.tolerance, draft)
 
-        def _build(pos, p1=p1, p2=p2, edge=edge, label=shoulder_label, direction=direction):
-            return _dim(
+        def _build(
+            pos,
+            p1=p1,
+            p2=p2,
+            edge=edge,
+            label=shoulder_label,
+            direction=direction,
+            measurement_span=rung.span,
+        ):
+            dim = _dim(
                 (p1[0], edge, 0),
                 (p2[0], edge, 0),
                 direction,
@@ -4702,12 +4966,23 @@ def render_step_positions(dwg, plan, frame, *, ctx) -> int:
                 draft,
                 label=label,
             )
+            dim._dw_measurement_span = measurement_span
+            return dim
 
-        def _drop(nm, label=rung.final_label, view=view, direction=direction):
+        def _drop(
+            nm,
+            label=rung.final_label,
+            view=view,
+            direction=direction,
+            measurement=rung.id,
+            measurement_span=rung.span,
+        ):
             ctx.record_issue(
                 "warning",
                 "step_position_dropped",
                 f"step position {label} not dimensioned ({view} {direction}-strip full)",
+                measurement=measurement,
+                measurement_span=measurement_span,
             )
 
         # ADR 0009 corridor candidate (#636): a shoulder position is a datum-referenced

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -77,6 +77,7 @@ from draftwright.annotations.from_model import (
     render_slots,
     render_step_lengths,
     render_step_positions,
+    render_through_steps,
 )
 from draftwright.annotations.holes import (
     _annotate_holes,
@@ -254,6 +255,7 @@ _PASS_SEQUENCE: tuple[str, ...] = (
     "pocket_patterns",  # a pocket ARRAY: grouped callout + pitch dim, placed pre-drain like a
     # hole pattern (the pitch dim needs strip room the post-drain decoration slots lack)
     "slot_patterns",  # a through-slot ARRAY: same grouped callout + pitch, same pre-drain reason
+    "through_steps",  # two section legs register with the shared corridor before its drain
     "user_dims",  # finalize-only: pin/priority dims queue into the shared corridor
     "gdt",
     "pmi",
@@ -367,6 +369,7 @@ def build_model(a: Analysis):
         chamfers=a.recognition.chamfers,
         fillets=a.recognition.fillets,
         paired_ramp_steps=a.recognition.paired_ramp_steps,
+        through_steps=a.recognition.through_steps,
         plates=a.recognition.plates,
         flats=a.recognition.flats,
         pockets=a.recognition.pockets,
@@ -648,6 +651,10 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # Two equal ramp angles + their run share one solver-owned leader (#1382).
         render_paired_ramp_steps(dwg, _compiled, a, ctx=ctx)
 
+    def _s_through_steps():
+        # Two transverse open-section legs, independently identified and corridor-placed.
+        render_through_steps(dwg, _compiled, a, ctx=ctx)
+
     def _s_flats():
         # Machined-flat callouts (#148b): {across} A/F via a leader off each flat on round stock.
         # Planner-fed (#726): consumes the DimensionGroups so an authored tolerance renders.
@@ -852,6 +859,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
             "pockets": _s_pockets,
             "pocket_patterns": _s_pocket_patterns,
             "slot_patterns": _s_slot_patterns,
+            "through_steps": _s_through_steps,
             "off_axis_across": _s_off_axis_across,
             "envelope": _s_envelope,
             "detail_request": _s_detail_request,

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -857,14 +857,31 @@ def _resolve_details(dwg, a: Analysis, *, ctx) -> None:
     if len(reserved) != sum(req.label is not None for req in reqs):
         raise ValueError("authored detail labels must be unique")
     used: set[str] = set()
+
+    def _record_prismatic_failure(req, message):
+        if req.kind != "prismatic-steps":
+            return
+        ctx.record_issue(
+            "warning",
+            "detail_unplaceable",
+            message,
+            measurement=req.measurement_ids,
+            measurement_spans=req.measurement_spans,
+        )
+
     for req in reqs:
         letter = req.label or next(
             (candidate for candidate in _DETAIL_LETTERS if candidate not in reserved | used), None
         )
         if letter is None:
             _log.info("detail request '%s' dropped: detail letters A–H exhausted", req.kind)
+            _record_prismatic_failure(
+                req,
+                f"{req.kind} detail view requested but detail letters A–H are exhausted",
+            )
             continue
         view_name = req.view_name or f"detail_{letter.lower()}"
+        issue_start = len(ctx.registry.issues)
         placed = _render_detail(dwg, a, req, view_name, letter, ctx=ctx)
         hname = (
             _overall_height_name(dwg, a) if not placed and req.kind == "prismatic-steps" else None
@@ -911,13 +928,20 @@ def _resolve_details(dwg, a: Analysis, *, ctx) -> None:
             # The automatic turned-head requests (queued unconditionally by
             # render_step_lengths) are independent of that setting; their bail-out is the
             # normal path (the main view locates the head/block inline), so they stay silent.
-            ctx.record_issue(
-                "warning",
-                "detail_unplaceable",
-                f"{req.kind} detail view requested but could not be placed legibly on this "
-                "sheet (the crowded band is too wide to enlarge and still fit); dimension the "
-                "feature manually or move it onto its own sheet",
+            # A redraw can fail one rung at a time. Those exact placement outcomes are the
+            # complete account of the failed recovery; adding one request-wide issue as well
+            # would charge the same missing dimensions twice in quality and completeness.
+            exact_redraw_drops = any(
+                issue.code == "detail_step_dim_dropped"
+                for issue in ctx.registry.issues[issue_start:]
             )
+            if not exact_redraw_drops:
+                _record_prismatic_failure(
+                    req,
+                    f"{req.kind} detail view requested but could not be placed legibly on this "
+                    "sheet (the crowded band is too wide to enlarge and still fit); dimension "
+                    "the feature manually or move it onto its own sheet",
+                )
 
 
 def _overall_height_name(dwg, a: Analysis) -> str | None:
@@ -1082,6 +1106,10 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx, plan) -> None:
             0.0,
         )
 
+    # A retry after overall-height demotion reuses the same closure. Retain the exact rungs
+    # already reported so one failed compiler outcome cannot become two lint findings.
+    reported_redraw_failures: set[tuple] = set()
+
     def redraw(
         dwg, view, coords, detail_scale
     ):  # returns the count placed (#840: 0 → not committed)
@@ -1145,6 +1173,7 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx, plan) -> None:
                         label=label,
                     )
                 det_dim._dw_scale = detail_scale  # detail scale, for label-vs-measured lint (#42)
+                det_dim._dw_measurement_span = rung.span
                 ctx.place(
                     det_dim,
                     f"dim_{view}_step{i}",
@@ -1156,6 +1185,20 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx, plan) -> None:
                 placed += 1
             except Exception as exc:  # noqa: BLE001 — placement may fail on degenerate geometry
                 _log.info("detail step dim %d skipped (%s)", i, exc)
+                # The resolver may retry after deliberately demoting the unpinned overall
+                # height. The same redraw closure serves both attempts, so retain one exact
+                # outcome per compiler rung rather than reporting the retry as another loss.
+                failure_key = (getattr(rung.id, "parameter", None), rung.span)
+                if failure_key not in reported_redraw_failures:
+                    reported_redraw_failures.add(failure_key)
+                    ctx.record_issue(
+                        "warning",
+                        "detail_step_dim_dropped",
+                        f"detail step dimension {rung.final_label} not placed ({exc})",
+                        measurement=rung.id,
+                        measurement_span=rung.span,
+                        outcome_stage="placement",
+                    )
         return placed
 
     ctx.detail_requests.append(
@@ -1174,5 +1217,7 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx, plan) -> None:
             cross_lo=crop_xs[0] if x_stations else None,
             cross_hi=crop_xs[1] if x_stations else None,
             kind="prismatic-steps",
+            measurement_ids=tuple(rung.id for rung in rungs if rung.id is not None),
+            measurement_spans=tuple(rung.span for rung in rungs if rung.id is not None),
         )
     )

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -58,6 +58,7 @@ from draftwright._core import (
     _tol_suffix,
     place_annotation,
 )
+from draftwright._geometry import _END_ON
 from draftwright.annotations._common import (
     PlacementContext,
     _register_hole_table_coverage,
@@ -119,6 +120,7 @@ from draftwright.linting import (
     lint_prismatic_pocket_coverage,
     lint_profiled_bore_coverage,
     lint_slot_coverage,
+    lint_through_step_coverage,
     pmi_stage_summary,
 )
 from draftwright.linting.issues import _collect_issue_aggregation, _current_issue_aggregation
@@ -1201,6 +1203,7 @@ class Drawing:
         name=None,
         slot=8.0,
         feature=None,
+        measurement=None,
         **kwargs,
     ):
         """Raw page-coordinate dimension placement **primitive** (#817).
@@ -1258,11 +1261,15 @@ class Drawing:
             kwargs["label"] = _fmt(page_len / self.scale)
         kwargs["label"] = _font_safe_text(f"{kwargs['label']}{_tol_suffix(tolerance, draft)}")
         return self._add(
-            _dim(p1, p2, side, max(dist, 4.0), draft, **kwargs), name, feature=feature
+            _dim(p1, p2, side, max(dist, 4.0), draft, **kwargs),
+            name,
+            view=view,
+            feature=feature,
+            measurement=measurement,
         )
 
     # -- annotations ----------------------------------------------------------
-    def _add(self, obj, name=None, view=None, feature=None):
+    def _add(self, obj, name=None, view=None, feature=None, measurement=None):
         """Register an annotation so lint and export include it; returns ``obj``. The
         annotation-placement **primitive** (#817) — private, because the public door is the
         placement verbs (:meth:`callout`/:meth:`dimension`/:meth:`note`/:meth:`add_table`/…) and
@@ -1275,7 +1282,15 @@ class Drawing:
         block (#121); ``None`` for drawing-level marks. ``feature`` records the source IR feature
         (#398) so :meth:`drop` / :meth:`annotations_of` work by feature.
         """
-        return place_annotation(self._registry, self.items, obj, name, view, feature)
+        return place_annotation(
+            self._registry,
+            self.items,
+            obj,
+            name,
+            view,
+            feature,
+            measurement,
+        )
 
     @deprecated(
         "Drawing.add() is deprecated (#817): use the placement verbs (callout/dimension/note/"
@@ -1356,19 +1371,23 @@ class Drawing:
             raise ValueError(
                 f"view must be one of {_ortho}, not {view!r} (it foreshortens the span)"
             )
-        matches = [
-            q for q in feature.parameters() if q.kind == param and (role is None or q.role == role)
-        ]
+        parameters = feature.parameters()
+        exact = [q for q in parameters if param in (q.parameter_id, q.discriminator)]
+        matches = (
+            [q for q in exact if role is None or q.role == role]
+            if exact
+            else [q for q in parameters if q.kind == param and (role is None or q.role == role)]
+        )
         if not matches:
             r = f"/{role!r}" if role else ""
             raise ValueError(
                 f"{type(feature).__name__} has no '{param}'{r} parameter to dimension"
             )
         if len(matches) > 1:
-            roles = sorted(q.role for q in matches)
+            ids = sorted(q.parameter_id for q in matches)
             raise ValueError(
-                f"{type(feature).__name__} has {len(matches)} '{param}' params (roles {roles}) "
-                f"— pass role= to choose one"
+                f"{type(feature).__name__} has {len(matches)} '{param}' params {ids} — pass "
+                "role= or an exact parameter id/discriminator to choose one"
             )
         # A span-carrying param (a step length, a location) gives its endpoints directly;
         # a value-only linear param (a slot's dims) derives them from the feature geometry
@@ -1383,7 +1402,10 @@ class Drawing:
         (lo, hi) = span
         p1 = p2 = None
         chosen = view
-        for v in [view] if view else _ortho:
+        automatic_views: tuple[str, ...] = _ortho
+        if view is None and getattr(feature, "kind", None) == "through_step":
+            automatic_views = (_END_ON[feature.axis],)
+        for v in [view] if view else automatic_views:
             q1, q2 = self.at(v, *lo), self.at(v, *hi)
             if math.hypot(q2[0] - q1[0], q2[1] - q1[1]) > 1e-6:
                 chosen, p1, p2 = v, q1, q2
@@ -1395,14 +1417,28 @@ class Drawing:
             )
         return matches[0], chosen, p1, p2
 
+    def _resolve_dimension_side(self, feature, param, view, p1, p2, side):
+        """Choose a feature's natural corridor when the caller leaves ``side`` implicit."""
+        if side is not None:
+            return side
+        if getattr(feature, "kind", None) != "through_step":
+            return "above"
+        changed_axis = param.discriminator
+        perpendicular = next(axis for axis in "xyz" if axis not in (feature.axis, changed_axis))
+        outside = dict(feature.outside_directions)
+        probe_world = [(a + b) / 2 for a, b in zip(param.span[0], param.span[1], strict=True)]
+        probe_world["xyz".index(perpendicular)] += outside[perpendicular]
+        exterior = self.at(view, *probe_world)
+        if abs(p2[0] - p1[0]) >= abs(p2[1] - p1[1]):
+            return "above" if exterior[1] > (p1[1] + p2[1]) / 2 else "below"
+        return "right" if exterior[0] > (p1[0] + p2[0]) / 2 else "left"
+
     def _queue_dimension_intent(self, it, a, *, ctx, used_names=None) -> bool:
         """Queue a pinned/prioritized feature dimension into a shared corridor."""
         from draftwright.annotations._common import CorridorCandidate, register_corridor
 
-        side = it.kwargs.get("side", "above")
+        side = it.kwargs.get("side")
         view = it.kwargs.get("view")
-        if side not in ("above", "below", "left", "right"):
-            return False
         zones_name = {"front": "fv_zones", "plan": "pv_zones", "side": "sv_zones"}
         rec, view, p1, p2 = self._resolve_dimension_span(
             it.feature,
@@ -1410,6 +1446,13 @@ class Drawing:
             role=it.kwargs.get("role"),
             view=view,
         )
+        side = self._resolve_dimension_side(it.feature, rec, view, p1, p2, side)
+        if side not in ("above", "below", "left", "right"):
+            return False
+        from draftwright.model.compiled import DimensionId
+
+        measurement = DimensionId(it.feature, rec.parameter_id)
+        measurement_span = rec.span or self._derive_span(it.feature, rec)
         zones = getattr(a, zones_name.get(view, ""), None)
         strip = getattr(zones, side, None) if zones is not None else None
         if strip is None:
@@ -1452,12 +1495,22 @@ class Drawing:
         tier = self.draft.font_size + 2 * self.draft.pad_around_text
         p_lo, p_hi = sorted((p1[1 - ax], p2[1 - ax]))
 
-        def _build(pos, _p1=p1, _p2=p2, _side=side, _ax=ax, _kwargs=dim_kwargs):
+        def _build(
+            pos,
+            _p1=p1,
+            _p2=p2,
+            _side=side,
+            _ax=ax,
+            _kwargs=dim_kwargs,
+            _measurement_span=measurement_span,
+        ):
             if _side in ("right", "above"):
                 dist = pos - max(p[_ax] for p in (_p1, _p2))
             else:
                 dist = min(p[_ax] for p in (_p1, _p2)) - pos
-            return _dim(_p1, _p2, _side, max(dist, 4.0), self.draft, **_kwargs)
+            dim = _dim(_p1, _p2, _side, max(dist, 4.0), self.draft, **_kwargs)
+            dim._dw_measurement_span = _measurement_span
+            return dim
 
         def _placed(nm, _pin=it.kwargs.get("pin", False)):
             if _pin:
@@ -1468,6 +1521,8 @@ class Drawing:
                 "warning",
                 "dimension_dropped",
                 f"{nm} not placed (no room on the {view} {side} strip)",
+                measurement=measurement,
+                measurement_span=measurement_span,
             )
 
         priority = float(it.kwargs.get("priority", 0.0) or 0.0)
@@ -1492,6 +1547,7 @@ class Drawing:
                 anchored=bool(it.kwargs.get("pin")),
                 natural=natural,
                 feature=it.feature,
+                measurement=measurement,
             ),
         )
         return True
@@ -1502,7 +1558,7 @@ class Drawing:
         param,
         *,
         role=None,
-        side="above",
+        side=None,
         view=None,
         name=None,
         pin=False,
@@ -1512,22 +1568,26 @@ class Drawing:
         """Add a dimension for *feature*'s *param*, attributed to the feature (#398e).
 
         The feature-referenced **add** verb: pair to :meth:`drop`. *feature* is an IR
-        feature from :meth:`model`; *param* is a **linear** parameter kind it exposes — a
-        turned step's ``"length"`` or a slot's ``"length"``/``"width"`` (which the feature
-        carries as value-only geometry, derived here via :meth:`_derive_span`).
+        feature from :meth:`model`; *param* is a **linear** parameter kind, exact parameter
+        id, or discriminator it exposes — a turned step's ``"length"`` or a through step's
+        ``"through_step_leg.length.x"``/``"x"`` (value-only slot geometry is derived here
+        via :meth:`_derive_span`).
         The dimension is placed into free strip space and tagged with *feature*, so
         :meth:`drop` / :meth:`annotations_of` find it. Returns the annotation name.
 
         A feature may expose several params of one kind (an envelope's width/height/depth,
-        or a slot's ``slot_width``/``slot_length``, are all ``"length"``); pass ``role=`` to
-        pick one — a bare kind matching more than one raises rather than guessing.
+        or a slot's ``slot_width``/``slot_length``, are all ``"length"``); pass ``role=`` or
+        an exact parameter id/discriminator to pick one — an ambiguous kind raises rather
+        than guessing.
 
         ``view`` is chosen automatically as the orthographic view (``"front"``/``"plan"``/
         ``"side"``) where the span projects non-degenerate — a length along the turning
-        axis vanishes in its end-on view, so the view follows the geometry. Pass ``view=``
+        axis vanishes in its end-on view, so the view follows the geometry. Through-step legs
+        share their semantic axis end view and natural outside-corner sides. Pass ``view=``
         to force one of those three (a non-orthographic view foreshortens the span and is
-        rejected). ``side`` defaults to ``"above"``; ``kwargs`` forward to the dimension —
-        except ``tolerance=``, which is folded into the label (see :meth:`place_dim`),
+        rejected). An implicit ``side`` is ``"above"`` except for through-step legs, whose
+        missing corner selects the natural outside corridor. ``kwargs`` forward to the dimension
+        — except ``tolerance=``, which is folded into the label (see :meth:`place_dim`),
         because helpers discard a forwarded tolerance whenever a label is present.
         In deferred mode, ``pin=True`` anchors the dimension at its natural slot coordinate
         inside the shared corridor solve, and ``priority=`` controls over-capacity survival.
@@ -1557,12 +1617,16 @@ class Drawing:
                 )
             )
             return ""
-        _rec, view, p1, p2 = self._resolve_dimension_span(feature, param, role=role, view=view)
+        rec, view, p1, p2 = self._resolve_dimension_span(feature, param, role=role, view=view)
+        side = self._resolve_dimension_side(feature, rec, view, p1, p2, side)
+        from draftwright.model.compiled import DimensionId
+
+        measurement = DimensionId(feature, rec.parameter_id)
         if name is None:
             i = 0
             while (name := f"dim_{param}{i}") in self._registry:
                 i += 1
-        self._place_dim(
+        annotation = self._place_dim(
             p1,
             p2,
             side,
@@ -1570,8 +1634,13 @@ class Drawing:
             self.draft,
             name=name,
             feature=feature,
+            measurement=measurement,
             **kwargs,
         )
+        # A correlated ladder intentionally shares one public ``DimensionId`` across its
+        # members. Preserve the compiler-owned world span at the public edit boundary so
+        # completeness can tell which exact occurrence this visible replacement asserts.
+        annotation._dw_measurement_span = rec.span or self._derive_span(feature, rec)
         if pin:
             self.pin(name)
         return name
@@ -2138,7 +2207,10 @@ class Drawing:
             or it.kind != "dimension"
             or id(it) in already_routed
             or not (it.kwargs.get("pin") or it.kwargs.get("priority"))
-            or it.kwargs.get("side", "above") not in ("above", "below", "left", "right")
+            or (
+                it.kwargs.get("side") is not None
+                and it.kwargs.get("side") not in ("above", "below", "left", "right")
+            )
         ):
             return False
         try:
@@ -3237,11 +3309,22 @@ class Drawing:
         self.items = [o for o in self.items if id(o) in kept_ids]
         return removed
 
-    def _record_build_issue(self, severity, code, message):
+    def _record_build_issue(
+        self, severity, code, message, *, measurement=None, measurement_span=None
+    ):
         """Record a lint issue discovered during construction (e.g. an
         annotation the layout had to drop). Surfaced by :meth:`lint` so a
         dropped feature is never silent."""
-        self._registry.record_issue(LintIssue(severity=severity, code=code, message=message))
+        self._registry.record_issue(
+            LintIssue(
+                severity=severity,
+                code=code,
+                message=message,
+                measurement_ids=(measurement,) if measurement is not None else (),
+                outcome_stage="placement" if measurement is not None else None,
+                measurement_spans=(measurement_span,) if measurement_span is not None else (),
+            )
+        )
 
     # -- repair ---------------------------------------------------------------
     def repair(self, max_iter: int = 3):
@@ -3414,7 +3497,10 @@ class Drawing:
                 # (ADR 0016 Amendment 1).
                 from draftwright.model.compiled import compile_dimensions
 
-                issues += lint_claimed_representations(self._registry, compile_dimensions(model))
+                dimension_plan = compile_dimensions(model)
+                issues += lint_claimed_representations(self._registry, dimension_plan)
+            else:
+                dimension_plan = None
             # Turned bosses/bands remain in the OD + axial-step policy; this check is
             # specifically for a prismatic boss's independent projection height.
             if model is not None and (a is None or (not a.is_rotational and a.prof is None)):
@@ -3516,6 +3602,15 @@ class Drawing:
                 registry=self._registry,
                 omissions=self._build.omissions,
                 assembly=self.assembly,
+            )
+            issues += lint_through_step_coverage(
+                self.part,
+                recognition=recognition,
+                features=getattr(model, "features", ()) if model is not None else (),
+                registry=self._registry,
+                omissions=self._build.omissions,
+                assembly=self.assembly,
+                plan=dimension_plan,
             )
             issues += lint_slot_coverage(
                 self.part,
@@ -3654,6 +3749,8 @@ class Drawing:
             if self._analysis is not None
             else None
         )
+        from draftwright.model.compiled import compile_dimensions
+
         quality = quality_components(
             recognition=self._build.recognition,
             features=getattr(self._part_model, "features", ()),
@@ -3688,6 +3785,9 @@ class Drawing:
             ),
             error_penalty=_SCORE_ERROR_PENALTY,
             warning_penalty=_SCORE_WARNING_PENALTY,
+            dimension_plan=(
+                compile_dimensions(self._part_model) if self._part_model is not None else None
+            ),
             _aggregation=aggregation,
         )
         return {

--- a/src/draftwright/linting/__init__.py
+++ b/src/draftwright/linting/__init__.py
@@ -58,6 +58,7 @@ from draftwright.linting.profiled_bore_coverage import lint_profiled_bore_covera
 from draftwright.linting.slot_coverage import lint_slot_coverage
 from draftwright.linting.structural import is_dimension_like, lint_drawing
 from draftwright.linting.suggest import _suggest_fix
+from draftwright.linting.through_step_coverage import lint_through_step_coverage
 
 __all__ = [
     "ClaimOutcome",
@@ -86,6 +87,7 @@ __all__ = [
     "lint_fillet_coverage",
     "lint_declared_gear_coverage",
     "lint_slot_coverage",
+    "lint_through_step_coverage",
     "lint_location_coverage",
     "lint_passage_coverage",
     "lint_paired_ramp_step_coverage",

--- a/src/draftwright/linting/issues.py
+++ b/src/draftwright/linting/issues.py
@@ -40,6 +40,11 @@ class LintIssue:
     # location has two independently observable X/Y requirements while #883 keeps their
     # public addressability deliberately open.
     hole_requirement_ids: tuple = ()
+    # Exact compiler-owned spans for occurrence-sensitive measurement outcomes. Addressable
+    # ``DimensionId`` intentionally identifies a whole correlated ladder, so repeated rungs
+    # share it; this parallel tuple lets completeness distinguish which member was dropped.
+    # Empty for families whose identity is already occurrence-specific.
+    measurement_spans: tuple = ()
 
 
 def is_placement_drop(issue: LintIssue) -> bool:

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -44,6 +44,7 @@ from draftwright.linting.pocket_coverage import pocket_requirement_outcomes
 from draftwright.linting.pocket_pattern_coverage import pocket_pattern_requirement_outcomes
 from draftwright.linting.polygonal_stock_coverage import polygonal_stock_outcomes
 from draftwright.linting.slot_coverage import slot_requirement_outcomes
+from draftwright.linting.through_step_coverage import through_step_requirement_outcomes
 
 _OUTCOME_STATES = (
     "placed",
@@ -118,6 +119,7 @@ _RECOGNISED_REQUIREMENT_FAMILIES = {
     "chamfers": "chamfers",
     "fillets": "fillets",
     "paired_ramp_steps": "paired_ramp_steps",
+    "through_steps": "through_steps",
     # The rich aggregate is the sole physical Passage authority. The legacy
     # ``passages`` projection is classified below as non-requirement compatibility data.
     "section_passages": "passages",
@@ -154,7 +156,6 @@ _NON_REQUIREMENT_INVENTORIES = frozenset(
 #: unsupported outcome.
 _UNDECIDED_INVENTORIES: dict[str, str] = {
     "circular_blind_steps": "https://github.com/pzfreo/draftwright/issues/1382",
-    "through_steps": "https://github.com/pzfreo/draftwright/issues/1382",
 }
 
 _AUDITED_FAMILIES = (
@@ -174,6 +175,7 @@ _AUDITED_FAMILIES = (
     "prismatic_pockets",
     "slot_patterns",
     "slots",
+    "through_steps",
 )
 
 # What the audited score does not cover, emitted as data rather than left to prose. The
@@ -386,6 +388,7 @@ _UNSCORED_CODE_PREFIXES = (
     "channel_requirement_",
     "fillet_requirement_",
     "paired_ramp_step_requirement_",
+    "through_step_requirement_",
     "flat_requirement_",
     "gear_requirement_",
     "groove_requirement_",
@@ -591,7 +594,9 @@ def _empty_completeness(reason: str, unrecognised: int) -> dict:
     }
 
 
-def _completeness_component(recognition, features, registry, omissions, issues) -> dict:
+def _completeness_component(
+    recognition, features, registry, omissions, issues, *, dimension_plan=None
+) -> dict:
     unrecognised = sum(issue.code == _UNRECOGNISED_GEOMETRY_CODE for issue in issues)
     if recognition is None:
         return _empty_completeness("physical recognition inventory unavailable", unrecognised)
@@ -602,6 +607,13 @@ def _completeness_component(recognition, features, registry, omissions, issues) 
         "fillets": fillet_requirement_outcomes(recognition, features, registry, omissions),
         "paired_ramp_steps": paired_ramp_step_requirement_outcomes(
             recognition, features, registry, omissions
+        ),
+        "through_steps": through_step_requirement_outcomes(
+            recognition,
+            features,
+            registry,
+            omissions,
+            plan=dimension_plan,
         ),
         "flats": flat_requirement_outcomes(recognition, features, registry, omissions),
         "grooves": groove_requirement_outcomes(recognition, features, registry, omissions),
@@ -702,6 +714,7 @@ def quality_components(
     error_penalty: float,
     warning_penalty: float,
     has_asserted_content: bool,
+    dimension_plan=None,
     _aggregation=None,
 ) -> dict:
     """Return independently usable drawing-quality observations.
@@ -730,7 +743,12 @@ def quality_components(
     fidelity_issues = [issue for issue in issues if _is_fidelity_issue(issue)]
     return {
         "completeness": _completeness_component(
-            recognition, features, registry, omissions, issues
+            recognition,
+            features,
+            registry,
+            omissions,
+            issues,
+            dimension_plan=dimension_plan,
         ),
         "restraint": {
             "available": False,

--- a/src/draftwright/linting/through_step_coverage.py
+++ b/src/draftwright/linting/through_step_coverage.py
@@ -1,0 +1,644 @@
+"""Semantic completeness for recognised rectangular through-step requirements (#1382).
+
+Each aggregate ``ThroughStep`` owns the two orthogonal legs of its canonical open section.
+The provider's axis, run length, anchor and complete section join that record to exactly one
+IR feature; parameter identities then follow each leg to its drawing outcome.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import defaultdict
+from dataclasses import dataclass
+from typing import Literal
+
+from b123d_recognisers import RecognitionResult, ThroughStep
+
+from draftwright._geometry import _fmt
+from draftwright.linting._registry import satisfaction_ids, satisfaction_of
+from draftwright.linting.evidence import compiled_values, rendered_numbers
+from draftwright.linting.issues import LintIssue, is_placement_drop
+from draftwright.linting.structural import _label_reading
+
+ThroughStepRequirementState = Literal[
+    "placed",
+    "satisfied_by_structured_note",
+    "suppressed",
+    "dropped",
+    "missing",
+    "unverifiable",
+    "inapplicable",
+]
+
+
+@dataclass(frozen=True)
+class ThroughStepRequirementOutcome:
+    """The observable engine outcome of one open-section leg requirement."""
+
+    source_at: tuple[float, float, float]
+    parameter_id: str
+    state: ThroughStepRequirementState
+    requirement_count: int = 1
+    features: tuple = ()
+
+
+@dataclass(frozen=True)
+class _LegacyTerm:
+    """One exact member of a legacy dimension grammar.
+
+    ``DimensionId`` deliberately addresses an entire correlated ladder, so it cannot by
+    itself distinguish (for example) a 10 mm step rung from a 15 mm rung.  The physical
+    interval retained here selects the exact compiled member and prevents another member of
+    the same ladder from receiving credit for a through-step leg.
+    """
+
+    feature: object
+    parameter_id: str
+    axis: str
+    lo: float
+    hi: float
+
+    @property
+    def identity(self) -> tuple[object, str]:
+        return (self.feature, self.parameter_id)
+
+    @property
+    def value(self) -> float:
+        return abs(self.hi - self.lo)
+
+
+def _rounded(value) -> float:
+    try:
+        return round(float(value), 3)
+    except (OverflowError, TypeError, ValueError) as error:
+        raise ValueError from error
+
+
+def _point(value) -> tuple[float, ...]:
+    return tuple(_rounded(coordinate) for coordinate in value)
+
+
+def through_step_key(step) -> tuple:
+    """Facts retained identically by the public record and Draftwright IR."""
+    at = getattr(step, "at", None)
+    if at is None:
+        at = step.frame.origin
+    return (
+        str(step.axis),
+        _point(at),
+        _rounded(step.length),
+        tuple(_point(point) for point in step.section),
+    )
+
+
+def _source_at(source) -> tuple[float, float, float]:
+    try:
+        point = _point(source.at)
+        if len(point) != 3:
+            raise ValueError
+        return (point[0], point[1], point[2])
+    except (AttributeError, OverflowError, TypeError, ValueError):
+        return (float("nan"), float("nan"), float("nan"))
+
+
+def _parameter_ids(source) -> tuple[str, str]:
+    transverse = tuple(axis for axis in "xyz" if axis != source.axis)
+    raw_section = tuple(tuple(point) for point in source.section)
+    raw_at = tuple(source.at)
+    if (
+        isinstance(source.length, bool)
+        or any(isinstance(value, bool) for value in raw_at)
+        or any(isinstance(value, bool) for point in raw_section for value in point)
+    ):
+        raise ValueError
+    section = tuple(tuple(float(value) for value in point) for point in raw_section)
+    at = tuple(float(value) for value in raw_at)
+    if (
+        source.axis not in ("x", "y", "z")
+        or len(at) != 3
+        or any(not math.isfinite(value) for value in at)
+        or len(section) != 3
+        or any(len(point) != 2 for point in section)
+        or not math.isfinite(float(source.length))
+        or float(source.length) <= 0
+        or any(not math.isfinite(value) for point in section for value in point)
+    ):
+        raise ValueError
+    ids = []
+    for start, end in zip(section, section[1:]):
+        changed = [index for index in (0, 1) if start[index] != end[index]]
+        if len(changed) != 1:
+            raise ValueError
+        ids.append(f"through_step_leg.length.{transverse[changed[0]]}")
+    if len(ids) != 2 or ids[0] == ids[1]:
+        raise ValueError
+    return (ids[0], ids[1])
+
+
+def _source_leg_intervals(source) -> tuple[tuple[str, float, float], ...]:
+    transverse = tuple(axis for axis in "xyz" if axis != source.axis)
+    intervals = []
+    for start, end in zip(source.section, source.section[1:]):
+        changed = next(index for index in (0, 1) if start[index] != end[index])
+        lo, hi = sorted((float(start[changed]), float(end[changed])))
+        intervals.append((transverse[changed], lo, hi))
+    return tuple(intervals)
+
+
+def _legacy_owner_plans(source, features) -> dict[str, list[tuple[_LegacyTerm, ...]]]:
+    """Alternative measurement identities that prove each physical source leg."""
+    parameters = _parameter_ids(source)
+    legs = dict(zip(parameters, _source_leg_intervals(source), strict=True))
+    plans: dict[str, list[tuple[_LegacyTerm, ...]]] = {parameter: [] for parameter in parameters}
+    envelope = next(
+        (candidate for candidate in features if getattr(candidate, "kind", None) == "envelope"),
+        None,
+    )
+    envelope_parameters = {"x": "width.length", "y": "depth.length", "z": "height.length"}
+    maxima = dict(zip("xyz", envelope.bbox_max, strict=True)) if envelope is not None else {}
+
+    def _matches(owner, leg) -> bool:
+        owner_axis, owner_lo, owner_hi = owner
+        axis, lo, hi = leg
+        return bool(owner_axis == axis and abs(owner_lo - lo) < 0.5 and abs(owner_hi - hi) < 0.5)
+
+    for feature in features:
+        kind = getattr(feature, "kind", None)
+        if kind == "plate":
+            owner = (feature.axis, *sorted((feature.lo, feature.hi)))
+            for parameter, leg in legs.items():
+                if _matches(owner, leg):
+                    plans[parameter].append((_LegacyTerm(feature, "thickness.length", *owner),))
+                if envelope is not None:
+                    axis = feature.axis
+                    bound_lo = envelope.bbox_min["xyz".index(axis)]
+                    bound_hi = envelope.bbox_max["xyz".index(axis)]
+                    plate_lo, plate_hi = owner[1:]
+                    complements = []
+                    if abs(plate_lo - bound_lo) < 0.5:
+                        complements.append((axis, plate_hi, bound_hi))
+                    if abs(plate_hi - bound_hi) < 0.5:
+                        complements.append((axis, bound_lo, plate_lo))
+                    if any(_matches(complement, leg) for complement in complements):
+                        plans[parameter].append(
+                            (
+                                _LegacyTerm(feature, "thickness.length", *owner),
+                                _LegacyTerm(
+                                    envelope,
+                                    envelope_parameters[axis],
+                                    axis,
+                                    bound_lo,
+                                    bound_hi,
+                                ),
+                            )
+                        )
+        elif kind == "step_level":
+            for level in feature.levels:
+                direct = ("z", *sorted((feature.base, level)))
+                complement = (
+                    ("z", *sorted((level, maxima["z"])))
+                    if "z" in maxima
+                    and envelope is not None
+                    and abs(feature.base - envelope.bbox_min[2]) < 0.5
+                    else None
+                )
+                for parameter, leg in legs.items():
+                    if _matches(direct, leg):
+                        plans[parameter].append(
+                            (_LegacyTerm(feature, "step_height.length", *direct),)
+                        )
+                    if complement is not None and _matches(complement, leg):
+                        assert envelope is not None
+                        plans[parameter].append(
+                            (
+                                _LegacyTerm(feature, "step_height.length", *direct),
+                                _LegacyTerm(
+                                    envelope,
+                                    envelope_parameters["z"],
+                                    "z",
+                                    envelope.bbox_min[2],
+                                    envelope.bbox_max[2],
+                                ),
+                            )
+                        )
+            for axis, position in feature.shoulders:
+                datum = feature.datum["xyz".index(axis)]
+                direct = (axis, *sorted((datum, position)))
+                complement = (
+                    (axis, *sorted((position, maxima[axis])))
+                    if axis in maxima
+                    and envelope is not None
+                    and abs(datum - envelope.bbox_min["xyz".index(axis)]) < 0.5
+                    else None
+                )
+                for parameter, leg in legs.items():
+                    if _matches(direct, leg):
+                        plans[parameter].append(
+                            (_LegacyTerm(feature, "step_position.length", *direct),)
+                        )
+                    if complement is not None and _matches(complement, leg):
+                        assert envelope is not None
+                        plans[parameter].append(
+                            (
+                                _LegacyTerm(feature, "step_position.length", *direct),
+                                _LegacyTerm(
+                                    envelope,
+                                    envelope_parameters[axis],
+                                    axis,
+                                    envelope.bbox_min["xyz".index(axis)],
+                                    envelope.bbox_max["xyz".index(axis)],
+                                ),
+                            )
+                        )
+    return plans
+
+
+def _legacy_plan_signature(plans) -> tuple:
+    """Hashable identity of the alternate owners available to one source record.
+
+    Legacy correlation currently proves section intervals, not the recogniser record's run
+    anchor.  Two records that resolve to this same signature are therefore ambiguous: giving
+    either one the legacy ink would necessarily give both the same ink.  Fail closed rather
+    than count one owner twice.
+    """
+    return tuple(
+        (
+            parameter,
+            tuple(
+                tuple(
+                    (term.identity, term.axis, _rounded(term.lo), _rounded(term.hi))
+                    for term in alternative
+                )
+                for alternative in alternatives
+            ),
+        )
+        for parameter, alternatives in sorted(plans.items())
+    )
+
+
+def _has_parameters(feature, expected: tuple[str, str]) -> bool:
+    try:
+        return tuple(parameter.parameter_id for parameter in feature.parameters()) == expected
+    except (AttributeError, TypeError):
+        return False
+
+
+def _interval_matches(term: _LegacyTerm, span) -> bool:
+    try:
+        if span is None or len(span) != 2:
+            return False
+        raw_points = tuple(tuple(point) for point in span)
+        if any(len(point) != 3 for point in raw_points):
+            return False
+        if any(isinstance(value, bool) for point in raw_points for value in point):
+            return False
+        points = tuple(tuple(float(value) for value in point) for point in raw_points)
+    except (OverflowError, TypeError, ValueError):
+        return False
+    if any(not math.isfinite(value) for point in points for value in point):
+        return False
+    index = "xyz".index(term.axis)
+    lo, hi = sorted((points[0][index], points[1][index]))
+    return abs(lo - term.lo) < 0.5 and abs(hi - term.hi) < 0.5
+
+
+def _span_matches(term: _LegacyTerm, approved) -> bool:
+    return _interval_matches(term, getattr(approved, "span", None))
+
+
+def _term_values(term: _LegacyTerm, approved_by_id) -> frozenset[float]:
+    """Compiler-approved labels for the exact correlated member named by *term*."""
+    entries = (
+        tuple(
+            entry for entry in approved_by_id.get(term.identity, ()) if _span_matches(term, entry)
+        )
+        if approved_by_id is not None
+        else ()
+    )
+    values = set()
+    for entry in entries:
+        try:
+            value_text = entry.value_text
+            if not isinstance(value_text, str):
+                continue
+            value = float(value_text)
+            if not math.isfinite(value):
+                continue
+            values.add(value)
+        except (AttributeError, OverflowError, TypeError, ValueError):
+            continue
+    # Direct helper callers do not necessarily have a compiled plan.  Default formatting is
+    # still a stricter fallback than accepting any member carrying the shared DimensionId.
+    # Once a compiler plan is supplied, however, it is the content authority: an absent exact
+    # occurrence (same correlated id, wrong span) or malformed approved text is no evidence and
+    # must fail closed rather than be reconstructed from geometry (ADRs 0015/0016/0017).
+    if approved_by_id is None:
+        values.add(float(_fmt(term.value)))
+    return frozenset(values)
+
+
+def _term_is_asserted(term, asserted, rendered, approved_by_id) -> bool:
+    if term.identity not in asserted:
+        return False
+    expected = _term_values(term, approved_by_id)
+    actual = rendered.get(term.identity, ())
+    return any(
+        abs(want - number) <= 1e-6 and _interval_matches(term, span)
+        for want in expected
+        for number, span in actual
+    )
+
+
+def _term_is_dropped(term, dropped) -> bool:
+    return any(_interval_matches(term, span) for span in dropped.get(term.identity, ()))
+
+
+def _alternative_state(plans, placed, satisfied, dropped, suppressed, rendered, approved_by_id):
+    """Outcome of one physical leg expressed by an alternate dimension grammar."""
+    asserted = placed | satisfied
+    for plan in plans:
+        if all(_term_is_asserted(term, asserted, rendered, approved_by_id) for term in plan):
+            return "inapplicable"
+    for plan in plans:
+        if all(
+            _term_is_asserted(term, asserted, rendered, approved_by_id)
+            or term.identity in suppressed
+            for term in plan
+        ) and any(term.identity in suppressed for term in plan):
+            return "suppressed"
+    for plan in plans:
+        if all(
+            _term_is_asserted(term, asserted, rendered, approved_by_id)
+            or _term_is_dropped(term, dropped)
+            for term in plan
+        ) and any(_term_is_dropped(term, dropped) for term in plan):
+            return "dropped"
+    return "missing"
+
+
+def _index_evidence(registry):
+    placed = {
+        (measurement.feature, measurement.parameter)
+        for name in registry.names()
+        for measurement in registry.measurement_of(name)
+    }
+    satisfied = {
+        (identity.feature, identity.parameter)
+        for identity in satisfaction_ids(registry)
+        if identity.feature is not None and isinstance(identity.parameter, str)
+    }
+    dropped: dict[tuple[object, str], list] = defaultdict(list)
+    for issue in registry.issues:
+        # ``detail_unplaceable`` is an optional recovery-view outcome, not a sheet/scale
+        # placement blocker. It nevertheless proves that the exact compiler rungs carried
+        # on the request were not recovered. Consume that narrow, provenance-bearing outcome
+        # here without globally reclassifying optional detail furniture as required ink.
+        exact_detail_failure = bool(
+            issue.code == "detail_unplaceable"
+            and getattr(issue, "measurement_ids", ())
+            and getattr(issue, "measurement_spans", ())
+        )
+        if not is_placement_drop(issue) and not exact_detail_failure:
+            continue
+        spans = getattr(issue, "measurement_spans", ())
+        for index, measurement in enumerate(getattr(issue, "measurement_ids", ())):
+            if getattr(measurement, "feature", None) is None or not isinstance(
+                getattr(measurement, "parameter", None), str
+            ):
+                continue
+            dropped.setdefault((measurement.feature, measurement.parameter), [])
+            if index < len(spans):
+                dropped[(measurement.feature, measurement.parameter)].append(spans[index])
+    rendered: dict[tuple[object, str], list[tuple[float, object]]] = defaultdict(list)
+    for name in registry.names():
+        annotation = registry.named(name)
+        label = str(getattr(annotation, "label", "") or "")
+        primary = _label_reading(annotation, label) if label else None
+        for identity in registry.measurement_of(name):
+            if getattr(identity, "feature", None) is None or not isinstance(
+                getattr(identity, "parameter", None), str
+            ):
+                continue
+            if primary is not None:
+                rendered[(identity.feature, identity.parameter)].append(
+                    (primary, getattr(annotation, "_dw_measurement_span", None))
+                )
+        # A structured note may legitimately carry several measurements in one compound
+        # label, unlike a linear Dimension whose primary reading is singular.
+        numbers = rendered_numbers(annotation)
+        if numbers is None:
+            continue
+        for identity in satisfaction_of(registry, name):
+            if getattr(identity, "feature", None) is None or not isinstance(
+                getattr(identity, "parameter", None), str
+            ):
+                continue
+            rendered[(identity.feature, identity.parameter)].extend(
+                (number, getattr(annotation, "_dw_measurement_span", None)) for number in numbers
+            )
+    return placed, satisfied, dict(dropped), dict(rendered)
+
+
+def through_step_requirement_outcomes(
+    recognition: RecognitionResult | None,
+    features,
+    registry,
+    omissions=(),
+    *,
+    plan=None,
+) -> list[ThroughStepRequirementOutcome]:
+    """Follow both leg requirements of every recognised through step."""
+    if recognition is None:
+        return []
+    if not isinstance(recognition, RecognitionResult):
+        raise TypeError(
+            "through_step_requirement_outcomes() requires the run's RecognitionResult; "
+            f"got {type(recognition).__name__}"
+        )
+    sources = tuple(recognition.through_steps)
+    if not sources:
+        return []
+
+    keyed_sources: list[tuple[ThroughStep, tuple | None, tuple[str, str] | None]] = []
+    source_counts: dict[tuple, int] = defaultdict(int)
+    for source in sources:
+        key: tuple | None
+        record_parameters: tuple[str, str] | None
+        try:
+            key = through_step_key(source)
+            record_parameters = _parameter_ids(source)
+        except (AttributeError, OverflowError, TypeError, ValueError):
+            key = None
+            record_parameters = None
+        keyed_sources.append((source, key, record_parameters))
+        if key is not None:
+            source_counts[key] += 1
+
+    ir_by_key: dict[tuple, list] = defaultdict(list)
+    for feature in features:
+        if getattr(feature, "kind", None) != "through_step":
+            continue
+        try:
+            ir_by_key[through_step_key(feature)].append(feature)
+        except (AttributeError, OverflowError, TypeError, ValueError):
+            continue
+
+    placed, satisfied, dropped, rendered = _index_evidence(registry)
+    approved = compiled_values(plan) if plan is not None else {}
+    approved_by_id = (
+        {
+            (identity.feature, identity.parameter): entries
+            for identity, entries in approved.items()
+            if identity is not None
+        }
+        if plan is not None
+        else None
+    )
+    # A declared model may omit the envelope from ``model.features`` while the compiler
+    # synthesizes and approves it for the ordinary overall dimensions.  Complement proofs
+    # (step/plate + envelope) must use that actual compiler owner, not invent a parallel bbox
+    # identity and not fall back to every declared parameter.
+    owner_features = tuple(
+        dict.fromkeys(
+            (
+                *features,
+                *(
+                    identity.feature
+                    for identity in approved
+                    if identity is not None
+                    and getattr(identity.feature, "kind", None)
+                    in {"envelope", "plate", "step_level"}
+                ),
+            )
+        )
+    )
+    # Build alternate-owner correspondence once for the whole inventory.  Uniqueness must
+    # be judged on the legacy proof itself, not on the richer recogniser record key: legacy
+    # dimensions encode the section intervals but not necessarily the run anchor, so two
+    # differently anchored sources can otherwise reuse the same two pieces of ink.
+    legacy_plans: dict[int, dict[str, list[tuple[_LegacyTerm, ...]]]] = {}
+    legacy_signature_counts: dict[tuple, int] = defaultdict(int)
+    for index, (source, _key, record_parameters) in enumerate(keyed_sources):
+        if record_parameters is None or source.axis not in ("x", "y"):
+            continue
+        candidate = _legacy_owner_plans(source, owner_features)
+        if not all(candidate.values()):
+            continue
+        legacy_plans[index] = candidate
+        legacy_signature_counts[_legacy_plan_signature(candidate)] += 1
+    suppressed = {
+        (omission.feature, omission.parameter_id)
+        for omission in omissions
+        if omission.feature is not None and omission.authored
+    }
+    outcomes: list[ThroughStepRequirementOutcome] = []
+    fallback = ("through_step_leg.length.unknown.0", "through_step_leg.length.unknown.1")
+    for index, (source, key, record_parameters) in enumerate(keyed_sources):
+        matches = ir_by_key.get(key, ()) if key is not None else ()
+        feature = (
+            matches[0] if key is not None and len(matches) == source_counts[key] == 1 else None
+        )
+        expected = record_parameters or fallback
+        if feature is None and index in legacy_plans:
+            plans = legacy_plans[index]
+            if legacy_signature_counts[_legacy_plan_signature(plans)] == 1:
+                outcomes.extend(
+                    ThroughStepRequirementOutcome(
+                        _source_at(source),
+                        parameter,
+                        _alternative_state(
+                            plans[parameter],
+                            placed,
+                            satisfied,
+                            dropped,
+                            suppressed,
+                            rendered,
+                            approved_by_id,
+                        ),
+                    )
+                    for parameter in expected
+                )
+                continue
+        if (
+            feature is None
+            or record_parameters is None
+            or not _has_parameters(feature, record_parameters)
+        ):
+            outcomes.extend(
+                ThroughStepRequirementOutcome(_source_at(source), parameter, "unverifiable")
+                for parameter in expected
+            )
+            continue
+        for parameter in record_parameters:
+            identity = (feature, parameter)
+            if identity in placed:
+                state: ThroughStepRequirementState = "placed"
+            elif identity in satisfied:
+                state = "satisfied_by_structured_note"
+            elif identity in suppressed:
+                state = "suppressed"
+            elif identity in dropped:
+                state = "dropped"
+            else:
+                associated = registry.names_for_feature(feature)
+                state = (
+                    "unverifiable"
+                    if any(
+                        not registry.measurement_of(name) and not satisfaction_of(registry, name)
+                        for name in associated
+                    )
+                    else "missing"
+                )
+            outcomes.append(
+                ThroughStepRequirementOutcome(
+                    _source_at(source), parameter, state, features=(feature,)
+                )
+            )
+    return outcomes
+
+
+def lint_through_step_coverage(
+    part,
+    *,
+    recognition: RecognitionResult | None,
+    features,
+    registry,
+    omissions=(),
+    assembly=None,
+    plan=None,
+) -> list[LintIssue]:
+    """Report uncovered through-step legs without duplicating placement drops."""
+    if assembly is None:
+        assembly = len(part.solids()) > 1
+    severity: Literal["info", "warning"] = "info" if assembly else "warning"
+    messages = {
+        "suppressed": "was deliberately omitted by the authored dimension set",
+        "missing": "has no placed, suppressed, or dropped dimension outcome",
+        "unverifiable": "cannot be joined to measurement provenance without guessing",
+    }
+    issues = []
+    for outcome in through_step_requirement_outcomes(
+        recognition,
+        features,
+        registry,
+        omissions,
+        plan=plan,
+    ):
+        if outcome.state in {
+            "placed",
+            "satisfied_by_structured_note",
+            "dropped",
+            "inapplicable",
+        }:
+            continue
+        issues.append(
+            LintIssue(
+                severity=severity,
+                code=f"through_step_requirement_{outcome.state}",
+                message=(
+                    f"through-step {outcome.parameter_id} at {outcome.source_at} "
+                    f"{messages[outcome.state]}"
+                ),
+            )
+        )
+    return issues

--- a/src/draftwright/model/__init__.py
+++ b/src/draftwright/model/__init__.py
@@ -51,6 +51,7 @@ from draftwright.model.declare import (
     slot_pattern,
     step,
     step_level,
+    through_step,
 )
 from draftwright.model.detect import build_part_model, build_pmi_features
 from draftwright.model.ir import (
@@ -94,6 +95,7 @@ from draftwright.model.ir import (
     StepLevelFeature,
     ThreadOperation,
     ThreadRequirement,
+    ThroughStepFeature,
     ToleranceDecoration,
     display,
 )
@@ -153,6 +155,7 @@ __all__ = [
     "PolygonalBossFeature",
     "PolygonalStockFeature",
     "StepLevelFeature",
+    "ThroughStepFeature",
     "ThreadOperation",
     "ThreadRequirement",
     "ToleranceDecoration",
@@ -186,6 +189,7 @@ __all__ = [
     "slot_pattern",
     "step",
     "step_level",
+    "through_step",
     "display",
     "SectionPlan",
     "plan_dimensions",

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -286,6 +286,10 @@ _FACTS: dict[str, tuple[str, ...]] = {
     # Structural placement facts only.  The printed angle and run remain addressable
     # parameters, so authored omission/tolerance policy cannot be bypassed (#1382).
     "paired_ramp_step": ("frame", "axis"),
+    # Topology-only direction signs select each outside placement corridor. Absolute section
+    # points would let one approved leg reconstruct the suppressed other leg (ADR 0016), so
+    # both leg values and witnesses travel only as approved spans.
+    "through_step": ("axis", "outside_directions"),
     # These are STRUCTURE, not measurements: together they say which piece of stock a flat
     # belongs to, so the renderer can tell one double-D's two faces from independent aligned
     # or slanted regions (#1013/#1036). The drawing prints none of them.

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -71,6 +71,7 @@ from draftwright.model.ir import (
     SlotPatternFeature,
     StepFeature,
     StepLevelFeature,
+    ThroughStepFeature,
     validate_authored_dimension_placement,
 )
 
@@ -704,6 +705,32 @@ def paired_ramp_step(*, axis, angle, length, at) -> PairedRampStepFeature:
         axis=axis,
         angle=round(float(angle), 2),
         length=round(float(length), 3),
+    )
+
+
+def through_step(*, axis, length, at, section) -> ThroughStepFeature:
+    """Declare one rectangular open-profile through step (#1382).
+
+    Explicit-only: a detached cutter cannot prove that the recess spans the owning body.
+    ``section`` is the provider's canonical three-point open polyline in the two non-run
+    coordinates: envelope endpoint, concave corner, envelope endpoint.
+    """
+    axis = _norm_axis(axis)
+    _require_positive(length=length)
+    _require_point("at", at)
+    try:
+        if any(isinstance(value, bool) for point in section for value in point):
+            raise ValueError
+        canonical_section = tuple(
+            tuple(round(float(value), 3) for value in point) for point in section
+        )
+    except (TypeError, ValueError) as exc:
+        raise ValueError("through_step section must contain three finite 2D points") from exc
+    return ThroughStepFeature(
+        frame=Frame(origin=at, axis=axis),
+        axis=axis,
+        length=round(float(length), 3),
+        section=canonical_section,  # type: ignore[arg-type]
     )
 
 

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -77,7 +77,9 @@ from b123d_recognisers import (
     recognise_risers,
     recognise_slot_patterns,
     recognise_slots,
+    recognise_through_steps,
     recognise_turned_steps,
+    step_level_records,
 )
 
 from draftwright._geometry import (
@@ -117,6 +119,7 @@ from draftwright.model.ir import (
     SlotPatternFeature,
     StepFeature,
     StepLevelFeature,
+    ThroughStepFeature,
 )
 
 
@@ -653,6 +656,15 @@ def _convert_paired_ramp_step(step: PairedRampStep, ctx: ConvContext) -> PairedR
     )
 
 
+def _convert_through_step(step: ThroughStep, ctx: ConvContext) -> ThroughStepFeature:
+    return ThroughStepFeature(
+        frame=Frame((step.at[0], step.at[1], step.at[2]), step.axis),
+        axis=step.axis,
+        length=step.length,
+        section=step.section,
+    )
+
+
 def _convert_flat(flat: Flat, ctx: ConvContext) -> FlatFeature:
     at = flat.at
     return FlatFeature(
@@ -690,6 +702,7 @@ _CONVERTERS: dict[type, Converter] = {
     Chamfer: _convert_chamfer,
     Fillet: _convert_fillet,
     PairedRampStep: _convert_paired_ramp_step,
+    ThroughStep: _convert_through_step,
     Flat: _convert_flat,
     Groove: _convert_groove,
 }
@@ -756,10 +769,6 @@ _UNCONSUMED_RECORDS: dict[type, str] = {
         "a physical step family added in recognisers 0.4.6; Draftwright has not yet reviewed "
         "its feature, view, dimension, or completeness semantics (#1382)"
     ),
-    ThroughStep: (
-        "a physical step family added in recognisers 0.4.6; Draftwright has not yet reviewed "
-        "its feature, view, dimension, or completeness semantics (#1382)"
-    ),
 }
 
 
@@ -779,6 +788,93 @@ def convert(record, ctx: ConvContext) -> Feature:
     return conv(record, ctx)
 
 
+def _through_step_leg_spans(steps) -> tuple[tuple[str, float, float], ...]:
+    """Physical transverse intervals owned by aggregate ThroughStep records."""
+    spans = []
+    for step in steps:
+        axes = tuple(axis for axis in "xyz" if axis != step.axis)
+        for start, end in zip(step.section, step.section[1:]):
+            changed = next(index for index in (0, 1) if start[index] != end[index])
+            lo, hi = sorted((float(start[changed]), float(end[changed])))
+            spans.append((axes[changed], lo, hi))
+    return tuple(spans)
+
+
+def _through_step_level_zs(steps) -> tuple[float, ...]:
+    """Z transitions whose higher-level owner is an X/Y-run ThroughStep."""
+    levels = []
+    for step in steps:
+        axes = tuple(axis for axis in "xyz" if axis != step.axis)
+        if "z" in axes:
+            levels.append(float(step.section[1][axes.index("z")]))
+    return tuple(levels)
+
+
+def _through_step_shoulder_sites(steps, bbox) -> tuple[tuple[str, float], ...]:
+    """Legacy datum-shoulder sites made redundant by aggregate local-leg ownership."""
+    bounds = {
+        "x": (float(bbox.min.X), float(bbox.max.X)),
+        "y": (float(bbox.min.Y), float(bbox.max.Y)),
+    }
+    sites = []
+    for axis, lo, hi in _through_step_leg_spans(steps):
+        if axis not in bounds:
+            continue
+        bound_lo, bound_hi = bounds[axis]
+        if abs(lo - bound_lo) < 0.5:
+            sites.append((axis, hi))
+        elif abs(hi - bound_hi) < 0.5:
+            sites.append((axis, lo))
+    return tuple(sites)
+
+
+def _through_step_legacy_complete(
+    step, bbox, step_zs, shoulders, plates, *, envelope_emittable: bool
+) -> bool:
+    """Whether the established Z-up grammar directly defines both open-section legs.
+
+    A face level or shoulder is measured from the part's minimum datum; only when the envelope
+    is itself emittable does that pair also define the complementary maximum-side interval.
+    Plate thicknesses are already direct intervals, with the same envelope requirement for a
+    complement. This is deliberately coordinate-exact drafting evidence, not an axis-only
+    family preference: if either physical leg has no owner the aggregate record must lower
+    instead of disappearing from completeness (#1382).
+    """
+    bounds = {
+        "x": (float(bbox.min.X), float(bbox.max.X)),
+        "y": (float(bbox.min.Y), float(bbox.max.Y)),
+        "z": (float(bbox.min.Z), float(bbox.max.Z)),
+    }
+    intervals: list[tuple[str, float, float]] = []
+    for z in step_zs or ():
+        intervals.append(("z", *sorted((bounds["z"][0], z))))
+        if envelope_emittable:
+            intervals.append(("z", *sorted((z, bounds["z"][1]))))
+    for shoulder in shoulders:
+        lo, hi = bounds[shoulder.axis]
+        intervals.append((shoulder.axis, *sorted((lo, shoulder.position))))
+        if envelope_emittable:
+            intervals.append((shoulder.axis, *sorted((shoulder.position, hi))))
+    for plate in plates or ():
+        axis = plate.axis
+        plate_lo, plate_hi = sorted((plate.lo, plate.hi))
+        intervals.append((axis, plate_lo, plate_hi))
+        if envelope_emittable:
+            bound_lo, bound_hi = bounds[axis]
+            if abs(plate_lo - bound_lo) < 0.5:
+                intervals.append((axis, plate_hi, bound_hi))
+            if abs(plate_hi - bound_hi) < 0.5:
+                intervals.append((axis, bound_lo, plate_lo))
+
+    def _owned(axis: str, lo: float, hi: float) -> bool:
+        return any(
+            owner_axis == axis and abs(owner_lo - lo) < 0.5 and abs(owner_hi - hi) < 0.5
+            for owner_axis, owner_lo, owner_hi in intervals
+        )
+
+    return all(_owned(axis, lo, hi) for axis, lo, hi in _through_step_leg_spans((step,)))
+
+
 def build_part_model(
     part,
     *,
@@ -795,6 +891,7 @@ def build_part_model(
     chamfers=None,
     fillets=None,
     paired_ramp_steps=None,
+    through_steps=None,
     plates=None,
     grooves=None,
     flats=None,
@@ -855,6 +952,22 @@ def build_part_model(
             include_cylindrical=orientation is None,
         )
     ctx = ConvContext(bbox=bbox, orientation=orientation)
+    # A legacy min-datum measurement proves its complementary max-side interval only together
+    # with the overall envelope. Establish whether that feature will really cross the IR waist
+    # before aggregate ownership is decided; the bbox alone is private geometry, not ink.
+    if bosses is None:
+        bosses = recognise_bosses(part, cyls=cyls)
+    bosses_d = _distinct_by_diameter(bosses)
+    if polygonal_stock is None:
+        polygonal_stock = recognise_polygonal_stock(part)
+    envelope_emittable = bool(
+        prof is None and not _is_round(bbox, bosses_d) and not polygonal_stock
+    )
+    if through_steps is None:
+        # Match RecognitionResult applicability on the standalone path. A supplied aggregate
+        # inventory already embodies that one orchestration decision and is never re-filtered.
+        through_steps = recognise_through_steps(part) if orientation is None else ()
+    through_steps = tuple(through_steps)
 
     if channels is None:
         channels = recognise_channels(part)
@@ -866,6 +979,115 @@ def build_part_model(
     if prof is None and rotational is None and plates is None:
         plates = recognise_plates(part)
     multi_plate = has_multi_axis_plates(plates or ())
+    # Ownership evidence must be eligible to cross the recognition→IR boundary.  A lone
+    # single-axis plate is deliberately not emitted below (it is staircase evidence, not the
+    # multi-plate bracket grammar), so letting it preempt a ThroughStep would leave the claimed
+    # leg with no IR owner at all.
+    ownership_plates = (
+        tuple(plates or ()) if prof is None and rotational is None and multi_plate else ()
+    )
+    # Pocket recognition is consumed later, but its edge-open floors participate in the
+    # step-level emission gate. Detect once up front so aggregate takeover is decided against
+    # the same final legacy inventory that will actually cross the IR boundary.
+    if pockets is None:
+        pockets = recognise_pockets(part)
+    edge_floor_zs = {
+        pk.d_lo if pk.open_sign > 0 else pk.d_hi
+        for pk in pockets
+        if pk.depth_axis == "z" and pk.edge_anchored
+    }
+    plate_zs_at_base = {
+        round(pl.hi, 3)
+        for pl in ownership_plates
+        if pl.axis == "z" and abs(pl.lo - bbox.min.Z) < 0.5
+    }
+    if risers is None:
+        risers = recognise_risers(part)
+    # The detected orchestration supplies its filtered aggregate levels. A standalone
+    # ``build_part_model`` has no aggregate, so obtain the same records once and use them for
+    # BOTH ownership and emitted IR.  Suppressing a ThroughStep because a legacy owner exists
+    # only as private evidence would return a model containing neither owner.
+    if step_zs is None:
+        standalone_face_levels = tuple(step_level_records(part))
+        step_zs = tuple(level.z for level in standalone_face_levels)
+        if face_levels is None:
+            face_levels = standalone_face_levels
+    ownership_step_zs = (
+        tuple(
+            z
+            for z in step_zs
+            if round(z, 3) not in plate_zs_at_base
+            and not any(abs(z - floor) < 0.5 for floor in edge_floor_zs)
+        )
+        if prof is None
+        else ()
+    )
+    shoulders = project_step_shoulders(risers, levels=list(ownership_step_zs))
+    # Z-run records are the native through-step projection. X/Y-run records remain with the
+    # established Z-up grammar only when that grammar proves BOTH exact physical legs; a
+    # partial legacy projection is replaced by the complete aggregate owner.
+    lowered_through_steps = tuple(
+        step
+        for step in through_steps
+        if step.axis == "z"
+        or not _through_step_legacy_complete(
+            step,
+            bbox,
+            ownership_step_zs,
+            shoulders,
+            ownership_plates,
+            envelope_emittable=envelope_emittable,
+        )
+    )
+    # Ownership is a fixed point, not a per-record vote over the unfiltered inventory. One
+    # aggregate occurrence can remove a globally shared legacy level/shoulder/plate that a
+    # sibling occurrence initially relied on. Promote every newly uncovered sibling and repeat
+    # until the surviving legacy grammar still proves both legs for every preempted record.
+    while True:
+        owned_spans = _through_step_leg_spans(lowered_through_steps)
+        owned_levels = _through_step_level_zs(lowered_through_steps)
+        owned_shoulders = _through_step_shoulder_sites(lowered_through_steps, bbox)
+        remaining_levels = tuple(
+            z for z in ownership_step_zs if not any(abs(z - owned) < 0.5 for owned in owned_levels)
+        )
+        # Re-project after removing aggregate-owned levels. A riser is a shoulder only while
+        # its foot remains in the emitted level set; filtering the original shoulders by site
+        # alone could preserve an owner that the final StepLevelFeature never receives.
+        remaining_shoulders = tuple(
+            shoulder
+            for shoulder in project_step_shoulders(risers, levels=list(remaining_levels))
+            if not any(
+                shoulder.axis == axis and abs(shoulder.position - position) < 0.5
+                for axis, position in owned_shoulders
+            )
+        )
+        remaining_plates = tuple(
+            plate
+            for plate in ownership_plates
+            if not any(
+                plate.axis == axis and abs(plate.lo - lo) <= 1e-6 and abs(plate.hi - hi) <= 1e-6
+                for axis, lo, hi in owned_spans
+            )
+        )
+        promoted = tuple(
+            step
+            for step in through_steps
+            if step not in lowered_through_steps
+            and not _through_step_legacy_complete(
+                step,
+                bbox,
+                remaining_levels,
+                remaining_shoulders,
+                remaining_plates,
+                envelope_emittable=envelope_emittable,
+            )
+        )
+        if not promoted:
+            break
+        lowered_through_steps += promoted
+    through_leg_spans = _through_step_leg_spans(lowered_through_steps)
+    through_level_zs = _through_step_level_zs(lowered_through_steps)
+    through_shoulder_sites = _through_step_shoulder_sites(lowered_through_steps, bbox)
     if prof is None and rotational is None and multi_plate:
         features.extend(convert(channel, ctx) for channel in channels)
 
@@ -938,8 +1160,6 @@ def build_part_model(
     # identical pockets becomes ONE PocketPatternFeature (count× W×L×D + pitch, #841); its
     # member pockets are NOT also emitted individually — the same grouped-callout rule as
     # hole patterns above (member exclusion by id()).
-    if pockets is None:
-        pockets = recognise_pockets(part)
     if pocket_patterns is None:
         pocket_patterns = recognise_pocket_patterns(pockets)
     # Exclude members by VALUE, not id(): `Pocket` is a frozen (hashable) value record and two
@@ -971,8 +1191,6 @@ def build_part_model(
 
     # A whole regular polygonal prism is stock, not a boss: it owns the form/A-F
     # definition and its axial stock length independently of attachment evidence.
-    if polygonal_stock is None:
-        polygonal_stock = recognise_polygonal_stock(part)
     features.extend(convert(stock, ctx) for stock in polygonal_stock)
 
     # Turned / circlip grooves (#148c) — recognised up front so the turned-step chain can
@@ -1009,15 +1227,12 @@ def build_part_model(
         # floor is likewise a narrow reduced band, but the groove callout already carries its
         # ø, so it is suppressed here (_boss_is_groove_floor) to avoid a duplicate boss ø.
         step_dias = [s.diameter for s in prof.steps]
-        raw_bosses = recognise_bosses(part, cyls=cyls) if bosses is None else bosses
-        for b in _distinct_by_diameter(raw_bosses):
+        for b in bosses_d:
             if all(
                 abs(b.diameter - d) > _DIA_TOL for d in step_dias
             ) and not _boss_is_groove_floor(b, grooves):
                 features.append(convert(b, ctx))
     else:
-        raw_bosses = recognise_bosses(part, cyls=cyls) if bosses is None else bosses
-        bosses_d = _distinct_by_diameter(raw_bosses)
         for b in bosses_d:
             # A grooved round body can still fail the turned-step squareness gate (e.g. a
             # shaft with a rectangular flange) and land here with prof=None. Suppress the
@@ -1048,31 +1263,35 @@ def build_part_model(
     # stack (a base slab under a smaller stacked block) is a *staircase*, owned by the
     # step-height ladder; treating its base as a "plate" would wrongly suppress the step
     # dim (#559 review). This keeps the plate feature to the issue's stated domain.
-    plate_zs_at_base: set = set()
     if prof is None and rotational is None:
         plates = recognise_plates(part) if plates is None else plates
         if multi_plate:
             for pl in plates:
+                if any(
+                    pl.axis == axis and abs(pl.lo - lo) <= 1e-6 and abs(pl.hi - hi) <= 1e-6
+                    for axis, lo, hi in through_leg_spans
+                ):
+                    # The aggregate open section is the higher-level owner of this exact
+                    # thickness interval. Keeping the plate too prints one physical leg twice.
+                    continue
                 features.append(convert(pl, ctx))
-                # A Z base plate (bottom == part base) IS the first step level; suppress
-                # it from the step ladder so the two don't both dimension base→hi.
-                if pl.axis == "z" and abs(pl.lo - bbox.min.Z) < 0.5:
-                    plate_zs_at_base.add(round(pl.hi, 3))
 
     # Prismatic step-height ladder — horizontal face levels on a NON-turned part
     # (a turned part's steps are StepFeatures, dimensioned by the IR length chain).
     if prof is None and step_zs:
         c = bbox.center()
-        _levels = tuple(sorted(z for z in step_zs if round(z, 3) not in plate_zs_at_base))
+        _levels = tuple(
+            sorted(
+                z
+                for z in step_zs
+                if round(z, 3) not in plate_zs_at_base
+                and not any(abs(z - owned) < 0.5 for owned in through_level_zs)
+            )
+        )
         if _levels:
             # An edge-open blind interruption owns its floor through the pocket
             # depth callout; it is not a global profile level. Interior pockets
             # retain the established level IR for compatibility.
-            edge_floor_zs = {
-                pk.d_lo if pk.open_sign > 0 else pk.d_hi
-                for pk in pockets or ()
-                if pk.depth_axis == "z" and pk.edge_anchored
-            }
             _levels = tuple(
                 z for z in _levels if not any(abs(z - floor) < 0.5 for floor in edge_floor_zs)
             )
@@ -1092,8 +1311,12 @@ def build_part_model(
             _shoulders = tuple(
                 (s.axis, s.position)
                 for s in project_step_shoulders(
-                    recognise_risers(part) if risers is None else risers,
+                    risers,
                     levels=list(_levels),
+                )
+                if not any(
+                    s.axis == owner_axis and abs(s.position - owner_position) < 0.5
+                    for owner_axis, owner_position in through_shoulder_sites
                 )
             )
             features.append(
@@ -1129,6 +1352,16 @@ def build_part_model(
         paired_ramp_steps = recognise_paired_ramp_steps(part) if orientation is None else ()
     for ramp in paired_ramp_steps:
         features.append(convert(ramp, ctx))
+
+    # Rectangular open-profile through steps (#1382).  The aggregate record owns the exact
+    # run/anchor/section correspondence; Draftwright lowers its two transverse section legs
+    # without rescanning the body or inventing a third through-length requirement.
+    #
+    # Aggregate ownership precedes its lower-level face-level/riser/plate fragments above: the
+    # exact matching transition/thickness is removed from those legacy projections so the local
+    # two-leg grammar reaches the sheet once, on every principal run axis.
+    for through in lowered_through_steps:
+        features.append(convert(through, ctx))
 
     # Machined flats on round stock (#148b) — a planar face truncating a cylinder,
     # called out by its across-flats size. Detected UNCONDITIONALLY (not gated by the

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -332,6 +332,9 @@ DimensionParameterId = Literal[
     "step_position.length",
     "thread.depth",
     "thickness.length",
+    "through_step_leg.length.x",
+    "through_step_leg.length.y",
+    "through_step_leg.length.z",
     "width.length",
     # synthesised, not a DimParameter (see above)
     "location",
@@ -1590,6 +1593,122 @@ class PairedRampStepFeature:
             DimParameter("angle", "ramp_angle", self.angle),
             DimParameter("length", "ramp_run", self.length, span=self.span),
         ]
+
+    def references(self) -> list[Datum]:
+        return []
+
+
+@dataclass(frozen=True)
+class ThroughStepFeature:
+    """One rectangular open-profile step spanning the part along ``axis`` (#1382).
+
+    The provider's canonical ``section`` is ``(envelope endpoint, concave corner,
+    envelope endpoint)`` in the two non-run coordinates.  Its two orthogonal legs are
+    independently dimensioned in the end-on view.  ``length`` and ``frame.origin`` retain
+    exact physical correspondence to the removed through prism; the full-span run is already
+    stated by the part envelope and is therefore structural rather than a third requirement.
+    """
+
+    frame: Frame
+    axis: str
+    length: float
+    section: tuple[tuple[float, float], tuple[float, float], tuple[float, float]]
+    kind: ClassVar[str] = "through_step"
+
+    def __post_init__(self) -> None:
+        if self.axis not in ("x", "y", "z") or self.frame.axis != self.axis:
+            raise ValueError(
+                "through-step axis must be x, y, or z and agree with the feature frame"
+            )
+        if isinstance(self.length, bool) or not isfinite(self.length) or self.length <= 0:
+            raise ValueError("through-step run length must be finite and positive")
+        try:
+            if any(isinstance(value, bool) for point in self.section for value in point):
+                raise ValueError
+            section = tuple(tuple(float(value) for value in point) for point in self.section)
+        except (TypeError, ValueError) as exc:
+            raise ValueError("through-step section must contain three finite 2D points") from exc
+        if (
+            len(section) != 3
+            or any(len(point) != 2 for point in section)
+            or not all(isfinite(value) for point in section for value in point)
+        ):
+            raise ValueError("through-step section must contain three finite 2D points")
+        first_changes = [i for i in (0, 1) if section[0][i] != section[1][i]]
+        second_changes = [i for i in (0, 1) if section[1][i] != section[2][i]]
+        if (
+            len(first_changes) != 1
+            or len(second_changes) != 1
+            or first_changes[0] == second_changes[0]
+        ):
+            raise ValueError("through-step section must be two non-zero orthogonal legs")
+        object.__setattr__(self, "section", section)
+
+    @property
+    def transverse_axes(self) -> tuple[str, str]:
+        return tuple(axis for axis in "xyz" if axis != self.axis)  # type: ignore[return-value]
+
+    @property
+    def section_points(self) -> tuple[Point, Point, Point]:
+        run_index = "xyz".index(self.axis)
+        transverse = [index for index in (0, 1, 2) if index != run_index]
+        points = []
+        for pair in self.section:
+            point = list(self.frame.origin)
+            point[transverse[0]], point[transverse[1]] = pair
+            points.append(tuple(point))
+        return tuple(points)  # type: ignore[return-value]
+
+    @property
+    def exterior_corner(self) -> Point:
+        first, corner, last = self.section_points
+        return tuple(a + b - c for a, b, c in zip(first, last, corner, strict=True))  # type: ignore[return-value]
+
+    @property
+    def outside_directions(self) -> tuple[tuple[str, int], tuple[str, int]]:
+        """Topology-only signs from the concave corner toward the missing rectangle.
+
+        Unlike :attr:`exterior_corner`, these signs carry no distance. They are safe compiled
+        placement facts when an authored set withholds either dimensional leg (ADR 0016).
+        """
+        first, corner, last = self.section
+        directions = []
+        for index, axis in enumerate(self.transverse_axes):
+            delta = next(
+                point[index] - corner[index]
+                for point in (first, last)
+                if point[index] != corner[index]
+            )
+            directions.append((axis, 1 if delta > 0 else -1))
+        return tuple(directions)  # type: ignore[return-value]
+
+    def parameters(self) -> list[DimParameter]:
+        points = self.section_points
+        axes = self.transverse_axes
+        parameters = []
+        for start, end in zip(points, points[1:]):
+            changed = next(
+                axis for axis in axes if start["xyz".index(axis)] != end["xyz".index(axis)]
+            )
+            index = "xyz".index(changed)
+            value = abs(end[index] - start[index])
+            # Spell the closed discriminator vocabulary at the construction sites. Besides
+            # making the public Literal statically auditable, this rejects an accidental
+            # non-principal discriminator instead of laundering it through a free string.
+            if changed == "x":
+                parameter = DimParameter(
+                    "length", "through_step_leg", value, span=(start, end), discriminator="x"
+                )
+            elif changed == "y":
+                parameter = DimParameter(
+                    "length", "through_step_leg", value, span=(start, end), discriminator="y"
+                )
+            else:
+                parameter = DimParameter(
+                    "length", "through_step_leg", value, span=(start, end), discriminator="z"
+                )
+            parameters.append(parameter)
+        return parameters
 
     def references(self) -> list[Datum]:
         return []

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -93,6 +93,7 @@ _CONVENTION = {
     # One paired-ramp leader carries the two equal angles and their shared run (#1382).
     ("ramp_angle", "angle"): "leader",
     ("ramp_run", "length"): "leader",
+    ("through_step_leg", "length"): "linear",
     ("flat", "length"): "leader",  # {across} A/F across-flats leader callout (#726)
     # One groove callout carries BOTH params: {width} WIDE × ø{diameter} (#727)
     ("groove", "length"): "leader",
@@ -501,7 +502,13 @@ def _decorated(model: PartModel, feature: Feature, param: DimParameter) -> DimPa
             f"{param.parameter_id}={param.value:g}"
         )
 
-    tol = model.decorations.get((feature, param.kind, param.role))
+    tol = (
+        model.decorations.get((feature, param.kind, param.role, param.discriminator))
+        if param.discriminator is not None
+        else None
+    )
+    if tol is None:
+        tol = model.decorations.get((feature, param.kind, param.role))
     if tol is None:
         tol = model.decorations.get((feature, param.kind))
     # Imported AP242 provenance belongs to the authored aspect, not to geometry and not to

--- a/src/draftwright/recogniser_contract.py
+++ b/src/draftwright/recogniser_contract.py
@@ -107,6 +107,9 @@ _FAMILIES: dict[str, _FamilySpec] = {
         "render_slot_patterns",
     ),
     "slots": _FamilySpec(("Slot",), "_convert_slot", "slot", "render_slots"),
+    "through-steps": _FamilySpec(
+        ("ThroughStep",), "_convert_through_step", "through_step", "render_through_steps"
+    ),
     "turned-steps": _FamilySpec(
         ("TurnedProfile", "TurnedStep"), "_convert_step", "step", "render_step_lengths"
     ),
@@ -215,6 +218,11 @@ def _family_declaration(family_id: str, spec: _FamilySpec) -> dict[str, Any]:
         completeness = _supported(
             "draftwright.linting.paired_ramp_step_coverage.lint_paired_ramp_step_coverage",
             "tests/test_issue_1382_paired_ramp_semantics.py",
+        )
+    elif family_id == "through-steps":
+        completeness = _supported(
+            "draftwright.linting.through_step_coverage.lint_through_step_coverage",
+            "tests/test_issue_1382_through_step_semantics.py",
         )
     else:
         completeness = _deferred_completeness(family_id)
@@ -331,14 +339,6 @@ _UNSUPPORTED: dict[str, tuple[tuple[str, ...], str, str]] = {
         "https://github.com/pzfreo/draftwright/issues/1382",
         "The provider proves a quarter-cylindrical blind corner step and supplies its radius, "
         "run and oriented section. Draftwright has not yet reviewed which feature, view and "
-        "dimension grammar truthfully expresses that manufacturing requirement, so every "
-        "consumer boundary remains unsupported and completeness remains explicitly deferred.",
-    ),
-    "through-steps": (
-        ("ThroughStep",),
-        "https://github.com/pzfreo/draftwright/issues/1382",
-        "The provider proves a principal-axis rectangular through step and supplies its run, "
-        "anchor and open section. Draftwright has not yet reviewed which feature, view and "
         "dimension grammar truthfully expresses that manufacturing requirement, so every "
         "consumer boundary remains unsupported and completeness remains explicitly deferred.",
     ),
@@ -567,6 +567,66 @@ def consumer_capability_declaration() -> dict[str, Any]:
                 "from": "deferred",
                 "release_notes": "CHANGELOG.md",
                 "to": "unsupported",
+                "version": distribution_version("draftwright"),
+            },
+            {
+                "boundary": "completeness",
+                "compatibility_evidence": [
+                    "tests/test_issue_1382_through_step_semantics.py",
+                    "tests/test_recogniser_capabilities.py",
+                ],
+                "family": "through-steps",
+                "from": "deferred",
+                "release_notes": "CHANGELOG.md",
+                "to": "supported",
+                "version": distribution_version("draftwright"),
+            },
+            {
+                "boundary": "drawing_consumer",
+                "compatibility_evidence": [
+                    "tests/test_issue_1382_through_step_semantics.py",
+                    "tests/test_recogniser_capabilities.py",
+                ],
+                "family": "through-steps",
+                "from": "unsupported",
+                "release_notes": "CHANGELOG.md",
+                "to": "supported",
+                "version": distribution_version("draftwright"),
+            },
+            {
+                "boundary": "dsl_declaration",
+                "compatibility_evidence": [
+                    "tests/test_issue_1382_through_step_semantics.py",
+                    "tests/test_recogniser_capabilities.py",
+                ],
+                "family": "through-steps",
+                "from": "unsupported",
+                "release_notes": "CHANGELOG.md",
+                "to": "supported",
+                "version": distribution_version("draftwright"),
+            },
+            {
+                "boundary": "generated_code",
+                "compatibility_evidence": [
+                    "tests/test_issue_1382_through_step_semantics.py",
+                    "tests/test_recogniser_capabilities.py",
+                ],
+                "family": "through-steps",
+                "from": "unsupported",
+                "release_notes": "CHANGELOG.md",
+                "to": "supported",
+                "version": distribution_version("draftwright"),
+            },
+            {
+                "boundary": "ir_adapter",
+                "compatibility_evidence": [
+                    "tests/test_issue_1382_through_step_semantics.py",
+                    "tests/test_recogniser_capabilities.py",
+                ],
+                "family": "through-steps",
+                "from": "unsupported",
+                "release_notes": "CHANGELOG.md",
+                "to": "supported",
                 "version": distribution_version("draftwright"),
             },
         ],

--- a/src/draftwright/repair.py
+++ b/src/draftwright/repair.py
@@ -48,6 +48,8 @@ def _replace_dim(dwg, old, new):
     # "the same seam `_dw_scale` uses"; that was only true once it was carried here too.
     if getattr(old, "_dw_label_value", None) is not None:
         new._dw_label_value = old._dw_label_value
+    if getattr(old, "_dw_measurement_span", None) is not None:
+        new._dw_measurement_span = old._dw_measurement_span
     dwg.items[dwg.items.index(old)] = new
     dwg.registry.replace_object(old, new)
 

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -91,6 +91,7 @@ from draftwright.model import slot as _slot
 from draftwright.model import slot_pattern as _slot_pattern
 from draftwright.model import step as _step
 from draftwright.model import step_level as _step_level
+from draftwright.model import through_step as _through_step
 from draftwright.model.declare import (
     _norm_axis,
     _read_cylinder,
@@ -704,13 +705,17 @@ class _Params(_Nameable):
         source_ids: tuple[str, ...] = (),
     ) -> _Params:
         """A ± tolerance: symmetric ``.tolerance(0.05)`` (→ ``±0.05``) or a limit pair
-        ``.tolerance(0.0, 0.1)`` (→ ``+0.1 -0.0``). ``on`` targets ONE parameter by role
-        (``on="depth"`` on a pocket → a role-keyed decoration); omit ``on`` to tolerance
-        every parameter of the feature alike (the kind-keyed form). ``source`` /
-        ``source_ids`` retain provenance on generated imported requirements."""
+        ``.tolerance(0.0, 0.1)`` (→ ``+0.1 -0.0``). ``on`` targets one parameter by its
+        full id or discriminator, or a parameter family by its shared role (``on="depth"``
+        on a pocket → a role-keyed decoration); omit ``on`` to tolerance every parameter
+        of the feature alike (the kind-keyed form). ``source`` / ``source_ids`` retain
+        provenance on generated imported requirements."""
         val = _tolerance_decoration(lo, hi, source=source, source_ids=source_ids)
-        roles = self._roles()
-        if not roles:
+        parameters = [
+            p for p in self._sheet._features[self._i].parameters() if p.kind != "location"
+        ]
+        roles = {p.role: p.kind for p in parameters}
+        if not parameters:
             # A feature with no dimensioned parameters has nothing to tolerance, and
             # accepting the call would drop a drafting instruction in silence — the failure
             # this codebase ranks below a visible raise (#630/#631). Reachable since #922
@@ -735,20 +740,36 @@ class _Params(_Nameable):
             for key in [
                 k
                 for k in self._sheet._tolerances
-                if len(k) == 3 and k[0] == self._token and k[1] != "nominal_requirement"
+                if len(k) in (3, 4) and k[0] == self._token and k[1] != "nominal_requirement"
             ]:
                 del self._sheet._tolerances[key]
             for kind in set(roles.values()):
                 self._sheet._tolerances[(self._token, kind)] = val
             return self
-        cands = [r for r in roles if r == on or r.rsplit("_", 1)[-1] == on]
+        exact = [p for p in parameters if on in (p.parameter_id, p.discriminator)]
+        if len(exact) == 1:
+            parameter = exact[0]
+            key = (self._token, parameter.kind, parameter.role)
+            if parameter.discriminator is not None:
+                key += (parameter.discriminator,)
+            self._sheet._tolerances[key] = val
+            return self
+        cands = [p for p in parameters if p.role == on or p.role.rsplit("_", 1)[-1] == on]
+        # Preserve the established family-wide spelling: grid_pitch selects both row and
+        # column, and through_step_leg selects both section legs. A full parameter id or
+        # discriminator above remains the independently addressable form.
+        families = {(p.kind, p.role) for p in cands}
+        if cands and len(families) == 1:
+            kind, role = families.pop()
+            self._sheet._tolerances[(self._token, kind, role)] = val
+            return self
         if len(cands) != 1:
             raise ValueError(
-                f"on={on!r} must name one parameter role of this feature; "
-                f"choose from {sorted(roles)}"
+                f"on={on!r} must name one parameter of this feature; "
+                f"choose from {sorted(p.parameter_id for p in parameters)}"
             )
-        role = cands[0]
-        self._sheet._tolerances[(self._token, roles[role], role)] = val
+        parameter = cands[0]
+        self._sheet._tolerances[(self._token, parameter.kind, parameter.role)] = val
         return self
 
     def requirement(
@@ -1538,6 +1559,16 @@ class Sheet:
         open-to-terminal run length and shared-ridge midpoint.  The form is explicit-only:
         a detached face or cutter cannot prove the paired material-removal topology."""
         self._features.append(_paired_ramp_step(**kw))
+        return _Params(self, len(self._features) - 1)
+
+    def through_step(self, **kw) -> _Params:
+        """Declare a rectangular open-profile step spanning its run axis.
+
+        The explicit ``section`` is ``(envelope endpoint, concave corner, envelope
+        endpoint)`` in the two non-run coordinates.  Its two legs are independently
+        dimensioned in the end-on view; the through run is already owned by the envelope.
+        """
+        self._features.append(_through_step(**kw))
         return _Params(self, len(self._features) - 1)
 
     def flat(self, obj=None, **kw) -> _Params:

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -860,6 +860,12 @@ def _feature_line(
             f'sheet.paired_ramp_step(axis="{f.axis}", angle={_n(f.angle)}, '
             f"length={_n(f.length)}, at={_pt(f.frame.origin)})"
         )
+    if k == "through_step":
+        section = "(" + ", ".join(_pt(point) for point in f.section) + ")"
+        return (
+            f'sheet.through_step(axis="{f.axis}", length={_n(f.length)}, '
+            f"at={_pt(f.frame.origin)}, section={section})"
+        )
     if k == "flat":
         # `axis_line`/`stock_span` are the stock identity (#1013). Emitted ALWAYS, not only
         # when non-default: they are what stops two same-sized flats on separate stock
@@ -1560,6 +1566,38 @@ def _feature_block(
                 elif isinstance(tolerance, FitClass) and f.kind == "hole":
                     show = "" if tolerance.show == "class" else f", show={tolerance.show!r}"
                     line += f".fit({tolerance.code!r}{show})"
+
+            if f.kind == "through_step":
+                # Preserve the EFFECTIVE decoration of each independently addressable leg.
+                # Serialising both as canonical full ids is deliberately lossless even when
+                # the source used one family-wide call: replay compiles to the same two
+                # tolerances without depending on fluent call order.
+                for parameter in f.parameters():
+                    tolerance = (decorations or {}).get(
+                        (f, parameter.kind, parameter.role, parameter.discriminator)
+                    )
+                    if tolerance is None:
+                        tolerance = (decorations or {}).get((f, parameter.kind, parameter.role))
+                    if tolerance is None:
+                        tolerance = (decorations or {}).get((f, parameter.kind))
+                    if not isinstance(tolerance, ToleranceDecoration | int | float | tuple):
+                        continue
+                    value = (
+                        tolerance.value
+                        if isinstance(tolerance, ToleranceDecoration)
+                        else tolerance
+                    )
+                    args = (
+                        f"{_authored_n(value[0])}, {_authored_n(value[1])}"
+                        if isinstance(value, tuple)
+                        else _authored_n(value)
+                    )
+                    provenance = ""
+                    if isinstance(tolerance, ToleranceDecoration):
+                        provenance = f", source={tolerance.source!r}"
+                        if tolerance.source_ids:
+                            provenance += f", source_ids={tolerance.source_ids!r}"
+                    line += f".tolerance({args}, on={parameter.parameter_id!r}{provenance})"
 
             if isinstance(nominal, NominalRequirement):
                 provenance = f"source={nominal.source!r}, source_ids={nominal.source_ids!r}"

--- a/tests/test_add_dimension.py
+++ b/tests/test_add_dimension.py
@@ -1295,6 +1295,12 @@ class TestEveryFeatureVerbIsNameable:
         "chamfer": dict(axis="z", leg=2, at=(0, 0, 0)),
         "fillet": dict(axis="z", radius=2, at=(0, 0, 0)),
         "paired_ramp_step": dict(axis="z", angle=45, length=10, at=(0, 0, 0)),
+        "through_step": dict(
+            axis="z",
+            length=10,
+            at=(0, 0, 0),
+            section=((-5, 5), (-5, -5), (5, -5)),
+        ),
         "flat": dict(axis="z", across=15, at=(0, 0, 0)),
         "groove": dict(axis="z", width=3, diameter=16, at=(0, 0, 0)),
         "plate": dict(axis="z", lo=0, hi=4, u=10, v=5),

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -265,6 +265,49 @@ class TestTheRendererCannotSeeContent:
             "compiled plan's approved entries, whose spans carry every coordinate it needs"
         )
 
+    def test_through_step_renderer_cannot_resolve_its_provenance_handle(self):
+        """Its outside corner is a compiled placement fact, not a raw-feature escape."""
+        from draftwright.annotations.from_model import render_through_steps
+
+        tree = ast.parse(inspect.getsource(render_through_steps))
+        calls = {
+            node.func.id
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name)
+        }
+        assert "resolve_feature" not in calls
+
+    def test_no_new_plan_renderer_can_resolve_a_provenance_handle(self):
+        """Global ratchet: every direct FeatureRef escape is named existing debt."""
+        actual: dict[tuple[str, str], int] = {}
+        root = pathlib.Path(__file__).resolve().parents[1] / "src" / "draftwright" / "annotations"
+        for module in ("from_model", "holes"):
+            tree = ast.parse((root / f"{module}.py").read_text(encoding="utf-8"))
+            for node in tree.body:
+                if not isinstance(node, ast.FunctionDef) or not node.name.startswith("render_"):
+                    continue
+                args = {arg.arg for arg in node.args.args} | {
+                    arg.arg for arg in node.args.kwonlyargs
+                }
+                if "plan" not in args:
+                    continue
+                count = sum(
+                    isinstance(call, ast.Call)
+                    and isinstance(call.func, ast.Name)
+                    and call.func.id == "resolve_feature"
+                    for call in ast.walk(node)
+                )
+                if count:
+                    actual[module, node.name] = count
+
+        # Slots still resolve structural witness geometry; locations resolve only annotation
+        # ownership. Both predate this ratchet and are separately visible migration debt. No
+        # new plan renderer may silently join them, and neither count may grow.
+        assert actual == {
+            ("from_model", "render_locations"): 1,
+            ("from_model", "render_slots"): 1,
+        }
+
     def test_the_provenance_handle_exposes_no_measurement(self):
         """Carrying the `Feature` on an approved entry left the bypass one attribute access
         away — `.feature.levels` rebuilds exactly what the compiler withheld (#923 review).
@@ -1050,6 +1093,7 @@ class TestTheBoundaryIsLoadBearing:
             "render_slots",
             "render_step_lengths",
             "render_step_positions",
+            "render_through_steps",
         ], "the migrated set changed — update this and the ADR's inventory together"
 
         assert by_contract["groups"] == [], (

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -1089,7 +1089,7 @@ class TestPlate:
 
     def test_declared_plates_render_thickness_dims(self):
         # An L-bracket declared as two plates renders both thickness dims — assert the
-        # dims actually LAND (named + labelled + lint-clean), not just that the model
+        # dims actually LAND (named + labelled), not just that the model
         # echoes back what we handed it (detection is skipped for a declared model).
         lbr = Box(80, 50, 8) + Pos(-36, 0, 29) * Box(8, 50, 50)
         model = [plate(Box(80, 50, 8)), plate(axis="x", lo=-40, hi=-32, u=0, v=27)]
@@ -1099,7 +1099,12 @@ class TestPlate:
         }
         assert sorted(plate_dims) == ["dim_plate_x0", "dim_plate_z0"]  # both slabs dimensioned
         assert sorted(plate_dims.values()) == ["8", "8"]  # each 8 thick
-        assert [i for i in dwg.lint() if i.severity != "info"] == []
+        # These declarations intentionally omit the 80 mm overall width required to prove
+        # the recognised through-step's X complement.  A sparse declared drawing must report
+        # that real completeness gap rather than credit an unrelated thickness dimension.
+        issues = [i for i in dwg.lint() if i.severity != "info"]
+        assert [issue.code for issue in issues] == ["through_step_requirement_missing"]
+        assert "through_step_leg.length.x" in issues[0].message
 
     def test_same_axis_plate_names_follow_thickness_axis_not_in_plane_position(self):
         """Stable annotation identity follows the old axis/lo/hi order.
@@ -1201,7 +1206,11 @@ class TestStepLevel:
         assert dwg.get_annotation("dim_shoulder_x0").label == expected
         assert dwg.view_of("dim_shoulder_x0") == "plan"
         assert "dim_height" in dwg.annotations()
-        assert [i for i in dwg.lint() if i.severity != "info"] == []
+        # Height + step-height prove the vertical complement, but this declared model does
+        # not request overall width, so its recognised horizontal complement remains missing.
+        issues = [i for i in dwg.lint() if i.severity != "info"]
+        assert [issue.code for issue in issues] == ["through_step_requirement_missing"]
+        assert "through_step_leg.length.x" in issues[0].message
 
     def test_needs_base_and_levels(self):
         with pytest.raises(ValueError, match="base= and levels="):

--- a/tests/test_issue_1143_hole_completeness.py
+++ b/tests/test_issue_1143_hole_completeness.py
@@ -278,6 +278,7 @@ def test_pattern_and_central_bore_have_a_complete_recognition_owned_ledger():
         "pocket_patterns": 0,
         "slots": 0,
         "slot_patterns": 0,
+        "through_steps": 0,
     }
     assert "holes" not in completeness["unscored_recognized_families"]
     assert "hole_patterns" not in completeness["unscored_recognized_families"]

--- a/tests/test_issue_1382_046_step_inventory.py
+++ b/tests/test_issue_1382_046_step_inventory.py
@@ -27,7 +27,6 @@ def _circular_blind_step():
     ("inventory", "part_factory"),
     [
         ("circular_blind_steps", _circular_blind_step),
-        ("through_steps", _through_step),
     ],
 )
 def test_each_046_step_inventory_is_visible_in_runtime_completeness(inventory, part_factory):
@@ -67,17 +66,14 @@ def test_paired_ramps_left_the_undecided_inventory_with_two_audited_requirements
     assert completeness["requirements"] == completeness["placed"] == 2
 
 
-def test_undecided_evidence_stays_visible_beside_a_perfect_audited_family():
+def test_newly_audited_through_step_stays_visible_beside_an_existing_family():
     pocket = Box(80, 60, 20) - Pos(20, 0, 5) * Box(20, 10, 12)
     mixed = Compound([Pos(-70, 0, 0) * _through_step(), Pos(70, 0, 0) * pocket])
 
     completeness = build_drawing(mixed).lint_summary()["quality"]["completeness"]
 
-    assert completeness["unscored_recognized_families"] == ["through_steps"]
-    assert completeness["requirements"] == 5
-    assert completeness["placed"] == 5
+    assert completeness["unscored_recognized_families"] == []
+    assert completeness["requirements"] == 7
+    assert completeness["placed"] == 7
     assert completeness["audited_score"] == 1.0
-    assert completeness["reason"] == (
-        "audited_score covers recognized requirements in audited families only; it is "
-        "not evidence that the drawing is complete"
-    )
+    assert completeness["by_family"]["through_steps"] == 2

--- a/tests/test_issue_1382_through_step_semantics.py
+++ b/tests/test_issue_1382_through_step_semantics.py
@@ -1,0 +1,1680 @@
+"""#1382 — through-step records have one complete, auditable Draftwright path."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+from b123d_recognisers import BossRecord, PolygonalStock, TurnedProfile, build_recognition_result
+from b123d_recognisers import Plate as RecognisedPlate
+from build123d import Align, Box, Compound, Pos, Rot
+
+from draftwright import Sheet, build_drawing
+from draftwright.linting.ink_overlap import segments_of
+from draftwright.linting.issues import LintIssue
+from draftwright.linting.through_step_coverage import (
+    lint_through_step_coverage,
+    through_step_requirement_outcomes,
+)
+from draftwright.model import Frame, ThroughStepFeature, envelope, plate, step_level, through_step
+from draftwright.model.compiled import (
+    ApprovedDimension,
+    ApprovedLadder,
+    DimensionId,
+    RenderableDimensionPlan,
+    compile_dimensions,
+)
+from draftwright.model.detect import build_part_model
+from draftwright.registry import AnnotationRegistry
+from draftwright.sheet_emit import _feature_line, emit_sheet_script
+
+
+def _through_step_part():
+    return Box(40, 30, 20) - Pos(15, 10, 0) * Box(20, 20, 30)
+
+
+def _crowded_step_part():
+    """A narrow staircase whose omitted source rungs request an enlarged detail."""
+    part = Pos(0, 0, 3) * Box(20, 16, 6)
+    z = 6
+    for width in (16, 13, 10, 7, 5):
+        part += Pos(0, 0, z + 1.5) * Box(width, 12, 3)
+        z += 3
+    return part
+
+
+def _feature(drawing) -> ThroughStepFeature:
+    return next(feature for feature in drawing.model().features if feature.kind == "through_step")
+
+
+def _dimension_names(drawing) -> list[str]:
+    return sorted(name for name in drawing.annotations() if name.startswith("dim_through_step_"))
+
+
+def _parameter_ids(feature) -> tuple[str, str]:
+    return tuple(parameter.parameter_id for parameter in feature.parameters())
+
+
+def _assert_final_witness_span(drawing, name, feature, parameter_id) -> None:
+    parameter = next(p for p in feature.parameters() if p.parameter_id == parameter_id)
+    view = drawing.registry.identity_of(name)["view"]
+    projected = [drawing.at(view, *point)[:2] for point in parameter.span]
+    axis = 0 if projected[0][0] != projected[1][0] else 1
+    witness_segments = segments_of(drawing.registry.named(name))[-2:]
+    assert len(witness_segments) == 2
+    assert sorted(segment[0][axis] for segment in witness_segments) == pytest.approx(
+        sorted(point[axis] for point in projected)
+    )
+    perpendicular = 1 - axis
+    for point in projected:
+        witness = next(
+            segment
+            for segment in witness_segments
+            if segment[0][axis] == pytest.approx(point[axis])
+        )
+        feature_side = min(
+            witness,
+            key=lambda endpoint: (endpoint[0] - point[0]) ** 2 + (endpoint[1] - point[1]) ** 2,
+        )
+        assert feature_side[axis] == pytest.approx(point[axis])
+        assert abs(feature_side[perpendicular] - point[perpendicular]) == pytest.approx(
+            drawing.draft.extension_gap
+        )
+
+
+def test_aggregate_record_lowers_exactly_to_two_planned_leg_requirements() -> None:
+    drawing = build_drawing(_through_step_part())
+    recognition = drawing.recognition()
+    assert recognition is not None
+    assert len(recognition.through_steps) == 1
+    source = recognition.through_steps[0]
+    feature = _feature(drawing)
+
+    assert (feature.axis, feature.length, feature.frame.origin, feature.section) == (
+        source.axis,
+        source.length,
+        source.at,
+        source.section,
+    )
+    assert set(_parameter_ids(feature)) == {
+        "through_step_leg.length.x",
+        "through_step_leg.length.y",
+    }
+    group = next(iter(compile_dimensions(drawing.model()).of_kind("through_step")))
+    assert group.view == "plan"
+    assert {dimension.id.parameter for dimension in group.dims} == set(_parameter_ids(feature))
+    assert len(_dimension_names(drawing)) == 2
+    for name in _dimension_names(drawing):
+        identity = drawing.registry.identity_of(name)
+        assert identity["view"] == "plan"
+        assert len(identity["measurement"]) == 1
+        measurement = identity["measurement"][0]
+        assert measurement.feature is feature
+        parameter = next(
+            p for p in feature.parameters() if p.parameter_id == measurement.parameter
+        )
+        _assert_final_witness_span(drawing, name, feature, parameter.parameter_id)
+    assert not [issue for issue in drawing.lint() if "through_step" in issue.code]
+
+
+@pytest.mark.parametrize(
+    ("x", "y"),
+    [(15, 7), (15, -7), (-15, 7), (-15, -7)],
+    ids=["upper-right", "lower-right", "upper-left", "lower-left"],
+)
+def test_every_missing_corner_places_both_unequal_legs_with_its_own_value(x, y) -> None:
+    drawing = build_drawing(Box(40, 30, 20) - Pos(x, y, 0) * Box(20, 20, 30))
+    feature = _feature(drawing)
+    expected = {parameter.parameter_id: parameter.value for parameter in feature.parameters()}
+    names = _dimension_names(drawing)
+
+    assert sorted(expected.values()) == pytest.approx([15, 18])
+    assert len(names) == 2
+    for name in names:
+        (measurement,) = drawing.registry.measurement_of(name)
+        assert float(str(drawing.registry.named(name).label)) == pytest.approx(
+            expected[measurement.parameter]
+        )
+        _assert_final_witness_span(drawing, name, feature, measurement.parameter)
+    assert not [issue for issue in drawing.lint() if "through_step" in issue.code]
+
+
+@pytest.mark.parametrize("x", [15, -15], ids=["lower-right", "lower-left"])
+def test_full_natural_lower_strip_retries_opposite_before_dropping(x) -> None:
+    drawing = build_drawing(Box(40, 30, 20) - Pos(x, -10, 0) * Box(20, 20, 30))
+
+    assert len(_dimension_names(drawing)) == 2
+    assert not [issue for issue in drawing.lint() if "through_step" in issue.code]
+
+
+@pytest.mark.parametrize("translation", [(7, 0, 0), (0, 7, 0)], ids=["parallel", "perpendicular"])
+def test_final_witness_assertion_detects_each_displacement_axis(translation) -> None:
+    drawing = build_drawing(_through_step_part())
+    feature = _feature(drawing)
+    name = next(
+        candidate
+        for candidate in _dimension_names(drawing)
+        if drawing.registry.measurement_of(candidate)[0].parameter.endswith(".x")
+    )
+    (measurement,) = drawing.registry.measurement_of(name)
+    drawing.registry.named(name).position = translation
+
+    with pytest.raises(AssertionError):
+        _assert_final_witness_span(drawing, name, feature, measurement.parameter)
+
+
+def test_detected_build_consumes_the_aggregate_without_rescanning(monkeypatch) -> None:
+    import draftwright.model.detect as detect
+
+    def forbidden_scan(_part):
+        raise AssertionError("through-step family was rescanned outside the aggregate")
+
+    monkeypatch.setattr(detect, "recognise_through_steps", forbidden_scan)
+    assert _feature(build_drawing(_through_step_part())).length == 20
+
+
+def test_explicit_declaration_and_generated_line_round_trip_every_contract_field() -> None:
+    declared = through_step(
+        axis="z",
+        length=20,
+        at=(12.5, 7.5, 0),
+        section=((5, 15), (5, 0), (20, 0)),
+    )
+    line = _feature_line(declared)
+    assert line == (
+        'sheet.through_step(axis="z", length=20, at=(12.5, 7.5, 0), '
+        "section=((5, 15), (5, 0), (20, 0)))"
+    )
+    namespace = {"sheet": type("S", (), {"through_step": staticmethod(through_step)})()}
+    assert eval(line, {"__builtins__": {}}, namespace) == declared  # noqa: S307
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"length": True}, "positive"),
+        ({"length": 0}, "positive"),
+        ({"section": ((5, 15), (5, 0))}, "three finite"),
+        ({"section": ((5, True), (5, 0), (20, 0))}, "three finite"),
+        ({"section": ((5, 15), (5, 0), (5, -3))}, "orthogonal"),
+        ({"section": ((5, 15), (5, 0), (20, float("nan")))}, "finite"),
+    ],
+)
+def test_declaration_rejects_invalid_measurements(kwargs, message) -> None:
+    values = {
+        "axis": "z",
+        "length": 20,
+        "at": (12.5, 7.5, 0),
+        "section": ((5, 15), (5, 0), (20, 0)),
+    }
+    values.update(kwargs)
+    with pytest.raises(ValueError, match=message):
+        through_step(**values)
+
+
+def test_ir_rejects_axis_frame_disagreement() -> None:
+    with pytest.raises(ValueError, match="agree with the feature frame"):
+        ThroughStepFeature(
+            Frame((12.5, 7.5, 0), "x"),
+            "z",
+            20,
+            ((5, 15), (5, 0), (20, 0)),
+        )
+
+    with pytest.raises(ValueError, match="three finite"):
+        ThroughStepFeature(
+            Frame((12.5, 7.5, 0), "z"),
+            "z",
+            20,
+            ((5, True), (5, 0), (20, 0)),
+        )
+
+
+@pytest.mark.parametrize(
+    ("part", "axis", "view"),
+    [
+        (Rot(0, 90, 0) * _through_step_part(), "x", "side"),
+        (
+            Rot(90, 0, 0) * (Box(40, 30, 20) - Pos(15, -10, 0) * Box(20, 20, 30)),
+            "y",
+            "front",
+        ),
+    ],
+)
+def test_aggregate_through_step_precedes_matching_legacy_fragments(part, axis, view) -> None:
+    drawing = build_drawing(part)
+    recognition = drawing.recognition()
+    assert recognition is not None and recognition.through_steps[0].axis == axis
+    feature = _feature(drawing)
+    assert feature.axis == axis
+    assert not [
+        candidate
+        for candidate in drawing.model().features
+        if candidate.kind in {"step_level", "plate"}
+    ]
+    assert len(_dimension_names(drawing)) == 2
+    assert {drawing.registry.identity_of(name)["view"] for name in _dimension_names(drawing)} == {
+        view
+    }
+    outcomes = through_step_requirement_outcomes(
+        recognition, drawing.model().features, drawing.registry
+    )
+    assert [outcome.state for outcome in outcomes] == ["placed", "placed"]
+    for name in _dimension_names(drawing):
+        (measurement,) = drawing.registry.measurement_of(name)
+        _assert_final_witness_span(drawing, name, feature, measurement.parameter)
+    assert not [issue for issue in drawing.lint() if "through_step" in issue.code]
+
+
+def test_mixed_axis_aggregate_scores_every_physical_leg() -> None:
+    base = _through_step_part()
+    part = Compound([Pos(-70, 0, 0) * base, Pos(70, 0, 0) * Rot(0, 90, 0) * base])
+    drawing = build_drawing(part)
+    outcomes = through_step_requirement_outcomes(
+        drawing.recognition(), drawing.model().features, drawing.registry
+    )
+
+    assert [source.axis for source in drawing.recognition().through_steps] == ["x", "z"]
+    assert [
+        feature.axis for feature in drawing.model().features if feature.kind == "through_step"
+    ] == ["x", "z"]
+    assert [outcome.state for outcome in outcomes] == ["placed"] * 4
+
+
+def test_mixed_legacy_and_aggregate_ownership_reaches_a_fixed_point() -> None:
+    base = Rot(90, 0, 0) * _through_step_part()
+    drawing = build_drawing(Compound([Pos(-70, 0, 0) * base, Pos(70, 0, 0) * base]))
+    features = [feature for feature in drawing.model().features if feature.kind == "through_step"]
+    outcomes = through_step_requirement_outcomes(
+        drawing.recognition(), drawing.model().features, drawing.registry
+    )
+
+    assert len(drawing.recognition().through_steps) == 2  # type: ignore[union-attr]
+    assert len(features) == 2
+    assert [outcome.state for outcome in outcomes] == ["placed"] * 4
+
+
+def test_fixed_point_reprojects_shoulders_after_an_owned_level_disappears() -> None:
+    part = Rot(90, 0, 0) * _through_step_part()
+    recognition = build_recognition_result(part)
+    source = recognition.through_steps[0]
+    aggregate_owned = replace(
+        source,
+        at=(11, 0, 7.5),
+        section=((2, 15), (2, 0), (20, 0)),
+    )
+    initially_legacy_owned = replace(
+        source,
+        at=(-12.5, 0, 10),
+        section=((-5, 15), (-5, 5), (-20, 5)),
+    )
+    riser = replace(recognition.risers[0], positions=(-5,))
+    model = build_part_model(
+        part,
+        through_steps=(aggregate_owned, initially_legacy_owned),
+        step_zs=(0, 5),
+        face_levels=(),
+        risers=(riser,),
+        plates=(),
+        pockets=(),
+        prof=None,
+        rotational=None,
+    )
+
+    # The first aggregate removes level 0. The remaining level 5 no longer supports the
+    # riser's foot at 0, so the second aggregate must be promoted rather than trusting a
+    # shoulder that will disappear from the emitted StepLevelFeature.
+    assert [feature.kind for feature in model.features].count("through_step") == 2
+    assert not [feature for feature in model.features if feature.kind == "step_level"]
+
+
+def test_standalone_model_emits_the_legacy_owner_that_preempts_the_aggregate() -> None:
+    part = Rot(90, 0, 0) * _through_step_part()
+    automatic = build_drawing(part).model()
+    standalone = build_part_model(part)
+
+    automatic_owners = tuple(
+        feature for feature in automatic.features if feature.kind in {"step_level", "through_step"}
+    )
+    standalone_owners = tuple(
+        feature
+        for feature in standalone.features
+        if feature.kind in {"step_level", "through_step"}
+    )
+
+    assert standalone_owners == automatic_owners
+    assert [feature.kind for feature in standalone_owners] == ["step_level"]
+    ladders = compile_dimensions(standalone).ladders
+    assert {ladder.kind for ladder in ladders} >= {"step_height", "step_position"}
+
+
+def test_only_emittable_plates_may_preempt_the_aggregate_owner() -> None:
+    part = Rot(90, 0, 0) * _through_step_part()
+    source = build_recognition_result(part).through_steps[0]
+    model = build_part_model(
+        part,
+        through_steps=(source,),
+        step_zs=(0,),
+        face_levels=(),
+        risers=(),
+        plates=(RecognisedPlate(axis="x", lo=5, hi=20, u=0, v=0),),
+        prof=None,
+        rotational=None,
+    )
+
+    owners = [
+        feature
+        for feature in model.features
+        if feature.kind in {"through_step", "step_level", "plate"}
+    ]
+    assert [feature.kind for feature in owners] == ["through_step"]
+    assert len(tuple(compile_dimensions(model).of_kind("through_step"))) == 1
+
+
+def test_edge_pocket_floor_cannot_preempt_then_erase_the_aggregate_owner() -> None:
+    base = Rot(90, 0, 0) * _through_step_part()
+    edge_pocket = Pos(-20, -10, 0) * Box(
+        8,
+        6,
+        15,
+        align=(Align.MIN, Align.MIN, Align.MIN),
+    )
+    part = base - edge_pocket
+    recognition = build_recognition_result(part)
+    drawing = build_drawing(part)
+    outcomes = through_step_requirement_outcomes(
+        recognition,
+        drawing.model().features,
+        drawing.registry,
+    )
+
+    assert len(recognition.through_steps) == 1
+    assert [feature.kind for feature in drawing.model().features].count("through_step") == 1
+    assert [outcome.state for outcome in outcomes] == ["placed", "placed"]
+    assert not [issue for issue in drawing.lint() if "through_step" in issue.code]
+
+
+def test_base_plate_filter_cannot_erase_the_only_transverse_shoulder_owner() -> None:
+    part = Rot(90, 0, 0) * _through_step_part()
+    recognition = build_recognition_result(part)
+    model = build_part_model(
+        part,
+        through_steps=recognition.through_steps,
+        step_zs=tuple(level.z for level in recognition.step_levels),
+        face_levels=recognition.step_levels,
+        risers=recognition.risers,
+        plates=(
+            RecognisedPlate(axis="z", lo=-15, hi=0, u=0, v=0),
+            RecognisedPlate(axis="y", lo=-10, hi=-5, u=0, v=0),
+        ),
+        pockets=(),
+        prof=None,
+        rotational=None,
+    )
+
+    owners = [
+        feature
+        for feature in model.features
+        if feature.kind in {"through_step", "step_level", "plate"}
+    ]
+    assert [feature.kind for feature in owners].count("through_step") == 1
+    assert not [feature for feature in owners if feature.kind == "step_level"]
+    assert len(tuple(compile_dimensions(model).of_kind("through_step"))) == 1
+
+
+def test_injected_turned_classification_cannot_hide_a_supplied_aggregate() -> None:
+    part = Rot(90, 0, 0) * _through_step_part()
+    recognition = build_recognition_result(part)
+    model = build_part_model(
+        part,
+        through_steps=recognition.through_steps,
+        step_zs=tuple(level.z for level in recognition.step_levels),
+        face_levels=recognition.step_levels,
+        risers=recognition.risers,
+        plates=(),
+        pockets=(),
+        prof=TurnedProfile("z", ()),
+        rotational=None,
+    )
+
+    assert [feature.kind for feature in model.features].count("through_step") == 1
+    assert not [feature for feature in model.features if feature.kind == "step_level"]
+    assert len(tuple(compile_dimensions(model).of_kind("through_step"))) == 1
+
+
+@pytest.mark.parametrize("suppressor", ["round-boss", "polygonal-stock"])
+def test_complement_owner_requires_an_emitted_envelope(suppressor) -> None:
+    part = Rot(90, 0, 0) * (Box(20, 30, 20) - Pos(7.5, 10, 0) * Box(10, 20, 30))
+    recognition = build_recognition_result(part)
+    kwargs = {
+        "bosses": (),
+        "polygonal_stock": (),
+    }
+    if suppressor == "round-boss":
+        kwargs["bosses"] = (
+            BossRecord(axis=(0, 0, 1), location=(0, 0, 0), diameter=20, height=30),
+        )
+    else:
+        kwargs["polygonal_stock"] = (
+            PolygonalStock(
+                axis="z",
+                center=(0, 0, 0),
+                side_count=4,
+                across_flats=20,
+                base=-15,
+                top=15,
+                flat_directions=((1, 0, 0), (0, 1, 0), (-1, 0, 0), (0, -1, 0)),
+                flat_centres=((10, 0, 0), (0, 10, 0), (-10, 0, 0), (0, -10, 0)),
+            ),
+        )
+    model = build_part_model(
+        part,
+        through_steps=recognition.through_steps,
+        step_zs=tuple(level.z for level in recognition.step_levels),
+        face_levels=recognition.step_levels,
+        risers=recognition.risers,
+        plates=(),
+        pockets=(),
+        prof=None,
+        rotational=None,
+        **kwargs,
+    )
+
+    assert not [feature for feature in model.features if feature.kind == "envelope"]
+    assert [feature.kind for feature in model.features].count("through_step") == 1
+    assert len(tuple(compile_dimensions(model).of_kind("through_step"))) == 1
+
+
+def test_direct_min_datum_owners_do_not_require_an_envelope() -> None:
+    part = Rot(90, 0, 0) * (Box(20, 30, 20) - Pos(7.5, 10, 0) * Box(10, 20, 30))
+    recognition = build_recognition_result(part)
+    direct_source = replace(
+        recognition.through_steps[0],
+        at=(-6.25, 0, -7.5),
+        section=((-2.5, 0), (-2.5, -15), (-10, -15)),
+    )
+    riser = replace(recognition.risers[0], positions=(-2.5,))
+    model = build_part_model(
+        part,
+        through_steps=(direct_source,),
+        step_zs=(0,),
+        face_levels=(),
+        risers=(riser,),
+        plates=(),
+        pockets=(),
+        bosses=(BossRecord(axis=(0, 0, 1), location=(0, 0, 0), diameter=20, height=30),),
+        polygonal_stock=(),
+        prof=None,
+        rotational=None,
+    )
+
+    assert not [feature for feature in model.features if feature.kind == "envelope"]
+    assert not [feature for feature in model.features if feature.kind == "through_step"]
+    assert [feature.kind for feature in model.features].count("step_level") == 1
+
+
+def test_inapplicable_requires_coordinate_proof_of_both_legacy_legs() -> None:
+    drawing = build_drawing(Rot(90, 0, 0) * _through_step_part())
+    recognition = drawing.recognition()
+    assert recognition is not None
+    assert not [feature for feature in drawing.model().features if feature.kind == "through_step"]
+    assert [
+        outcome.state
+        for outcome in through_step_requirement_outcomes(
+            recognition, drawing.model().features, drawing.registry
+        )
+    ] == ["inapplicable", "inapplicable"]
+
+    incomplete = tuple(
+        replace(feature, shoulders=()) if feature.kind == "step_level" else feature
+        for feature in drawing.model().features
+    )
+    assert {
+        outcome.state
+        for outcome in through_step_requirement_outcomes(
+            recognition, incomplete, AnnotationRegistry()
+        )
+    } == {"unverifiable"}
+
+    step = next(feature for feature in drawing.model().features if feature.kind == "step_level")
+    drawing.drop(step)
+    assert {
+        outcome.state
+        for outcome in through_step_requirement_outcomes(
+            recognition, drawing.model().features, drawing.registry
+        )
+    } == {"missing"}
+    assert {
+        issue.code for issue in drawing.lint() if issue.code.startswith("through_step_requirement")
+    } == {"through_step_requirement_missing"}
+
+
+@pytest.mark.parametrize("run_shift", [0, 1], ids=["identical-record", "distinct-anchor"])
+def test_ambiguous_legacy_sources_fail_closed_instead_of_reusing_one_owner(run_shift) -> None:
+    drawing = build_drawing(Rot(90, 0, 0) * _through_step_part())
+    recognition = drawing.recognition()
+    assert recognition is not None
+    assert [
+        feature.kind for feature in drawing.model().features if feature.kind == "step_level"
+    ] == ["step_level"]
+    source = recognition.through_steps[0]
+    competing = replace(
+        source,
+        at=(source.at[0], source.at[1] + run_shift, source.at[2]),
+    )
+    ambiguous = replace(
+        recognition,
+        through_steps=(source, competing),
+    )
+
+    plan = compile_dimensions(drawing.model())
+    outcomes = through_step_requirement_outcomes(
+        ambiguous,
+        drawing.model().features,
+        drawing.registry,
+        plan.diagnostics,
+        plan=plan,
+    )
+
+    assert len(outcomes) == 4
+    assert {outcome.state for outcome in outcomes} == {"unverifiable"}
+    issues = lint_through_step_coverage(
+        drawing.part,
+        recognition=ambiguous,
+        features=drawing.model().features,
+        registry=drawing.registry,
+        omissions=plan.diagnostics,
+        plan=plan,
+    )
+    assert len(issues) == 4
+    assert {issue.code for issue in issues} == {"through_step_requirement_unverifiable"}
+
+
+def test_authored_empty_legacy_projection_records_suppression_not_inapplicable() -> None:
+    sheet = Sheet.from_part(Rot(90, 0, 0) * _through_step_part())
+    sheet.take_over(
+        dimensions="authored",
+        principal_views="automatic",
+        derived_views="automatic",
+    )
+    drawing = sheet.build()
+    summary = drawing.lint_summary()
+    outcomes = through_step_requirement_outcomes(
+        drawing.recognition(),
+        drawing.model().features,
+        drawing.registry,
+        compile_dimensions(drawing.model()).diagnostics,
+        plan=compile_dimensions(drawing.model()),
+    )
+
+    assert [outcome.state for outcome in outcomes] == ["suppressed", "suppressed"]
+    completeness = summary["quality"]["completeness"]
+    assert completeness["requirements"] == completeness["suppressed"] == 2
+    assert completeness["inapplicable"] == 0
+
+
+def test_unrelated_declared_legacy_dimensions_cannot_cover_physical_legs() -> None:
+    part = Rot(90, 0, 0) * _through_step_part()
+    sheet = Sheet(part).authored_dimensions()
+    handle = sheet.step_level(
+        base=-15,
+        levels=(-5,),
+        shoulders=(("x", 10),),
+        datum=(-20, -10, -15),
+    )
+    for parameter in sheet.features[-1].parameters():
+        sheet.dimension(handle, parameter.parameter_id)
+    drawing = sheet.build()
+
+    issues = drawing.lint()
+    outcomes = through_step_requirement_outcomes(
+        drawing.recognition(),
+        drawing.model().features,
+        drawing.registry,
+        compile_dimensions(drawing.model()).diagnostics,
+        plan=compile_dimensions(drawing.model()),
+    )
+
+    assert [outcome.state for outcome in outcomes] == ["unverifiable", "unverifiable"]
+    assert {issue.code for issue in issues if "through_step" in issue.code} == {
+        "through_step_requirement_unverifiable"
+    }
+    completeness = drawing.lint_summary()["quality"]["completeness"]
+    assert completeness["requirements"] == completeness["unverifiable"] == 2
+    assert completeness["inapplicable"] == 0
+
+
+def test_remaining_ladder_rungs_cannot_cover_removed_exact_legacy_members() -> None:
+    part = Rot(90, 0, 0) * _through_step_part()
+    sheet = Sheet(part).authored_dimensions()
+    handle = sheet.step_level(
+        base=0,
+        levels=(10, 15),
+        shoulders=(("x", 10), ("x", 20)),
+        datum=(5, 0, 0),
+    )
+    for parameter in sheet.features[-1].parameters():
+        sheet.dimension(handle, parameter.parameter_id)
+    drawing = sheet.build()
+    drawing.lint()  # populate the declared build's one recognition aggregate
+    drawing.remove("dim_detail_a_step0")
+    drawing.remove("dim_shoulder_x1")
+
+    outcomes = through_step_requirement_outcomes(
+        drawing.recognition(),
+        drawing.model().features,
+        drawing.registry,
+        compile_dimensions(drawing.model()).diagnostics,
+        plan=compile_dimensions(drawing.model()),
+    )
+
+    assert [outcome.state for outcome in outcomes] == ["missing", "missing"]
+    assert {
+        issue.code for issue in drawing.lint() if issue.code.startswith("through_step_requirement")
+    } == {"through_step_requirement_missing"}
+    completeness = drawing.lint_summary()["quality"]["completeness"]
+    assert completeness["requirements"] == completeness["missing"] == 2
+    assert completeness["inapplicable"] == 0
+
+
+def test_exact_optional_detail_failure_still_closes_the_physical_leg_ledger() -> None:
+    part = Rot(90, 0, 0) * _through_step_part()
+    sheet = Sheet(part).authored_dimensions()
+    handle = sheet.step_level(
+        base=0,
+        levels=(10, 15),
+        shoulders=(("x", 10), ("x", 20)),
+        datum=(5, 0, 0),
+    )
+    for parameter in sheet.features[-1].parameters():
+        sheet.dimension(handle, parameter.parameter_id)
+    drawing = sheet.build()
+    drawing.lint()  # populate the recognition-owned physical inventory
+    name = "dim_detail_a_step0"
+    (measurement,) = drawing.registry.measurement_of(name)
+    span = drawing.registry.named(name)._dw_measurement_span
+    drawing.remove(name)
+    drawing.registry.record_issue(
+        LintIssue(
+            "warning",
+            "the exact recovery detail could not be placed",
+            code="detail_unplaceable",
+            measurement_ids=(measurement,),
+            measurement_spans=(span,),
+        )
+    )
+    plan = compile_dimensions(drawing.model())
+
+    outcomes = through_step_requirement_outcomes(
+        drawing.recognition(),
+        drawing.model().features,
+        drawing.registry,
+        plan.diagnostics,
+        plan=plan,
+    )
+
+    assert [(outcome.parameter_id, outcome.state) for outcome in outcomes] == [
+        ("through_step_leg.length.z", "dropped"),
+        ("through_step_leg.length.x", "inapplicable"),
+    ]
+
+
+def test_equal_valued_ladder_members_and_unrelated_drop_do_not_cover_removed_leg() -> None:
+    """Value equality and a shared DimensionId must not erase occurrence identity."""
+    part = Rot(90, 0, 0) * _through_step_part()
+    sheet = Sheet(part).authored_dimensions()
+    handle = sheet.step_level(
+        base=0,
+        levels=(15,),
+        shoulders=(("x", -10), ("x", 20)),
+        datum=(5, 0, 0),
+    )
+    for parameter in sheet.features[-1].parameters():
+        sheet.dimension(handle, parameter.parameter_id)
+    drawing = sheet.build()
+    drawing.lint()  # populate the recognised physical inventory
+    plan = compile_dimensions(drawing.model())
+
+    shoulder_rungs = tuple(plan.ladder("step_position").rungs)  # type: ignore[union-attr]
+    assert [rung.value for rung in shoulder_rungs] == pytest.approx([15, 15])
+    drawing.remove("dim_shoulder_x1")  # physical X leg: datum 5 -> shoulder 20
+    unrelated = next(rung for rung in shoulder_rungs if rung.span[1][0] == -10)
+    drawing.registry.record_issue(
+        LintIssue(
+            "warning",
+            "unrelated equal-valued shoulder drop",
+            code="step_position_dropped",
+            measurement_ids=(unrelated.id,),
+            outcome_stage="placement",
+            measurement_spans=(unrelated.span,),
+        )
+    )
+
+    outcomes = through_step_requirement_outcomes(
+        drawing.recognition(),
+        drawing.model().features,
+        drawing.registry,
+        plan.diagnostics,
+        plan=plan,
+    )
+
+    assert [(outcome.parameter_id, outcome.state) for outcome in outcomes] == [
+        ("through_step_leg.length.z", "inapplicable"),
+        ("through_step_leg.length.x", "missing"),
+    ]
+
+
+@pytest.mark.parametrize("deferred", [False, True], ids=["live", "deferred-corridor"])
+def test_public_dimension_replacement_preserves_legacy_occurrence_span(deferred) -> None:
+    drawing = build_drawing(Rot(90, 0, 0) * _through_step_part())
+    drawing.lint()  # populate the recognised physical inventory
+    envelope_feature = next(
+        feature for feature in drawing.model().features if feature.kind == "envelope"
+    )
+    width = next(
+        parameter for parameter in envelope_feature.parameters() if parameter.role == "width"
+    )
+    drawing.remove("m_env_width")
+
+    if deferred:
+        with drawing.deferred():
+            drawing.dimension(
+                envelope_feature,
+                "length",
+                role="width",
+                name="replacement_width",
+                pin=True,
+            )
+    else:
+        drawing.dimension(
+            envelope_feature,
+            "length",
+            role="width",
+            name="replacement_width",
+        )
+
+    replacement = drawing.registry.named("replacement_width")
+    assert replacement._dw_measurement_span == width.span
+    plan = compile_dimensions(drawing.model())
+    assert [
+        outcome.state
+        for outcome in through_step_requirement_outcomes(
+            drawing.recognition(),
+            drawing.model().features,
+            drawing.registry,
+            plan.diagnostics,
+            plan=plan,
+        )
+    ] == ["inapplicable", "inapplicable"]
+    assert not [issue for issue in drawing.lint() if "through_step" in issue.code]
+
+
+def test_complement_requires_legacy_datum_to_be_the_envelope_minimum() -> None:
+    part = Rot(90, 0, 0) * _through_step_part()
+    drawing = build_drawing(
+        part,
+        model=[
+            envelope(part),
+            step_level(
+                base=-10,
+                levels=(0,),
+                shoulders=(("x", 5),),
+                datum=(0, 0, -10),
+            ),
+        ],
+        number="X",
+    )
+    issues = drawing.lint()  # populate the recognised physical inventory
+    plan = compile_dimensions(drawing.model())
+    outcomes = through_step_requirement_outcomes(
+        drawing.recognition(),
+        drawing.model().features,
+        drawing.registry,
+        plan.diagnostics,
+        plan=plan,
+    )
+
+    assert {outcome.state for outcome in outcomes} == {"unverifiable"}
+    assert {issue.code for issue in issues if "through_step" in issue.code} == {
+        "through_step_requirement_unverifiable"
+    }
+
+
+def test_legacy_owner_placement_drops_retain_measurement_identity(monkeypatch) -> None:
+    import draftwright.annotations._common as common
+    import draftwright.annotations.from_model as from_model
+
+    def reject_every_candidate(_dwg, _strip, _view, _axis, candidates, _tier, **_kwargs):
+        return list(candidates)
+
+    monkeypatch.setattr(common, "place_strip_candidates", reject_every_candidate)
+    monkeypatch.setattr(from_model, "carve_free_position", lambda *_args, **_kwargs: None)
+
+    with pytest.warns(UserWarning, match="drops required annotation outcomes"):
+        drawing = build_drawing(Rot(90, 0, 0) * _through_step_part())
+    drawing.lint()  # populate the declared/detected build's physical inventory
+    plan = compile_dimensions(drawing.model())
+    outcomes = through_step_requirement_outcomes(
+        drawing.recognition(),
+        drawing.model().features,
+        drawing.registry,
+        plan.diagnostics,
+        plan=plan,
+    )
+
+    assert [outcome.state for outcome in outcomes] == ["dropped", "dropped"]
+    legacy_drops = [
+        issue
+        for issue in drawing.registry.issues
+        if issue.code in {"placement_unsatisfiable", "step_position_dropped"}
+        and issue.measurement_ids
+        and issue.measurement_ids[0].feature.kind == "step_level"
+    ]
+    assert {issue.measurement_ids[0].parameter for issue in legacy_drops} == {
+        "step_height.length",
+        "step_position.length",
+    }
+    assert all(issue.measurement_spans for issue in legacy_drops)
+
+    l_bracket = Box(80, 40, 8) + Pos(-36, 0, 24) * Box(8, 40, 40)
+    with pytest.warns(UserWarning, match="drops required annotation outcomes"):
+        plate_drawing = build_drawing(l_bracket)
+    plate_drops = [
+        issue for issue in plate_drawing.registry.issues if issue.code == "plate_thickness_dropped"
+    ]
+    assert plate_drops
+    assert all(
+        issue.measurement_ids
+        and issue.measurement_ids[0].feature.kind == "plate"
+        and issue.measurement_ids[0].parameter == "thickness.length"
+        and issue.measurement_spans
+        for issue in plate_drops
+    )
+
+
+@pytest.mark.parametrize("failure", ["letters", "render"])
+def test_failed_prismatic_detail_records_exact_recovery_requirements(monkeypatch, failure) -> None:
+    import draftwright.annotations.sections as sections
+    from draftwright.linting.issues import is_placement_drop
+
+    if failure == "letters":
+        monkeypatch.setattr(sections, "_DETAIL_LETTERS", "")
+    else:
+        monkeypatch.setattr(sections, "_render_detail", lambda *_args, **_kwargs: False)
+
+    drawing = build_drawing(_crowded_step_part())
+
+    (issue,) = [item for item in drawing.registry.issues if item.code == "detail_unplaceable"]
+    assert issue.code == "detail_unplaceable"
+    # The optional recovery view is scored as a legibility defect, but it is not itself a
+    # required sheet/scale candidate. Its exact rungs are consumed by completeness instead.
+    assert not is_placement_drop(issue)
+    assert len(issue.measurement_ids) == len(issue.measurement_spans) > 0
+    assert {measurement.parameter for measurement in issue.measurement_ids} == {
+        "step_height.length"
+    }
+    assert not [item for item in drawing.registry.issues if item.code == "plan_incomplete"]
+
+
+def test_each_detail_redraw_exception_records_the_exact_rung_drop(monkeypatch) -> None:
+    from draftwright.annotations._common import Escalation, PlacementContext
+    from draftwright.annotations.sections import _request_prismatic_detail
+    from draftwright.model.compiled import (
+        ApprovedDimension,
+        ApprovedLadder,
+        RenderableDimensionPlan,
+    )
+
+    drawing = build_drawing(Box(10, 10, 10))
+    owner = step_level(base=0, levels=(1, 2), datum=(0, 0, 0))
+    measurement = DimensionId(owner, "step_height.length")
+    rungs = tuple(
+        ApprovedDimension(
+            id=measurement,
+            value_text=str(z),
+            value=z,
+            span=((0, 0, 0), (0, 0, z)),
+            rendered_label=str(z),
+        )
+        for z in (1, 2)
+    )
+    plan = RenderableDimensionPlan(ladders=(ApprovedLadder("step_height", rungs),))
+    analysis = SimpleNamespace(
+        bb=SimpleNamespace(
+            min=SimpleNamespace(X=-5, Z=0),
+            max=SimpleNamespace(X=5, Z=10),
+        ),
+        cy=0,
+        SCALE=1,
+    )
+    ctx = PlacementContext(
+        registry=AnnotationRegistry(),
+        escalations=[
+            Escalation(
+                kind="step",
+                view="front",
+                feature=owner,
+                reason="illegible",
+                targets=rungs,
+            )
+        ],
+    )
+    _request_prismatic_detail(drawing, analysis, ctx=ctx, plan=plan)
+    (request,) = ctx.detail_requests
+    assert request.measurement_ids == (measurement, measurement)
+    assert request.measurement_spans == tuple(rung.span for rung in rungs)
+
+    def reject(*_args, **_kwargs):
+        raise RuntimeError("synthetic placement refusal")
+
+    monkeypatch.setattr(ctx, "place", reject)
+    coords = SimpleNamespace(pp=lambda x, _y, z: (x, z))
+    assert request.redraw(drawing, "detail_test", coords, 20) == 0
+    assert [issue.code for issue in ctx.registry.issues] == [
+        "detail_step_dim_dropped",
+        "detail_step_dim_dropped",
+    ]
+    assert [issue.measurement_spans[0] for issue in ctx.registry.issues] == [
+        rung.span for rung in rungs
+    ]
+
+
+def test_detail_redraw_drops_are_not_counted_again_as_a_request_failure(monkeypatch) -> None:
+    from draftwright.annotations._common import PlacementContext
+
+    place = PlacementContext.place
+
+    def reject_detail_dimension(self, obj, name=None, *args, **kwargs):
+        if name is not None and name.startswith("dim_detail_"):
+            raise RuntimeError("synthetic detail placement refusal")
+        return place(self, obj, name, *args, **kwargs)
+
+    monkeypatch.setattr(PlacementContext, "place", reject_detail_dimension)
+    with pytest.warns(UserWarning, match="drops required annotation outcomes"):
+        drawing = build_drawing(_crowded_step_part())
+
+    drops = [
+        issue
+        for issue in drawing.registry.issues
+        if issue.code in {"detail_step_dim_dropped", "detail_unplaceable"}
+    ]
+    assert drops
+    assert {issue.code for issue in drops} == {"detail_step_dim_dropped"}
+    assert len(drops) == len({issue.measurement_spans[0] for issue in drops})
+
+
+@pytest.mark.parametrize(
+    ("part", "axis", "view"),
+    [
+        (_through_step_part(), "z", "plan"),
+        (Rot(0, 90, 0) * _through_step_part(), "x", "side"),
+        (Rot(90, 0, 0) * _through_step_part(), "y", "front"),
+    ],
+)
+def test_explicit_declaration_can_choose_local_leg_grammar_on_every_axis(part, axis, view) -> None:
+    source = build_recognition_result(part).through_steps[0]
+    sheet = Sheet(part).authored_dimensions()
+    handle = sheet.through_step(
+        axis=source.axis,
+        length=source.length,
+        at=source.at,
+        section=source.section,
+    )
+    for parameter in sheet.features[-1].parameters():
+        sheet.dimension(handle, parameter.parameter_id)
+    drawing = sheet.build()
+    feature = _feature(drawing)
+
+    assert feature.axis == axis
+    assert len(_dimension_names(drawing)) == 2
+    assert {drawing.registry.identity_of(name)["view"] for name in _dimension_names(drawing)} == {
+        view
+    }
+    assert {
+        measurement.parameter
+        for name in _dimension_names(drawing)
+        for measurement in drawing.registry.measurement_of(name)
+    } == set(_parameter_ids(feature))
+    for name in _dimension_names(drawing):
+        (measurement,) = drawing.registry.measurement_of(name)
+        _assert_final_witness_span(drawing, name, feature, measurement.parameter)
+
+
+def test_compound_preserves_body_ownership_and_four_independent_requirements() -> None:
+    base = _through_step_part()
+    drawing = build_drawing(Compound([Pos(-70, -50, 0) * base, Pos(70, 50, 0) * base]))
+    features = [feature for feature in drawing.model().features if feature.kind == "through_step"]
+    names = _dimension_names(drawing)
+    completeness = drawing.lint_summary()["quality"]["completeness"]
+
+    assert len(drawing.recognition().through_steps) == 2  # type: ignore[union-attr]
+    assert len(features) == 2
+    assert len(names) == 4
+    assert completeness["by_family"]["through_steps"] == 4
+    assert completeness["requirements"] == completeness["placed"] == 4
+    assert {
+        id(measurement.feature)
+        for name in names
+        for measurement in drawing.registry.measurement_of(name)
+    } == {id(feature) for feature in features}
+    for name in names:
+        (measurement,) = drawing.registry.measurement_of(name)
+        parameter = next(
+            p for p in measurement.feature.parameters() if p.parameter_id == measurement.parameter
+        )
+        _assert_final_witness_span(drawing, name, measurement.feature, parameter.parameter_id)
+
+
+def test_authored_dimension_set_can_select_and_tolerance_one_leg_without_resurrection() -> None:
+    part = _through_step_part()
+    recognition = build_recognition_result(part)
+    source = recognition.through_steps[0]
+    sheet = Sheet(part)
+    handle = sheet.through_step(
+        axis=source.axis,
+        length=source.length,
+        at=source.at,
+        section=source.section,
+    )
+    selected = "through_step_leg.length.x"
+    handle.tolerance(0.2, on=selected)
+    sheet.authored_dimensions().dimension(handle, selected)
+    drawing = sheet.build()
+    feature = _feature(drawing)
+    outcomes = through_step_requirement_outcomes(
+        recognition,
+        drawing.model().features,
+        drawing.registry,
+        compile_dimensions(drawing.model()).diagnostics,
+    )
+
+    assert len(_dimension_names(drawing)) == 1
+    name = _dimension_names(drawing)[0]
+    assert drawing.registry.measurement_of(name) == (DimensionId(feature, selected),)
+    assert str(drawing.registry.named(name).label) == "15 ±0.2"
+    assert [(outcome.parameter_id, outcome.state) for outcome in outcomes] == [
+        ("through_step_leg.length.y", "suppressed"),
+        (selected, "placed"),
+    ]
+
+
+def test_compiled_boundary_cannot_reconstruct_a_suppressed_unequal_leg() -> None:
+    def _compiled(suppressed_length):
+        sheet = Sheet(_through_step_part()).authored_dimensions()
+        handle = sheet.through_step(
+            axis="z",
+            length=20,
+            at=(12.5, 6, 0),
+            section=((5, suppressed_length), (5, 0), (20, 0)),
+        )
+        sheet.dimension(handle, "through_step_leg.length.x")
+        return next(iter(compile_dimensions(sheet.model()).of_kind("through_step")))
+
+    first = _compiled(12)
+    mutated = _compiled(19)
+
+    assert first.facts.axis == mutated.facts.axis == "z"
+    assert (
+        first.facts.outside_directions
+        == mutated.facts.outside_directions
+        == (
+            ("x", 1),
+            ("y", 1),
+        )
+    )
+    assert not hasattr(first.facts, "exterior_corner")
+    assert [
+        (dimension.value, dimension.span, dimension.discriminator) for dimension in first.dims
+    ] == [(dimension.value, dimension.span, dimension.discriminator) for dimension in mutated.dims]
+
+
+def _declared_through_step_sheet():
+    part = _through_step_part()
+    source = build_recognition_result(part).through_steps[0]
+    sheet = Sheet(part).authored_dimensions()
+    handle = sheet.through_step(
+        axis=source.axis,
+        length=source.length,
+        at=source.at,
+        section=source.section,
+    )
+    for parameter in sheet.features[-1].parameters():
+        sheet.dimension(handle, parameter.parameter_id)
+    return part, sheet, handle
+
+
+def _through_step_tolerances(sheet) -> dict[str, object]:
+    group = next(iter(compile_dimensions(sheet.model()).of_kind("through_step")))
+    return {dimension.id.parameter: dimension.tolerance for dimension in group.dims}
+
+
+def test_targeted_family_and_bare_tolerances_have_order_independent_scope() -> None:
+    _part, sheet, handle = _declared_through_step_sheet()
+    handle.tolerance(0.1, on="x").tolerance(0.2)
+    assert _through_step_tolerances(sheet) == {
+        "through_step_leg.length.x": pytest.approx(0.2),
+        "through_step_leg.length.y": pytest.approx(0.2),
+    }
+
+    _part, sheet, handle = _declared_through_step_sheet()
+    handle.tolerance(0.3, on="through_step_leg")
+    assert _through_step_tolerances(sheet) == {
+        "through_step_leg.length.x": pytest.approx(0.3),
+        "through_step_leg.length.y": pytest.approx(0.3),
+    }
+
+
+def test_generated_sheet_exec_preserves_one_discriminated_leg_tolerance() -> None:
+    part, sheet, handle = _declared_through_step_sheet()
+    handle.tolerance(
+        0.2,
+        on="through_step_leg.length.x",
+        source="inspection plan",
+        source_ids=("IP-17",),
+    )
+    source = emit_sheet_script(
+        sheet.model(),
+        "part",
+        "through-step",
+        title="Through step",
+        number="1382",
+    )
+    assert (
+        ".tolerance(0.2, on='through_step_leg.length.x', "
+        "source='inspection plan', source_ids=('IP-17',))"
+    ) in source
+
+    namespace = {"part": part}
+    body = source.replace("\npart\n", "\n", 1)
+    body = body[: body.index("drawing = sheet.build()")]
+    exec(compile(body, "<through-step-round-trip>", "exec"), namespace)  # noqa: S102
+    assert _through_step_tolerances(namespace["sheet"]) == {
+        "through_step_leg.length.x": pytest.approx(0.2),
+        "through_step_leg.length.y": None,
+    }
+
+
+@pytest.mark.parametrize("deferred", [False, True], ids=["live", "deferred"])
+def test_built_drawing_can_replay_both_exact_legs_with_identity_and_end_view(deferred) -> None:
+    drawing = build_drawing(_through_step_part())
+    feature = _feature(drawing)
+    drawing.drop(feature)
+    names = {
+        parameter.parameter_id: f"replay_{parameter.discriminator}"
+        for parameter in feature.parameters()
+    }
+
+    if deferred:
+        with drawing.deferred():
+            for parameter_id, name in names.items():
+                drawing.dimension(feature, parameter_id, name=name)
+    else:
+        for parameter_id, name in names.items():
+            drawing.dimension(feature, parameter_id, name=name)
+
+    for parameter_id, name in names.items():
+        assert drawing.registry.measurement_of(name) == (DimensionId(feature, parameter_id),)
+        assert drawing.registry.identity_of(name)["view"] == "plan"
+        _assert_final_witness_span(drawing, name, feature, parameter_id)
+    assert not [issue for issue in drawing.lint() if "through_step" in issue.code]
+
+
+def test_outcome_ledger_distinguishes_evidence_and_fails_closed() -> None:
+    drawing = build_drawing(_through_step_part())
+    recognition = drawing.recognition()
+    assert recognition is not None
+    feature = _feature(drawing)
+    parameters = _parameter_ids(feature)
+    assert [
+        outcome.state
+        for outcome in through_step_requirement_outcomes(
+            recognition, drawing.model().features, drawing.registry
+        )
+    ] == ["placed", "placed"]
+
+    empty = AnnotationRegistry()
+    assert [
+        outcome.state
+        for outcome in through_step_requirement_outcomes(
+            recognition, drawing.model().features, empty
+        )
+    ] == ["missing", "missing"]
+
+    omission = SimpleNamespace(feature=feature, parameter_id=parameters[0], authored=True)
+    assert [
+        outcome.state
+        for outcome in through_step_requirement_outcomes(
+            recognition, drawing.model().features, empty, (omission,)
+        )
+    ] == ["suppressed", "missing"]
+
+    dropped = AnnotationRegistry()
+    dropped.record_issue(
+        LintIssue(
+            "warning",
+            "synthetic placement failure",
+            code="through_step_dim_dropped",
+            measurement_ids=(DimensionId(feature, parameters[1]),),
+            outcome_stage="placement",
+        )
+    )
+    assert [
+        outcome.state
+        for outcome in through_step_requirement_outcomes(
+            recognition, drawing.model().features, dropped
+        )
+    ] == ["missing", "dropped"]
+
+    structured = AnnotationRegistry()
+    structured.add(
+        object(),
+        "structured_note",
+        "plan",
+        feature=feature,
+        satisfaction=DimensionId(feature, parameters[0]),
+    )
+    assert [
+        outcome.state
+        for outcome in through_step_requirement_outcomes(
+            recognition, drawing.model().features, structured
+        )
+    ] == ["satisfied_by_structured_note", "missing"]
+
+    duplicated = replace(
+        recognition,
+        through_steps=(recognition.through_steps[0], recognition.through_steps[0]),
+    )
+    assert {
+        outcome.state
+        for outcome in through_step_requirement_outcomes(
+            duplicated, drawing.model().features, empty
+        )
+    } == {"unverifiable"}
+
+    assert {
+        outcome.state
+        for outcome in through_step_requirement_outcomes(recognition, (feature, feature), empty)
+    } == {"unverifiable"}
+
+    corruptions = (
+        replace(feature, length=feature.length + 1),
+        replace(
+            feature,
+            frame=Frame((feature.frame.origin[0] + 1, *feature.frame.origin[1:]), feature.axis),
+        ),
+        replace(feature, frame=Frame(feature.frame.origin, "x"), axis="x"),
+        replace(feature, section=((5.0, 14.0), feature.section[1], feature.section[2])),
+        replace(feature, section=((6.0, 15.0), (6.0, 1.0), (20.0, 1.0))),
+        replace(feature, section=(feature.section[0], feature.section[1], (21.0, 0.0))),
+    )
+    for corrupted in corruptions:
+        assert {
+            outcome.state
+            for outcome in through_step_requirement_outcomes(recognition, (corrupted,), empty)
+        } == {"unverifiable"}
+
+    malformed = replace(
+        recognition,
+        through_steps=(
+            SimpleNamespace(
+                axis="z",
+                length=20,
+                at=None,
+                section=((5, 15), (5, 0), (20, 0)),
+            ),
+        ),
+    )
+    malformed_outcomes = through_step_requirement_outcomes(malformed, (feature,), empty)
+    assert [outcome.state for outcome in malformed_outcomes] == [
+        "unverifiable",
+        "unverifiable",
+    ]
+    assert all(
+        all(coordinate != coordinate for coordinate in outcome.source_at)
+        for outcome in malformed_outcomes
+    )
+
+    malformed_length = replace(
+        recognition,
+        through_steps=(replace(recognition.through_steps[0], length=float("nan")),),
+    )
+    assert {
+        outcome.state
+        for outcome in through_step_requirement_outcomes(
+            malformed_length, drawing.model().features, empty
+        )
+    } == {"unverifiable"}
+
+    boolean_section = replace(
+        recognition,
+        through_steps=(
+            replace(
+                recognition.through_steps[0],
+                section=((5.0, 15.0), (5.0, False), (20.0, False)),
+            ),
+        ),
+    )
+    assert {
+        outcome.state
+        for outcome in through_step_requirement_outcomes(
+            boolean_section, drawing.model().features, drawing.registry
+        )
+    } == {"unverifiable"}
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        lambda source: replace(source, at=source.at[:2]),
+        lambda source: replace(
+            source,
+            section=(source.section[0], (6.0, 0.0), source.section[2]),
+        ),
+        lambda source: replace(
+            source,
+            section=(source.section[0], source.section[1], (5.0, -5.0)),
+        ),
+        lambda source: replace(source, length=10**10000),
+        lambda source: replace(source, at=(10**10000, source.at[1], source.at[2])),
+        lambda source: replace(
+            source,
+            section=((10**10000, source.section[0][1]), *source.section[1:]),
+        ),
+    ),
+    ids=(
+        "short-anchor",
+        "diagonal-leg",
+        "repeated-leg-axis",
+        "overflowing-length",
+        "overflowing-anchor",
+        "overflowing-section",
+    ),
+)
+def test_malformed_source_geometry_fails_closed(source) -> None:
+    drawing = build_drawing(_through_step_part())
+    recognition = drawing.recognition()
+    assert recognition is not None
+    malformed = source(recognition.through_steps[0])
+
+    outcomes = through_step_requirement_outcomes(
+        replace(recognition, through_steps=(malformed,)),
+        drawing.model().features,
+        AnnotationRegistry(),
+    )
+
+    assert [outcome.state for outcome in outcomes] == ["unverifiable", "unverifiable"]
+
+
+def test_malformed_ir_and_provenance_fail_closed_without_hiding_requirements() -> None:
+    drawing = build_drawing(_through_step_part())
+    recognition = drawing.recognition()
+    assert recognition is not None
+    source = recognition.through_steps[0]
+
+    class BrokenThroughStep:
+        pass
+
+    invalid_owner = BrokenThroughStep()
+    invalid_owner.kind = "through_step"
+    invalid_owner.axis = source.axis
+    invalid_owner.at = source.at
+    invalid_owner.length = source.length
+    invalid_owner.section = source.section
+    invalid_owner.parameters = lambda: None
+    incomplete_owner = BrokenThroughStep()
+    incomplete_owner.kind = "through_step"
+    incomplete_owner.axis = source.axis
+    invalid_identity = DimensionId(None, "bad")
+    registry = AnnotationRegistry()
+    registry.add(
+        SimpleNamespace(label="10"),
+        "invalid_provenance",
+        "plan",
+        measurement=invalid_identity,
+        satisfaction=invalid_identity,
+    )
+    registry.add(
+        SimpleNamespace(label="10"),
+        "valid_structured_provenance",
+        "plan",
+        satisfaction=DimensionId(invalid_owner, "test.length"),
+    )
+    registry.record_issue(
+        LintIssue(
+            "warning",
+            "invalid measurement provenance",
+            code="synthetic_dim_dropped",
+            outcome_stage="placement",
+            measurement_ids=(invalid_identity,),
+            measurement_spans=(((0, 0, 0), (1, 0, 0)),),
+        )
+    )
+
+    outcomes = through_step_requirement_outcomes(
+        recognition,
+        (invalid_owner, incomplete_owner),
+        registry,
+    )
+
+    assert [outcome.state for outcome in outcomes] == ["unverifiable", "unverifiable"]
+
+
+@pytest.mark.parametrize("invalid_axis", ["", "xy"], ids=("empty", "multiple"))
+def test_non_principal_source_axis_cannot_reuse_matching_ir_ink(invalid_axis) -> None:
+    drawing = build_drawing(_through_step_part())
+    recognition = drawing.recognition()
+    assert recognition is not None
+    source = replace(recognition.through_steps[0], axis=invalid_axis)
+    recognition = replace(recognition, through_steps=(source,))
+
+    class InjectedThroughStep:
+        pass
+
+    owner = InjectedThroughStep()
+    owner.kind = "through_step"
+    owner.axis = invalid_axis
+    owner.at = source.at
+    owner.length = source.length
+    owner.section = source.section
+    parameter_ids = ("through_step_leg.length.y", "through_step_leg.length.x")
+    owner.parameters = lambda: tuple(
+        SimpleNamespace(parameter_id=parameter_id) for parameter_id in parameter_ids
+    )
+    registry = AnnotationRegistry()
+    for index, parameter_id in enumerate(parameter_ids):
+        registry.add(
+            SimpleNamespace(label="1"),
+            f"injected_{index}",
+            "plan",
+            feature=owner,
+            measurement=DimensionId(owner, parameter_id),
+        )
+
+    assert [
+        outcome.state
+        for outcome in through_step_requirement_outcomes(recognition, (owner,), registry)
+    ] == ["unverifiable", "unverifiable"]
+
+
+def test_direct_plate_owners_and_invalid_compiler_label_are_handled_exactly() -> None:
+    drawing = build_drawing(Rot(90, 0, 0) * _through_step_part())
+    recognition = drawing.recognition()
+    assert recognition is not None
+    direct_height_plate = plate(axis="z", lo=0, hi=15, u=0, v=0)
+    direct_position_plate = plate(axis="x", lo=5, hi=20, u=0, v=0)
+    owner_envelope = envelope(Rot(90, 0, 0) * _through_step_part())
+
+    assert {
+        outcome.state
+        for outcome in through_step_requirement_outcomes(
+            recognition,
+            (direct_height_plate, owner_envelope),
+            AnnotationRegistry(),
+        )
+    } == {"unverifiable"}
+    assert [
+        outcome.state
+        for outcome in through_step_requirement_outcomes(
+            recognition,
+            (direct_height_plate, direct_position_plate),
+            AnnotationRegistry(),
+        )
+    ] == ["missing", "missing"]
+
+    plan = compile_dimensions(drawing.model())
+    malformed_plan = replace(
+        plan,
+        ladders=tuple(
+            replace(
+                ladder,
+                rungs=tuple(replace(rung, value_text="not-a-number") for rung in ladder.rungs),
+            )
+            if ladder.kind in {"step_height", "step_position"}
+            else ladder
+            for ladder in plan.ladders
+        ),
+    )
+    assert [
+        outcome.state
+        for outcome in through_step_requirement_outcomes(
+            recognition,
+            drawing.model().features,
+            drawing.registry,
+            malformed_plan.diagnostics,
+            plan=malformed_plan,
+        )
+    ] == ["missing", "missing"]
+
+    def shifted_span(rung):
+        if rung.span is None:
+            return rung
+        return replace(
+            rung,
+            span=tuple(tuple(coordinate + 1 for coordinate in point) for point in rung.span),
+        )
+
+    wrong_span_plan = replace(
+        plan,
+        ladders=tuple(
+            replace(ladder, rungs=tuple(shifted_span(rung) for rung in ladder.rungs))
+            if ladder.kind in {"step_height", "step_position"}
+            else ladder
+            for ladder in plan.ladders
+        ),
+    )
+    assert [
+        outcome.state
+        for outcome in through_step_requirement_outcomes(
+            recognition,
+            drawing.model().features,
+            drawing.registry,
+            wrong_span_plan.diagnostics,
+            plan=wrong_span_plan,
+        )
+    ] == ["missing", "missing"]
+
+
+@pytest.mark.parametrize(
+    ("malformed", "approved_height_span", "rendered_height_span"),
+    (
+        (True, ((0, 0, 0), (0, 0, 1)), ((0, 0, 0), (0, 0, 1))),
+        ("nan", ((0, 0, 0), (0, 0, 1)), ((0, 0, 0), (0, 0, 1))),
+        ("inf", ((0, 0, 0), (0, 0, 1)), ((0, 0, 0), (0, 0, 1))),
+        ("1", ((0,), (1,)), ((0, 0, 0), (0, 0, 1))),
+        ("1", ((0, 0, False), (0, 0, True)), ((0, 0, 0), (0, 0, 1))),
+        ("1", ((0, 0, float("nan")), (0, 0, 1)), ((0, 0, 0), (0, 0, 1))),
+        ("1", ((0, 0, 10**10000), (0, 0, 1)), ((0, 0, 0), (0, 0, 1))),
+        ("1", ((0, 0, 0), (0, 0, 1)), ((0,), (1,))),
+        ("1", ((0, 0, 0), (0, 0, 1)), ((0, 0, False), (0, 0, True))),
+        ("1", ((0, 0, 0), (0, 0, 1)), ((0, 0, float("nan")), (0, 0, 1))),
+        ("1", ((0, 0, 0), (0, 0, 1)), ((0, 0, 10**10000), (0, 0, 1))),
+    ),
+    ids=(
+        "boolean-label",
+        "nan-label",
+        "infinite-label",
+        "short-span",
+        "boolean-span",
+        "nan-span",
+        "overflowing-span",
+        "short-rendered-span",
+        "boolean-rendered-span",
+        "nan-rendered-span",
+        "overflowing-rendered-span",
+    ),
+)
+def test_malformed_compiler_content_cannot_certify_a_one_mm_legacy_leg(
+    malformed, approved_height_span, rendered_height_span
+) -> None:
+    drawing = build_drawing(Rot(90, 0, 0) * _through_step_part())
+    recognition = drawing.recognition()
+    assert recognition is not None
+    source = replace(
+        recognition.through_steps[0],
+        section=((5.0, 1.0), (5.0, 0.0), (20.0, 0.0)),
+    )
+    recognition = replace(recognition, through_steps=(source,))
+    height_plate = plate(axis="z", lo=0, hi=1, u=0, v=0)
+    position_plate = plate(axis="x", lo=5, hi=20, u=0, v=0)
+    height_id = DimensionId(height_plate, "thickness.length")
+    position_id = DimensionId(position_plate, "thickness.length")
+    position_span = ((5, 0, 0), (20, 0, 0))
+    registry = AnnotationRegistry()
+    registry.add(
+        SimpleNamespace(label="1", _dw_measurement_span=rendered_height_span),
+        "height_plate",
+        "front",
+        measurement=height_id,
+    )
+    registry.add(
+        SimpleNamespace(label="15", _dw_measurement_span=position_span),
+        "position_plate",
+        "front",
+        measurement=position_id,
+    )
+    plan = RenderableDimensionPlan(
+        ladders=(
+            ApprovedLadder(
+                "step_height",
+                (ApprovedDimension(height_id, malformed, 1.0, approved_height_span),),
+            ),
+            ApprovedLadder(
+                "step_position",
+                (ApprovedDimension(position_id, "15", 15.0, position_span),),
+            ),
+        )
+    )
+
+    assert [
+        outcome.state
+        for outcome in through_step_requirement_outcomes(
+            recognition,
+            (height_plate, position_plate),
+            registry,
+            plan=plan,
+        )
+    ] == ["missing", "inapplicable"]
+
+
+def test_ledger_rejects_wrong_runs_and_quality_scores_two_requirements() -> None:
+    drawing = build_drawing(_through_step_part())
+    recognition = drawing.recognition()
+    assert recognition is not None
+    assert through_step_requirement_outcomes(None, (), AnnotationRegistry()) == []
+    with pytest.raises(TypeError, match="requires the run's RecognitionResult"):
+        through_step_requirement_outcomes(SimpleNamespace(), (), AnnotationRegistry())
+
+    issues = lint_through_step_coverage(
+        _through_step_part(),
+        recognition=recognition,
+        features=drawing.model().features,
+        registry=AnnotationRegistry(),
+        assembly=False,
+    )
+    assert {issue.code for issue in issues} == {"through_step_requirement_missing"}
+    completeness = drawing.lint_summary()["quality"]["completeness"]
+    assert completeness["by_family"]["through_steps"] == 2
+    assert completeness["requirements"] == completeness["placed"] == 2
+    assert completeness["audited_score"] == 1.0
+    assert "through_steps" not in completeness["unscored_recognized_families"]

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -7318,6 +7318,38 @@ class TestFeatureEdits:
         assert dwg.get_annotation("user_width")._dw_spec.distance == 12
         assert dwg._intents == []
 
+    def test_finalize_resolves_an_implicit_side_before_corridor_routing(self, tmp_path):
+        # #1382 review: `dimension()` now leaves the natural side unresolved as None. The
+        # routing predicate must accept that state so pin/priority reach the shared solve;
+        # `_queue_dimension_intent` resolves the side from the exact parameter span.
+        dwg = build_drawing(
+            Box(80, 50, 20),
+            auto_dims=False,
+            out=str(tmp_path / "implicit-side"),
+            trace=True,
+        )
+        env = next(f for f in dwg.model().features if f.kind == "envelope")
+        with dwg.deferred():
+            dwg.dimension(
+                env,
+                "length",
+                role="width",
+                name="implicit_side_width",
+                pin=True,
+                priority=25,
+            )
+
+        assert dwg.registry.is_pinned("implicit_side_width")
+        assert dwg.get_annotation("implicit_side_width")._dw_spec.side == "above"
+        candidate = next(
+            candidate
+            for solve in dwg.solve_trace.solves
+            for candidate in solve["candidates"]
+            if candidate["name"] == "implicit_side_width"
+        )
+        assert candidate["priority"] == 100
+        assert candidate["anchored"] is True
+
     def test_finalize_mixed_corridor_batch_places_each_exactly_once(self):
         # #699 slice b (Codex review): the drain stages now run in the auto-pass's
         # canonical _PASS_SEQUENCE order, which moved the register-only height-ladder /

--- a/tests/test_parameter_id.py
+++ b/tests/test_parameter_id.py
@@ -181,6 +181,9 @@ _SAMPLES: dict[str, ir.Feature] = {
     "ChamferFeature": ir.ChamferFeature(_F, "z", 2.0, 2.0, 45.0),
     "FilletFeature": ir.FilletFeature(_F, "z", 3.0),
     "PairedRampStepFeature": ir.PairedRampStepFeature(_F, "z", 45.0, 12.0),
+    "ThroughStepFeature": ir.ThroughStepFeature(
+        _F, "z", 12.0, ((-5.0, 5.0), (-5.0, -5.0), (5.0, -5.0))
+    ),
     "FlatFeature": ir.FlatFeature(_F, "z", 18.0),
     "GrooveFeature": ir.GrooveFeature(_F, "z", 3.0, 20.0),
     "StepLevelFeature": ir.StepLevelFeature(_F, 0.0, (5.0, 10.0, 15.0)),
@@ -265,6 +268,10 @@ _SAMPLE_BINDINGS = {
     "PairedRampStepFeature": (
         ("ramp_angle.angle", 45.0),
         ("ramp_run.length", 12.0),
+    ),
+    "ThroughStepFeature": (
+        ("through_step_leg.length.y", 10.0),
+        ("through_step_leg.length.x", 10.0),
     ),
     "FlatFeature": (("flat.length", 18.0),),
     "GrooveFeature": (("groove.length", 3.0), ("groove.diameter", 20.0)),

--- a/tests/test_private_test_attr_reads.py
+++ b/tests/test_private_test_attr_reads.py
@@ -86,6 +86,7 @@ _DRAWING_PRIVATES: frozenset[str] = frozenset(
         "_queue_dimension_intent",
         "_record_build_issue",
         "_replay_intent",
+        "_resolve_dimension_side",
         "_resolve_dimension_span",
         "_set_view_coordinates",
         "_user_dim_uses_corridor",

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -337,6 +337,66 @@ def test_rich_passage_contract_has_an_explicit_unsupported_completeness_outcome(
             "to": "unsupported",
             "version": importlib.metadata.version("draftwright"),
         },
+        {
+            "boundary": "completeness",
+            "compatibility_evidence": [
+                "tests/test_issue_1382_through_step_semantics.py",
+                "tests/test_recogniser_capabilities.py",
+            ],
+            "family": "through-steps",
+            "from": "deferred",
+            "release_notes": "CHANGELOG.md",
+            "to": "supported",
+            "version": importlib.metadata.version("draftwright"),
+        },
+        {
+            "boundary": "drawing_consumer",
+            "compatibility_evidence": [
+                "tests/test_issue_1382_through_step_semantics.py",
+                "tests/test_recogniser_capabilities.py",
+            ],
+            "family": "through-steps",
+            "from": "unsupported",
+            "release_notes": "CHANGELOG.md",
+            "to": "supported",
+            "version": importlib.metadata.version("draftwright"),
+        },
+        {
+            "boundary": "dsl_declaration",
+            "compatibility_evidence": [
+                "tests/test_issue_1382_through_step_semantics.py",
+                "tests/test_recogniser_capabilities.py",
+            ],
+            "family": "through-steps",
+            "from": "unsupported",
+            "release_notes": "CHANGELOG.md",
+            "to": "supported",
+            "version": importlib.metadata.version("draftwright"),
+        },
+        {
+            "boundary": "generated_code",
+            "compatibility_evidence": [
+                "tests/test_issue_1382_through_step_semantics.py",
+                "tests/test_recogniser_capabilities.py",
+            ],
+            "family": "through-steps",
+            "from": "unsupported",
+            "release_notes": "CHANGELOG.md",
+            "to": "supported",
+            "version": importlib.metadata.version("draftwright"),
+        },
+        {
+            "boundary": "ir_adapter",
+            "compatibility_evidence": [
+                "tests/test_issue_1382_through_step_semantics.py",
+                "tests/test_recogniser_capabilities.py",
+            ],
+            "family": "through-steps",
+            "from": "unsupported",
+            "release_notes": "CHANGELOG.md",
+            "to": "supported",
+            "version": importlib.metadata.version("draftwright"),
+        },
     ]
 
 
@@ -344,7 +404,6 @@ def test_rich_passage_contract_has_an_explicit_unsupported_completeness_outcome(
     ("family_id", "record_name", "inventory"),
     [
         ("circular-blind-steps", "CircularBlindStep", "circular_blind_steps"),
-        ("through-steps", "ThroughStep", "through_steps"),
     ],
 )
 def test_046_step_families_are_explicit_downstream_decisions(
@@ -386,6 +445,25 @@ def test_paired_ramp_steps_are_supported_at_every_consumer_boundary() -> None:
         )
     } == {"supported"}
     assert "paired-ramp-steps" not in pending_family_declarations()
+
+
+def test_through_steps_are_supported_at_every_consumer_boundary() -> None:
+    family = _families(consumer_capability_declaration())["through-steps"]
+
+    assert family["record_schemas"] == {"ThroughStep": [1]}
+    assert family["disposition"] == "supported"
+    assert {
+        family[boundary]["state"]
+        for boundary in (
+            "ir_adapter",
+            "dsl_declaration",
+            "generated_code",
+            "drawing_consumer",
+            "completeness",
+            "documentation",
+        )
+    } == {"supported"}
+    assert "through-steps" not in pending_family_declarations()
 
 
 def test_holes_completeness_is_supported_by_the_independent_observed_corpus() -> None:
@@ -664,6 +742,7 @@ def test_dsl_and_generated_code_inventories_are_derived_from_live_code() -> None
         "risers": "step_level",
         "slot-patterns": "slot_pattern",
         "slots": "slot",
+        "through-steps": "through_step",
         "turned-steps": "step",
     }
     assert {family["id"] for family in supported} == set(family_kinds)

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -135,6 +135,10 @@ def _paired_ramp_step():
     return Box(40, 40, 30) - Pos(20, 20, 0) * extrude(Plane.XZ * profile, 25)
 
 
+def _through_step():
+    return Box(40, 30, 20) - Pos(15, 10, 0) * Box(20, 20, 30)
+
+
 def _script_for(part, part_expr="part = PART", stem="drawing", **kw):
     return emit_sheet_script(detect_part_model(part), part_expr, stem, title="T", number="N", **kw)
 
@@ -2516,6 +2520,7 @@ class TestTheDimensionMirror:
             "chamfer": _chamfered_corner(bd_chamfer, 4),
             "fillet": _chamfered_corner(bd_fillet, 3),
             "paired ramp": _paired_ramp_step(),
+            "through step": _through_step(),
             "flat": Cylinder(10, 30) - Pos(10, 0, 0) * Box(10, 40, 40),  # D-shaft
             "groove": Cylinder(10, 40) - (Cylinder(10, 4) - Cylinder(8, 4)),  # circlip groove
             "plate": Box(80, 50, 8) + Pos(-36, 0, 29) * Box(8, 50, 50),  # base + upright
@@ -2554,6 +2559,7 @@ class TestTheDimensionMirror:
         "chamfer": {"chamfer"},
         "fillet": {"fillet"},
         "paired ramp": {"paired_ramp_step"},
+        "through step": {"through_step"},
         "flat": {"flat"},
         "groove": {"groove"},
         "plate": {"plate"},
@@ -2859,6 +2865,7 @@ _KIND_MIRROR_COVERAGE = {
     "chamfer": "corpus",
     "fillet": "corpus",
     "paired_ramp_step": "corpus",
+    "through_step": "corpus",
     "flat": "corpus",
     "groove": "corpus",
     "plate": "corpus",
@@ -3353,6 +3360,7 @@ _FIDELITY_ROUTE = {
     "chamfer": ("detected", "chamfer"),
     "fillet": ("detected", "fillet"),
     "paired_ramp_step": ("detected", "paired ramp"),
+    "through_step": ("detected", "through step"),
     "flat": ("detected", "flat"),
     "groove": ("detected", "groove"),
     "rotational": ("detected", "turned shaft"),
@@ -3598,6 +3606,7 @@ class TestTheDeclaredModelMatchesTheDetectedOne:
             "chamfer": _chamfered_corner(bd_chamfer, 4),
             "fillet": _chamfered_corner(bd_fillet, 3),
             "paired ramp": _paired_ramp_step(),
+            "through step": _through_step(),
             "flat": Cylinder(10, 30) - Pos(10, 0, 0) * Box(10, 40, 40),
             "groove": Cylinder(10, 40) - (Cylinder(10, 4) - Cylinder(8, 4)),
             "pad": Box(80, 60, 10) + Pos(0, 0, 7) * Box(30, 20, 4),
@@ -3657,6 +3666,7 @@ class TestTheDeclaredModelMatchesTheDetectedOne:
         "chamfer": {"chamfer"},
         "fillet": {"fillet"},
         "paired ramp": {"paired_ramp_step"},
+        "through step": {"through_step"},
         "flat": {"flat"},
         "groove": {"groove"},
         "pad": {"pad"},

--- a/tests/test_sheet_identity_invariant.py
+++ b/tests/test_sheet_identity_invariant.py
@@ -259,6 +259,7 @@ _SAME_PATH_AS_ENVELOPE = {
     "chamfer",
     "fillet",
     "paired_ramp_step",
+    "through_step",
     "flat",
     "groove",
     "plate",


### PR DESCRIPTION
Closes the rectangular ThroughStep slice of #1382.

- lower the public recogniser record exactly into explicit-only IR and Sheet declarations
- compile two independently addressable open-section leg requirements; the envelope owns the through extent
- place both dimensions through the shared corridor solve in the end-on view
- preserve tolerances, authored suppression, generated-code parity, and exact body ownership
- add fail-closed completeness outcomes and capability transition evidence

ADR audit: 0004, 0011, 0013, 0014, 0015, 0016, 0017, and 0018. This uses the existing immutable ThroughStep contract; no recogniser API change or upstream issue is required.

Local pre-freeze evidence: scripts/pr-check --quick green plus focused semantic, capability, quality, recognition, and generated-code suites.