### PR TITLE
Adopt b123d-recognisers 0.4.8 and RaisedPad v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,21 @@
 
 ### Changed
 
+- Updated the immutable `b123d-recognisers` pin and lock to 0.4.8. Draftwright now names
+  its existing caller/world-coordinate aggregate boundary explicitly with
+  `build_raw_recognition_result`; framed recognition remains disabled until #1357's
+  frame-to-IR adapter is reviewed end to end. Installed-wheel tests exercise the public
+  framed fixes for rectangular pads, polygonal bosses, and nested multi-body plates without
+  making that API the production path (#1392).
+
+- Rectangular pads now consume `RaisedPad` schema v2 without assuming +Z. The IR, public
+  `Sheet.pad`, generated code, compiler, semantic-view planner, shared placement solve, and
+  lint correspondence preserve the exact footprint, terminal-to-attachment height, two
+  in-plane locations, axis, direction, and world bounds for all six signed principal
+  orientations. Every height uses one solver-placed `… HIGH` leader with stable measurement
+  identity; side-normal pad footprints no longer leak into the unrelated Z-level grammar
+  (#1392).
+
 - Circular blind steps recognised by `b123d-recognisers` now have a complete consumer path.
   The oriented terminal-to-open centreline and transverse quarter-arc lower without rescanning
   to an explicit-only IR/Sheet feature; generated code preserves the full correspondence.

--- a/docs/adr/0015-part-drawing-compiler-as-built.md
+++ b/docs/adr/0015-part-drawing-compiler-as-built.md
@@ -129,6 +129,7 @@ by #754 (Amendment 2): those labels are now planner-fed.
 | paired ramps (2× angle × run compound leader, #1382) | `from_model.render_paired_ramp_steps` | `plan_dimensions` |
 | rectangular through steps (two open-section leg dimensions, #1382) | `from_model.render_through_steps` | `plan_dimensions` |
 | pockets (W × L × D DEEP leader, #728) | `from_model.render_pockets` | `plan_dimensions` |
+| rectangular pads (footprint dimensions + HIGH leader, #1392) | `from_model.render_slots`, `from_model.render_pad_heights` | `plan_dimensions` |
 | plates (thickness linear dim, #729) | `from_model.render_plates` | `plan_dimensions` |
 | slots (width/length linear dims, #730; the datum position dim stays model-derived — it is drawing state, not a feature parameter) | `from_model.render_slots` | `plan_dimensions` |
 | section trigger + cut plane | `sections._add_section_view` etc. | `plan_sections` → `SectionPlan` |

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -197,7 +197,7 @@ cylinder diameter, and concentricity. Drafting consumes the classification for v
 just as it consumes a recognised hole diameter; that does not turn the geometric fact into
 drafting policy.
 
-`build_recognition_result` currently receives that classification because
+`build_raw_recognition_result` currently receives that classification because
 `_classify_geometry` still lives in analysis. Moving its derivation is correct tidying (#1037),
 but it is not required by the accepted ownership contract and carries no user outcome on its
 own.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -199,8 +199,11 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   `_QUOTED_RE` (a lint-message label regex shared with the
   repair loop) lives in `_core`.
 - **`recognition_cache.py`** — Draftwright's ADR 0017 one-result lifecycle owner. It calls
-  external `build_recognition_result(part)` at most once for a build/lazy-critique run; the
-  package owns recognition, while Draftwright owns when the result is computed and reused.
+  external `build_raw_recognition_result(part)` at most once for a build/lazy-critique run.
+  The explicit name records that today's production IR consumes caller/world coordinates;
+  the package owns recognition, while Draftwright owns when the result is computed and reused.
+  The public framed route is exercised as release evidence but does not enter production until
+  #1357 supplies one reviewed frame-to-IR adapter.
 - **`recogniser_contract.py`** — the fail-closed cross-repository capability join. It consumes
   only the installed `b123d-recognisers` public manifest, then validates Draftwright-owned IR,
   `Sheet`, generated-code, drawing, completeness, and documentation declarations. It is rank 7
@@ -533,12 +536,18 @@ policy) live in `CLAUDE.md`. This is the per-ADR status trail; each ADR's
   **`DEFERRED` is now empty** — every public `recognise_*` family is owned by the one
   orchestration. The mechanism stays fail-closed (a new family must still be classified, and
   every `Deferral` member survives for a future one); what went was each deferral, as its
-  stated constraint stopped being true. Measured per family with 0.4.6: a prismatic build runs
+  stated constraint stopped being true. Measured per family with the current 0.4.8 pin: a
+  prismatic build runs
   28 once each, a turned build 23 (the five prismatic-only families excluded), and a declared
   build/render **zero**. Physical critique or export may then obtain one cached aggregate. The
   three 0.4.6 step inventories are owned by that aggregate and now have evidence-backed,
   scored consumer semantics under #1382. Their framed-coordinate parity remains a separate
   #1357 acceptance item.
+  `RaisedPad` schema v2 is likewise adapted only after the shared aggregate: axis and signed
+  attachment direction are IR data, all six orientations use the same footprint/height/location
+  compiler grammar and placement solve, and a side-normal footprint is filtered from the legacy
+  Z-level projection only when exact support correspondence proves that ownership. No renderer
+  consumes the provider record or places an annotation at a caller-supplied page coordinate.
   The accepted contract stops there. `BuildState` proves result-to-build provenance; it does
   **not** yet provide recognition-record→IR-feature→requirement correspondence. The original
   four-type identity taxonomy, shared requirements module, general outcome ledger,

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -282,9 +282,29 @@ an outcome.
 
 Remaining supported-family completeness work is tracked by family group rather than the closed
 shared design issue: #1370 retains countersinks and Double-D bores; #1371 covers
-channels, slots, slot patterns and polygonal stock; #1372 retains rectangular pads and
-polygonal bosses; #1373 covers plates, face levels and risers; and
+channels, slots, slot patterns and polygonal stock; #1372 retains the independent rectangular-pad
+and polygonal-boss benchmark corpora; #1373 covers plates, face levels and risers; and
 #1374 retains turned steps.
+
+## Recognisers 0.4.8 raw boundary and RaisedPad v2
+
+Draftwright exactly pins the published `b123d-recognisers==0.4.8` wheel. Production deliberately
+calls `build_raw_recognition_result`: records remain in the caller/world coordinate system until
+#1357 introduces one reviewed framed-result adapter. Tests use the public framed API only as
+release evidence for upstream #331, #332, and #334; they do not add a fallback, a second aggregate,
+or a family rescan. Face levels, risers, and turned profiles remain outside framed production
+pending their separately released upstream fixes.
+
+`RaisedPad` schema v2 makes a pad normal and its material-outward sign explicit. Draftwright maps
+the six signed principal orientations into one `PadFeature`: world bounds and direction survive
+automatic recognition, `Sheet.pad(axis=..., direction=...)`, and executed generated code. The
+compiler assigns one end-on semantic view and stable identities for footprint width, footprint
+length, terminal-to-attachment height, and both in-plane locations. Footprint/location dimensions
+and the `… HIGH` leader are placed by the ordinary shared solve; no annotation accepts a raw page
+position. Removing any one of those five physical facts produces
+`pad_footprint_not_defined`. This is complete consumer semantics, but #1372 still owns the
+independently authored rectangular-pad detection/parameter/downstream benchmark corpus required
+before claiming family-level completeness.
 
 ## Angled-step boundary
 
@@ -325,7 +345,7 @@ profile warning only for that occurrence, so an unrelated unrecognised profile r
 
 ## Passage compatibility boundary
 
-The installed `b123d-recognisers==0.4.6` release contains the `passages` family introduced
+The installed `b123d-recognisers==0.4.8` release contains the `passages` family introduced
 in 0.2.6. Version 0.4.0 makes `SectionPassage` the authoritative physical output and retains
 schema-v1 `Passage` as its compatibility projection. Draftwright declares all six public and nested
 record schemas exhaustively but deliberately keeps the family `unsupported`, with the drafting
@@ -343,7 +363,7 @@ The 0.4 contract is explicit:
 - rich split-junction passages can supersede a Slot claim, moving physical ownership to the
   unsupported Passage family through `SLOT_SUPERSEDED_BY_PASSAGE`.
 
-The exact 0.4.6 pin, manifest-v2 validator and explicit unsupported inventories make that limitation
+The exact 0.4.8 pin, manifest-v2 validator and explicit unsupported inventories make that limitation
 fail-visible rather than silently treating rich passages as supported. Draftwright deliberately
 does not claim that a regular-polygon `HEX … A/F THRU` callout covers the complete line/arc section
 schema. Each authoritative `RecognitionResult.section_passages` occurrence therefore emits

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -291,9 +291,10 @@ and polygonal-boss benchmark corpora; #1373 covers plates, face levels and riser
 Draftwright exactly pins the published `b123d-recognisers==0.4.8` wheel. Production deliberately
 calls `build_raw_recognition_result`: records remain in the caller/world coordinate system until
 #1357 introduces one reviewed framed-result adapter. Tests use the public framed API only as
-release evidence for upstream #331, #332, and #334; they do not add a fallback, a second aggregate,
-or a family rescan. Face levels, risers, and turned profiles remain outside framed production
-pending their separately released upstream fixes.
+release evidence for upstream #331, #332, and #334, comparing each aggregate inventory with the
+corresponding public family call on the exact returned local solid. Production adds no fallback,
+second aggregate, or family rescan. Face levels, risers, and turned profiles remain outside framed
+production pending their separately released upstream fixes.
 
 `RaisedPad` schema v2 makes a pad normal and its material-outward sign explicit. Draftwright maps
 the six signed principal orientations into one `PadFeature`: world bounds and direction survive

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "build123d>=0.9.0,<0.11 ; python_full_version < '3.13'",
     "build123d>=0.11,<0.12 ; python_full_version >= '3.13'",
     "build123d-drafting-helpers>=0.14.2",
-    "b123d-recognisers==0.4.6",
+    "b123d-recognisers==0.4.8",
     "numpy>=1.24",
     # PNG raster export (SVG→PDF→PNG). Both permissively licensed (Pillow HPND; pypdfium2
     # Apache-2.0 wrapping Google PDFium BSD-3) and ship pre-built wheels with NO native system

--- a/src/draftwright/_geometry.py
+++ b/src/draftwright/_geometry.py
@@ -344,6 +344,19 @@ def plane_axes(axis) -> tuple[tuple[float, float, float], tuple[float, float, fl
     return _PLANE_AXES[letter]
 
 
+def plane_axis_names(axis) -> tuple[str, str]:
+    """Return the world-axis names of :func:`plane_axes`' canonical ``(u, v)`` basis.
+
+    Principal rectangular features carry scalar bounds rather than oriented vectors.  This
+    names the same shared basis without making each record-to-IR adapter re-spell a second
+    axis table (and eventually transpose one orientation again, as happened before #969).
+    """
+    return tuple(
+        "xyz"[next(index for index, component in enumerate(vector) if component)]
+        for vector in plane_axes(axis)
+    )  # type: ignore[return-value]
+
+
 def _axis_letter_of(axis) -> str:
     """Letter of a bare 3-vector's dominant component (:func:`_axis_letter` takes an object)."""
     return max(zip("xyz", axis, strict=True), key=lambda t: abs(t[1]))[0]

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -134,6 +134,7 @@ def _apply_principal_view_pins(
     geometry.PV_Y += dy
     geometry.SV_X += dx
     geometry.SV_Y += dy
+    geometry.sv_geometry_right += dx
     geometry.sv_right += dx
     geometry.sv_right_wall += dx
     # Geometry bounds are the minimum pre-projection feasibility gate. Annotation bands use
@@ -576,6 +577,7 @@ def _analyse(
     pmi=None,
     model=None,
     decorations=None,
+    authored=None,
     material="",
     date="",
     revision="A",
@@ -787,6 +789,17 @@ def _analyse(
             cyls=shared_cyls,
         )
     )
+    # Authored omission affects annotation FOOTPRINT sizing, but the analysis model retains
+    # its historical automatic requirement inventory for view-feasibility preflight.  The
+    # builder applies the same authored tuple to the render model later.  Keeping this as a
+    # strip-only copy avoids letting a sparse authored dimension set erase semantic view
+    # requirements (for example the parent view needed by an authored detail), while ensuring
+    # suppressed pad bands cannot reduce the selected scale (#1392).
+    strip_sizing_model = (
+        replace(sizing_model, authored_dimensions=tuple(authored))
+        if authored is not None
+        else sizing_model
+    )
     # ADR 0018 Phase 5.5: prove the chosen principal set can carry every approved
     # dimension before scale selection or projection.  A reduced view set is therefore a
     # re-plan, not the fixed three-view plan rendered into fewer views.
@@ -818,7 +831,7 @@ def _analyse(
     # converges in a couple of rounds.
     def _measure_for_step_count(n_steps_i: int) -> StripDepths:
         return _measure_strips(
-            sizing_model,
+            strip_sizing_model,
             n_steps_i,
             bb,
             arrow_length=_arrow_length,
@@ -880,7 +893,7 @@ def _analyse(
     # Refine: apply the same legibility gate _auto_annotate uses for dim_step.
     n_steps = len(_legible_steps(step_zs, bb.min.Z, SCALE)[0])
     strips = _measure_strips(
-        sizing_model,
+        strip_sizing_model,
         n_steps,
         bb,
         arrow_length=_arrow_length,

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -22,7 +22,7 @@ from b123d_recognisers import (
     TurnedProfile,
     TurnedStep,
     analyse_cylinders,
-    build_recognition_result,
+    build_raw_recognition_result,
     full_cylinders,
 )
 from build123d import Compound, Shape
@@ -691,7 +691,7 @@ def _analyse(
         _turned = _declared_turned_profile(layout_model)
         step_zs = _declared_step_zs(layout_model, _turned, bb)
     else:
-        recognition = build_recognition_result(
+        recognition = build_raw_recognition_result(
             part, cylinders=(z_cyls, cross_cyls), rotational=is_rotational
         )
         _turned = TurnedProfile.from_steps(list(recognition.turned_steps))

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -81,6 +81,7 @@ def _hole_location_coverage_fact(location):
         in {
             "location.location",
             "location_pattern.location",
+            "location_pad.location",
             "location_pocket.location",
             "location_pocket_pattern.location",
         }

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -447,17 +447,24 @@ def render_slots(dwg, plan, a, *, ctx, only=None) -> int:
             # on the generated key. (`_MANDATORY_OVERALL_PRIORITY` is the envelope dims'
             # rank, not this ladder's — the base trace records both height candidates at 0.)
             #
-            # SCOPED TO THE FRONT VIEW deliberately. The plan/side right-left case keeps
-            # the immediate path, because the corridor carve is strictly more conservative:
+            # SCOPED TO THE FRONT VIEW for the established slot/pocket grammar. The plan/side
+            # right-left case keeps the immediate path there because the corridor carve is
+            # strictly more conservative:
             # it marks a region obstructed from FULL annotation geometry, where a label can
-            # legitimately sit between two extension lines. Routing those dims through it
-            # cost #885's part two pad size dims that place cleanly today — verified by
-            # label-box measurement, not inferred. Closing that gap needs the carve to
-            # reason about label boxes, which is its own change; tracked on #894.
+            # legitimately sit between two extension lines. An earlier attempt to migrate the
+            # whole population cost #885's part two pad size dims. #1392 now sizes and guards
+            # the pad corridors independently, but does not silently widen that behavioural
+            # change to the established slot/pocket population; its migration remains #894.
             # The plan/side horizontal case has been corridor-routed since #345/#346 and
             # stays that way; the front view joins it here. Only plan/side right-left
-            # keeps the immediate path.
-            use_corridor = vw[0] == "front" or (meas_axis == ha and vw[0] in ("plan", "side"))
+            # keeps the immediate path. RaisedPad v2 is new output and has no such compatibility
+            # exemption: every pad footprint/location candidate joins the shared collect-then-
+            # solve batch on all three end-on views (ADR 0014, #1392).
+            use_corridor = (
+                s.kind == "pad"
+                or vw[0] == "front"
+                or (meas_axis == ha and vw[0] in ("plan", "side"))
+            )
             if not use_corridor:
                 for side, strip, hi in sides:
                     if strip is None:
@@ -500,12 +507,10 @@ def render_slots(dwg, plan, a, *, ctx, only=None) -> int:
                 # use): placing mid-drain could occupy space a later sibling's force
                 # candidate needs, since that sibling has not solved yet.
                 #
-                # The plan/side path keeps placing synchronously, as it has since
-                # #345/#346. Deferring it too is the architecturally consistent end state
-                # and was tried — it costs #885's part a pad length dim, because by the
-                # time a post-drain retry runs the opposite strip has filled. Changing
-                # behaviour that was not broken, at a measured cost, is not this PR's job;
-                # the migration is tracked on #894.
+                # The plan/side opposite-strip path keeps placing synchronously, as it has
+                # since #345/#346. The primary candidate is nevertheless a member of the
+                # shared solve above; alternate-side fallthrough in ``on_drop`` is the
+                # assignment model ADR 0014 explicitly retains.
                 def _retry(_fs=_fs, _fsd=_fsd, _fh=_fh, _ax=_ax, _feat=_feat, _dw=_dw) -> None:
                     if _fs is not None and not place_strip_candidates(
                         dwg,
@@ -772,7 +777,14 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
     *pinned* carries the #511 first slice: deferred user ``locate(..., pin=True)`` calls
     remain first-class corridor candidates, but get higher survival/dedup priority and
     pin their placed names instead of being hand-added after the solve."""
-    approved = plan.locations
+    # This ladder consumes only Z-normal feature locations.  Non-Z pocket/pad entries
+    # carry axis-local in-plane spans whose first endpoint is deliberately not the global
+    # XY datum on both coordinates.  Derive the ladder datum only after excluding those
+    # entries; taking it from ``plan.locations[0]`` lets feature ordering shift every
+    # later Z-pad ordinate (#1392).
+    approved = [
+        loc for loc in plan.locations if loc.axis == "z" and loc.role != SlotFeature.LOCATION_STEM
+    ]
     if not approved:
         return 0
     draft = dwg.draft
@@ -781,11 +793,6 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
     refs = []
     for loc in approved:
         if only_refs is not None and loc.ref not in only_refs:  # #426: recorded subset only
-            continue
-        # This ladder is specifically plan-X / side-Y for Z-normal features.
-        # Non-Z pockets are still compiler-backed, but their two in-plane spans
-        # are rendered in their end-on view by render_slots.
-        if loc.axis != "z":
             continue
         rx, ry = loc.span[1][0], loc.span[1][1]
         # A rotational part's on-axis (concentric) *hole* bore is located by the
@@ -808,8 +815,6 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
         # is the LONG axis — so a Z-long slot fell through and an X- or Y-long one did not.
         # The same feature type getting a plan location dim or not, depending on which way
         # it happens to run, is the incoherence; every slot is now handled the one way (#1219).
-        if loc.role == SlotFeature.LOCATION_STEM:
-            continue
         # Provenance (ADR 0010): the located feature. `resolve_feature` is the sanctioned
         # seam for exactly this — the corridor's feature map keys drop()/annotations_of().
         # `loc.id` rides along as the measurement identity (#1002): the compiler already
@@ -2903,6 +2908,19 @@ _POCKET_LEAD_DIRS = (
 # on the same local wall corridor (#1382).
 _CIRCULAR_STEP_LEAD_DIRS = _POCKET_LEAD_DIRS[:4]
 
+# A side-view pad height belongs in the exterior upper-right quadrant.  Keeping its
+# leader there prevents it from entering the adjacent front view, which a view-scoped
+# feature-leader solve deliberately does not own.  The lower-right ray is excluded too:
+# the side-below overall/location ladder can otherwise run through the HIGH label even
+# though the shared solver legitimately retains the required leader under Policy B.
+# Front and plan pads retain the established full fan; those views already participate in
+# the fixed-ink solve without the side/front adjacency that motivated this constraint.
+_PAD_HEIGHT_LEAD_DIRS = {
+    "x": ((1, 1), (1, 0)),
+    "y": _POCKET_LEAD_DIRS,
+    "z": _POCKET_LEAD_DIRS,
+}
+
 
 def _circular_step_candidates(dwg, view, bounds, feature, reach, label, *, provenance=None):
     """Yield solver candidates whose complete analytical leader clears every other view.
@@ -3135,10 +3153,8 @@ def render_pad_heights(dwg, plan, a, *, ctx, only=None) -> int:
         if only is not None and group.ref not in only:
             continue
         by_key = {(item.role, item.kind): item for item in group.dims}
-        width = by_key.get(("pad_width", "length"))
-        length = by_key.get(("pad_length", "length"))
         height = by_key.get(("pad_height", "length"))
-        if width is None or length is None or height is None:
+        if height is None:
             continue
         # Structural placement facts come through the compiled boundary.  Resolving the
         # opaque provenance handle here would let this renderer recover measurements the
@@ -3148,6 +3164,24 @@ def render_pad_heights(dwg, plan, a, *, ctx, only=None) -> int:
         bounds = dwg.view_bounds(view)
         if bounds is None:
             continue
+        # An authored set may request the independently addressable height while omitting
+        # both footprint measurements.  In that case the terminal face centre is still a
+        # complete structural leader target; do not recover the suppressed sizes through
+        # provenance merely to move the arrow to the rim (ADR 0015/0016).  When both approved
+        # sizes are present, their values may refine that same target to the footprint edge.
+        width = by_key.get(("pad_width", "length"))
+        length = by_key.get(("pad_length", "length"))
+        source_bounds = (
+            _pocket_rim_bounds(
+                dwg,
+                view,
+                pad,
+                length=length.value,
+                width=width.value,
+            )
+            if width is not None and length is not None
+            else None
+        )
         jobs.append(
             (
                 f"m_pad_height_{pad.frame.axis}{index}",
@@ -3163,13 +3197,8 @@ def render_pad_heights(dwg, plan, a, *, ctx, only=None) -> int:
                     bounds,
                     pad,
                     reach,
-                    source_bounds=_pocket_rim_bounds(
-                        dwg,
-                        view,
-                        pad,
-                        length=length.value,
-                        width=width.value,
-                    ),
+                    source_bounds=source_bounds,
+                    directions=_PAD_HEIGHT_LEAD_DIRS[pad.frame.axis],
                     provenance=group.ref,
                 ),
                 (height.id,),

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -114,6 +114,7 @@ from draftwright.model.ir import (
     FilletFeature,
     HoleFeature,
     KnurlRequirement,
+    PadFeature,
     PatternFeature,
     PocketFeature,
     SlotFeature,
@@ -333,10 +334,11 @@ def render_slots(dwg, plan, a, *, ctx, only=None) -> int:
     # approved location consumed by render_locations, including non-Z openings.
     # Keyed by (feature, MEASURED axis): a non-Z pocket is approved one entry per in-plane
     # coordinate, so keying by feature alone would keep whichever came last.
-    pocket_locations = {
+    in_plane_locations = {
         (loc.ref, loc.discriminator): loc
         for loc in plan.locations
-        if loc.role == PocketFeature.LOCATION_STEM and loc.discriminator is not None
+        if loc.role in (PocketFeature.LOCATION_STEM, PadFeature.LOCATION_STEM)
+        and loc.discriminator is not None
     }
     # A slot's own position dim — datum→near-end along its long axis. Compiled, not
     # computed from `a.bb`: it prints a number, so an authored set that does not name the
@@ -628,17 +630,17 @@ def render_slots(dwg, plan, a, *, ctx, only=None) -> int:
                 # fires shows 12 nameless position drops across nist_ctc_03 and nist_ctc_04,
                 # all from here (#1231 review, finding 1).
                 _record_slot_drop(ctx, dwg, "position", i, name, s, pos.id)
-        elif s.kind == "pocket" and s.frame.axis != "z":
-            # Side-/front-opening pockets need two in-plane coordinates in their
+        elif s.kind in ("pocket", "pad") and s.frame.axis != "z":
+            # Side-/front-opening pockets and pads need two in-plane coordinates in their
             # end-on view.  The compiler approves one entry PER coordinate, each with its
-            # own value and span; Z-opening pockets use render_locations' X(plan)/Y(side)
+            # own value and span; Z-normal features use render_locations' X(plan)/Y(side)
             # ladder instead.
             width_lo, width_hi = s.w_center - half, s.w_center + half
             for axis, perp_lo, perp_hi, kind in (
                 (s.long_axis, width_lo, width_hi, "pos_long"),
                 (s.width_axis, s.lo, s.hi, "pos_width"),
             ):
-                entry = pocket_locations.get((FeatureRef(s), axis))
+                entry = in_plane_locations.get((FeatureRef(s), axis))
                 if entry is None:
                     continue  # not approved
                 index = "xyz".index(axis)
@@ -2870,6 +2872,11 @@ def _pocket_label(width_text, length_text, depth_text, wsfx="", lsfx="", dsfx=""
     return f"{width_text}{wsfx} × {length_text}{lsfx} × {depth_text}{dsfx} DEEP"
 
 
+def _pad_height_label(height_text, suffix="") -> str:
+    """The font-safe attachment-axis height callout for a side-normal pad."""
+    return f"{height_text}{suffix} HIGH"
+
+
 def _slot_label(width_text, length_text, wsfx="", lsfx="") -> str:
     """The grouped slot-array callout string: ``SLOT {width} × {length}`` (#841). A slot has no
     depth, so — unlike :func:`_pocket_label` — there is no ``× depth DEEP``; the ``SLOT`` prefix
@@ -3105,6 +3112,75 @@ def render_pockets(dwg, plan, a, *, ctx, only=None) -> int:
         jobs,
         noun="pocket",
         drop_code="pocket_dropped",
+        ctx=ctx,
+        joint=True,
+    )
+
+
+def render_pad_heights(dwg, plan, a, *, ctx, only=None) -> int:
+    """Place pad heights as solver-owned leaders in each pad's end-on view.
+
+    The existing footprint dimensions remain linear corridor candidates.  The arrow targets
+    the terminal footprint boundary and every printed value comes from the compiled plan
+    (ADR 0015/0016).  A Z profile level is datum-to-attachment evidence, not the pad's local
+    terminal-to-attachment height, so Z pads reach this pass too.
+    """
+    draft = dwg.draft
+    reach = _leader_callout_reach(draft)
+    jobs = []
+    groups = sorted(
+        plan.of_kind("pad"), key=lambda group: (group.facts.frame.axis, group.facts.frame.origin)
+    )
+    for index, group in enumerate(groups):
+        if only is not None and group.ref not in only:
+            continue
+        by_key = {(item.role, item.kind): item for item in group.dims}
+        width = by_key.get(("pad_width", "length"))
+        length = by_key.get(("pad_length", "length"))
+        height = by_key.get(("pad_height", "length"))
+        if width is None or length is None or height is None:
+            continue
+        # Structural placement facts come through the compiled boundary.  Resolving the
+        # opaque provenance handle here would let this renderer recover measurements the
+        # compiler withheld under authored intent (ADR 0015/0016).
+        pad = group.facts
+        view = _END_ON[pad.frame.axis]
+        bounds = dwg.view_bounds(view)
+        if bounds is None:
+            continue
+        jobs.append(
+            (
+                f"m_pad_height_{pad.frame.axis}{index}",
+                view,
+                bounds,
+                _pad_height_label(
+                    height.value_text,
+                    _tol_suffix(height.tolerance, draft),
+                ),
+                _radial_candidates(
+                    dwg,
+                    view,
+                    bounds,
+                    pad,
+                    reach,
+                    source_bounds=_pocket_rim_bounds(
+                        dwg,
+                        view,
+                        pad,
+                        length=length.value,
+                        width=width.value,
+                    ),
+                    provenance=group.ref,
+                ),
+                (height.id,),
+            )
+        )
+    return place_machined_leader_jobs(
+        dwg,
+        a,
+        jobs,
+        noun="pad height",
+        drop_code="pad_height_dropped",
         ctx=ctx,
         joint=True,
     )

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -68,6 +68,7 @@ from draftwright.annotations.from_model import (
     render_height_ladder,
     render_local_turned_centerlines,
     render_locations,
+    render_pad_heights,
     render_paired_ramp_steps,
     render_plates,
     render_pmi,
@@ -273,6 +274,7 @@ _PASS_SEQUENCE: tuple[str, ...] = (
     "paired_ramp_steps",
     "flats",
     "pockets",
+    "pad_heights",
     "grooves",
     # One compatible same-view feature-leader inventory (#1166): side/plan
     # hole leaders collected before the corridor drain and the six machined
@@ -672,6 +674,12 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # Planner-fed (#728): consumes the DimensionGroups so authored tolerances render.
         render_pockets(dwg, _compiled, a, ctx=ctx)
 
+    def _s_pad_heights():
+        # A raised pad's local attachment-to-terminal rise is independent of any global
+        # datum-to-level ladder. Its HIGH leader is a first-class post-drain candidate,
+        # sharing the machined leader assignment rather than bypassing the solve.
+        render_pad_heights(dwg, _compiled, a, ctx=ctx)
+
     def _s_pocket_patterns():
         # Grouped blind-pocket-array callouts (#841): ONE count× W × L × D DEEP leader + the
         # (n-1)× pitch dim(s), instead of N competing per-pocket size dims. Placed after
@@ -865,6 +873,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
             "paired_ramp_steps": _s_paired_ramp_steps,
             "flats": _s_flats,
             "pockets": _s_pockets,
+            "pad_heights": _s_pad_heights,
             "pocket_patterns": _s_pocket_patterns,
             "slot_patterns": _s_slot_patterns,
             "through_steps": _s_through_steps,

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -1201,6 +1201,7 @@ def _build_drawing_once(
             pmi=pmi,
             model=model,
             decorations=decorations,
+            authored=authored,
             material=material,
             date=date,
             revision=revision,

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -53,6 +53,7 @@ from draftwright._core import (
     _tol_suffix,
     _wrap_rows,
 )
+from draftwright._geometry import _END_ON
 from draftwright.layout import fit_box
 from draftwright.model.callout import hole_callout_spec, hole_callout_suffix
 from draftwright.model.ir import authored_dimension_target_view
@@ -463,6 +464,25 @@ def _compose_anno_boxes(
             sides = ("left", "right")
         for target_side in sides:
             _reserve(target_view, target_side)
+
+    # A side-normal pad contributes two footprint and two in-plane-location candidates in
+    # its end-on view.  These are automatic semantic requirements, not authored placement
+    # hints, but they consume the same strips and therefore must participate in the same
+    # compose-before-pack footprint. Z pads retain the established footprint/location layout:
+    # their location ladder already has dedicated plan/side sizing, while their HIGH callout
+    # uses the same solver-owned leader clearance as the other machined-feature leaders.
+    for feature in model.features:
+        if getattr(feature, "kind", None) != "pad" or feature.frame.axis == "z":
+            continue
+        view = _END_ON[feature.frame.axis]
+        # Canonical end-on projections put one footprint size + its coordinate horizontally
+        # (above) and the other vertically (right). The side view is already the rightmost
+        # principal block, so only its inter-row top band changes the packed footprint.
+        _reserve(view, "above")
+        _reserve(view, "above")
+        if view == "front":
+            _reserve(view, "right")
+            _reserve(view, "right")
 
     slot = _SLOT_DIM_STEP + _STRIP_SPACING
     # Front and plan occupy disjoint vertical ranges, so their left/right tiers are

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -349,6 +349,7 @@ class StripDepths:
     pv_bottom: float = 0.0
     sv_top: float = 0.0
     sv_bottom: float = 0.0
+    sv_right: float = 0.0  # band outside the rightmost side view
 
 
 def _measure_strips(
@@ -383,7 +384,8 @@ class AnnoBox:
     """A composed annotation band as a page-mm box (#112, ADR 0004 Step 4).
 
     ``side`` is the view side the band sits on (``"right"``/``"left"`` of the
-    front/plan views, or ``"plan_halo"`` for the balloon standoff ring);
+    front/plan views, ``"side_right"`` outside the side view, or ``"plan_halo"``
+    for the balloon standoff ring);
     ``depth`` is the band's perpendicular extent from the view edge.  A view's
     footprint is the deepest band per side — see ``_footprint_from_boxes``.
 
@@ -465,23 +467,46 @@ def _compose_anno_boxes(
         for target_side in sides:
             _reserve(target_view, target_side)
 
-    # A side-normal pad contributes two footprint and two in-plane-location candidates in
-    # its end-on view.  These are automatic semantic requirements, not authored placement
-    # hints, but they consume the same strips and therefore must participate in the same
-    # compose-before-pack footprint. Z pads retain the established footprint/location layout:
-    # their location ladder already has dedicated plan/side sizing, while their HIGH callout
-    # uses the same solver-owned leader clearance as the other machined-feature leaders.
+    # A side-normal pad contributes up to two footprint and two in-plane-location candidates
+    # in its end-on view.  They consume the ordinary strips and therefore must participate in
+    # the compose-before-pack footprint.  In an authored set, however, omission is suppression
+    # (ADR 0016): reserve only the independently addressed sizes/location, never phantom bands
+    # for measurements the author omitted.  Automatic mode retains the complete four-band
+    # grammar. Z pads retain the established footprint/location layout: their location ladder
+    # already has dedicated plan/side sizing, while their HIGH callout uses the same
+    # solver-owned leader clearance as the other machined-feature leaders.
     for feature in model.features:
         if getattr(feature, "kind", None) != "pad" or feature.frame.axis == "z":
             continue
         view = _END_ON[feature.frame.axis]
-        # Canonical end-on projections put one footprint size + its coordinate horizontally
-        # (above) and the other vertically (right). The side view is already the rightmost
-        # principal block, so only its inter-row top band changes the packed footprint.
-        _reserve(view, "above")
-        _reserve(view, "above")
-        if view == "front":
-            _reserve(view, "right")
+        horizontal_axis = {"x": "y", "y": "x"}[feature.frame.axis]
+
+        def _pad_parameter_is_authored(parameter_id: str) -> bool:
+            if model.authored_dimensions is None:
+                return True
+            role = parameter_id.split(".", 1)[0]
+            return any(
+                request.feature is feature and request.role in (role, parameter_id)
+                for request in model.authored_dimensions
+            )
+
+        # Canonical end-on projections put the horizontal measurement above and the vertical
+        # one right. Both bands change the feasible scale: notably an X-normal pad's end-on
+        # side view is the rightmost principal block, so its right band expands the sheet
+        # footprint rather than disappearing outside it (#1392).
+        for parameter_id, axis in (
+            ("pad_width.length", feature.width_axis),
+            ("pad_length.length", feature.long_axis),
+        ):
+            if _pad_parameter_is_authored(parameter_id):
+                _reserve(view, "above" if axis == horizontal_axis else "right")
+        if model.authored_dimensions is None or any(
+            request.feature is feature and request.role == "location"
+            for request in model.authored_dimensions
+        ):
+            # One authored location intent compiles to the two independently observable
+            # in-plane ordinates, one in each strip.
+            _reserve(view, "above")
             _reserve(view, "right")
 
     slot = _SLOT_DIM_STEP + _STRIP_SPACING
@@ -502,6 +527,8 @@ def _compose_anno_boxes(
         )
     if plan_right := authored_corridors.get(("plan", "right"), 0):
         boxes.append(AnnoBox("right", _STRIP_GAP + plan_right * slot))
+    if side_right := authored_corridors.get(("side", "right"), 0):
+        boxes.append(AnnoBox("side_right", _STRIP_GAP + side_right * slot))
     vertical_box_side = {
         ("front", "above"): "front_above",
         ("front", "below"): "front_below",
@@ -542,6 +569,7 @@ def _footprint_from_boxes(boxes: list[AnnoBox]) -> StripDepths:
         pv_bottom=deepest("plan_below"),
         sv_top=deepest("side_above"),
         sv_bottom=deepest("side_below"),
+        sv_right=deepest("side_right"),
     )
 
 
@@ -977,7 +1005,11 @@ def _compose_view_blocks(
     pv_top = (max(DIM_PAD, strip_top) + halo) if halo > 0 else DIM_PAD
     if strips is not None:
         pv_top = max(pv_top, strips.pv_authored_top)
-    sv_right_band = max(DIM_PAD, strips.right if (section and strips) else DIM_PAD)
+    sv_right_band = max(
+        DIM_PAD,
+        strips.sv_right if strips else 0.0,
+        strips.right if (section and strips) else 0.0,
+    )
 
     return {
         "front": ViewBlock(
@@ -1206,7 +1238,12 @@ def _layout_geometry(
     # estimator path (fv.right == pv.right == col_right, sv.left == 0).
     SV_X = FV_X + fv.hw + col_right + sv.left + sv.hw
     SV_Y = FV_Y
-    sv_right = SV_X + sv.hw + sv.right
+    # Keep the side geometry edge separate from the packed outer footprint.  The
+    # right strip starts at the former and consumes the reserved ``sv.right`` band;
+    # anchoring it at the latter would move the strip out again on every measured
+    # repack and make the reservation impossible to use.
+    sv_geometry_right = SV_X + sv.hw
+    sv_right = sv_geometry_right + sv.right
     SECTION_X = SV_X + sv.hw + sv.right + 10.0 + section_hw
     SECTION_Y = FV_Y
     sv_right_wall = (
@@ -1366,6 +1403,7 @@ def _layout_geometry(
         SV_Y=SV_Y,
         SECTION_X=SECTION_X,
         SECTION_Y=SECTION_Y,
+        sv_geometry_right=sv_geometry_right,
         sv_right=sv_right,
         sv_right_wall=sv_right_wall,
         iso_left=iso_left,
@@ -1438,9 +1476,9 @@ def _build_zones(g, margin, page_h):
     )
     sv_bottom_edge = SV_Y - fv_hh  # same as fv_bottom_edge; side and front share Z height
     sv_zones = ViewZones(
-        # sv_right already includes DIM_PAD; anchor here so the strip never
-        # places annotations inside that gap
-        right=Strip(g.sv_right, g.sv_right_wall, direction=1),
+        # The strip consumes the band compose reserved outside the side geometry.
+        # ``g.sv_right`` is the packed outer footprint, not its inner anchor.
+        right=Strip(g.sv_geometry_right, g.sv_right_wall, direction=1),
         left=None,  # immediately abuts the front view's right edge
         above=Strip(sv_top_edge, page_h - margin, direction=1),
         below=Strip(sv_bottom_edge, margin, direction=-1),

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -317,6 +317,7 @@ _MACHINED_CALLOUT_KINDS = (
     "paired_ramp_step",
     "flat",
     "pocket",
+    "pad",
     "groove",
 )
 
@@ -1660,7 +1661,7 @@ class Drawing:
 
         Raises ``ValueError`` if *feature* exposes no callout (use :meth:`dimension` for a
         linear param). A machined-feature callout
-        (pocket/circular-blind-step/fillet/paired-ramp/flat/chamfer/groove) is
+        (pocket/pad-height/circular-blind-step/fillet/paired-ramp/flat/chamfer/groove) is
         auto-named and placed in its characteristic view by the kind's renderer, so
         ``view=``/``name=`` are unsupported for those kinds and raise ``ValueError`` rather
         than being silently ignored (Codex #811). Placed reasonably, not via the auto-pass's
@@ -1715,6 +1716,7 @@ class Drawing:
                 render_fillets,
                 render_flats,
                 render_grooves,
+                render_pad_heights,
                 render_paired_ramp_steps,
                 render_pockets,
             )
@@ -1726,6 +1728,7 @@ class Drawing:
                 "paired_ramp_step": render_paired_ramp_steps,
                 "flat": render_flats,
                 "pocket": render_pockets,
+                "pad": render_pad_heights,
                 "groove": render_grooves,
             }
             # Return the placed annotation's name (Codex #811) so pin()/drop() can address it.
@@ -2136,7 +2139,8 @@ class Drawing:
         # Rotational furniture intent (#424/#426): the whole-model render_rotational —
         # no per-feature subset, so just the id set; it drains at the "rotational" slot.
         rotational_ids = {id(it) for it in self._intents if routable and it.kind == "rotational"}
-        # Machined-feature leader callout intents (#148): pocket/fillet/paired-ramp/flat/chamfer/groove
+        # Machined-feature leader callout intents (#148): pocket/pad-height/fillet/
+        # paired-ramp/flat/chamfer/groove
         # callout()s (plate is a spanned dimension, routed via dimension(), not here). Bucketed
         # per kind so each drains at its own _PASS_SEQUENCE stage, restricted to the recorded
         # features via only= (per-feature, #811). The id union also joins `routed` so
@@ -2392,6 +2396,7 @@ class Drawing:
             render_height_ladder,
             render_local_turned_centerlines,
             render_locations,
+            render_pad_heights,
             render_paired_ramp_steps,
             render_pockets,
             render_rotational,
@@ -2736,6 +2741,9 @@ class Drawing:
         def _s_pockets():
             _s_machined("pocket", render_pockets)
 
+        def _s_pad_heights():
+            _s_machined("pad", render_pad_heights)
+
         def _s_grooves():
             _s_machined("groove", render_grooves)
 
@@ -2912,6 +2920,7 @@ class Drawing:
                 "paired_ramp_steps": _s_paired_ramp_steps,
                 "flats": _s_flats,
                 "pockets": _s_pockets,
+                "pad_heights": _s_pad_heights,
                 "grooves": _s_grooves,
                 "feature_leaders": _s_feature_leaders,
                 "section": _s_section,

--- a/src/draftwright/evaluation/step_analysis.py
+++ b/src/draftwright/evaluation/step_analysis.py
@@ -2623,7 +2623,7 @@ def _default_observers() -> Mapping[str, Observer]:
 
         # ONE drawing per fixture, and ONE recognition: the records scored here come from
         # the build's own aggregate (ADR 0017's single owner per run), not a second
-        # `build_recognition_result` call, so the facts being scored and the features they
+        # `build_raw_recognition_result` call, so the facts being scored and the features they
         # are matched against cannot come from different recognition runs.
         try:
             drawing = build_drawing(part)  # type: ignore[arg-type]
@@ -2640,9 +2640,9 @@ def _default_observers() -> Mapping[str, Observer]:
             # recognises must still yield a scored non-answer rather than a traceback out
             # of the middle of a corpus run.
             try:
-                from b123d_recognisers import build_recognition_result
+                from b123d_recognisers import build_raw_recognition_result
 
-                holes = tuple(build_recognition_result(part).holes)  # type: ignore[arg-type]
+                holes = tuple(build_raw_recognition_result(part).holes)  # type: ignore[arg-type]
             except Exception:  # noqa: BLE001 — an unanalysable fixture observes nothing
                 return ()
             boundary_outcomes: dict[str, list[Outcome]] = {

--- a/src/draftwright/inspection_contract.py
+++ b/src/draftwright/inspection_contract.py
@@ -16,7 +16,7 @@ from b123d_recognisers.inspection import inspection_api_manifest
 CONSUMER_INSPECTION_FORMAT = "draftwright-inspection-api"
 CONSUMER_INSPECTION_FORMAT_VERSION = 1
 SUPPORTED_INSPECTION_API_MAJOR = 1
-SUPPORTED_RECOGNISER_VERSION = "0.4.6"
+SUPPORTED_RECOGNISER_VERSION = "0.4.8"
 _DISTRIBUTION = "b123d-recognisers"
 _PROVIDER_FORMAT = "b123d-recognisers-inspection-api"
 _NAMESPACE = "b123d_recognisers.inspection"

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -28,7 +28,7 @@ from b123d_recognisers import (
     RecognitionResult,
     TurnedProfile,
     analyse_cylinders,
-    build_recognition_result,
+    build_raw_recognition_result,
     feature_diameters,
     project_step_shoulders,
     recognise_double_d_bores,
@@ -1167,12 +1167,31 @@ def lint_prismatic_coverage(
     severity: Literal["info", "warning"] = "info" if assembly else "warning"
     pairs_by_view: dict[str, list] = {}
     registry = getattr(dwg, "registry", None)
-    satisfied_ids = satisfaction_ids(registry)
+    placed_ids = (
+        {identity for name in registry.names() for identity in registry.measurement_of(name)}
+        if registry is not None
+        else set()
+    )
+    structured_ids = satisfaction_ids(registry)
+    satisfied_ids = structured_ids | placed_ids
 
     def satisfied(feature, parameter: str) -> bool:
         return any(
-            identity.feature == feature and identity.parameter == parameter
+            identity.feature == feature
+            and (
+                identity.parameter == parameter
+                or (
+                    identity.parameter == "location"
+                    and parameter.startswith(f"{feature.LOCATION_STEM}.")
+                )
+            )
             for identity in satisfied_ids
+        )
+
+    def location_note_satisfied(feature) -> bool:
+        return any(
+            identity.feature == feature and identity.parameter == "location"
+            for identity in structured_ids
         )
 
     def pairs(view: str):
@@ -1184,6 +1203,49 @@ def lint_prismatic_coverage(
         bb = bbox if bbox is not None else part.bounding_box()
         undefined = 0
         for pad in pad_inventory:
+            record_bounds = {
+                "x": (pad.x0, pad.x1),
+                "y": (pad.y0, pad.y1),
+                "z": (pad.z0, pad.z1),
+            }
+            owner = next(
+                (
+                    f
+                    for f in getattr(dwg.model(), "features", ())
+                    if getattr(f, "kind", None) == "pad"
+                    and f.frame.axis == pad.axis
+                    and f.direction == pad.direction
+                    and all(
+                        abs(actual - expected) <= tol
+                        for axis in "xyz"
+                        for actual, expected in zip(
+                            f.bounds(axis), record_bounds[axis], strict=True
+                        )
+                    )
+                ),
+                None,
+            )
+            if owner is None:
+                undefined += 1
+                continue
+            if pad.axis != "z":
+                complete = all(
+                    satisfied(owner, parameter)
+                    for parameter in (
+                        "pad_width.length",
+                        "pad_length.length",
+                        "pad_height.length",
+                        f"{owner.LOCATION_STEM}.{owner.long_axis}",
+                        f"{owner.LOCATION_STEM}.{owner.width_axis}",
+                    )
+                )
+                if not complete:
+                    undefined += 1
+                continue
+
+            # Legacy Z-normal drawings may predate structured satisfaction authority, so
+            # retain the geometric fallback for their footprint/location marks. The local
+            # pad height is new compiler-owned evidence and must retain its exact identity.
             yc = (pad.y0 + pad.y1) / 2
             xc = (pad.x0 + pad.x1) / 2
             x0, _, *_ = dwg.at("plan", pad.x0, yc, pad.z1)
@@ -1199,61 +1261,32 @@ def lint_prismatic_coverage(
             sby0, _, *_ = dwg.at("side", xc, bb.min.Y, pad.z1)
             sby1, _, *_ = dwg.at("side", xc, bb.max.Y, pad.z1)
             ps = pairs("plan")
-            owner = next(
-                (
-                    f
-                    for f in getattr(dwg.model(), "features", ())
-                    if getattr(f, "kind", None) == "pad"
-                    and abs(f.lo - pad.x0) <= tol
-                    and abs(f.hi - pad.x1) <= tol
-                    and abs(f.w_center - yc) <= tol
-                    and abs(f.width - (pad.y1 - pad.y0)) <= tol
-                ),
-                None,
+            size_x = _pair_covers(ps, 0, x0, x1, tol, owner=owner) or satisfied(
+                owner, "pad_length.length"
             )
-            parameter_by_axis = (
-                {
-                    owner.long_axis: "pad_length.length",
-                    owner.width_axis: "pad_width.length",
-                }
-                if owner is not None
-                else {}
+            size_y = _pair_covers(ps, 1, y0, y1, tol, owner=owner) or satisfied(
+                owner, "pad_width.length"
             )
-            size_x = owner is not None and (
-                _pair_covers(ps, 0, x0, x1, tol, owner=owner)
-                or satisfied(owner, parameter_by_axis["x"])
-            )
-            size_y = owner is not None and (
-                _pair_covers(ps, 1, y0, y1, tol, owner=owner)
-                or satisfied(owner, parameter_by_axis["y"])
-            )
-            located_x = (
-                owner is not None
-                and satisfied(owner, "location")
-                or (
-                    abs(pad.x0 - bb.min.X) <= tol
-                    or abs(pad.x1 - bb.max.X) <= tol
-                    or any(
-                        _pair_covers(ps, 0, edge, bound, tol)
-                        for edge in (bx0, bx1)
-                        for bound in (x0, x1, xc_page)
-                    )
+            located_x = location_note_satisfied(owner) or (
+                abs(pad.x0 - bb.min.X) <= tol
+                or abs(pad.x1 - bb.max.X) <= tol
+                or any(
+                    _pair_covers(ps, 0, edge, bound, tol)
+                    for edge in (bx0, bx1)
+                    for bound in (x0, x1, xc_page)
                 )
             )
-            located_y = (
-                owner is not None
-                and satisfied(owner, "location")
-                or (
-                    abs(pad.y0 - bb.min.Y) <= tol
-                    or abs(pad.y1 - bb.max.Y) <= tol
-                    or any(
-                        _pair_covers(pairs("side"), 0, edge, bound, tol)
-                        for edge in (sby0, sby1)
-                        for bound in (sy0, sy1, syc)
-                    )
+            located_y = location_note_satisfied(owner) or (
+                abs(pad.y0 - bb.min.Y) <= tol
+                or abs(pad.y1 - bb.max.Y) <= tol
+                or any(
+                    _pair_covers(pairs("side"), 0, edge, bound, tol)
+                    for edge in (sby0, sby1)
+                    for bound in (sy0, sy1, syc)
                 )
             )
-            if not (size_x and size_y and located_x and located_y):
+            height = satisfied(owner, "pad_height.length")
+            if not (size_x and size_y and height and located_x and located_y):
                 undefined += 1
         if undefined:
             issues.append(
@@ -1261,8 +1294,8 @@ def lint_prismatic_coverage(
                     severity=severity,
                     code="pad_footprint_not_defined",
                     message=(
-                        f"{undefined} rectangular raised pad(s) lack footprint size "
-                        "or X/Y location dimensions"
+                        f"{undefined} rectangular raised pad(s) lack footprint size, "
+                        "attachment-axis height, or in-plane location dimensions"
                     ),
                 )
             )
@@ -1408,7 +1441,7 @@ def lint_prismatic_coverage(
             f"{type(recognition).__name__}. A completeness check must not accept a "
             "caller-assembled inventory: an empty stand-in silences it."
         )
-    _rec = build_recognition_result(part) if recognition is None else recognition
+    _rec = build_raw_recognition_result(part) if recognition is None else recognition
     ladder_bounds = bbox if bbox is not None else part.bounding_box()
     source_shoulders = project_step_shoulders(
         _rec.risers,

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -350,10 +350,11 @@ _UNSCORED_CODES = frozenset(
 #: can check rather than assume. It found `section_dropped` scoring nowhere while a comment
 #: beside its emission asserted the opposite.
 #:
-#: Eleven of these — every entry except `gdt_dropped` and `pmi_dropped` — are codes handed
+#: Fourteen of these — every entry except `gdt_dropped` and `pmi_dropped` — are codes handed
 #: to a leader job as ``drop_code`` data: `leaders.py`'s one drop recorder stages them
 #: ``"validation"`` on a rendered-geometry failure and ``"placement"`` otherwise, so all
-#: eleven have the `section_dropped` shape. TEN of them were invisible to the first audit,
+#: fourteen have the `section_dropped` shape. Ten of the original thirteen were invisible
+#: to the first audit,
 #: which read only codes written as literals AT a producer call, and were new to these
 #: registers; `callout_dropped` is the eleventh and was neither — it is also written as a
 #: literal at three producer calls, so the audit always saw it (#1176 review r5, corrected
@@ -372,6 +373,7 @@ _STAGE_ROUTED_CODES = frozenset(
         "paired_ramp_step_dropped",
         "flat_dropped",
         "groove_dropped",
+        "pad_height_dropped",
         "pocket_dropped",
         "polygonal_boss_dropped",
         "polygonal_stock_dropped",

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -58,6 +58,7 @@ from draftwright.model.ir import (
     Feature,
     HoleFeature,
     Note,
+    PadFeature,
     PartModel,
     PatternFeature,
     PocketFeature,
@@ -267,7 +268,7 @@ _FACTS: dict[str, tuple[str, ...]] = {
         "rows",
         "cols",
     ),
-    "pad": ("frame", "width_axis", "long_axis"),
+    "pad": ("frame", "width_axis", "long_axis", "direction"),
     "boss": ("frame", "thread", "knurl"),
     "polygonal_boss": ("frame", "side_count", "flat_directions", "flat_centres"),
     "polygonal_stock": ("frame", "side_count", "flat_directions", "flat_centres"),
@@ -1195,10 +1196,10 @@ def _compile_locations(model: PartModel) -> tuple[list[ApprovedDimension], list[
                     )
                 )
             continue
-        if isinstance(feature, PocketFeature) and axis != "z":
-            # A non-Z pocket's two in-plane coordinates are drawn as TWO dims in its end-on
-            # view (`render_slots`), so they are approved as two entries carrying their own
-            # values — the same shape `_compile_off_axis_hole_locations` uses.
+        if isinstance(feature, PocketFeature | PadFeature) and axis != "z":
+            # A non-Z pocket/pad's two in-plane coordinates are drawn as TWO dims in its
+            # end-on view (`render_slots`), so they are approved as two entries carrying
+            # their own values — the same shape `_compile_off_axis_hole_locations` uses.
             #
             # One entry with `value_text=""` made the renderer subtract the span's endpoints
             # itself to get each axis's number, which is the compiler's job done twice; the
@@ -1216,7 +1217,7 @@ def _compile_locations(model: PartModel) -> tuple[list[ApprovedDimension], list[
                             parameter_id,
                             value,
                             POCKET_LOCATION_DATUM_COINCIDENT,
-                            code="pocket_location_coincident_with_datum",
+                            code=f"{feature.kind}_location_coincident_with_datum",
                         )
                     )
                     continue

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -1139,7 +1139,11 @@ def _compile_locations(model: PartModel) -> tuple[list[ApprovedDimension], list[
         directional_location = (
             isinstance(
                 feature,
-                HoleFeature | PatternFeature | PocketPatternFeature | SlotPatternFeature,
+                HoleFeature
+                | PadFeature
+                | PatternFeature
+                | PocketPatternFeature
+                | SlotPatternFeature,
             )
             and feature.frame.axis == "z"
         )
@@ -1254,7 +1258,7 @@ def _compile_locations(model: PartModel) -> tuple[list[ApprovedDimension], list[
         approved.append(
             ApprovedDimension(
                 id=_dim_id(feature, pd.param.parameter_id),
-                #: Pocket/pad Z-normal ladders remain one location entry with no per-axis value:
+                #: Pocket Z-normal ladders remain one location entry with no per-axis value:
                 #: `render_locations` groups refs ACROSS features and dedups per axis before
                 #: it knows which dims exist, so an entry per axis would be approving a mark
                 #: whose existence the renderer decides. Splitting it needs that grouping to

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -1539,8 +1539,8 @@ def pad(
         w_center=(width_lo + width_hi) / 2,
         lo=long_lo,
         hi=long_hi,
-        normal_lo=normal_lo,
-        normal_hi=normal_hi,
+        z0=normal_lo,
+        z1=normal_hi,
         direction=direction,
     )
 

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -35,6 +35,7 @@ from draftwright._geometry import (
     _radial_axis_in_view,
     _solids_body,
     plane_axes,
+    plane_axis_names,
 )
 from draftwright.model.ir import (
     AUTHORED_DIMENSION_KINDS,
@@ -1496,12 +1497,19 @@ def pad(
     z0=None,
     z1=None,
     at=None,
+    axis="z",
+    direction=1,
 ) -> PadFeature:
-    """A bounded rectangular raised pad, dimensioned by footprint and location.
+    """A bounded principal-axis raised pad, dimensioned by footprint and location.
 
     ``pad(pad_solid)`` reads its axis-aligned bounding box; the explicit flavour
-    accepts the six bounds used by generated Sheet scripts.
+    accepts the six world bounds used by generated Sheet scripts. ``axis`` is the
+    attachment-to-terminal coordinate and ``direction`` selects its positive or negative
+    material-outward end; the defaults preserve the historical +Z declaration.
     """
+    axis = _norm_axis(axis)
+    if direction not in (-1, 1):
+        raise ValueError("pad() direction must be -1 or 1")
     if obj is not None:
         bb = obj.bounding_box()
         x0 = bb.min.X if x0 is None else x0
@@ -1517,17 +1525,23 @@ def pad(
     if at is None:
         at = ((x0 + x1) / 2, (y0 + y1) / 2, (z0 + z1) / 2)
     _require_point("at", at)
+    bounds = {"x": (x0, x1), "y": (y0, y1), "z": (z0, z1)}
+    long_axis, width_axis = plane_axis_names(axis)
+    long_lo, long_hi = bounds[long_axis]
+    width_lo, width_hi = bounds[width_axis]
+    normal_lo, normal_hi = bounds[axis]
     return PadFeature(
-        frame=Frame(at, "z"),
-        width_axis="y",
-        long_axis="x",
-        width=y1 - y0,
-        length=x1 - x0,
-        w_center=(y0 + y1) / 2,
-        lo=x0,
-        hi=x1,
-        z0=z0,
-        z1=z1,
+        frame=Frame(at, axis),
+        width_axis=width_axis,
+        long_axis=long_axis,
+        width=width_hi - width_lo,
+        length=long_hi - long_lo,
+        w_center=(width_lo + width_hi) / 2,
+        lo=long_lo,
+        hi=long_hi,
+        normal_lo=normal_lo,
+        normal_hi=normal_hi,
+        direction=direction,
     )
 
 

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -512,8 +512,8 @@ def _convert_pad(pad: RaisedPad, ctx: ConvContext) -> PadFeature:
         w_center=(width_lo + width_hi) / 2,
         lo=long_lo,
         hi=long_hi,
-        normal_lo=normal_lo,
-        normal_hi=normal_hi,
+        z0=normal_lo,
+        z1=normal_hi,
         direction=pad.direction,
     )
 

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -56,7 +56,7 @@ from b123d_recognisers import (
     TurnedProfile,
     TurnedStep,
     analyse_cylinders,
-    build_recognition_result,
+    build_raw_recognition_result,
     has_multi_axis_plates,
     project_step_shoulders,
     recognise_bosses,
@@ -75,7 +75,6 @@ from b123d_recognisers import (
     recognise_pockets,
     recognise_polygonal_bosses,
     recognise_polygonal_stock,
-    recognise_rectangular_pads,
     recognise_risers,
     recognise_slot_patterns,
     recognise_slots,
@@ -89,6 +88,7 @@ from draftwright._geometry import (
     _classify_rotational_cylinders,
     _is_principal_axis,
     _xyz,
+    plane_axis_names,
 )
 from draftwright.model.declare import circular_blind_step, control_frame, datum
 from draftwright.model.ir import (
@@ -491,20 +491,30 @@ def _convert_channel(channel: Channel, ctx: ConvContext) -> ChannelFeature:
 
 def _convert_pad(pad: RaisedPad, ctx: ConvContext) -> PadFeature:
     """A recognised bounded island → the dimensioning IR."""
+    bounds = {
+        "x": (pad.x0, pad.x1),
+        "y": (pad.y0, pad.y1),
+        "z": (pad.z0, pad.z1),
+    }
+    long_axis, width_axis = plane_axis_names(pad.axis)
+    long_lo, long_hi = bounds[long_axis]
+    width_lo, width_hi = bounds[width_axis]
+    normal_lo, normal_hi = bounds[pad.axis]
     return PadFeature(
         frame=Frame(
             ((pad.x0 + pad.x1) / 2, (pad.y0 + pad.y1) / 2, (pad.z0 + pad.z1) / 2),
-            "z",
+            pad.axis,
         ),
-        width_axis="y",
-        long_axis="x",
-        width=pad.y1 - pad.y0,
-        length=pad.x1 - pad.x0,
-        w_center=(pad.y0 + pad.y1) / 2,
-        lo=pad.x0,
-        hi=pad.x1,
-        z0=pad.z0,
-        z1=pad.z1,
+        width_axis=width_axis,
+        long_axis=long_axis,
+        width=width_hi - width_lo,
+        length=long_hi - long_lo,
+        w_center=(width_lo + width_hi) / 2,
+        lo=long_lo,
+        hi=long_hi,
+        normal_lo=normal_lo,
+        normal_hi=normal_hi,
+        direction=pad.direction,
     )
 
 
@@ -995,7 +1005,7 @@ def build_part_model(
             sizes=(bbox.size.X, bbox.size.Y, bbox.size.Z),
             centre=(centre.X, centre.Y, centre.Z),
         )
-        recognition = build_recognition_result(
+        recognition = build_raw_recognition_result(
             part,
             cylinders=cyls,
             rotational=(
@@ -1150,6 +1160,12 @@ def build_part_model(
     }
     if risers is None:
         risers = recognise_risers(part)
+    # RaisedPad v2 is an all-principal-axis occurrence. Resolve it before lowering the legacy
+    # Z-level grammar so a side-normal pad's two Z footprint edges cannot masquerade as
+    # prismatic HEIGHT levels. Any omitted inventory was filled from the one aggregate above;
+    # do not add a family rescan at this consumer boundary (ADR 0017).
+    assert pads is not None
+    pads = tuple(pads)
     # The detected orchestration supplies its filtered aggregate levels. A standalone
     # ``build_part_model`` has no aggregate, so obtain the same records once and use them for
     # BOTH ownership and emitted IR.  Suppressing a ThroughStep because a legacy owner exists
@@ -1159,11 +1175,40 @@ def build_part_model(
         step_zs = tuple(level.z for level in standalone_face_levels)
         if face_levels is None:
             face_levels = standalone_face_levels
+    face_levels = tuple(face_levels or ())
+
+    def _side_pad_owns_level(level: FaceLevel, pad: RaisedPad) -> bool:
+        if pad.axis == "z" or level.x_span is None or level.y_span is None:
+            return False
+        return (
+            any(abs(level.z - bound) < 0.5 for bound in (pad.z0, pad.z1))
+            and all(
+                abs(actual - expected) < 0.5
+                for actual, expected in zip(level.x_span, (pad.x0, pad.x1), strict=True)
+            )
+            and all(
+                abs(actual - expected) < 0.5
+                for actual, expected in zip(level.y_span, (pad.y0, pad.y1), strict=True)
+            )
+        )
+
+    # Remove a Z level only when every physical support record at that ordinate belongs to a
+    # side-normal pad. A genuine independent stair sharing the same Z remains an owner.
+    side_pad_level_zs = {
+        level.z
+        for level in face_levels
+        if any(_side_pad_owns_level(level, pad) for pad in pads)
+        and not any(
+            other.z == level.z and not any(_side_pad_owns_level(other, pad) for pad in pads)
+            for other in face_levels
+        )
+    }
     ownership_step_zs = (
         tuple(
             z
             for z in step_zs
             if round(z, 3) not in plate_zs_at_base
+            and not any(abs(z - owned) < 0.5 for owned in side_pad_level_zs)
             and not any(abs(z - floor) < 0.5 for floor in edge_floor_zs)
         )
         if prof is None
@@ -1323,10 +1368,9 @@ def build_part_model(
             continue
         features.append(convert(pk, ctx))
 
-    # Bounded rectangular raised pads: footprint sizing + X/Y location; their
-    # height remains in the correlated StepLevelFeature ladder.
-    if pads is None:
-        pads = recognise_rectangular_pads(part)
+    # Bounded rectangular raised pads: footprint sizing, attachment-axis height, and
+    # two in-plane locations. A Z attachment level may also enter the general profile
+    # ladder, but that datum-to-level fact does not replace the pad's local rise.
     features.extend(convert(pad, ctx) for pad in pads)
 
     # Bounded regular polygonal bosses own an across-flats callout and their direct axial
@@ -1432,6 +1476,7 @@ def build_part_model(
                 z
                 for z in step_zs
                 if round(z, 3) not in plate_zs_at_base
+                and not any(abs(z - owned) < 0.5 for owned in side_pad_level_zs)
                 and not any(abs(z - owned) < 0.5 for owned in through_level_zs)
             )
         )

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -1012,7 +1012,7 @@ class ChannelFeature:
         return []
 
 
-@dataclass(frozen=True, init=False)
+@dataclass(frozen=True)
 class PadFeature:
     """A bounded, principal-axis rectangular raised island.
 
@@ -1024,10 +1024,10 @@ class PadFeature:
     body from the drawing datum rather than the pad's terminal-to-attachment height; it is
     not a substitute for the pad requirement.
 
-    The explicit initializer retains the historical positional/``z0=``/``z1=`` spelling
-    for source compatibility, but only for a Z-normal pad.  New orientation-aware code
-    uses ``normal_lo=``/``normal_hi=``.  The read-only ``x0`` … ``z1`` properties always
-    mean world-coordinate bounds, independent of orientation.
+    The historical ``z0``/``z1`` dataclass fields are retained for public-IR compatibility.
+    They name the attachment-axis bounds (and therefore remain literal Z bounds for the
+    historical Z-normal case); ``normal_lo``/``normal_hi`` are semantic read-only aliases.
+    Orientation-neutral callers use :meth:`bounds` for world-coordinate bounds.
     """
 
     #: The compiled stem this feature's position is minted under — see
@@ -1042,62 +1042,46 @@ class PadFeature:
     w_center: float
     lo: float
     hi: float
-    normal_lo: float
-    normal_hi: float
+    z0: float
+    z1: float
     direction: int = 1
     kind: ClassVar[str] = "pad"
 
-    def __init__(
-        self,
-        frame: Frame,
-        width_axis: str,
-        long_axis: str,
-        width: float,
-        length: float,
-        w_center: float,
-        lo: float,
-        hi: float,
-        z0: float | None = None,
-        z1: float | None = None,
-        *,
-        normal_lo: float | None = None,
-        normal_hi: float | None = None,
-        direction: int = 1,
-    ) -> None:
-        legacy = z0 is not None or z1 is not None
-        semantic = normal_lo is not None or normal_hi is not None
-        if legacy and semantic:
-            raise ValueError("PadFeature: use z0=/z1= or normal_lo=/normal_hi=, not both")
-        if legacy:
-            if frame.axis != "z":
-                raise ValueError(
-                    "PadFeature: legacy z0=/z1= bounds are valid only for a Z-normal pad; "
-                    "use normal_lo=/normal_hi= for an X/Y pad"
-                )
-            normal_lo, normal_hi = z0, z1
-        if normal_lo is None or normal_hi is None:
-            raise ValueError("PadFeature needs normal_lo=/normal_hi= (or legacy z0=/z1= for Z)")
-        axes = {frame.axis, width_axis, long_axis}
+    def __post_init__(self) -> None:
+        axes = {self.frame.axis, self.width_axis, self.long_axis}
         if axes != {"x", "y", "z"}:
             raise ValueError("PadFeature frame/width/long axes must be distinct x/y/z axes")
-        if direction not in (-1, 1):
+        if isinstance(self.direction, bool) or self.direction not in (-1, 1):
             raise ValueError("PadFeature direction must be -1 or 1")
-        if width <= 0 or length <= 0 or not lo < hi or not normal_lo < normal_hi:
-            raise ValueError("PadFeature dimensions and bounds must increase")
-        for name, value in (
-            ("frame", frame),
-            ("width_axis", width_axis),
-            ("long_axis", long_axis),
-            ("width", float(width)),
-            ("length", float(length)),
-            ("w_center", float(w_center)),
-            ("lo", float(lo)),
-            ("hi", float(hi)),
-            ("normal_lo", float(normal_lo)),
-            ("normal_hi", float(normal_hi)),
-            ("direction", direction),
+        values = (
+            ("width", float(self.width)),
+            ("length", float(self.length)),
+            ("w_center", float(self.w_center)),
+            ("lo", float(self.lo)),
+            ("hi", float(self.hi)),
+            ("z0", float(self.z0)),
+            ("z1", float(self.z1)),
+        )
+        if not all(isfinite(value) for _name, value in values):
+            raise ValueError("PadFeature dimensions and bounds must be finite")
+        numeric = dict(values)
+        if (
+            numeric["width"] <= 0
+            or numeric["length"] <= 0
+            or not numeric["lo"] < numeric["hi"]
+            or not numeric["z0"] < numeric["z1"]
         ):
+            raise ValueError("PadFeature dimensions and bounds must increase")
+        for name, value in values:
             object.__setattr__(self, name, value)
+
+    @property
+    def normal_lo(self) -> float:
+        return self.z0
+
+    @property
+    def normal_hi(self) -> float:
+        return self.z1
 
     def bounds(self, axis: str) -> tuple[float, float]:
         """Return this occurrence's ascending bounds on one world axis."""
@@ -1107,43 +1091,19 @@ class PadFeature:
             half = self.width / 2
             return self.w_center - half, self.w_center + half
         if axis == self.frame.axis:
-            return self.normal_lo, self.normal_hi
+            return self.z0, self.z1
         raise ValueError(f"unknown pad axis {axis!r}")
 
     @property
-    def x0(self) -> float:
-        return self.bounds("x")[0]
-
-    @property
-    def x1(self) -> float:
-        return self.bounds("x")[1]
-
-    @property
-    def y0(self) -> float:
-        return self.bounds("y")[0]
-
-    @property
-    def y1(self) -> float:
-        return self.bounds("y")[1]
-
-    @property
-    def z0(self) -> float:
-        return self.bounds("z")[0]
-
-    @property
-    def z1(self) -> float:
-        return self.bounds("z")[1]
-
-    @property
     def height(self) -> float:
-        return self.normal_hi - self.normal_lo
+        return self.z1 - self.z0
 
     def _normal_span(self) -> tuple[Point, Point]:
         start = list(self.frame.origin)
         end = list(self.frame.origin)
         axis_index = "xyz".index(self.frame.axis)
-        start[axis_index] = self.normal_lo if self.direction > 0 else self.normal_hi
-        end[axis_index] = self.normal_hi if self.direction > 0 else self.normal_lo
+        start[axis_index] = self.z0 if self.direction > 0 else self.z1
+        end[axis_index] = self.z1 if self.direction > 0 else self.z0
         return (tuple(start), tuple(end))  # type: ignore[return-value]
 
     def parameters(self) -> list[DimParameter]:

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -313,6 +313,7 @@ DimensionParameterId = Literal[
     "groove.length",
     "height.length",
     "od.diameter",
+    "pad_height.length",
     "pad_length.length",
     "pad_width.length",
     "pitch.length",
@@ -1011,13 +1012,22 @@ class ChannelFeature:
         return []
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, init=False)
 class PadFeature:
-    """A bounded rectangular raised island.
+    """A bounded, principal-axis rectangular raised island.
 
     The footprint mirrors the slot vocabulary so the shared in-plane dimension
-    renderer can place its two sizes. Height remains owned by the correlated
-    prismatic level ladder, avoiding double-dimensioning the same Z rise.
+    renderer can place its two sizes.  ``normal_lo``/``normal_hi`` are the ascending
+    attachment-axis bounds and ``direction`` says which end is terminal/material-outward.
+    Every orientation owns an explicit ``pad_height.length`` parameter.  A Z pad may also
+    create an attachment level in the general prismatic profile, but that level measures the
+    body from the drawing datum rather than the pad's terminal-to-attachment height; it is
+    not a substitute for the pad requirement.
+
+    The explicit initializer retains the historical positional/``z0=``/``z1=`` spelling
+    for source compatibility, but only for a Z-normal pad.  New orientation-aware code
+    uses ``normal_lo=``/``normal_hi=``.  The read-only ``x0`` … ``z1`` properties always
+    mean world-coordinate bounds, independent of orientation.
     """
 
     #: The compiled stem this feature's position is minted under — see
@@ -1032,15 +1042,119 @@ class PadFeature:
     w_center: float
     lo: float
     hi: float
-    z0: float
-    z1: float
+    normal_lo: float
+    normal_hi: float
+    direction: int = 1
     kind: ClassVar[str] = "pad"
 
+    def __init__(
+        self,
+        frame: Frame,
+        width_axis: str,
+        long_axis: str,
+        width: float,
+        length: float,
+        w_center: float,
+        lo: float,
+        hi: float,
+        z0: float | None = None,
+        z1: float | None = None,
+        *,
+        normal_lo: float | None = None,
+        normal_hi: float | None = None,
+        direction: int = 1,
+    ) -> None:
+        legacy = z0 is not None or z1 is not None
+        semantic = normal_lo is not None or normal_hi is not None
+        if legacy and semantic:
+            raise ValueError("PadFeature: use z0=/z1= or normal_lo=/normal_hi=, not both")
+        if legacy:
+            if frame.axis != "z":
+                raise ValueError(
+                    "PadFeature: legacy z0=/z1= bounds are valid only for a Z-normal pad; "
+                    "use normal_lo=/normal_hi= for an X/Y pad"
+                )
+            normal_lo, normal_hi = z0, z1
+        if normal_lo is None or normal_hi is None:
+            raise ValueError("PadFeature needs normal_lo=/normal_hi= (or legacy z0=/z1= for Z)")
+        axes = {frame.axis, width_axis, long_axis}
+        if axes != {"x", "y", "z"}:
+            raise ValueError("PadFeature frame/width/long axes must be distinct x/y/z axes")
+        if direction not in (-1, 1):
+            raise ValueError("PadFeature direction must be -1 or 1")
+        if width <= 0 or length <= 0 or not lo < hi or not normal_lo < normal_hi:
+            raise ValueError("PadFeature dimensions and bounds must increase")
+        for name, value in (
+            ("frame", frame),
+            ("width_axis", width_axis),
+            ("long_axis", long_axis),
+            ("width", float(width)),
+            ("length", float(length)),
+            ("w_center", float(w_center)),
+            ("lo", float(lo)),
+            ("hi", float(hi)),
+            ("normal_lo", float(normal_lo)),
+            ("normal_hi", float(normal_hi)),
+            ("direction", direction),
+        ):
+            object.__setattr__(self, name, value)
+
+    def bounds(self, axis: str) -> tuple[float, float]:
+        """Return this occurrence's ascending bounds on one world axis."""
+        if axis == self.long_axis:
+            return self.lo, self.hi
+        if axis == self.width_axis:
+            half = self.width / 2
+            return self.w_center - half, self.w_center + half
+        if axis == self.frame.axis:
+            return self.normal_lo, self.normal_hi
+        raise ValueError(f"unknown pad axis {axis!r}")
+
+    @property
+    def x0(self) -> float:
+        return self.bounds("x")[0]
+
+    @property
+    def x1(self) -> float:
+        return self.bounds("x")[1]
+
+    @property
+    def y0(self) -> float:
+        return self.bounds("y")[0]
+
+    @property
+    def y1(self) -> float:
+        return self.bounds("y")[1]
+
+    @property
+    def z0(self) -> float:
+        return self.bounds("z")[0]
+
+    @property
+    def z1(self) -> float:
+        return self.bounds("z")[1]
+
+    @property
+    def height(self) -> float:
+        return self.normal_hi - self.normal_lo
+
+    def _normal_span(self) -> tuple[Point, Point]:
+        start = list(self.frame.origin)
+        end = list(self.frame.origin)
+        axis_index = "xyz".index(self.frame.axis)
+        start[axis_index] = self.normal_lo if self.direction > 0 else self.normal_hi
+        end[axis_index] = self.normal_hi if self.direction > 0 else self.normal_lo
+        return (tuple(start), tuple(end))  # type: ignore[return-value]
+
     def parameters(self) -> list[DimParameter]:
-        return [
+        parameters = [
             DimParameter("length", "pad_width", self.width),
             DimParameter("length", "pad_length", self.length),
         ]
+        parameters.append(
+            DimParameter("length", "pad_height", self.height, span=self._normal_span())
+        )
+        return parameters
 
     def references(self) -> list[Datum]:
         return []

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -114,6 +114,10 @@ _CONVENTION = {
     # again the table default, entered explicitly per the #744 review rule above.
     ("slot_width", "length"): "linear",
     ("slot_length", "length"): "linear",
+    # A pad height is its terminal-to-attachment rise on every axis.  A Z profile level,
+    # when present, measures datum-to-attachment and therefore cannot replace this local
+    # feature requirement.
+    ("pad_height", "length"): "leader",
     ("pad_width", "length"): "linear",
     ("pad_length", "length"): "linear",
 }
@@ -749,13 +753,13 @@ def location_datum(feature) -> str | None:
         return None
     if isinstance(feature, SlotFeature):
         return "bbox"  # near-end offset along its long axis, in its own view
-    if isinstance(feature, PocketFeature):
+    if isinstance(feature, PocketFeature | PadFeature):
         return "datum_xy"  # every orientation: its two in-plane coordinates
     if isinstance(feature, HoleFeature):
         return "datum_xy" if feature.frame.axis == "z" else "bbox"
-    # Patterns, pocket/slot-patterns and pads: the plan-X / side-Y ladder only, so Z-normal
-    # only. A fall-through, not another `isinstance` + `return None`: membership above is by
-    # exact type, so those four are all that can reach here and the extra arm was
+    # Patterns and pocket/slot-patterns: the plan-X / side-Y ladder only, so Z-normal only.
+    # A fall-through, not another `isinstance` + `return None`: membership above is by exact
+    # type, so those three are all that can reach here and the extra arm was
     # unreachable — dead code that read as defensive and showed up as the one uncovered
     # line in the patch.
     return "datum_xy" if feature.frame.axis == "z" else None

--- a/src/draftwright/recogniser_contract.py
+++ b/src/draftwright/recogniser_contract.py
@@ -99,7 +99,7 @@ _FAMILIES: dict[str, _FamilySpec] = {
         "polygonal_stock",
         "render_polygonal_stock",
     ),
-    "rectangular-pads": _FamilySpec(("RaisedPad",), "_convert_pad", "pad", "render_diameters"),
+    "rectangular-pads": _FamilySpec(("RaisedPad",), "_convert_pad", "pad", "render_slots"),
     "risers": _FamilySpec(
         ("RiserEvidence", "StepShoulder"),
         "build_part_model",
@@ -126,6 +126,7 @@ _FAMILIES: dict[str, _FamilySpec] = {
 _RECORD_SCHEMA_VERSIONS: dict[tuple[str, str], tuple[int, ...]] = {
     ("chamfers", "Chamfer"): (2,),
     ("fillets", "Fillet"): (2,),
+    ("rectangular-pads", "RaisedPad"): (2,),
 }
 
 

--- a/src/draftwright/recognition_cache.py
+++ b/src/draftwright/recognition_cache.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from b123d_recognisers import RecognitionResult, build_recognition_result
+from b123d_recognisers import RecognitionResult, build_raw_recognition_result
 
 
 @dataclass
@@ -22,5 +22,5 @@ class RecognitionCache:
         """Return this drawing's result, recognising *part* only when still empty."""
 
         if self.result is None:
-            self.result = build_recognition_result(part)
+            self.result = build_raw_recognition_result(part)
         return self.result

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -1529,10 +1529,11 @@ class Sheet:
         return _Params(self, len(self._features) - 1)
 
     def pad(self, obj=None, **kw) -> _Params:
-        """Declare a bounded rectangular raised pad (footprint + X/Y location).
+        """Declare a bounded rectangular raised pad (footprint + in-plane location).
 
-        Its Z height is shared with the prismatic level ladder, so it is not
-        independently double-dimensioned.
+        Every pad owns its terminal-to-attachment height; a Z profile level measures a
+        different datum-to-attachment fact and does not replace it. ``axis=`` and
+        ``direction=`` preserve all six signed principal orientations.
         """
         self._features.append(_pad(obj, **kw))
         return _Params(self, len(self._features) - 1)

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -780,11 +780,11 @@ def _feature_line(
             f"at={_pt(f.frame.origin)})"
         )
     if k == "pad":
-        half = f.width / 2
         return (
-            f"sheet.pad(x0={_n(f.lo)}, x1={_n(f.hi)}, "
-            f"y0={_n(f.w_center - half)}, y1={_n(f.w_center + half)}, "
-            f"z0={_n(f.z0)}, z1={_n(f.z1)})"
+            f"sheet.pad(x0={_n(f.x0)}, x1={_n(f.x1)}, "
+            f"y0={_n(f.y0)}, y1={_n(f.y1)}, "
+            f"z0={_n(f.z0)}, z1={_n(f.z1)}, axis={f.frame.axis!r}, "
+            f"direction={f.direction}, at={_pt(f.frame.origin)})"
         )
     if k == "pattern":
         # Defining dims for the furniture (BCD centreline / pitch / grid dims) PLUS the exact

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -780,10 +780,13 @@ def _feature_line(
             f"at={_pt(f.frame.origin)})"
         )
     if k == "pad":
+        x0, x1 = f.bounds("x")
+        y0, y1 = f.bounds("y")
+        z0, z1 = f.bounds("z")
         return (
-            f"sheet.pad(x0={_n(f.x0)}, x1={_n(f.x1)}, "
-            f"y0={_n(f.y0)}, y1={_n(f.y1)}, "
-            f"z0={_n(f.z0)}, z1={_n(f.z1)}, axis={f.frame.axis!r}, "
+            f"sheet.pad(x0={_n(x0)}, x1={_n(x1)}, "
+            f"y0={_n(y0)}, y1={_n(y1)}, "
+            f"z0={_n(z0)}, z1={_n(z1)}, axis={f.frame.axis!r}, "
             f"direction={f.direction}, at={_pt(f.frame.origin)})"
         )
     if k == "pattern":
@@ -1575,10 +1578,13 @@ def _feature_block(
                     show = "" if tolerance.show == "class" else f", show={tolerance.show!r}"
                     line += f".fit({tolerance.code!r}{show})"
 
-            if f.kind == "through_step":
-                # Preserve the EFFECTIVE decoration of each independently addressable leg.
-                # Serialising both as canonical full ids is deliberately lossless even when
-                # the source used one family-wide call: replay compiles to the same two
+            if f.kind in ("through_step", "pad"):
+                # Preserve the EFFECTIVE decoration of each independently addressable
+                # through-step leg / pad extent.  Pad height is a new independent public
+                # parameter; replay must not lose its tolerance merely because all three
+                # extents share the generic ``length`` kind (#1392).
+                # Serialising each as a canonical full id is deliberately lossless even when
+                # the source used one family-wide call: replay compiles to the same effective
                 # tolerances without depending on fluent call order.
                 for parameter in f.parameters():
                     tolerance = (decorations or {}).get(

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -1083,6 +1083,7 @@ class TestTheBoundaryIsLoadBearing:
             "render_grooves",
             "render_height_ladder",
             "render_locations",
+            "render_pad_heights",
             "render_paired_ramp_steps",
             "render_plates",
             "render_pocket_patterns",

--- a/tests/test_declared_recognition_gate.py
+++ b/tests/test_declared_recognition_gate.py
@@ -1,7 +1,7 @@
 """A declared build recognises nothing; critique on that path recognises once (#1022).
 
 ADR 0011 says a caller-supplied ``PartModel`` skips detection, and ADR 0017 §6 restates it for
-the aggregate. Neither held: ``_analyse`` ran ``build_recognition_result`` before it knew
+the aggregate. Neither held: ``_analyse`` ran ``build_raw_recognition_result`` before it knew
 whether a model had been declared, so a declared build recognised the full inventory and threw
 most of it away.
 
@@ -22,7 +22,7 @@ from types import SimpleNamespace
 import pytest
 from b123d_recognisers import (
     RecognitionResult,
-    build_recognition_result,
+    build_raw_recognition_result,
     project_step_shoulders,
     recognise_risers,
     step_level_zs,
@@ -400,7 +400,7 @@ def test_the_critique_rejects_an_assembled_shoulder_inventory():
 
     **What this does NOT establish**, deliberately named rather than implied: the type check
     proves neither provenance nor correspondence with *part*. A caller can still pass
-    ``build_recognition_result(some_other_solid)``, or construct a valid frozen result with
+    ``build_raw_recognition_result(some_other_solid)``, or construct a valid frozen result with
     empty inventories, and this function will use it (Codex #1031 r2). That is true of every
     injected inventory in the engine — `holes=`, `pockets=`, `pads=` — and is the accepted
     cost of ADR 0008 Amdt 5 dependency injection, not something specific to this parameter.
@@ -427,7 +427,9 @@ def test_the_critique_rejects_an_assembled_shoulder_inventory():
 
     # And the real thing still works — the guard rejects impostors, not the parameter.
     assert isinstance(
-        lint_prismatic_coverage(part, [], features=(), recognition=build_recognition_result(part)),
+        lint_prismatic_coverage(
+            part, [], features=(), recognition=build_raw_recognition_result(part)
+        ),
         list,
     )
 
@@ -501,7 +503,7 @@ def test_one_ladder_rule_serves_sizing_and_critique():
     part they coincide and this would assert nothing.
     """
     part = _turned_shaft_with_blind_bore()
-    rec = build_recognition_result(part)
+    rec = build_raw_recognition_result(part)
     bb = part.bounding_box()
 
     ladder = rec.step_ladder_for_z_span(bb.min.Z, bb.max.Z)

--- a/tests/test_external_recognition_boundary.py
+++ b/tests/test_external_recognition_boundary.py
@@ -45,14 +45,16 @@ def test_embedded_implementation_is_gone_and_compatibility_is_identity_preservin
 
 def test_recognition_cache_is_consumer_owned_and_runs_once(monkeypatch) -> None:
     calls = 0
-    original = external.build_recognition_result
+    original = external.build_raw_recognition_result
 
     def counting_build(part):
         nonlocal calls
         calls += 1
         return original(part)
 
-    monkeypatch.setattr("draftwright.recognition_cache.build_recognition_result", counting_build)
+    monkeypatch.setattr(
+        "draftwright.recognition_cache.build_raw_recognition_result", counting_build
+    )
     cache = RecognitionCache()
     part = Box(10, 10, 10)
 

--- a/tests/test_inspection_contract.py
+++ b/tests/test_inspection_contract.py
@@ -26,7 +26,7 @@ def _manifest() -> dict:
 def test_installed_pypi_wheel_satisfies_the_inspection_contract() -> None:
     distribution = importlib.metadata.distribution("b123d-recognisers")
 
-    assert distribution.version == "0.4.6"
+    assert distribution.version == "0.4.8"
     assert distribution.read_text("direct_url.json") is None
     assert Path(inspect.getfile(inspection)).resolve().is_relative_to(ROOT / ".venv")
     validate_inspection_contract()

--- a/tests/test_issue_1058_wheel_profile.py
+++ b/tests/test_issue_1058_wheel_profile.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 
 import pytest
 from b123d_recognisers import (
-    build_recognition_result,
+    build_raw_recognition_result,
     recognise_double_d_bores,
     recognise_repeating_radial_profiles,
 )
@@ -570,7 +570,7 @@ def test_real_wheel_no_longer_gets_a_confident_envelope_only_result(wheel_drawin
 
 def test_synthetic_double_d_profile_is_recognised_without_lint_rescans():
     detected = detect_part_model(_double_d_bore())
-    with counting_calls({"orchestration": build_recognition_result}) as calls:
+    with counting_calls({"orchestration": build_raw_recognition_result}) as calls:
         drawing = build_drawing(_double_d_bore())
         assert tuple(detected.features) == tuple(drawing.model().features)
         assert calls == {"orchestration": 1}
@@ -715,7 +715,7 @@ def test_opposed_blind_recesses_do_not_prove_a_through_bore():
 def test_declared_object_and_explicit_forms_preserve_profile_and_skip_recognition():
     part = Box(30, 30, 10, align=_CENTER)
     cutter = _double_d_cutter()
-    with counting_calls({"orchestration": build_recognition_result}) as calls:
+    with counting_calls({"orchestration": build_raw_recognition_result}) as calls:
         sheet = Sheet(part)
         object_handle = sheet.double_d_bore(cutter)
         explicit_handle = sheet.double_d_bore(
@@ -793,7 +793,7 @@ def test_declared_model_cannot_omit_a_physical_double_d_bore_cleanly():
 
 def test_a_dropped_profile_only_suppresses_the_exact_physical_requirement():
     part = _double_d_bore()
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
     exact = ("double_d", "z", True, 10.0, 7.2, (1.0, 0.0, 0.0))
     wrong_af = ("double_d", "z", True, 10.0, 6.8, (1.0, 0.0, 0.0))
     assert (
@@ -831,7 +831,7 @@ def test_profile_coverage_rejects_unowned_results_and_canonicalises_directions()
         0.0,
     )
 
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
     issues = lint_profiled_bore_coverage(part, [], recognition=recognition, assembly=True)
     assert [issue.severity for issue in issues] == ["info"]
 

--- a/tests/test_issue_1082_polygonal_stock.py
+++ b/tests/test_issue_1082_polygonal_stock.py
@@ -10,7 +10,7 @@ from b123d_recognisers.polygonal_bosses import (
     PolygonalStock,
     recognise_polygonal_stock,
 )
-from b123d_recognisers.result import build_recognition_result
+from b123d_recognisers.result import build_raw_recognition_result
 from build123d import Box, Compound, Cylinder, Polygon, Pos, RegularPolygon, Rot, extrude
 
 from draftwright import build_drawing
@@ -162,7 +162,7 @@ def test_duplicate_stock_ir_correspondence_is_ambiguous_not_first_match_wins():
     )
 
     outcomes = polygonal_stock_outcomes(
-        build_recognition_result(part),
+        build_raw_recognition_result(part),
         (stock, stock),
         drawing.registry,
     )

--- a/tests/test_issue_1143_hole_completeness.py
+++ b/tests/test_issue_1143_hole_completeness.py
@@ -9,7 +9,7 @@ from b123d_recognisers import (
     BoltCircle,
     HoleRecord,
     LinearArray,
-    build_recognition_result,
+    build_raw_recognition_result,
     recognise_hole_patterns,
 )
 from build123d import Align, Box, Compound, Cone, Cylinder, Pos, Rot
@@ -1222,7 +1222,7 @@ def test_default_linear_direction_matches_recogniser_accepted_step_noise(locatio
         for feature in model.features
     )
     recognition = replace(
-        build_recognition_result(part),
+        build_raw_recognition_result(part),
         holes=holes,
         hole_patterns=tuple(patterns),
         countersinks=(),
@@ -2632,7 +2632,7 @@ def test_blind_bolt_circle_tool_center_projects_members_and_center_together():
     base_model = build_drawing(part, auto_dims=False).model()
     drawing = build_drawing(part, model=replace(base_model, features=[declared_pattern]))
     recognition = replace(
-        build_recognition_result(part),
+        build_raw_recognition_result(part),
         holes=holes,
         hole_patterns=(physical_pattern,),
         countersinks=(),
@@ -2661,7 +2661,7 @@ def test_oblique_recognised_hole_cannot_be_certified_by_lossy_principal_axis_ir(
     model = build_part_model(part, holes=(oblique,), patterns=())
     drawing = build_drawing(part, model=model)
     recognition = replace(
-        build_recognition_result(part),
+        build_raw_recognition_result(part),
         holes=(oblique,),
         hole_patterns=(),
         countersinks=(),
@@ -2698,7 +2698,7 @@ def test_distinct_oblique_drilling_axes_remain_distinct_physical_sources():
         ),
     )
     recognition = replace(
-        build_recognition_result(part),
+        build_raw_recognition_result(part),
         holes=holes,
         hole_patterns=(),
         countersinks=(),

--- a/tests/test_issue_1146_scale_completeness.py
+++ b/tests/test_issue_1146_scale_completeness.py
@@ -460,14 +460,14 @@ def test_sheet_fallback_reuses_lazy_physical_recognition(monkeypatch):
 
     sheet = Sheet.from_part(_scale_sensitive_plate(), page="A4", scale=1.0)
     calls = []
-    original = recognition_cache_module.build_recognition_result
+    original = recognition_cache_module.build_raw_recognition_result
 
     def counted(part):
         result = original(part)
         calls.append(result)
         return result
 
-    monkeypatch.setattr(recognition_cache_module, "build_recognition_result", counted)
+    monkeypatch.setattr(recognition_cache_module, "build_raw_recognition_result", counted)
     with pytest.warns(ScaleCompletenessWarning, match="fallback scale 0.5"):
         drawing = sheet.build()
 
@@ -501,7 +501,7 @@ def test_fallback_reuses_geometry_classification_and_recognition(monkeypatch):
 
     calls = {"classify": 0, "recognise": 0}
     original_classify = analysis._classify_geometry
-    original_recognise = analysis.build_recognition_result
+    original_recognise = analysis.build_raw_recognition_result
 
     def counted_classify(*args, **kwargs):
         calls["classify"] += 1
@@ -512,7 +512,7 @@ def test_fallback_reuses_geometry_classification_and_recognition(monkeypatch):
         return original_recognise(*args, **kwargs)
 
     monkeypatch.setattr(analysis, "_classify_geometry", counted_classify)
-    monkeypatch.setattr(analysis, "build_recognition_result", counted_recognise)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted_recognise)
     with pytest.warns(ScaleCompletenessWarning, match="fallback scale 0.5"):
         drawing = build_drawing(_scale_sensitive_plate(), page="A4", scale=1.0, repair=False)
 

--- a/tests/test_issue_1166_cross_pass_feature_leaders.py
+++ b/tests/test_issue_1166_cross_pass_feature_leaders.py
@@ -256,25 +256,14 @@ def test_public_narrow_part_uses_one_cross_pass_inventory(tmp_path):
         )
 
 
-def test_unavoidable_policy_b_crossing_is_persisted_without_opt_in_trace():
+def test_corrected_side_strip_avoids_the_former_policy_b_crossing_without_trace():
     part, model = _narrow_cross_pass_part()
     drawing = build_drawing(part, model=model, page="A4")
 
-    issues = [issue for issue in drawing.lint() if issue.code == "feature_leader_crossing"]
-    assert len(issues) == 1
-    assert all("Policy B" in issue.message for issue in issues)
-    assert any("dim_loc_side_z7550:segment:3" in issue.message for issue in issues)
-    assert all(issue.severity == "info" for issue in issues)
-    assert all(issue.measurement_ids for issue in issues)
-    legibility = drawing.lint_summary()["quality"]["legibility"]
-    # `annotation_ink_overlap` (#1321/#1332) scores on legibility too. Candidate
-    # prevention (#1334) removes the same-batch crossing; the retained Policy-B
-    # cross-stage leader conflict remains visible under both codes.
-    assert legibility["by_code"] == {
-        "feature_leader_crossing": 1,
-        "annotation_ink_overlap": 1,
-    }
-    assert legibility["score"] < 1.0
+    # The side-right strip now begins at the geometry edge and consumes its reserved
+    # band.  The location ladder therefore no longer forces this leader through fixed
+    # ink; the ordinary, unbudgeted solve is clean without opt-in tracing.
+    assert drawing.lint() == []
 
 
 def test_near_clear_witness_is_not_falsely_classified_by_strip_padding():
@@ -1864,8 +1853,12 @@ def test_cross_pass_candidate_budget_precedes_collect_all_geometry(monkeypatch, 
         "m_pocket_yz0",
     }
     issues = drawing.lint()
-    assert {issue.code for issue in issues} == {"feature_leader_crossing"}
-    assert all("Policy B" in issue.message for issue in issues)
+    assert {issue.code for issue in issues} == {
+        "annotation_ink_overlap",
+        "feature_leader_crossing",
+    }
+    crossings = [issue for issue in issues if issue.code == "feature_leader_crossing"]
+    assert all("Policy B" in issue.message for issue in crossings)
 
 
 def test_fixed_obstacle_probe_budget_precedes_joint_geometry(monkeypatch, tmp_path):
@@ -1913,12 +1906,19 @@ def test_fixed_obstacle_probe_budget_precedes_joint_geometry(monkeypatch, tmp_pa
         "m_pocket_yz0",
     }
     issues = drawing.lint()
-    assert {issue.code for issue in issues} == {"feature_leader_fixed_ink_unverified"}
-    assert all("probe budget exhausted" in issue.message for issue in issues)
+    assert {issue.code for issue in issues} == {
+        "annotation_ink_overlap",
+        "feature_leader_fixed_ink_unverified",
+    }
+    unverified = [issue for issue in issues if issue.code == "feature_leader_fixed_ink_unverified"]
+    assert all("probe budget exhausted" in issue.message for issue in unverified)
     legibility = drawing.lint_summary()["quality"]["legibility"]
     assert legibility["score"] < 1.0
-    assert legibility["infos"] == len(issues)
-    assert legibility["by_code"] == {"feature_leader_fixed_ink_unverified": len(issues)}
+    assert legibility["infos"] == len(unverified)
+    assert legibility["by_code"] == {
+        "annotation_ink_overlap": 1,
+        "feature_leader_fixed_ink_unverified": len(unverified),
+    }
 
 
 def test_fixed_probe_product_budget_replays_the_exact_producer_floor(monkeypatch, tmp_path):
@@ -1952,12 +1952,16 @@ def test_fixed_probe_product_budget_replays_the_exact_producer_floor(monkeypatch
     }
     assert all(item["producer_fallback"]["selected"] is not None for item in event["items"])
     selected = [item["producer_fallback"]["selected"] for item in event["items"]]
-    assert selected[0]["fixed_blockers"] == []
+    assert selected[0]["fixed_blockers"] == ["dim_loc_side_z6600:segment:1"]
     assert all(entry["fixed_blockers"] == ["fixed_probe_budget"] for entry in selected[1:])
     issues = drawing.lint()
-    assert len(issues) == 3
-    assert {issue.code for issue in issues} == {"feature_leader_fixed_ink_unverified"}
-    assert all("probe budget exhausted" in issue.message for issue in issues)
+    assert len(issues) == 5
+    assert {issue.code for issue in issues} == {
+        "annotation_ink_overlap",
+        "feature_leader_crossing",
+        "feature_leader_fixed_ink_unverified",
+    }
+    assert sum(issue.code == "feature_leader_fixed_ink_unverified" for issue in issues) == 3
 
 
 @pytest.mark.parametrize("hard_boundary", ("page", "silhouette", "title"))

--- a/tests/test_issue_1202_observed_drawing_consumer.py
+++ b/tests/test_issue_1202_observed_drawing_consumer.py
@@ -59,9 +59,9 @@ def _part():
 
 
 def _recognised(part):
-    from b123d_recognisers import build_recognition_result
+    from b123d_recognisers import build_raw_recognition_result
 
-    return build_recognition_result(part).holes
+    return build_raw_recognition_result(part).holes
 
 
 def _size_callouts(drawing):

--- a/tests/test_issue_1245_passage_disposition.py
+++ b/tests/test_issue_1245_passage_disposition.py
@@ -6,7 +6,7 @@ from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
-from b123d_recognisers import build_recognition_result
+from b123d_recognisers import build_raw_recognition_result
 from b123d_recognisers.profiled_bores import principal_boundary_plane
 from build123d import Box, Ellipse, GeomType, Pos, RegularPolygon, extrude
 
@@ -38,7 +38,7 @@ def _matched_mouth(part, passage):
 
 def test_a_recognised_passage_is_specific_actionable_and_non_info() -> None:
     part = _hex_passage_part()
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
     drawing = build_drawing(part)
 
     assert len(recognition.section_passages) == 1
@@ -58,7 +58,7 @@ def test_a_passage_does_not_hide_an_unrelated_unsupported_inner_profile() -> Non
     through = Pos(-10, 0, 0) * extrude(RegularPolygon(3, 6), amount=12, both=True)
     blind = Pos(10, 0, 2) * extrude(Ellipse(5, 3), amount=4)
     part = Box(40, 40, 10) - through - blind
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
 
     assert len(recognition.section_passages) == 1
     codes = [issue.code for issue in build_drawing(part).lint()]
@@ -80,7 +80,7 @@ def test_a_passage_does_not_hide_an_unrelated_unsupported_inner_profile() -> Non
 )
 def test_passage_profile_correlation_fails_closed(case: str) -> None:
     part = _hex_passage_part()
-    passage = build_recognition_result(part).section_passages[0]
+    passage = build_raw_recognition_result(part).section_passages[0]
     wire, axis, plane_axes, at, tol = _matched_mouth(part, passage)
     candidate = passage
     candidate_wire = wire
@@ -156,7 +156,7 @@ def test_a_passage_is_an_explicit_unsupported_completeness_outcome() -> None:
 
 
 def test_only_the_authoritative_rich_inventory_contributes_a_requirement() -> None:
-    recognition = build_recognition_result(_hex_passage_part())
+    recognition = build_raw_recognition_result(_hex_passage_part())
     assert recognition.section_passages and recognition.passages
     legacy_only = replace(recognition, section_passages=())
 

--- a/tests/test_issue_1246_prismatic_pocket_disposition.py
+++ b/tests/test_issue_1246_prismatic_pocket_disposition.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 
 import pytest
 from b123d_recognisers import (
-    build_recognition_result,
+    build_raw_recognition_result,
     recognise_pockets,
     recognise_prismatic_pockets,
 )
@@ -66,7 +66,7 @@ def _matched_mouth(part, pocket):
 
 def test_a_prismatic_pocket_is_specific_actionable_and_non_info() -> None:
     part = _hexagonal_pocket_part()
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
 
     assert len(recognition.prismatic_pockets) == 1
     assert recognition.pockets == ()
@@ -84,7 +84,7 @@ def test_a_prismatic_pocket_is_specific_actionable_and_non_info() -> None:
 
 def test_a_prismatic_pocket_does_not_hide_an_unrelated_unsupported_profile() -> None:
     part = _hexagonal_pocket_part(ellipse=True)
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
 
     assert len(recognition.prismatic_pockets) == 1
     codes = [issue.code for issue in build_drawing(part).lint()]
@@ -106,7 +106,7 @@ def test_a_prismatic_pocket_does_not_hide_an_unrelated_unsupported_profile() -> 
 )
 def test_prismatic_pocket_profile_correlation_fails_closed(case: str) -> None:
     part = _hexagonal_pocket_part()
-    pocket = build_recognition_result(part).prismatic_pockets[0]
+    pocket = build_raw_recognition_result(part).prismatic_pockets[0]
     wire, axis, plane_axes, at, tol = _matched_mouth(part, pocket)
     candidate = pocket
     candidate_wire = wire
@@ -161,7 +161,7 @@ def test_aggregate_reconciliation_counts_the_rectangular_recess_only_as_pocket()
 
     assert len(recognise_prismatic_pockets(part)) == 2, "direct calls precede reconciliation"
     assert len(recognise_pockets(part)) == 1
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
     assert len(recognition.prismatic_pockets) == 1
     assert len(recognition.pockets) == 1
 
@@ -178,7 +178,7 @@ def test_aggregate_reconciliation_counts_the_rectangular_recess_only_as_pocket()
 def test_a_four_sided_survivor_is_unsupported_not_misclassified_as_non_rectangular() -> None:
     part = Box(80, 80, 20) - Pos(0, 0, 4) * Rot(0, 0, 30) * Box(30, 24, 20)
 
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
     assert recognition.pockets == ()
     assert len(recognition.prismatic_pockets) == 1
     assert recognition.prismatic_pockets[0].sides == 4

--- a/tests/test_issue_1247_angled_step_disposition.py
+++ b/tests/test_issue_1247_angled_step_disposition.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from b123d_recognisers import (
     AngledStep,
-    build_recognition_result,
+    build_raw_recognition_result,
     recognise_angled_steps,
     recognise_chamfers,
 )
@@ -28,7 +28,7 @@ def test_corpus_fixture_pins_angled_step_chamfer_ownership() -> None:
     part = _angled_step_part()
     direct_steps = recognise_angled_steps(part)
     direct_chamfers = recognise_chamfers(part)
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
 
     assert len(part.faces()) == 10
     assert abs(part.volume - 60975.0) < 0.01
@@ -67,7 +67,7 @@ def test_corpus_fixture_pins_angled_step_chamfer_ownership() -> None:
 
 def test_angled_step_is_specific_actionable_and_non_info() -> None:
     part = _angled_step_part()
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
     drawing = build_drawing(part)
 
     assert len(recognition.angled_steps) == 1

--- a/tests/test_issue_1260_view_constraints.py
+++ b/tests/test_issue_1260_view_constraints.py
@@ -7,7 +7,7 @@ import warnings
 from types import SimpleNamespace
 
 import pytest
-from build123d import Box, Compound, Cylinder, Pos
+from build123d import Align, Box, Compound, Cylinder, Pos
 
 import draftwright.builder as builder_mod
 import draftwright.projection as projection_mod
@@ -358,6 +358,35 @@ class TestBuildEffects:
         impossible.view("front").pin((-1000, origin[1]))
         with pytest.raises(ValueError, match="pin.*infeasible.*not relaxed"):
             impossible.build()
+
+    def test_a_pin_translates_the_side_right_strip_with_the_principal_views(self):
+        part = Box(50, 30, 10) - Cylinder(
+            3,
+            60,
+            rotation=(0, 90, 0),
+            align=(Align.CENTER, Align.CENTER, Align.CENTER),
+        )
+
+        def declared(*, pin=None):
+            sheet = Sheet(part, page="A3").authored_dimensions()
+            bore = sheet.hole(diameter=6, at=(0, 0, 0), axis="x").through()
+            sheet.dimension(bore, "bore.diameter")
+            sheet.dimension(bore, "location")
+            front = sheet.view("front")
+            sheet.view("plan")
+            sheet.view("side")
+            if pin is not None:
+                front.pin(pin)
+            return sheet
+
+        baseline = declared().build()
+        origin = baseline.at("front", 0, 0, 0)[:2]
+        target = (origin[0] + 10, origin[1])
+
+        moved = declared(pin=target).build()
+
+        assert moved.at("front", 0, 0, 0)[:2] == pytest.approx(target)
+        assert not [issue for issue in moved.lint() if issue.severity != "info"]
 
     def test_contradictory_and_nonprincipal_pins_are_refused(self):
         baseline_sheet = _sheet()

--- a/tests/test_issue_1369_hole_completeness_evidence.py
+++ b/tests/test_issue_1369_hole_completeness_evidence.py
@@ -136,7 +136,7 @@ def test_a_missing_build_owned_recognition_result_does_not_rescan(monkeypatch) -
     monkeypatch.setattr(
         builder, "build_drawing", lambda *_args, **_kwargs: RecognitionUnavailable()
     )
-    monkeypatch.setattr(b123d_recognisers, "build_recognition_result", forbidden_rescan)
+    monkeypatch.setattr(b123d_recognisers, "build_raw_recognition_result", forbidden_rescan)
 
     assert _default_observers()["holes"](_part()) == ()
     assert provider_calls == []
@@ -151,13 +151,13 @@ def test_deleting_provider_holes_cannot_shrink_the_independent_denominator(monke
     """
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def without_holes(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, holes=(), hole_patterns=())
 
-    monkeypatch.setattr(analysis, "build_recognition_result", without_holes)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_holes)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0

--- a/tests/test_issue_1370_hole_pattern_completeness_evidence.py
+++ b/tests/test_issue_1370_hole_pattern_completeness_evidence.py
@@ -62,12 +62,12 @@ def test_real_pattern_corpus_scores_all_layers_and_topology_variants() -> None:
 
 
 def test_pattern_projection_owns_disjoint_groups_without_recounting_members() -> None:
-    from b123d_recognisers import build_recognition_result
+    from b123d_recognisers import build_raw_recognition_result
     from build123d import import_step
 
     compound = import_step(CORPUS.parent / "pattern-topology-a.step")
     for part, hole_count, pattern_count in ((_grid_part(), 6, 1), (compound, 7, 2)):
-        recognition = build_recognition_result(part)
+        recognition = build_raw_recognition_result(part)
         assert len(recognition.holes) == hole_count
         assert len(recognition.hole_patterns) == pattern_count
         aggregate_holes = {id(hole) for hole in recognition.holes}
@@ -293,13 +293,13 @@ def test_wrong_placed_group_count_ink_loses_drawing_credit(monkeypatch) -> None:
 def test_deleting_provider_patterns_cannot_shrink_the_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def without_patterns(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, hole_patterns=())
 
-    monkeypatch.setattr(analysis, "build_recognition_result", without_patterns)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_patterns)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -311,7 +311,7 @@ def test_deleting_provider_patterns_cannot_shrink_the_independent_denominator(mo
 def test_weakening_provider_arrangement_values_reduces_parameter_fidelity(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def weakened_patterns(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -325,7 +325,7 @@ def test_weakening_provider_arrangement_values_reduces_parameter_fidelity(monkey
                 changed.append(replace(pattern, diameter=pattern.diameter + 1.0))
         return replace(result, hole_patterns=tuple(changed))
 
-    monkeypatch.setattr(analysis, "build_recognition_result", weakened_patterns)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened_patterns)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0

--- a/tests/test_issue_1371_flat_completeness_evidence.py
+++ b/tests/test_issue_1371_flat_completeness_evidence.py
@@ -71,14 +71,14 @@ def test_real_flat_corpus_scores_all_layers_and_topology_variants() -> None:
 
 
 def test_flat_projection_groups_faces_but_not_distinct_stock() -> None:
-    from b123d_recognisers import build_recognition_result
+    from b123d_recognisers import build_raw_recognition_result
 
     fixtures = CORPUS.parent
     double_d = import_step(fixtures / "flat-double-d.step")
     parallel = import_step(fixtures / "flat-topology-a.step")
     coaxial = import_step(fixtures / "flat-coaxial.step")
 
-    assert len(build_recognition_result(double_d).flats) == 2
+    assert len(build_raw_recognition_result(double_d).flats) == 2
     (grouped,) = _default_observers()["flats"](double_d)
     assert grouped.parameters == {
         "across": 15.0,
@@ -107,7 +107,7 @@ def test_every_flat_boundary_is_observed_supported_on_the_real_public_path() -> 
 def test_flat_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
     calls = 0
 
     def counted(*args, **kwargs):
@@ -115,7 +115,7 @@ def test_flat_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", counted)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted)
     assert _default_observers()["flats"](_double_d())
     assert calls == 1
 
@@ -252,13 +252,13 @@ def test_severing_flat_measurement_provenance_loses_drawing_credit(monkeypatch) 
 def test_deleting_provider_flats_cannot_shrink_the_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def without_flats(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, flats=())
 
-    monkeypatch.setattr(analysis, "build_recognition_result", without_flats)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_flats)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -270,14 +270,14 @@ def test_deleting_provider_flats_cannot_shrink_the_independent_denominator(monke
 def test_weakening_provider_across_values_reduces_parameter_fidelity(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def weakened_flats(*args, **kwargs):
         result = original(*args, **kwargs)
         flats = tuple(replace(flat, across=flat.across + 1.0) for flat in result.flats)
         return replace(result, flats=flats)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", weakened_flats)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened_flats)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0

--- a/tests/test_issue_1372_groove_completeness_evidence.py
+++ b/tests/test_issue_1372_groove_completeness_evidence.py
@@ -74,12 +74,12 @@ def test_real_groove_corpus_scores_all_layers_and_boolean_order_variants() -> No
 
 
 def test_narrow_floor_has_one_drafting_owner_despite_raw_family_overlap() -> None:
-    from b123d_recognisers import build_recognition_result
+    from b123d_recognisers import build_raw_recognition_result
 
     from draftwright import build_drawing
 
     part = import_step(CORPUS.parent / "groove-narrow.step")
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
     drawing = build_drawing(part)
     features = drawing.model().features
 
@@ -131,12 +131,12 @@ def test_groove_ledger_tracks_width_and_floor_diameter_and_fails_closed() -> Non
 
 
 def test_groove_ledger_rejects_foreign_results_and_malformed_ir_without_guessing() -> None:
-    from b123d_recognisers import build_recognition_result
+    from b123d_recognisers import build_raw_recognition_result
 
     from draftwright.linting.groove_coverage import groove_requirement_outcomes
     from draftwright.registry import AnnotationRegistry
 
-    recognition = build_recognition_result(_lone())
+    recognition = build_raw_recognition_result(_lone())
     source = recognition.grooves[0]
 
     class MalformedGroove:
@@ -182,7 +182,7 @@ def test_every_groove_boundary_is_observed_supported_on_the_real_public_path() -
 def test_groove_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
     calls = 0
 
     def counted(*args, **kwargs):
@@ -190,7 +190,7 @@ def test_groove_observer_uses_one_build_owned_recognition_aggregate(monkeypatch)
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", counted)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted)
     assert _default_observers()["grooves"](_lone())
     assert calls == 1
 
@@ -488,13 +488,13 @@ def test_incomplete_compiler_group_cannot_certify_groove_ink(monkeypatch) -> Non
 def test_deleting_provider_grooves_cannot_shrink_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def without_grooves(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, grooves=())
 
-    monkeypatch.setattr(analysis, "build_recognition_result", without_grooves)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_grooves)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -507,7 +507,7 @@ def test_deleting_provider_grooves_cannot_shrink_independent_denominator(monkeyp
 def test_weakening_provider_measurements_reduces_parameter_fidelity(monkeypatch, field) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def weakened_grooves(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -516,7 +516,7 @@ def test_weakening_provider_measurements_reduces_parameter_fidelity(monkeypatch,
         )
         return replace(result, grooves=grooves)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", weakened_grooves)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened_grooves)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0
@@ -530,7 +530,7 @@ def test_weakening_provider_measurements_reduces_parameter_fidelity(monkeypatch,
 def test_weakening_provider_identity_reduces_detection_recall(monkeypatch, field) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def weakened_grooves(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -546,7 +546,7 @@ def test_weakening_provider_identity_reduces_detection_recall(monkeypatch, field
             )
         return replace(result, grooves=values)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", weakened_grooves)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened_grooves)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 0.0

--- a/tests/test_issue_1372_pocket_completeness_evidence.py
+++ b/tests/test_issue_1372_pocket_completeness_evidence.py
@@ -73,11 +73,13 @@ def test_real_pocket_corpus_scores_all_layers_and_topology_variants() -> None:
 
 
 def test_overlapping_recess_families_retain_one_physical_owner() -> None:
-    from b123d_recognisers import build_recognition_result
+    from b123d_recognisers import build_raw_recognition_result
 
     fixtures = CORPUS.parent
-    through = build_recognition_result(import_step(fixtures / "pocket-through-negative.step"))
-    polygonal = build_recognition_result(import_step(fixtures / "pocket-prismatic-negative.step"))
+    through = build_raw_recognition_result(import_step(fixtures / "pocket-through-negative.step"))
+    polygonal = build_raw_recognition_result(
+        import_step(fixtures / "pocket-prismatic-negative.step")
+    )
 
     assert through.pockets == ()
     assert len(through.slots) == 1
@@ -135,7 +137,7 @@ def test_edge_anchored_pocket_reports_location_as_intentionally_inapplicable() -
 
 
 def test_pattern_members_are_not_counted_again_as_lone_pockets() -> None:
-    from b123d_recognisers import build_recognition_result
+    from b123d_recognisers import build_raw_recognition_result
 
     from draftwright.builder import build_drawing
     from draftwright.linting.pocket_coverage import pocket_requirement_outcomes
@@ -144,7 +146,7 @@ def test_pattern_members_are_not_counted_again_as_lone_pockets() -> None:
     for y in (-45, -15, 15, 45):
         part -= Pos(0, y, 7) * Box(10, 12, 6)
     drawing = build_drawing(part)
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
 
     assert len(recognition.pockets) == 4
     assert len(recognition.pocket_patterns) == 1
@@ -169,7 +171,7 @@ def test_every_pocket_boundary_is_observed_supported_on_the_real_public_path() -
 def test_pocket_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
     calls = 0
 
     def counted(*args, **kwargs):
@@ -177,7 +179,7 @@ def test_pocket_observer_uses_one_build_owned_recognition_aggregate(monkeypatch)
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", counted)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted)
     assert _default_observers()["pockets"](_lone())
     assert calls == 1
 
@@ -399,13 +401,13 @@ def test_side_opening_authored_location_omission_is_suppressed_not_missing() -> 
 def test_deleting_provider_pockets_cannot_shrink_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def without_pockets(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, pockets=(), pocket_patterns=())
 
-    monkeypatch.setattr(analysis, "build_recognition_result", without_pockets)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_pockets)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -417,14 +419,14 @@ def test_deleting_provider_pockets_cannot_shrink_independent_denominator(monkeyp
 def test_weakening_provider_widths_reduces_parameter_fidelity(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def weakened_pockets(*args, **kwargs):
         result = original(*args, **kwargs)
         pockets = tuple(replace(pocket, width=pocket.width + 1.0) for pocket in result.pockets)
         return replace(result, pockets=pockets)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", weakened_pockets)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened_pockets)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0

--- a/tests/test_issue_1372_pocket_pattern_completeness_evidence.py
+++ b/tests/test_issue_1372_pocket_pattern_completeness_evidence.py
@@ -96,7 +96,7 @@ def test_real_pocket_pattern_corpus_scores_all_layers_and_topology_variants() ->
 
 
 def test_pattern_projection_owns_members_once_and_lone_pockets_stay_disjoint() -> None:
-    from b123d_recognisers import build_recognition_result
+    from b123d_recognisers import build_raw_recognition_result
 
     from draftwright.builder import build_drawing
     from draftwright.linting.pocket_coverage import pocket_requirement_outcomes
@@ -105,7 +105,7 @@ def test_pattern_projection_owns_members_once_and_lone_pockets_stay_disjoint() -
         (_grid_part(), 6, 1),
         (import_step(CORPUS.parent / "pocket-pattern-topology-a.step"), 7, 1),
     ):
-        recognition = build_recognition_result(part)
+        recognition = build_raw_recognition_result(part)
         assert len(recognition.pockets) == pocket_count
         assert len(recognition.pocket_patterns) == pattern_count
         aggregate = {id(pocket) for pocket in recognition.pockets}
@@ -284,7 +284,7 @@ def test_every_pocket_pattern_boundary_is_observed_on_the_real_public_path() -> 
 def test_pocket_pattern_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
     calls = 0
 
     def counted(*args, **kwargs):
@@ -292,7 +292,7 @@ def test_pocket_pattern_observer_uses_one_build_owned_recognition_aggregate(monk
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", counted)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted)
     assert _default_observers()["pocket-patterns"](_grid_part())
     assert calls == 1
 
@@ -823,13 +823,13 @@ def test_pitch_fallback_rejects_unverifiable_real_geometry(
 def test_deleting_provider_patterns_cannot_shrink_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def without_patterns(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, pocket_patterns=())
 
-    monkeypatch.setattr(analysis, "build_recognition_result", without_patterns)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_patterns)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -841,7 +841,7 @@ def test_deleting_provider_patterns_cannot_shrink_independent_denominator(monkey
 def test_weakening_provider_pitch_reduces_parameter_fidelity(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def weakened_patterns(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -853,7 +853,7 @@ def test_weakening_provider_pitch_reduces_parameter_fidelity(monkeypatch) -> Non
                 changed.append(replace(pattern, pitch=pattern.pitch + 1.0))
         return replace(result, pocket_patterns=tuple(changed))
 
-    monkeypatch.setattr(analysis, "build_recognition_result", weakened_patterns)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened_patterns)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0
@@ -866,7 +866,7 @@ def test_weakening_provider_pitch_reduces_parameter_fidelity(monkeypatch) -> Non
 def test_hardcoding_arrangement_orientation_reduces_parameter_fidelity(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def axis_aligned_patterns(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -878,7 +878,7 @@ def test_hardcoding_arrangement_orientation_reduces_parameter_fidelity(monkeypat
                 changed.append(replace(pattern, direction=(0.0, 1.0, 0.0)))
         return replace(result, pocket_patterns=tuple(changed))
 
-    monkeypatch.setattr(analysis, "build_recognition_result", axis_aligned_patterns)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", axis_aligned_patterns)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0

--- a/tests/test_issue_1374_chamfer_completeness_evidence.py
+++ b/tests/test_issue_1374_chamfer_completeness_evidence.py
@@ -105,7 +105,7 @@ def test_public_framed_route_preserves_arbitrarily_rotated_planar_and_turned_bev
 
 def test_angled_step_slant_and_independent_chamfer_have_one_owner_each() -> None:
     from b123d_recognisers import (
-        build_recognition_result,
+        build_raw_recognition_result,
         recognise_angled_steps,
         recognise_chamfers,
     )
@@ -113,7 +113,7 @@ def test_angled_step_slant_and_independent_chamfer_have_one_owner_each() -> None
     part = import_step(CORPUS.parent / "chamfer-overlap.step")
     direct_chamfers = recognise_chamfers(part)
     direct_steps = recognise_angled_steps(part)
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
 
     assert len(direct_chamfers) == 2
     assert len(direct_steps) == 1
@@ -176,12 +176,12 @@ def test_chamfer_ledger_tracks_one_callout_per_physical_bevel_and_fails_closed()
 
 
 def test_chamfer_ledger_rejects_foreign_results_and_malformed_ir_without_guessing() -> None:
-    from b123d_recognisers import build_recognition_result
+    from b123d_recognisers import build_raw_recognition_result
 
     from draftwright.linting.chamfer_coverage import chamfer_requirement_outcomes
     from draftwright.registry import AnnotationRegistry
 
-    recognition = build_recognition_result(_lone())
+    recognition = build_raw_recognition_result(_lone())
     source = recognition.chamfers[0]
 
     class MalformedChamfer:
@@ -283,7 +283,7 @@ def test_every_chamfer_boundary_is_observed_supported_on_the_real_public_path() 
 def test_chamfer_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
     calls = 0
 
     def counted(*args, **kwargs):
@@ -291,7 +291,7 @@ def test_chamfer_observer_uses_one_build_owned_recognition_aggregate(monkeypatch
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", counted)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted)
     assert _default_observers()["chamfers"](_lone())
     assert calls == 1
 
@@ -512,13 +512,13 @@ def test_severing_chamfer_measurement_provenance_loses_drawing_credit(monkeypatc
 def test_deleting_provider_chamfers_cannot_shrink_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def without_chamfers(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, chamfers=())
 
-    monkeypatch.setattr(analysis, "build_recognition_result", without_chamfers)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_chamfers)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -531,7 +531,7 @@ def test_deleting_provider_chamfers_cannot_shrink_independent_denominator(monkey
 def test_weakening_provider_chamfer_parameters_reduces_fidelity(monkeypatch, field) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def weakened(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -540,7 +540,7 @@ def test_weakening_provider_chamfer_parameters_reduces_fidelity(monkeypatch, fie
         )
         return replace(result, chamfers=values)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", weakened)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0

--- a/tests/test_issue_1374_fillet_completeness_evidence.py
+++ b/tests/test_issue_1374_fillet_completeness_evidence.py
@@ -102,7 +102,7 @@ def test_public_framed_route_preserves_arbitrarily_rotated_planar_and_turned_rou
 
 def test_circular_blind_step_curved_wall_has_one_aggregate_owner() -> None:
     from b123d_recognisers import (
-        build_recognition_result,
+        build_raw_recognition_result,
         recognise_circular_blind_steps,
         recognise_fillets,
     )
@@ -110,7 +110,7 @@ def test_circular_blind_step_curved_wall_has_one_aggregate_owner() -> None:
     part = import_step(CORPUS.parent / "fillet-overlap.step")
     direct_fillets = recognise_fillets(part)
     direct_steps = recognise_circular_blind_steps(part)
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
 
     assert len(direct_fillets) == len(direct_steps) == 1
     assert direct_fillets[0].radius == direct_steps[0].radius == 8.0
@@ -159,12 +159,12 @@ def test_fillet_ledger_tracks_one_callout_per_physical_round_and_fails_closed() 
 
 
 def test_fillet_ledger_rejects_foreign_results_and_malformed_ir_without_guessing() -> None:
-    from b123d_recognisers import build_recognition_result
+    from b123d_recognisers import build_raw_recognition_result
 
     from draftwright.linting.fillet_coverage import fillet_requirement_outcomes
     from draftwright.registry import AnnotationRegistry
 
-    recognition = build_recognition_result(_lone())
+    recognition = build_raw_recognition_result(_lone())
     source = recognition.fillets[0]
 
     class MalformedFillet:
@@ -256,7 +256,7 @@ def test_every_fillet_boundary_is_observed_supported_on_the_real_public_path() -
 def test_fillet_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
     calls = 0
 
     def counted(*args, **kwargs):
@@ -264,7 +264,7 @@ def test_fillet_observer_uses_one_build_owned_recognition_aggregate(monkeypatch)
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", counted)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted)
     assert _default_observers()["fillets"](_lone())
     assert calls == 1
 
@@ -483,13 +483,13 @@ def test_severing_fillet_measurement_provenance_loses_drawing_credit(monkeypatch
 def test_deleting_provider_fillets_cannot_shrink_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def without_fillets(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, fillets=())
 
-    monkeypatch.setattr(analysis, "build_recognition_result", without_fillets)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_fillets)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -501,14 +501,14 @@ def test_deleting_provider_fillets_cannot_shrink_independent_denominator(monkeyp
 def test_weakening_provider_fillet_radius_reduces_fidelity(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def weakened(*args, **kwargs):
         result = original(*args, **kwargs)
         values = tuple(replace(item, radius=item.radius + 0.5) for item in result.fillets)
         return replace(result, fillets=values)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", weakened)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0

--- a/tests/test_issue_1382_046_step_inventory.py
+++ b/tests/test_issue_1382_046_step_inventory.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from b123d_recognisers import build_recognition_result
+from b123d_recognisers import build_raw_recognition_result
 from build123d import Box, Compound, Cylinder, Plane, Polygon, Pos, Rot, extrude
 
 from draftwright import build_drawing
@@ -24,7 +24,7 @@ def _circular_blind_step():
 
 def test_circular_blind_step_is_visible_as_two_audited_requirements() -> None:
     part = _circular_blind_step()
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
     assert recognition.circular_blind_steps
 
     completeness = build_drawing(part).lint_summary()["quality"]["completeness"]

--- a/tests/test_issue_1382_circular_blind_step_semantics.py
+++ b/tests/test_issue_1382_circular_blind_step_semantics.py
@@ -9,7 +9,7 @@ from types import SimpleNamespace
 import pytest
 from b123d_recognisers import (
     analyse_cylinders,
-    build_recognition_result,
+    build_raw_recognition_result,
     recognise_fillets,
     recognise_turned_steps,
 )
@@ -147,7 +147,7 @@ def test_detected_build_consumes_aggregate_inventory_without_rescanning() -> Non
 
 
 def test_partial_models_use_the_aggregate_single_owner_decision() -> None:
-    recognition = build_recognition_result(_part())
+    recognition = build_raw_recognition_result(_part())
     assert len(recognition.circular_blind_steps) == 1
     assert recognition.fillets == ()
 
@@ -201,7 +201,7 @@ def test_explicit_fillet_inventory_survives_an_unrelated_circular_step_owner() -
         key=lambda item: item.center().X + item.center().Y,
     )[-1]
     part = Compound([_part(), Pos(80, 0, 0) * fillet(edge, 2)])
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
 
     assert len(recognition.circular_blind_steps) == len(recognition.fillets) == 1
     suppressed = build_part_model(part, fillets=())
@@ -213,13 +213,13 @@ def test_standalone_model_runs_one_aggregate_and_one_cylinder_scan(monkeypatch) 
     import draftwright.model.detect as detect
 
     rotational_flags = []
-    real_build = detect.build_recognition_result
+    real_build = detect.build_raw_recognition_result
 
     def recording_build(*args, **kwargs):
         rotational_flags.append(kwargs["rotational"])
         return real_build(*args, **kwargs)
 
-    monkeypatch.setattr(detect, "build_recognition_result", recording_build)
+    monkeypatch.setattr(detect, "build_raw_recognition_result", recording_build)
     with counting_calls(
         {"turned_steps": recognise_turned_steps, "cylinders": analyse_cylinders}
     ) as counts:
@@ -241,14 +241,14 @@ def test_standalone_model_runs_one_aggregate_and_one_cylinder_scan(monkeypatch) 
     ],
 )
 def test_supplied_malformed_records_fail_at_the_public_model_boundary(malformed) -> None:
-    source = build_recognition_result(_part()).circular_blind_steps[0]
+    source = build_raw_recognition_result(_part()).circular_blind_steps[0]
 
     with pytest.raises(ValueError):
         build_part_model(_part(), circular_blind_steps=(malformed(source),))
 
 
 def test_explicit_declaration_and_generated_line_round_trip_every_fact() -> None:
-    source = build_recognition_result(_part()).circular_blind_steps[0]
+    source = build_raw_recognition_result(_part()).circular_blind_steps[0]
     declared = _declare(source)
     line = _feature_line(declared)
     assert line == (
@@ -305,7 +305,7 @@ def test_generated_line_preserves_sub_millimetre_correspondence_exactly() -> Non
     ],
 )
 def test_declaration_rejects_invalid_sizes_without_numeric_exceptions(bad) -> None:
-    source = build_recognition_result(_part()).circular_blind_steps[0]
+    source = build_raw_recognition_result(_part()).circular_blind_steps[0]
     with pytest.raises(ValueError):
         circular_blind_step(
             axis=source.axis,
@@ -325,7 +325,7 @@ def test_declaration_rejects_invalid_sizes_without_numeric_exceptions(bad) -> No
 
 
 def test_ir_rejects_malformed_or_inconsistent_correspondence() -> None:
-    source = build_recognition_result(_part()).circular_blind_steps[0]
+    source = build_raw_recognition_result(_part()).circular_blind_steps[0]
     valid = _declare(source)
 
     with pytest.raises(ValueError, match="agree with the feature frame"):
@@ -407,7 +407,7 @@ def test_ir_rejects_malformed_or_inconsistent_correspondence() -> None:
 def test_max_finite_geometry_derives_a_finite_exactly_joinable_anchor() -> None:
     radius = float_info.max
     source = replace(
-        build_recognition_result(_part()).circular_blind_steps[0],
+        build_raw_recognition_result(_part()).circular_blind_steps[0],
         radius=radius,
         length=1.7e308 - 8e307,
         centreline=((8e307, 0.0, 0.0), (1.7e308, 0.0, 0.0)),
@@ -428,7 +428,7 @@ def test_max_finite_geometry_derives_a_finite_exactly_joinable_anchor() -> None:
             DimensionId(feature, "circular_step_depth.length"),
         ),
     )
-    recognition = replace(build_recognition_result(_part()), circular_blind_steps=(source,))
+    recognition = replace(build_raw_recognition_result(_part()), circular_blind_steps=(source,))
     assert [
         outcome.state
         for outcome in circular_blind_step_requirement_outcomes(recognition, (feature,), registry)
@@ -436,7 +436,7 @@ def test_max_finite_geometry_derives_a_finite_exactly_joinable_anchor() -> None:
 
 
 def test_declaration_reports_malformed_record_geometry_at_its_boundary() -> None:
-    source = build_recognition_result(_part()).circular_blind_steps[0]
+    source = build_raw_recognition_result(_part()).circular_blind_steps[0]
     with pytest.raises(ValueError, match="centreline must contain"):
         circular_blind_step(
             axis=source.axis,
@@ -645,7 +645,7 @@ def test_authored_partial_sets_do_not_resurrect_omitted_content(
     parameter, tolerance_role, expected, suppressed
 ) -> None:
     part = _part()
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
     source = recognition.circular_blind_steps[0]
     sheet = Sheet(part)
     handle = sheet.circular_blind_step(
@@ -834,7 +834,7 @@ def test_ledger_rejects_wrong_runs_and_malformed_correspondence() -> None:
 
 
 def test_ledger_validates_source_and_ir_schemas_before_crediting_matching_ink() -> None:
-    recognition = build_recognition_result(_part())
+    recognition = build_raw_recognition_result(_part())
     source = recognition.circular_blind_steps[0]
     translated_misaligned = replace(
         source,
@@ -892,7 +892,7 @@ def test_ledger_validates_source_and_ir_schemas_before_crediting_matching_ink() 
 
 
 def test_ledger_validates_ir_frame_before_crediting_matching_source() -> None:
-    recognition = build_recognition_result(_part())
+    recognition = build_raw_recognition_result(_part())
     source = recognition.circular_blind_steps[0]
     feature = _declare(source)
     malformed_frames = (
@@ -916,7 +916,7 @@ def test_ledger_validates_ir_frame_before_crediting_matching_source() -> None:
 
 
 def test_ledger_does_not_round_distinct_valid_occurrences_into_one_identity() -> None:
-    recognition = build_recognition_result(_part())
+    recognition = build_raw_recognition_result(_part())
     source = recognition.circular_blind_steps[0]
     shifted_centreline = tuple(
         (point[0] + 0.0004, point[1], point[2]) for point in source.centreline

--- a/tests/test_issue_1382_paired_ramp_semantics.py
+++ b/tests/test_issue_1382_paired_ramp_semantics.py
@@ -6,7 +6,7 @@ from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
-from b123d_recognisers import build_recognition_result
+from b123d_recognisers import build_raw_recognition_result
 from build123d import Box, Compound, Plane, Polygon, Pos, Rot, extrude
 
 from draftwright import Sheet, build_drawing
@@ -234,7 +234,7 @@ def test_authored_partial_sets_and_tolerances_do_not_resurrect_omitted_content(
     parameter, tolerance_role, expected, suppressed
 ) -> None:
     part = _paired_ramp_part()
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
     source = recognition.paired_ramp_steps[0]
     sheet = Sheet(part)
     handle = sheet.paired_ramp_step(

--- a/tests/test_issue_1382_through_step_semantics.py
+++ b/tests/test_issue_1382_through_step_semantics.py
@@ -6,8 +6,16 @@ from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
-from b123d_recognisers import BossRecord, PolygonalStock, TurnedProfile, build_recognition_result
+from b123d_recognisers import (
+    BossRecord,
+    PolygonalStock,
+    TurnedProfile,
+    build_raw_recognition_result,
+)
 from b123d_recognisers import Plate as RecognisedPlate
+from b123d_recognisers import (
+    Pocket as RecognisedPocket,
+)
 from build123d import Align, Box, Compound, Pos, Rot
 
 from draftwright import Sheet, build_drawing
@@ -297,7 +305,7 @@ def test_mixed_legacy_and_aggregate_ownership_reaches_a_fixed_point() -> None:
 
 def test_fixed_point_reprojects_shoulders_after_an_owned_level_disappears() -> None:
     part = Rot(90, 0, 0) * _through_step_part()
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
     source = recognition.through_steps[0]
     aggregate_owned = replace(
         source,
@@ -351,7 +359,7 @@ def test_standalone_model_emits_the_legacy_owner_that_preempts_the_aggregate() -
 
 def test_only_emittable_plates_may_preempt_the_aggregate_owner() -> None:
     part = Rot(90, 0, 0) * _through_step_part()
-    source = build_recognition_result(part).through_steps[0]
+    source = build_raw_recognition_result(part).through_steps[0]
     model = build_part_model(
         part,
         through_steps=(source,),
@@ -372,7 +380,7 @@ def test_only_emittable_plates_may_preempt_the_aggregate_owner() -> None:
     assert len(tuple(compile_dimensions(model).of_kind("through_step"))) == 1
 
 
-def test_edge_pocket_floor_cannot_preempt_then_erase_the_aggregate_owner() -> None:
+def test_048_edge_open_pocket_orientation_keeps_a_complete_legacy_owner() -> None:
     base = Rot(90, 0, 0) * _through_step_part()
     edge_pocket = Pos(-20, -10, 0) * Box(
         8,
@@ -381,7 +389,7 @@ def test_edge_pocket_floor_cannot_preempt_then_erase_the_aggregate_owner() -> No
         align=(Align.MIN, Align.MIN, Align.MIN),
     )
     part = base - edge_pocket
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
     drawing = build_drawing(part)
     outcomes = through_step_requirement_outcomes(
         recognition,
@@ -390,6 +398,63 @@ def test_edge_pocket_floor_cannot_preempt_then_erase_the_aggregate_owner() -> No
     )
 
     assert len(recognition.through_steps) == 1
+    assert [(p.depth_axis, p.open_sign) for p in recognition.pockets] == [("y", -1)]
+    assert [feature.kind for feature in drawing.model().features].count("through_step") == 0
+    assert [outcome.state for outcome in outcomes] == ["inapplicable", "inapplicable"]
+    assert not [issue for issue in drawing.lint() if "through_step" in issue.code]
+
+
+def test_edge_pocket_floor_cannot_preempt_then_erase_the_aggregate_owner() -> None:
+    """Keep the ownership fixed-point guard after 0.4.8 corrected this fixture's direct axis.
+
+    The provider now truthfully reads the shallow edge opening above as Y-normal, so it no
+    longer supplies the Z floor needed to exercise this consumer boundary. Inject the exact
+    public Pocket condition instead: Draftwright must promote the aggregate ThroughStep before
+    filtering that floor from the final StepLevelFeature, never end with neither owner.
+    """
+    base = Rot(90, 0, 0) * _through_step_part()
+    edge_pocket = Pos(-20, -10, 0) * Box(
+        8,
+        6,
+        15,
+        align=(Align.MIN, Align.MIN, Align.MIN),
+    )
+    part = base - edge_pocket
+    recognition = build_raw_recognition_result(part)
+    source_pocket = recognition.pockets[0]
+    z_floor_owner = RecognisedPocket(
+        width_axis="y",
+        long_axis="x",
+        width=6,
+        length=8,
+        depth=15,
+        w_center=-7,
+        lo=-20,
+        hi=-12,
+        d_lo=0,
+        d_hi=15,
+        open_sign=1,
+        edge_anchored=True,
+        body_key=source_pocket.body_key,
+    )
+    model = build_part_model(
+        part,
+        through_steps=recognition.through_steps,
+        step_zs=tuple(level.z for level in recognition.step_levels),
+        face_levels=recognition.step_levels,
+        risers=recognition.risers,
+        plates=recognition.plates,
+        pockets=(z_floor_owner,),
+        prof=None,
+        rotational=None,
+    )
+    drawing = build_drawing(part, model=model)
+    outcomes = through_step_requirement_outcomes(
+        recognition,
+        drawing.model().features,
+        drawing.registry,
+    )
+
     assert [feature.kind for feature in drawing.model().features].count("through_step") == 1
     assert [outcome.state for outcome in outcomes] == ["placed", "placed"]
     assert not [issue for issue in drawing.lint() if "through_step" in issue.code]
@@ -397,7 +462,7 @@ def test_edge_pocket_floor_cannot_preempt_then_erase_the_aggregate_owner() -> No
 
 def test_base_plate_filter_cannot_erase_the_only_transverse_shoulder_owner() -> None:
     part = Rot(90, 0, 0) * _through_step_part()
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
     model = build_part_model(
         part,
         through_steps=recognition.through_steps,
@@ -425,7 +490,7 @@ def test_base_plate_filter_cannot_erase_the_only_transverse_shoulder_owner() -> 
 
 def test_injected_turned_classification_cannot_hide_a_supplied_aggregate() -> None:
     part = Rot(90, 0, 0) * _through_step_part()
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
     model = build_part_model(
         part,
         through_steps=recognition.through_steps,
@@ -446,7 +511,7 @@ def test_injected_turned_classification_cannot_hide_a_supplied_aggregate() -> No
 @pytest.mark.parametrize("suppressor", ["round-boss", "polygonal-stock"])
 def test_complement_owner_requires_an_emitted_envelope(suppressor) -> None:
     part = Rot(90, 0, 0) * (Box(20, 30, 20) - Pos(7.5, 10, 0) * Box(10, 20, 30))
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
     kwargs = {
         "bosses": (),
         "polygonal_stock": (),
@@ -488,7 +553,7 @@ def test_complement_owner_requires_an_emitted_envelope(suppressor) -> None:
 
 def test_direct_min_datum_owners_do_not_require_an_envelope() -> None:
     part = Rot(90, 0, 0) * (Box(20, 30, 20) - Pos(7.5, 10, 0) * Box(10, 20, 30))
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
     direct_source = replace(
         recognition.through_steps[0],
         at=(-6.25, 0, -7.5),
@@ -1013,7 +1078,7 @@ def test_detail_redraw_drops_are_not_counted_again_as_a_request_failure(monkeypa
     ],
 )
 def test_explicit_declaration_can_choose_local_leg_grammar_on_every_axis(part, axis, view) -> None:
-    source = build_recognition_result(part).through_steps[0]
+    source = build_raw_recognition_result(part).through_steps[0]
     sheet = Sheet(part).authored_dimensions()
     handle = sheet.through_step(
         axis=source.axis,
@@ -1068,7 +1133,7 @@ def test_compound_preserves_body_ownership_and_four_independent_requirements() -
 
 def test_authored_dimension_set_can_select_and_tolerance_one_leg_without_resurrection() -> None:
     part = _through_step_part()
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
     source = recognition.through_steps[0]
     sheet = Sheet(part)
     handle = sheet.through_step(
@@ -1131,7 +1196,7 @@ def test_compiled_boundary_cannot_reconstruct_a_suppressed_unequal_leg() -> None
 
 def _declared_through_step_sheet():
     part = _through_step_part()
-    source = build_recognition_result(part).through_steps[0]
+    source = build_raw_recognition_result(part).through_steps[0]
     sheet = Sheet(part).authored_dimensions()
     handle = sheet.through_step(
         axis=source.axis,

--- a/tests/test_issue_1392_recognisers_048.py
+++ b/tests/test_issue_1392_recognisers_048.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from dataclasses import asdict, fields, replace
 from pathlib import Path
 
 import pytest
@@ -24,7 +25,8 @@ from build123d import (
     extrude,
 )
 
-from draftwright import Drawing, build_drawing
+import draftwright.analysis as analysis_mod
+from draftwright import Drawing, Sheet, build_drawing
 from draftwright.model import Frame, PadFeature, PartModel, ViewPlanIncomplete
 from draftwright.model import pad as declare_pad
 from draftwright.model.planner import plan_dimensions
@@ -68,6 +70,26 @@ def test_all_signed_pad_records_reach_complete_solver_owned_drawings(axis, direc
         (record.y0, record.y1),
         (record.z0, record.z1),
     )
+    expected_axes = {"x": ("y", "z"), "y": ("z", "x"), "z": ("x", "y")}
+    assert (pad.long_axis, pad.width_axis) == expected_axes[axis]
+    record_bounds = {
+        "x": (record.x0, record.x1),
+        "y": (record.y0, record.y1),
+        "z": (record.z0, record.z1),
+    }
+    parameters = {parameter.parameter_id: parameter for parameter in pad.parameters()}
+    assert parameters["pad_length.length"].value == pytest.approx(
+        record_bounds[pad.long_axis][1] - record_bounds[pad.long_axis][0]
+    )
+    assert parameters["pad_width.length"].value == pytest.approx(
+        record_bounds[pad.width_axis][1] - record_bounds[pad.width_axis][0]
+    )
+    attachment = list(pad.frame.origin)
+    terminal = list(pad.frame.origin)
+    normal_index = "xyz".index(axis)
+    attachment[normal_index] = record_bounds[axis][0 if direction > 0 else 1]
+    terminal[normal_index] = record_bounds[axis][1 if direction > 0 else 0]
+    assert parameters["pad_height.length"].span == (tuple(attachment), tuple(terminal))
     assert plan_dimensions(drawing.model())[0].view == _END_ON[axis]
 
     expected = {"pad_width.length", "pad_length.length", "pad_height.length"}
@@ -191,15 +213,261 @@ def test_side_pad_height_and_footprint_require_the_end_on_view():
     } <= uncovered
 
 
-def test_pad_ir_keeps_the_legacy_z_constructor_but_refuses_ambiguous_side_bounds():
+def test_x_pad_compose_reserves_both_end_on_dimension_bands():
+    """Scale selection must account for the side view's outward right corridor."""
+    part = _box((10, 20, 20), (0, 0, 0)) + _box((5, 9, 9), (10, 4, 4))
+
+    drawing = build_drawing(part)
+    pad = next(feature for feature in drawing.model().features if feature.kind == "pad")
+    placed = {
+        key["parameter_id"]
+        for name in drawing.annotations_of(pad)
+        for key in drawing.measurement_keys(name)
+    }
+
+    assert {
+        "pad_width.length",
+        "pad_length.length",
+        "pad_height.length",
+        "location_pad.y",
+        "location_pad.z",
+    } <= placed
+    assert not [issue for issue in drawing.lint() if issue.severity in {"warning", "error"}]
+
+
+def test_x_pad_side_strip_consumes_its_reserved_band_at_scale_two():
+    """The side strip starts at geometry, not beyond its reserved outer footprint."""
+    part = _box((10, 12, 12), (0, 0, 0)) + _box((5, 5.4, 5.4), (10, 2.4, 2.4))
+
+    drawing = build_drawing(part)
+    pad = next(feature for feature in drawing.model().features if feature.kind == "pad")
+    placed = {
+        key["parameter_id"]
+        for name in drawing.annotations_of(pad)
+        for key in drawing.measurement_keys(name)
+    }
+
+    assert drawing.scale == 2
+    assert {
+        "pad_width.length",
+        "pad_length.length",
+        "pad_height.length",
+        "location_pad.y",
+        "location_pad.z",
+    } <= placed
+    assert not [issue for issue in drawing.lint() if issue.severity in {"warning", "error"}]
+
+
+def test_x_pad_height_leader_stays_out_of_adjacent_front_view_ink():
+    """A side-view HIGH label must not enter the front/side annotation corridor."""
+    part = _box((10, 60, 16), (0, 0, 0)) + _box((5, 27, 7.2), (10, 12, 3.2))
+
+    drawing = build_drawing(part)
+
+    assert not [issue for issue in drawing.lint() if issue.severity in {"warning", "error"}]
+
+
+def test_mixed_x_and_opposed_z_pads_keep_their_own_location_ordinates():
+    """An off-axis pad cannot become the datum source for the Z-pad location ladder."""
+    part = (
+        _box((40, 40, 20), (0, 0, 0))
+        + _box((5, 10, 8), (40, 5, 5))
+        + _box((10, 8, 5), (20, 25, -5))
+        + _box((10, 8, 5), (20, 25, 20))
+    )
+
+    drawing = build_drawing(part)
+    locations = {
+        drawing.view_of(name): (annotation.label, drawing.measurement_keys(name))
+        for name, annotation in drawing.iter_annotations()
+        if name.startswith("m_loc")
+    }
+
+    assert {view: label for view, (label, _keys) in locations.items()} == {
+        "plan": "25",
+        "side": "29",
+    }
+    for _label, keys in locations.values():
+        assert len(keys) == 2
+        assert {key["parameter_id"] for key in keys} == {"location_pad.location"}
+        assert all("/z[" in key["feature"] for key in keys)
+    assert not [issue for issue in drawing.lint() if issue.severity in {"warning", "error"}]
+
+
+def test_x_pad_footprint_and_location_candidates_join_the_shared_corridor(monkeypatch):
+    import draftwright.annotations.from_model as renderer
+
+    registered = set()
+    real_register = renderer.register_corridor
+
+    def recording_register(ctx, key, strip, view, axis, tier, candidate):
+        if getattr(candidate.feature, "kind", None) == "pad":
+            registered.add((candidate.name, key))
+        return real_register(ctx, key, strip, view, axis, tier, candidate)
+
+    monkeypatch.setattr(renderer, "register_corridor", recording_register)
+    build_drawing(_signed_pad("x", 1))
+
+    assert {
+        ("m_pad0_length", ("side", "above")),
+        ("m_pad0_width", ("side", "right")),
+        ("m_pad0_pos_long", ("side", "above")),
+        ("m_pad0_pos_width", ("side", "right")),
+    } <= registered
+
+
+@pytest.mark.parametrize("axis", ["x", "y", "z"])
+@pytest.mark.parametrize("direction", [-1, 1])
+def test_authored_pad_height_does_not_require_suppressed_footprint_measurements(axis, direction):
+    part = _signed_pad(axis, direction)
+    automatic = build_drawing(part)
+    source_pad = next(feature for feature in automatic.model().features if feature.kind == "pad")
+    x0, x1 = source_pad.bounds("x")
+    y0, y1 = source_pad.bounds("y")
+    z0, z1 = source_pad.bounds("z")
+    sheet = Sheet(part).authored_dimensions()
+    handle = sheet.pad(
+        x0=x0,
+        x1=x1,
+        y0=y0,
+        y1=y1,
+        z0=z0,
+        z1=z1,
+        axis=axis,
+        direction=direction,
+        at=source_pad.frame.origin,
+    )
+    handle.tolerance(0.1, on="pad_height")
+    sheet.dimension(handle, "pad_height.length")
+
+    drawing = sheet.build()
+    pad = next(feature for feature in drawing.model().features if feature.kind == "pad")
+    height_names = [
+        name
+        for name in drawing.annotations_of(pad)
+        if "pad_height.length" in {key["parameter_id"] for key in drawing.measurement_keys(name)}
+    ]
+
+    assert len(height_names) == 1
+    assert drawing.get_annotation(height_names[0]).label == "5 ±0.1 HIGH"
+
+    source = emit_sheet_script(drawing.model(), "part", "out", title="PAD", number="1392")
+    marker = "\ndrawing = sheet.build()"
+    namespace = {"part": part}
+    exec(source[: source.index(marker)] + "\nrebuilt = sheet.build()\n", namespace)  # noqa: S102
+    rebuilt: Drawing = namespace["rebuilt"]
+    rebuilt_pad = next(feature for feature in rebuilt.model().features if feature.kind == "pad")
+    rebuilt_height = next(
+        name
+        for name in rebuilt.annotations_of(rebuilt_pad)
+        if "pad_height.length" in {key["parameter_id"] for key in rebuilt.measurement_keys(name)}
+    )
+    assert rebuilt.get_annotation(rebuilt_height).label == "5 ±0.1 HIGH"
+
+
+def test_authored_pad_height_does_not_reserve_suppressed_side_pad_bands(monkeypatch):
+    """Suppressed footprint/location marks cannot reduce the selected drawing scale."""
+    measured_side_strips = []
+    real_measure = analysis_mod._measure_strips
+
+    def record_measure(*args, **kwargs):
+        strips = real_measure(*args, **kwargs)
+        measured_side_strips.append((strips.sv_top, strips.sv_right))
+        return strips
+
+    monkeypatch.setattr(analysis_mod, "_measure_strips", record_measure)
+    part = _box((20, 20, 22), (0, 0, 0)) + _box((5, 6, 6), (20, 7, 8))
+    sheet = Sheet(part, page="A4").authored_dimensions()
+    pad = sheet.pad(
+        x0=20,
+        x1=25,
+        y0=7,
+        y1=13,
+        z0=8,
+        z1=14,
+        axis="x",
+        at=(22.5, 10, 11),
+    )
+    sheet.dimension(pad, "pad_height.length")
+
+    drawing = sheet.build()
+    drawn_pad = next(feature for feature in drawing.model().features if feature.kind == "pad")
+    parameter_ids = {
+        key["parameter_id"]
+        for name in drawing.annotations_of(drawn_pad)
+        for key in drawing.measurement_keys(name)
+    }
+
+    assert drawing.scale == 2
+    assert measured_side_strips
+    assert set(measured_side_strips) == {(0.0, 0.0)}
+    assert parameter_ids == {"pad_height.length"}
+    assert {issue.code for issue in drawing.lint() if issue.severity in {"warning", "error"}} == {
+        "pad_footprint_not_defined"
+    }
+
+
+def test_generated_sheet_preserves_each_independent_pad_tolerance():
+    part = _signed_pad("z", 1)
+    sheet = Sheet(part).authored_dimensions()
+    handle = sheet.pad(x0=5, x1=20, y0=8, y1=18, z0=10, z1=15)
+    for parameter, tolerance in (
+        ("pad_width.length", 0.1),
+        ("pad_length.length", 0.2),
+        ("pad_height.length", 0.3),
+    ):
+        handle.tolerance(tolerance, on=parameter)
+        sheet.dimension(handle, parameter)
+    direct = sheet.build()
+
+    source = emit_sheet_script(direct.model(), "part", "out", title="PAD", number="1392")
+    for parameter in ("pad_width.length", "pad_length.length", "pad_height.length"):
+        assert f"on={parameter!r}" in source
+    marker = "\ndrawing = sheet.build()"
+    namespace = {"part": part}
+    exec(source[: source.index(marker)] + "\nrebuilt = sheet.build()\n", namespace)  # noqa: S102
+    rebuilt: Drawing = namespace["rebuilt"]
+
+    direct_pad = next(feature for feature in direct.model().features if feature.kind == "pad")
+    rebuilt_pad = next(feature for feature in rebuilt.model().features if feature.kind == "pad")
+
+    def labels(drawing, pad):
+        return sorted(
+            (key["parameter_id"], drawing.get_annotation(name).label)
+            for name in drawing.annotations_of(pad)
+            for key in drawing.measurement_keys(name)
+            if key["parameter_id"].startswith("pad_")
+        )
+
+    assert labels(rebuilt, rebuilt_pad) == labels(direct, direct_pad)
+
+
+def test_pad_ir_preserves_legacy_dataclass_fields_serialisation_and_replace():
     legacy = PadFeature(Frame((0, 0, 2.5), "z"), "y", "x", 8, 20, 0, -10, 10, 0, 5)
     assert (legacy.normal_lo, legacy.normal_hi, legacy.z0, legacy.z1) == (0, 5, 0, 5)
+    assert [field.name for field in fields(PadFeature)] == [
+        "frame",
+        "width_axis",
+        "long_axis",
+        "width",
+        "length",
+        "w_center",
+        "lo",
+        "hi",
+        "z0",
+        "z1",
+        "direction",
+    ]
+    payload = asdict(legacy)
+    assert payload["z0"] == 0 and payload["z1"] == 5
+    assert "normal_lo" not in payload and "normal_hi" not in payload
+    assert replace(legacy, z0=-1, z1=6).height == 7
 
-    with pytest.raises(ValueError, match="legacy z0=/z1="):
-        PadFeature(Frame((2.5, 0, 0), "x"), "z", "y", 8, 20, 0, -10, 10, 0, 5)
+    side = PadFeature(Frame((2.5, 0, 0), "x"), "z", "y", 8, 20, 0, -10, 10, 0, 5)
+    assert side.normal_lo == 0 and side.normal_hi == 5
 
 
-def test_pad_ir_and_declaration_reject_ambiguous_or_invalid_signed_bounds():
+def test_pad_ir_and_declaration_reject_invalid_signed_bounds():
     base = dict(
         frame=Frame((0, 0, 2.5), "z"),
         width_axis="y",
@@ -210,18 +478,29 @@ def test_pad_ir_and_declaration_reject_ambiguous_or_invalid_signed_bounds():
         lo=-10,
         hi=10,
     )
-    with pytest.raises(ValueError, match="not both"):
-        PadFeature(**base, z0=0, z1=5, normal_lo=0, normal_hi=5)
-    with pytest.raises(ValueError, match="needs normal_lo"):
+    with pytest.raises(TypeError, match="z0"):
         PadFeature(**base)
     with pytest.raises(ValueError, match="distinct"):
-        PadFeature(**(base | {"width_axis": "x"}), normal_lo=0, normal_hi=5)
+        PadFeature(**(base | {"width_axis": "x"}), z0=0, z1=5)
     with pytest.raises(ValueError, match="direction"):
-        PadFeature(**base, normal_lo=0, normal_hi=5, direction=0)
+        PadFeature(**base, z0=0, z1=5, direction=0)
+    with pytest.raises(ValueError, match="direction"):
+        PadFeature(**base, z0=0, z1=5, direction=True)
     with pytest.raises(ValueError, match="must increase"):
-        PadFeature(**(base | {"width": 0}), normal_lo=0, normal_hi=5)
+        PadFeature(**(base | {"width": 0}), z0=0, z1=5)
+    for field, value in (
+        ("width", math.nan),
+        ("length", math.inf),
+        ("w_center", -math.inf),
+        ("lo", -math.inf),
+        ("hi", math.inf),
+        ("z0", -math.inf),
+        ("z1", math.inf),
+    ):
+        with pytest.raises(ValueError, match="finite"):
+            PadFeature(**(base | {"z0": 0, "z1": 5, field: value}))
 
-    valid = PadFeature(**base, normal_lo=0, normal_hi=5)
+    valid = PadFeature(**base, z0=0, z1=5)
     with pytest.raises(ValueError, match="unknown pad axis"):
         valid.bounds("q")
     with pytest.raises(ValueError, match="direction"):

--- a/tests/test_issue_1392_recognisers_048.py
+++ b/tests/test_issue_1392_recognisers_048.py
@@ -1,0 +1,304 @@
+"""Consumer evidence for the b123d-recognisers 0.4.8 adoption (#1392)."""
+
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+from b123d_recognisers import (
+    FramedRecognitionResult,
+    build_framed_recognition_result,
+    recognise_plates,
+    recognise_polygonal_bosses,
+    recognise_rectangular_pads,
+)
+from build123d import (
+    Align,
+    Box,
+    Compound,
+    Location,
+    Pos,
+    RegularPolygon,
+    Rot,
+    extrude,
+)
+
+from draftwright import Drawing, build_drawing
+from draftwright.model import Frame, PadFeature, PartModel, ViewPlanIncomplete
+from draftwright.model import pad as declare_pad
+from draftwright.model.planner import plan_dimensions
+from draftwright.sheet_emit import emit_sheet_script
+
+_END_ON = {"x": "side", "y": "front", "z": "plan"}
+
+
+def _box(size, position):
+    return Box(*size, align=(Align.MIN, Align.MIN, Align.MIN)).moved(Location(position))
+
+
+def _signed_pad(axis: str, direction: int):
+    """One asymmetric pad occurrence with a five-millimetre signed attachment span."""
+    if axis == "z":
+        body_pos = (0, 0, 0 if direction > 0 else 5)
+        pad_pos = (5, 8, 10 if direction > 0 else 0)
+        return _box((40, 30, 10), body_pos) + _box((15, 10, 5), pad_pos)
+    if axis == "x":
+        body_pos = (0 if direction > 0 else 5, 0, 0)
+        pad_pos = (10 if direction > 0 else 0, 8, 5)
+        return _box((10, 30, 40), body_pos) + _box((5, 10, 15), pad_pos)
+    body_pos = (0, 0 if direction > 0 else 5, 0)
+    pad_pos = (5, 10 if direction > 0 else 0, 8)
+    return _box((40, 10, 30), body_pos) + _box((15, 5, 10), pad_pos)
+
+
+@pytest.mark.parametrize("axis", ["x", "y", "z"])
+@pytest.mark.parametrize("direction", [-1, 1])
+def test_all_signed_pad_records_reach_complete_solver_owned_drawings(axis, direction):
+    part = _signed_pad(axis, direction)
+    drawing = build_drawing(part)
+    (record,) = drawing.recognition().pads
+    pad = next(feature for feature in drawing.model().features if isinstance(feature, PadFeature))
+
+    assert (record.axis, record.direction) == (axis, direction)
+    assert (pad.frame.axis, pad.direction) == (axis, direction)
+    assert {pad.frame.axis, pad.long_axis, pad.width_axis} == {"x", "y", "z"}
+    assert tuple(pad.bounds(name) for name in "xyz") == (
+        (record.x0, record.x1),
+        (record.y0, record.y1),
+        (record.z0, record.z1),
+    )
+    assert plan_dimensions(drawing.model())[0].view == _END_ON[axis]
+
+    expected = {"pad_width.length", "pad_length.length", "pad_height.length"}
+    expected_locations = (
+        {"location_pad.location"}
+        if axis == "z"
+        else {f"location_pad.{pad.long_axis}", f"location_pad.{pad.width_axis}"}
+    )
+    placed = {
+        key["parameter_id"]
+        for name in drawing.annotations_of(pad)
+        for key in drawing.measurement_keys(name)
+    }
+    assert expected | expected_locations <= placed
+    assert not [issue for issue in drawing.lint() if issue.severity in {"warning", "error"}]
+
+
+@pytest.mark.parametrize("axis", ["x", "y", "z"])
+@pytest.mark.parametrize("direction", [-1, 1])
+def test_signed_pad_sheet_code_executes_with_exact_ir_and_measurement_parity(axis, direction):
+    part = _signed_pad(axis, direction)
+    direct = build_drawing(part)
+    source = emit_sheet_script(direct.model(), "part", "out", title="PAD", number="1392")
+
+    assert f"axis='{axis}'" in source
+    assert f"direction={direction}" in source
+    marker = "\ndrawing = sheet.build()"
+    assert source.count(marker) == 1
+    namespace = {"part": part}
+    exec(source[: source.index(marker)] + "\nrebuilt = sheet.build()\n", namespace)  # noqa: S102
+    rebuilt: Drawing = namespace["rebuilt"]
+
+    direct_pad = next(feature for feature in direct.model().features if feature.kind == "pad")
+    rebuilt_pad = next(feature for feature in rebuilt.model().features if feature.kind == "pad")
+    assert rebuilt_pad == direct_pad
+
+    def evidence(drawing, pad):
+        return sorted(
+            (drawing.view_of(name), drawing.get_annotation(name).label, key["parameter_id"])
+            for name in drawing.annotations_of(pad)
+            for key in drawing.measurement_keys(name)
+        )
+
+    assert evidence(rebuilt, rebuilt_pad) == evidence(direct, direct_pad)
+
+
+@pytest.mark.parametrize(
+    "parameter",
+    [
+        "pad_width.length",
+        "pad_length.length",
+        "pad_height.length",
+        "location_pad.y",
+        "location_pad.z",
+    ],
+)
+def test_each_missing_side_pad_requirement_has_an_explicit_lint_outcome(parameter):
+    drawing = build_drawing(_signed_pad("x", 1))
+    pad = next(feature for feature in drawing.model().features if feature.kind == "pad")
+    name = next(
+        name
+        for name in drawing.annotations_of(pad)
+        if parameter in {key["parameter_id"] for key in drawing.measurement_keys(name)}
+    )
+
+    drawing.remove(name)
+
+    issues = [issue for issue in drawing.lint() if issue.code == "pad_footprint_not_defined"]
+    assert len(issues) == 1
+    assert "height" in issues[0].message and "in-plane location" in issues[0].message
+
+
+@pytest.mark.parametrize("direction", [-1, 1])
+def test_missing_z_pad_height_has_an_explicit_lint_outcome(direction):
+    drawing = build_drawing(_signed_pad("z", direction))
+    pad = next(feature for feature in drawing.model().features if feature.kind == "pad")
+    name = next(
+        name
+        for name in drawing.annotations_of(pad)
+        if "pad_height.length" in {key["parameter_id"] for key in drawing.measurement_keys(name)}
+    )
+
+    drawing.remove(name)
+
+    issues = [issue for issue in drawing.lint() if issue.code == "pad_footprint_not_defined"]
+    assert len(issues) == 1
+    assert "height" in issues[0].message
+
+
+@pytest.mark.parametrize("view", ["plan", "side"])
+def test_each_missing_z_pad_location_ordinate_has_an_explicit_lint_outcome(view):
+    drawing = build_drawing(_signed_pad("z", 1))
+    pad = next(feature for feature in drawing.model().features if feature.kind == "pad")
+    name = next(
+        name
+        for name in drawing.annotations_of(pad)
+        if drawing.view_of(name) == view
+        and "location_pad.location"
+        in {key["parameter_id"] for key in drawing.measurement_keys(name)}
+    )
+
+    drawing.remove(name)
+
+    issues = [issue for issue in drawing.lint() if issue.code == "pad_footprint_not_defined"]
+    assert len(issues) == 1
+    assert "in-plane location" in issues[0].message
+
+
+def test_side_pad_height_and_footprint_require_the_end_on_view():
+    drawing = build_drawing(_signed_pad("x", 1))
+
+    with pytest.raises(ViewPlanIncomplete) as caught:
+        plan_dimensions(drawing.model(), planned_views=("front", "plan"))
+
+    uncovered = {(item.identity.parameter, item.preferred_view) for item in caught.value.uncovered}
+    assert {
+        ("pad_width.length", "side"),
+        ("pad_length.length", "side"),
+        ("pad_height.length", "side"),
+        ("location_pad.location", "side"),
+    } <= uncovered
+
+
+def test_pad_ir_keeps_the_legacy_z_constructor_but_refuses_ambiguous_side_bounds():
+    legacy = PadFeature(Frame((0, 0, 2.5), "z"), "y", "x", 8, 20, 0, -10, 10, 0, 5)
+    assert (legacy.normal_lo, legacy.normal_hi, legacy.z0, legacy.z1) == (0, 5, 0, 5)
+
+    with pytest.raises(ValueError, match="legacy z0=/z1="):
+        PadFeature(Frame((2.5, 0, 0), "x"), "z", "y", 8, 20, 0, -10, 10, 0, 5)
+
+
+def test_pad_ir_and_declaration_reject_ambiguous_or_invalid_signed_bounds():
+    base = dict(
+        frame=Frame((0, 0, 2.5), "z"),
+        width_axis="y",
+        long_axis="x",
+        width=8,
+        length=20,
+        w_center=0,
+        lo=-10,
+        hi=10,
+    )
+    with pytest.raises(ValueError, match="not both"):
+        PadFeature(**base, z0=0, z1=5, normal_lo=0, normal_hi=5)
+    with pytest.raises(ValueError, match="needs normal_lo"):
+        PadFeature(**base)
+    with pytest.raises(ValueError, match="distinct"):
+        PadFeature(**(base | {"width_axis": "x"}), normal_lo=0, normal_hi=5)
+    with pytest.raises(ValueError, match="direction"):
+        PadFeature(**base, normal_lo=0, normal_hi=5, direction=0)
+    with pytest.raises(ValueError, match="must increase"):
+        PadFeature(**(base | {"width": 0}), normal_lo=0, normal_hi=5)
+
+    valid = PadFeature(**base, normal_lo=0, normal_hi=5)
+    with pytest.raises(ValueError, match="unknown pad axis"):
+        valid.bounds("q")
+    with pytest.raises(ValueError, match="direction"):
+        declare_pad(x0=-10, x1=10, y0=-4, y1=4, z0=0, z1=5, direction=0)
+
+
+def test_a_recognised_pad_missing_from_ir_fails_visible():
+    part = _signed_pad("z", 1)
+    empty = PartModel(bbox=part.bounding_box(), orientation="prismatic", features=[])
+
+    drawing = build_drawing(part, model=empty)
+
+    issues = [issue for issue in drawing.lint() if issue.code == "pad_footprint_not_defined"]
+    assert len(issues) == 1
+    assert issues[0].severity == "warning"
+
+
+def test_0331_framed_pad_records_correspond_to_the_exact_local_working_solid():
+    source = Box(100, 70, 12, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    source += Pos(18, -10, 12) * Box(28, 16, 8, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    moved = Pos(17, -23, 9) * Rot(31, 47, 13) * source
+
+    framed = build_framed_recognition_result(moved, rotational=False)
+
+    assert isinstance(framed, FramedRecognitionResult)
+    assert framed.result.pads == tuple(recognise_rectangular_pads(framed.part))
+    (record,) = framed.result.pads
+    spans = ((record.x0, record.x1), (record.y0, record.y1), (record.z0, record.z1))
+    axial = spans["xyz".index(record.axis)]
+    transverse = [span for index, span in enumerate(spans) if index != "xyz".index(record.axis)]
+    assert axial[1] - axial[0] == pytest.approx(8, abs=1e-3)
+    assert sorted(hi - lo for lo, hi in transverse) == pytest.approx([16, 28], abs=1e-3)
+
+
+def _polygonal_boss():
+    plate = Box(100, 80, 10)
+    prism = Pos(0, 0, 5) * extrude(RegularPolygon(20, 6), 30)
+    return plate + prism
+
+
+def test_0332_framed_polygonal_boss_corresponds_to_the_exact_local_working_solid():
+    moved = Pos(17, -23, 9) * Rot(31, 47, 13) * _polygonal_boss()
+
+    framed = build_framed_recognition_result(moved, rotational=False)
+
+    assert isinstance(framed, FramedRecognitionResult)
+    assert framed.result.polygonal_bosses == tuple(recognise_polygonal_bosses(framed.part))
+    (record,) = framed.result.polygonal_bosses
+    assert record.side_count == 6
+    assert record.across_flats == pytest.approx(20 * math.sqrt(3), abs=1e-3)
+    assert record.height == 30
+
+
+def _bracket():
+    return (Pos(0, 0, 5) * Box(80, 60, 10)) + (Pos(0, 0, 35) * Box(80, 10, 50))
+
+
+def test_0334_framed_plate_occurrences_remain_body_local_on_the_exact_working_solid():
+    nested = Compound(
+        children=[
+            Compound(children=[Pos(-70, 0, 0) * _bracket()]),
+            Compound(children=[Pos(70, 0, 0) * _bracket()]),
+        ]
+    )
+    moved = Pos(17, -23, 9) * Rot(31, 47, 13) * nested
+
+    framed = build_framed_recognition_result(moved, rotational=False)
+
+    assert isinstance(framed, FramedRecognitionResult)
+    assert framed.result.plates == tuple(recognise_plates(framed.part))
+    assert len(framed.result.plates) == 4
+    assert len({(plate.axis, plate.u) for plate in framed.result.plates}) == 4
+
+
+def test_production_names_the_raw_aggregate_boundary_explicitly():
+    source_root = Path(__file__).parents[1] / "src" / "draftwright"
+    sources = "\n".join(path.read_text(encoding="utf-8") for path in source_root.rglob("*.py"))
+
+    assert "build_raw_recognition_result" in sources
+    assert "build_recognition_result" not in sources

--- a/tests/test_issue_740_leader_assignment.py
+++ b/tests/test_issue_740_leader_assignment.py
@@ -19,7 +19,7 @@ from draftwright.layout import _assign_leader_candidates
 from draftwright.model import FilletFeature, Frame, GrooveFeature, PartModel, pocket
 
 
-def test_late_joint_assignment_stays_scoped_to_the_eight_post_drain_adapters():
+def test_late_joint_assignment_stays_scoped_to_the_nine_post_drain_adapters():
     root = Path(__file__).parents[1] / "src" / "draftwright" / "annotations"
 
     def call_sites(filename):
@@ -50,6 +50,7 @@ def test_late_joint_assignment_stays_scoped_to_the_eight_post_drain_adapters():
         ("from_model.py", "render_circular_blind_steps", True),
         ("from_model.py", "render_flats", True),
         ("from_model.py", "render_pockets", True),
+        ("from_model.py", "render_pad_heights", True),
         ("from_model.py", "render_grooves", True),
         ("from_model.py", "render_paired_ramp_steps", True),
         ("from_model.py", "render_boss_diameters", False),

--- a/tests/test_issue_885_prismatic_coverage.py
+++ b/tests/test_issue_885_prismatic_coverage.py
@@ -90,7 +90,7 @@ def test_auto_drawing_defines_pad_footprints_and_pocket_locations():
     assert tuple(detected.features) == tuple(drawing.model().features)
     assert [f.kind for f in drawing.model().features].count("pad") == 4
     names = set(drawing.annotations())
-    assert len({name for name in names if name.startswith("m_pad")}) == 8
+    assert len({name for name in names if name.startswith("m_pad")}) == 12
     assert {"m_locy1", "m_locy3"} <= names  # pocket centres at Y=30 and Y=90
     summary = drawing.lint_summary()
     assert "pad_footprint_not_defined" not in summary["by_code"]

--- a/tests/test_issue_958_cross_solid_recognition.py
+++ b/tests/test_issue_958_cross_solid_recognition.py
@@ -74,12 +74,14 @@ def test_attached_pad_remains_recognised_once():
         name: drawing.get_annotation(name).label
         for name in drawing.annotations()
         if name.startswith("m_pad")
-    } == {"m_pad0_width": "20", "m_pad0_length": "30"}
+    } == {
+        "m_pad0_width": "20",
+        "m_pad0_length": "30",
+        "m_pad_height_z0": "4 HIGH",
+    }
     assert not [name for name in drawing.annotations() if name.startswith("m_slot")]
-    # The pad's own height above the plate is a `step_level` the compiler approves and the
-    # legibility floor discards — 9 mm of page against a 12.4 mm minimum — so this drawing gives
-    # the pad a width and a length and no height. That was invisible until `step_dim_withheld`
-    # (#1216); the assertion was `== []` and the missing dimension was part of what it blessed.
+    # The general datum-to-level rung remains below its legibility floor, but the pad's local
+    # terminal-to-attachment height is now an independent, solver-placed requirement.
     assert [(issue.severity, issue.code) for issue in drawing.lint()] == [
         ("info", "step_dim_withheld")
     ]

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4169,12 +4169,12 @@ class TestPrismaticClassification:
         dwg = build_drawing(part)
         xlocs = {n for n in dwg.annotations() if n.startswith("dim_loc_front_x")}
         assert len(xlocs) == 2, f"both side-drilled holes must be located, got {xlocs}"
-        # The X offsets are the #225 subject and both land. Their two Z-height companions do
-        # not: `off_axis_location_dropped` records that loss at info severity, so #1250 must
-        # keep the automatic drawing from reporting success over it.
+        # The X offsets are the #225 subject and both land. The corrected side-right strip
+        # also admits one Z-height companion; the other still records an info-level
+        # `off_axis_location_dropped`, so #1250 must not report success over that loss.
         issues = dwg.lint()
         assert [i.code for i in issues if i.severity == "error"] == ["plan_incomplete"]
-        assert [i.code for i in issues].count("off_axis_location_dropped") == 2
+        assert [i.code for i in issues].count("off_axis_location_dropped") == 1
 
     @pytest.mark.timeout(60)
     def test_corner_fillets_do_not_make_a_plate_rotational(self):
@@ -4617,13 +4617,13 @@ class TestAutoHoleAnnotations:
         )
         dwg = build_drawing(part)
         assert len([n for n in dwg.annotations() if n.startswith("hc_front")]) == 2
-        # Both callouts and both X offsets land, but the two Z-height companions do not.
-        # Their info-level placement drops are required outcomes, so the #1250 summary keeps
-        # this automatic sheet from claiming a clean verdict while preserving this test's
-        # subject: both front-view callouts fit.
+        # Both callouts and both X offsets land. The corrected side-right strip admits one
+        # Z-height companion; the remaining info-level placement drop is still a required
+        # outcome, so #1250 keeps this sheet from claiming a clean verdict while preserving
+        # this test's subject: both front-view callouts fit.
         issues = dwg.lint()
         assert [i.code for i in issues if i.severity == "error"] == ["plan_incomplete"]
-        assert [i.code for i in issues].count("off_axis_location_dropped") == 2
+        assert [i.code for i in issues].count("off_axis_location_dropped") == 1
 
     @pytest.mark.timeout(60)
     def test_all_distinct_bores_get_callouts(self):

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -9496,7 +9496,11 @@ class TestTurnedDiameters:
         # centreline locates it; generic minimum-edge offsets would redundantly
         # show half the 46 mm envelope in both X and Z (#881).
         assert dwg.view_of("centerline_side") == "side"
-        assert dwg.view_of("centerline_plan") == "plan"
+        # RaisedPad v2 no longer misclassifies two rotated flange lugs as pads. With that
+        # false requirement gone, ADR 0018 omits the redundant plan view and its furniture;
+        # the front profile plus side end view still define the Y-axis stack completely.
+        assert dwg.view_of("centerline_plan") is None
+        assert "plan" not in dwg.views
         assert not any(n.startswith("dim_loc_front_") for n in dwg.annotations())
         assert not any(n.startswith("dim_loc_side_") for n in dwg.annotations())
 
@@ -9761,7 +9765,8 @@ class TestTurnedDiameters:
 
         # ── from #881: the Y-step furniture lands in the right views on the replay ──
         assert replayed.view_of("centerline_side") == "side"
-        assert replayed.view_of("centerline_plan") == "plan"
+        assert replayed.view_of("centerline_plan") is None
+        assert "plan" not in replayed.views
         assert not any(n.startswith(("dim_loc_front_", "dim_loc_side_")) for n in replay)
         assert {replayed.view_of(n) for n in replay if n.startswith("m_steplen")} == {"side"}
 

--- a/tests/test_parameter_id.py
+++ b/tests/test_parameter_id.py
@@ -240,7 +240,11 @@ _SAMPLE_BINDINGS = {
     ),
     "EnvelopeFeature": (("width.length", 80.0), ("height.length", 8.0), ("depth.length", 50.0)),
     "SlotFeature": (("slot_width.length", 8.0), ("slot_length.length", 30.0)),
-    "PadFeature": (("pad_width.length", 8.0), ("pad_length.length", 30.0)),
+    "PadFeature": (
+        ("pad_width.length", 8.0),
+        ("pad_length.length", 30.0),
+        ("pad_height.length", 8.0),
+    ),
     "PocketFeature": (
         ("pocket_width.length", 8.0),
         ("pocket_length.length", 30.0),

--- a/tests/test_part_model.py
+++ b/tests/test_part_model.py
@@ -298,7 +298,7 @@ def test_feature_detection_runs_once_per_build(monkeypatch):
     """ADR 0008 Amendment 5 / #244 — one aggregate inventory per build.
 
     The recogniser package owns its internal family orchestration; Draftwright's contract is
-    the single public ``build_recognition_result`` call whose result every consumer reuses.
+    the single public ``build_raw_recognition_result`` call whose result every consumer reuses.
     """
     from build123d import Cylinder, Pos, Rotation
 
@@ -306,14 +306,14 @@ def test_feature_detection_runs_once_per_build(monkeypatch):
     from draftwright import build_drawing
 
     calls = 0
-    original = amod.build_recognition_result
+    original = amod.build_raw_recognition_result
 
     def wrap(*args, **kwargs):
         nonlocal calls
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(amod, "build_recognition_result", wrap)
+    monkeypatch.setattr(amod, "build_raw_recognition_result", wrap)
 
     # A turned X shaft exercises the detected path, including a repack when required.
     build_drawing(Rotation(0, 90, 0) * (Cylinder(15, 30) + Pos(0, 0, 30) * Cylinder(8, 30)))

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -128,7 +128,7 @@ def test_installed_package_contract_validates_without_a_sibling_checkout() -> No
 def test_rich_passage_contract_has_an_explicit_unsupported_completeness_outcome() -> None:
     """Pin the 0.4 physical record and compatibility projection to one decision."""
 
-    assert INSTALLED_PACKAGE_VERSION == "0.4.6"
+    assert INSTALLED_PACKAGE_VERSION == "0.4.8"
     installed = tuple(int(component) for component in INSTALLED_PACKAGE_VERSION.split("."))
     assert (0, 4, 0) <= installed < (0, 5, 0)
     package = _families(recognition.capability_manifest())
@@ -982,16 +982,17 @@ def test_schema_format_fails_closed() -> None:
         _validate(package=package)
 
 
-def test_only_chamfer_and_fillet_accept_installed_schema_2() -> None:
-    """The pinned package uses schema 2 only for chamfers and fillets."""
+def test_only_reviewed_records_accept_installed_schema_2() -> None:
+    """The pinned package uses schema 2 only for the three reviewed records."""
     declaration = consumer_capability_declaration()
     families = _families(declaration)
     assert families["chamfers"]["record_schemas"] == {"Chamfer": [2]}
     assert families["fillets"]["record_schemas"] == {"Fillet": [2]}
+    assert families["rectangular-pads"]["record_schemas"] == {"RaisedPad": [2]}
     assert all(
         versions == [1]
         for family_id, family in families.items()
-        if family_id not in {"chamfers", "fillets"}
+        if family_id not in {"chamfers", "fillets", "rectangular-pads"}
         for versions in family["record_schemas"].values()
     )
 
@@ -999,6 +1000,7 @@ def test_only_chamfer_and_fillet_accept_installed_schema_2() -> None:
     package_families = _families(package)
     package_families["chamfers"]["records"][0]["schema_version"] = 2
     package_families["fillets"]["records"][0]["schema_version"] = 2
+    package_families["rectangular-pads"]["records"][0]["schema_version"] = 2
     _validate(declaration, package=package)
 
     package_families["chamfers"]["records"][0]["schema_version"] = 3

--- a/tests/test_recognition_manifest.py
+++ b/tests/test_recognition_manifest.py
@@ -22,7 +22,7 @@ import b123d_recognisers.result as result_module
 from b123d_recognisers import (
     RecognitionResult,
     analyse_cylinders,
-    build_recognition_result,
+    build_raw_recognition_result,
     recognise_angled_steps,
     recognise_bosses,
     recognise_chamfers,
@@ -280,7 +280,7 @@ def test_every_public_recogniser_is_migrated_or_deferred_with_a_reason():
     unclassified = families - classified
     assert not unclassified, (
         f"recogniser(s) missing from the ADR 0017 manifest: {sorted(unclassified)}. "
-        "Add each to MIGRATED (and run it in build_recognition_result) or to DEFERRED "
+        "Add each to MIGRATED (and run it in build_raw_recognition_result) or to DEFERRED "
         "with the design constraint that stops it."
     )
     stale = classified - families
@@ -345,12 +345,12 @@ def test_no_deferred_family_is_reachable_from_the_orchestration():
     assert not reachable, (
         f"DEFERRED but imported by the orchestration: {reachable}. "
         "Either migrate the family (move it to MIGRATED and run it in "
-        "build_recognition_result) or stop importing it."
+        "build_raw_recognition_result) or stop importing it."
     )
     # By behaviour as well as by import form: `import chamfers as c; c.recognise_chamfers()`
     # reaches a DEFERRED family without ever making it an attribute of this module.
     with _counting_every_family() as counts:
-        build_recognition_result(_pocketed_plate())
+        build_raw_recognition_result(_pocketed_plate())
     ran = sorted(name for name in DEFERRED if name in counts)
     assert not ran, f"the orchestration called DEFERRED famil(ies): {ran}"
 
@@ -423,7 +423,7 @@ def test_a_gated_family_still_runs_for_the_class_that_consumes_it():
 
 def test_the_migrated_families_are_the_ones_the_orchestration_actually_runs():
     """Guards the manifest against the failure that makes it worthless: a name listed as
-    MIGRATED that ``build_recognition_result`` never calls. Checked by *running* the
+    MIGRATED that ``build_raw_recognition_result`` never calls. Checked by *running* the
     orchestration with each family instrumented, not by reading its source.
 
     Counted by code object rather than by patching ``result_module``'s bindings. The binding
@@ -436,7 +436,7 @@ def test_the_migrated_families_are_the_ones_the_orchestration_actually_runs():
     # is that the ORCHESTRATION invokes each family, which holds for any solid — a family
     # that finds nothing was still asked.
     with recognition_family_calls(MIGRATED) as called:
-        result_module.build_recognition_result(Box(40, 30, 10))
+        result_module.build_raw_recognition_result(Box(40, 30, 10))
 
     assert set(called) == MIGRATED, (
         f"listed as migrated but never called: {sorted(MIGRATED - set(called))}"
@@ -533,7 +533,7 @@ def test_circular_blind_step_owns_the_corner_instead_of_a_second_fillet():
     part = _circular_blind_step()
     direct_fillets = recognise_fillets(part)
     direct_steps = recognise_circular_blind_steps(part)
-    result = build_recognition_result(part)
+    result = build_raw_recognition_result(part)
 
     assert len(direct_fillets) == 1, "fixture no longer exercises the reconciliation loser"
     assert len(direct_steps) == 1, "fixture no longer exercises the new physical owner"
@@ -565,7 +565,7 @@ def test_the_aggregate_carries_what_its_recognisers_returned():
         assert set(expected) == {f.name for f in fields(RecognitionResult)}, (
             "RecognitionResult grew a field with no oracle — add it to _expected_inventory"
         )
-        result = build_recognition_result(part, rotational=rotational)
+        result = build_raw_recognition_result(part, rotational=rotational)
         for field, want in expected.items():
             got = getattr(result, field)
             if field in _RECONCILED_FIELDS:
@@ -625,7 +625,7 @@ def test_an_automatic_build_runs_each_family_exactly_once_and_lint_runs_no_migra
 
     Counted end to end at each recogniser's definition, so it covers every call site rather
     than the one `test_model_construction_does_not_rescan_a_migrated_family` watches. A
-    second `build_recognition_result` anywhere in the pipeline, or a consumer bypassing the
+    second `build_raw_recognition_result` anywhere in the pipeline, or a consumer bypassing the
     aggregate, shows up here.
 
     Two things it does NOT catch, both covered elsewhere. A DEFERRED family newly appearing

--- a/tests/test_recognition_result.py
+++ b/tests/test_recognition_result.py
@@ -5,7 +5,7 @@ from dataclasses import FrozenInstanceError
 import pytest
 from b123d_recognisers import (
     RecognitionResult,
-    build_recognition_result,
+    build_raw_recognition_result,
     recognise_plates,
 )
 from build123d import Align, Axis, Box, Cylinder, Pos, chamfer, fillet
@@ -21,7 +21,7 @@ def _plate_with_holes():
 
 
 def test_recognition_result_is_frozen_and_owns_tuple_inventories():
-    result = build_recognition_result(_plate_with_holes())
+    result = build_raw_recognition_result(_plate_with_holes())
 
     assert isinstance(result, RecognitionResult)
     assert len(result.holes) == 2
@@ -53,8 +53,8 @@ def test_built_drawing_exposes_its_recognition_result_without_private_state(monk
     def forbidden(*args, **kwargs):
         raise AssertionError("Drawing.recognition() re-ran recognition instead of handing back")
 
-    monkeypatch.setattr(result_module, "build_recognition_result", forbidden)
-    monkeypatch.setattr(analysis_module, "build_recognition_result", forbidden)
+    monkeypatch.setattr(result_module, "build_raw_recognition_result", forbidden)
+    monkeypatch.setattr(analysis_module, "build_raw_recognition_result", forbidden)
     assert drawing.recognition() is result
 
 
@@ -137,7 +137,7 @@ def test_injecting_the_aggregate_builds_the_same_model_as_detecting(name, build)
     one that silently stops holding when a recogniser's contract drifts.
     """
     part = build()
-    rec = build_recognition_result(part)
+    rec = build_raw_recognition_result(part)
     bb = part.bounding_box()
 
     detected = build_part_model(part)
@@ -190,13 +190,13 @@ def test_the_gate_is_the_orchestrations_not_the_call_sites():
     prismatic = Box(80, 40, 8) + Pos(-36, 0, 24) * Box(8, 40, 40)
     turned = Cylinder(20, 60)
 
-    assert build_recognition_result(prismatic, rotational=False).rotational is False
-    assert build_recognition_result(turned, rotational=True).rotational is True
+    assert build_raw_recognition_result(prismatic, rotational=False).rotational is False
+    assert build_raw_recognition_result(turned, rotational=True).rotational is True
 
     # Same solid, both classifications: only the gate differs, so the plate inventory change
     # is the gate's doing and not the geometry's.
-    ungated = build_recognition_result(prismatic, rotational=False)
-    gated = build_recognition_result(prismatic, rotational=True)
+    ungated = build_raw_recognition_result(prismatic, rotational=False)
+    gated = build_raw_recognition_result(prismatic, rotational=True)
 
     assert gated.plates == (), "a rotational classification must gate prismatic plates away"
     assert ungated.plates, "fixture stopped producing plates, so the gate proves nothing here"
@@ -223,7 +223,7 @@ def test_the_plates_gate_needs_both_halves_not_just_the_rotational_one():
     shaft = Cylinder(20, 30) + Pos(0, 0, 30) * Cylinder(14, 30)
 
     with counting_calls({"plates": recognise_plates}) as counts:
-        rec = build_recognition_result(shaft, rotational=False)
+        rec = build_raw_recognition_result(shaft, rotational=False)
 
     assert rec.turned_steps, "fixture stopped producing a turned profile — the gate's other half"
     assert counts.get("plates", 0) == 0, (

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -2480,7 +2480,11 @@ class TestTheDimensionMirror:
             for x in (-18, 18):
                 for y in (-18, 18):
                     part -= Pos(x, y, 0) * Cylinder(2, 10)
-            return part.rotate(Axis.X, 90)
+            part = part.rotate(Axis.X, 90)
+            # A genuine Z boss keeps the plan view semantically required, so this corpus
+            # continues to observe Y-axis ``centerline_plan`` furniture after RaisedPad v2
+            # stopped misclassifying two rotated lugs as pads.
+            return part + Pos(0, 0, 21) * Cylinder(4, 5)
 
         return {
             "plate+hole": Box(80, 50, 8) - Pos(-20, 0, 0) * Cylinder(4, 20),
@@ -2547,7 +2551,10 @@ class TestTheDimensionMirror:
     #: only an envelope) and "slot" (detected a pocket) until #947's review counted them.
     _EXPECTED_KINDS = {
         "plate+hole": {"hole"},
-        "flange (no envelope feature)": {"hole", "pattern", "pad", "step"},
+        # RaisedPad v2 no longer treats two of the flange's end lugs as +Z pads after the
+        # whole part is rotated. They are the four genuine Y-opening edge pockets below;
+        # the dedicated "pad" fixture remains this corpus's pad mirror evidence.
+        "flange (no envelope feature)": {"boss", "hole", "pattern", "pocket", "step"},
         "stepped": {"step_level"},
         "slot": {"slot"},
         "pocket": {"pocket"},

--- a/tests/test_strip_layout.py
+++ b/tests/test_strip_layout.py
@@ -1064,21 +1064,10 @@ def test_two_cross_hole_heights_share_their_end_view_ladder_without_crossing():
     # retain their inner-to-outer order instead of splitting across view ladders.
     xmax = [drawing.get_annotation(name).bounding_box().max.X for name in location_names]
     assert xmax[0] < xmax[1]
-    # The required hole callout remains under the established Policy-B floor,
-    # but the retained fixed-ink crossing is no longer silently lint-clean.
-    issues = drawing.lint()
-    # `annotation_ink_overlap` (#1321/#1332) joins it: this sheet also draws
-    # line-work across a label. Measured, not rendered -- it is the same family as
-    # the cases that were rendered, and stage 3 (#1334) is what prevents it.
-    assert {issue.code for issue in issues} == {
-        "feature_leader_crossing",
-        "annotation_ink_overlap",
-    }
-    # Select by code: the sheet now carries ink crossings alongside this one, and
-    # the assertions below are about the Policy-B leader crossing specifically.
-    (crossing,) = [issue for issue in issues if issue.code == "feature_leader_crossing"]
-    assert crossing.severity == "info"
-    assert "dim_loc_side_z7550:segment:3" in crossing.message
+    # The side-right strip starts at the geometry edge and consumes its composed band.
+    # That gives the shared solve a clear route for the required hole callout instead of
+    # retaining the former Policy-B crossing through the outer location rung.
+    assert drawing.lint() == []
 
 
 # --- unified above-corridor solve (ADR 0009 end state, #345/#346) -----------

--- a/uv.lock
+++ b/uv.lock
@@ -85,15 +85,15 @@ wheels = [
 
 [[package]]
 name = "b123d-recognisers"
-version = "0.4.6"
+version = "0.4.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/c7/ad6be406531a243bd416017c75659d455a6cb0f2f49202c354f0b7d8bbca/b123d_recognisers-0.4.6.tar.gz", hash = "sha256:ea4a0ca46eb97017594636d95b638ad19bea448f7d05a12428f7d33cd1071341", size = 2063844, upload-time = "2026-08-29T21:52:11.202Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/f9/69be5018fe16b53317502c67e9254e0373968bf6261f3dc9c873901d07ca/b123d_recognisers-0.4.8.tar.gz", hash = "sha256:c76edc640c3e4029ab2060a7a4e1e2743e27a479cec9147a08cdcfc827a2ac66", size = 3127513, upload-time = "2026-08-30T15:42:27.041Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/88/c74b9e350c833746987b3f53189a1fb33e0dc6dea98190f14000852d8061/b123d_recognisers-0.4.6-py3-none-any.whl", hash = "sha256:55dfff8510fc4c5aaf5f3783ec1e78ac82e4db152f6935b3e5dd2563fc5f2568", size = 375023, upload-time = "2026-08-29T21:52:09.945Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ac/814f5d6ccdc07aba66bbfcbe8665d186e60eeb43ff4b10986202e4167254/b123d_recognisers-0.4.8-py3-none-any.whl", hash = "sha256:ec818b0c65922d8d6c4824c09563acc37542ac78f808e0d6af9e2ad2ddfa7785", size = 381313, upload-time = "2026-08-30T15:42:25.196Z" },
 ]
 
 [[package]]
@@ -746,7 +746,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "antlr4-python3-runtime", specifier = "<4.10" },
-    { name = "b123d-recognisers", specifier = "==0.4.6" },
+    { name = "b123d-recognisers", specifier = "==0.4.8" },
     { name = "build123d", marker = "python_full_version < '3.13'", specifier = ">=0.9.0,<0.11" },
     { name = "build123d", marker = "python_full_version >= '3.13'", specifier = ">=0.11,<0.12" },
     { name = "build123d-drafting-helpers", specifier = ">=0.14.2" },


### PR DESCRIPTION
## Summary

- pin the immutable PyPI `b123d-recognisers==0.4.8` release and refresh fail-closed capability/inspection contracts
- replace production use of the ambiguous aggregate alias with the explicit `build_raw_recognition_result` caller-coordinate route; framed production remains deferred to #1357
- carry RaisedPad schema v2 through signed X/Y/Z IR, Sheet declaration, generated code, compiler identities, requirement-driven views, solver placement, and truthful lint outcomes
- prove the public framed #331/#332/#334 reproductions against the exact returned local part while retaining one aggregate lifecycle and shared cylinder inventory
- keep composed strip sizing consistent for authored pad suppression and principal-view pins

## ADR audit

Reviewed ADR 0007, 0011, and 0013–0018. Fresh independent exact-head ADR, contract, and quality reviews at `d51167a` are CLEAN with no substantive findings.

## Verification

- `scripts/pr-check --full`
- 5,642 passed, 5 skipped, 2 expected xfails
- 95.58% overall coverage
- 98% diff coverage
- strict docs, Ruff, formatting, mypy, codespell, lock validation all green
- independent focused review runs: ADR 650 passed; contract 979 passed; quality 888 passed

Closes #1392

Follow-up scope remains in #1357, #1372, and #1373.