### PR TITLE
Adopt recognisers 0.4.8 pad contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,21 @@
 
 ### Changed
 
+- Adopted the exact PyPI `b123d-recognisers==0.4.8` contract while deliberately retaining
+  caller/world-coordinate production behavior through the explicitly named
+  `build_raw_recognition_result()` route. RaisedPad schema v2 now preserves signed X/Y/Z
+  orientation and occurrence identity through IR, `Sheet.pad`, generated code, requirement-driven
+  views, solver-placed footprint/height/location dimensions, and physical completeness. Public
+  framed-contract regressions for rectangular pads, polygonal bosses, and body-local Plates are
+  pinned independently; framed production remains deferred to #1357 (#1392).
+  Two caller-coordinate inventory transitions are accepted explicitly: a rolled edge opening now
+  retains its physical Y depth axis instead of being interpreted as a Z-floor owner, and the
+  rolled flange corpus no longer misclassifies box-ended lobes as attached rectangular pads.
+  The corrected turned/flange inventory can also prove a formerly retained plan projection
+  redundant, so its plan-axis furniture is now omitted with that view as required by #1262.
+  Existing downstream ownership/emitter tests now assert those corrected meanings rather than
+  preserving the former orientation artefacts.
+
 - Circular blind steps recognised by `b123d-recognisers` now have a complete consumer path.
   The oriented terminal-to-open centreline and transverse quarter-arc lower without rescanning
   to an explicit-only IR/Sheet feature; generated code preserves the full correspondence.

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -3,7 +3,8 @@
 - **Status:** Accepted; narrowed after phase 1 (Amendment 1, 2026-08-05), with
   external-package/cache ownership clarified by Amendment 2 (2026-08-15) and turned
   edge-treatment applicability widened by Amendment 3 (2026-08-22), and the 0.4.6
-  prismatic step inventories incorporated by Amendment 4 (2026-08-30)
+  prismatic step inventories incorporated by Amendment 4 (2026-08-30). Amendment 5 names
+  the raw-coordinate production boundary during framed-recognition adoption.
 - **Date:** 2026-08-03
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -138,6 +139,21 @@ as that outcome instead of becoming `inapplicable`. A partially covered occurren
 as the aggregate owner and removes exact matching legacy fragments. The explicit Sheet declaration
 permits the same local two-leg grammar on every principal axis. This is a pure projection of the
 shared aggregate, not a second recognition scan.
+
+## Amendment 5 — raw coordinates are explicit while framed adoption is incomplete
+
+Draftwright's 0.4.8 adoption replaces every production call of the historical ambiguous
+`build_recognition_result` alias with `build_raw_recognition_result`. This is a naming change,
+not a coordinate change: `PartModel`, declared features, view planning, annotations, and public
+`Sheet` values remain in caller/world coordinates. The one Draftwright-owned cache and one shared
+cylinder inventory are unchanged.
+
+`build_framed_recognition_result` is a public provider-evidence route until #1357 lands one owned
+frame-to-IR adapter. Tests may inspect the returned exact local working solid and its result; no
+production path may mix those local records with caller-coordinate geometry, automatically fall
+back on refusal, or run a second aggregate to compare them. RaisedPad schema v2 is accepted only
+after signed X/Y/Z orientation, footprint, height, location, occurrence identity, declaration,
+generated code, placement, and critique cross the existing compiler boundaries together.
 
 ## Accepted Contract
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -199,7 +199,9 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   `_QUOTED_RE` (a lint-message label regex shared with the
   repair loop) lives in `_core`.
 - **`recognition_cache.py`** — Draftwright's ADR 0017 one-result lifecycle owner. It calls
-  external `build_recognition_result(part)` at most once for a build/lazy-critique run; the
+  external `build_raw_recognition_result(part)` at most once for a build/lazy-critique run. The
+  explicit name records that the current production IR remains in caller/world coordinates;
+  `build_framed_recognition_result()` is evidence-only until #1357 owns the frame-to-IR adapter. The
   package owns recognition, while Draftwright owns when the result is computed and reused.
 - **`recogniser_contract.py`** — the fail-closed cross-repository capability join. It consumes
   only the installed `b123d-recognisers` public manifest, then validates Draftwright-owned IR,

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -325,7 +325,7 @@ profile warning only for that occurrence, so an unrelated unrecognised profile r
 
 ## Passage compatibility boundary
 
-The installed `b123d-recognisers==0.4.6` release contains the `passages` family introduced
+The installed `b123d-recognisers==0.4.8` release contains the `passages` family introduced
 in 0.2.6. Version 0.4.0 makes `SectionPassage` the authoritative physical output and retains
 schema-v1 `Passage` as its compatibility projection. Draftwright declares all six public and nested
 record schemas exhaustively but deliberately keeps the family `unsupported`, with the drafting
@@ -343,7 +343,7 @@ The 0.4 contract is explicit:
 - rich split-junction passages can supersede a Slot claim, moving physical ownership to the
   unsupported Passage family through `SLOT_SUPERSEDED_BY_PASSAGE`.
 
-The exact 0.4.6 pin, manifest-v2 validator and explicit unsupported inventories make that limitation
+The exact 0.4.8 pin, manifest-v2 validator and explicit unsupported inventories make that limitation
 fail-visible rather than silently treating rich passages as supported. Draftwright deliberately
 does not claim that a regular-polygon `HEX … A/F THRU` callout covers the complete line/arc section
 schema. Each authoritative `RecognitionResult.section_passages` occurrence therefore emits
@@ -365,3 +365,18 @@ are proved; the explicit Sheet surface likewise supports all principal axes. Cir
 steps retain their oriented centreline/quarter-arc correspondence and communicate independently
 addressable radius and stopped-depth requirements in one end-view leader. Issue #1382 records
 the reviewed downstream dispositions.
+
+## Explicit raw-coordinate boundary and RaisedPad schema v2 in 0.4.8
+
+Draftwright production calls `build_raw_recognition_result()` explicitly. This preserves the
+established caller/world-coordinate IR while making the boundary reviewable; no refusal path
+silently falls back from framed to raw recognition. The public framed route is exercised only as
+provider-contract evidence until #1357 supplies one owned frame-to-IR adapter.
+
+`RaisedPad` schema v2 adds `axis` and `direction`. Draftwright accepts only schema v2 at this pin
+and carries all six signed principal orientations through one covariant IR/declaration/compiler
+path. Footprint, direct height, two in-plane locations, and a stable occurrence ordinal remain
+distinct measurement/ownership facts. Equal-looking pads on separate solids therefore cannot
+collapse at the structural `FeatureRef` seam. Polygonal-boss covariance and Plate body locality
+are pinned through the same installed public framed result, but their downstream completeness
+slices remain separately owned by #1372/#1373.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "build123d>=0.9.0,<0.11 ; python_full_version < '3.13'",
     "build123d>=0.11,<0.12 ; python_full_version >= '3.13'",
     "build123d-drafting-helpers>=0.14.2",
-    "b123d-recognisers==0.4.6",
+    "b123d-recognisers==0.4.8",
     "numpy>=1.24",
     # PNG raster export (SVG→PDF→PNG). Both permissively licensed (Pillow HPND; pypdfium2
     # Apache-2.0 wrapping Google PDFium BSD-3) and ship pre-built wheels with NO native system

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -22,7 +22,7 @@ from b123d_recognisers import (
     TurnedProfile,
     TurnedStep,
     analyse_cylinders,
-    build_recognition_result,
+    build_raw_recognition_result,
     full_cylinders,
 )
 from build123d import Compound, Shape
@@ -691,7 +691,7 @@ def _analyse(
         _turned = _declared_turned_profile(layout_model)
         step_zs = _declared_step_zs(layout_model, _turned, bb)
     else:
-        recognition = build_recognition_result(
+        recognition = build_raw_recognition_result(
             part, cylinders=(z_cyls, cross_cyls), rotational=is_rotational
         )
         _turned = TurnedProfile.from_steps(list(recognition.turned_steps))

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -114,6 +114,7 @@ from draftwright.model.ir import (
     FilletFeature,
     HoleFeature,
     KnurlRequirement,
+    PadFeature,
     PatternFeature,
     PocketFeature,
     SlotFeature,
@@ -333,10 +334,11 @@ def render_slots(dwg, plan, a, *, ctx, only=None) -> int:
     # approved location consumed by render_locations, including non-Z openings.
     # Keyed by (feature, MEASURED axis): a non-Z pocket is approved one entry per in-plane
     # coordinate, so keying by feature alone would keep whichever came last.
-    pocket_locations = {
+    planar_feature_locations = {
         (loc.ref, loc.discriminator): loc
         for loc in plan.locations
-        if loc.role == PocketFeature.LOCATION_STEM and loc.discriminator is not None
+        if loc.role in {PocketFeature.LOCATION_STEM, PadFeature.LOCATION_STEM}
+        and loc.discriminator is not None
     }
     # A slot's own position dim — datum→near-end along its long axis. Compiled, not
     # computed from `a.bb`: it prints a number, so an authored set that does not name the
@@ -628,8 +630,8 @@ def render_slots(dwg, plan, a, *, ctx, only=None) -> int:
                 # fires shows 12 nameless position drops across nist_ctc_03 and nist_ctc_04,
                 # all from here (#1231 review, finding 1).
                 _record_slot_drop(ctx, dwg, "position", i, name, s, pos.id)
-        elif s.kind == "pocket" and s.frame.axis != "z":
-            # Side-/front-opening pockets need two in-plane coordinates in their
+        elif s.kind in {"pocket", "pad"} and s.frame.axis != "z":
+            # Side-/front-opening pockets and pads need two in-plane coordinates in their
             # end-on view.  The compiler approves one entry PER coordinate, each with its
             # own value and span; Z-opening pockets use render_locations' X(plan)/Y(side)
             # ladder instead.
@@ -638,7 +640,7 @@ def render_slots(dwg, plan, a, *, ctx, only=None) -> int:
                 (s.long_axis, width_lo, width_hi, "pos_long"),
                 (s.width_axis, s.lo, s.hi, "pos_width"),
             ):
-                entry = pocket_locations.get((FeatureRef(s), axis))
+                entry = planar_feature_locations.get((FeatureRef(s), axis))
                 if entry is None:
                     continue  # not approved
                 index = "xyz".index(axis)
@@ -3360,7 +3362,7 @@ def render_polygonal_stock(dwg, plan, a, *, ctx) -> int:
 
 
 def render_boss_heights(dwg, plan, a, *, ctx) -> int:
-    """Queue prismatic boss heights and polygonal-stock lengths in a profile corridor."""
+    """Queue prismatic boss/pad heights and polygonal-stock lengths in profile corridors."""
     if a.is_rotational or a.prof is not None:
         return 0
     tier = dwg.draft.font_size + 2 * dwg.draft.pad_around_text
@@ -3376,16 +3378,28 @@ def render_boss_heights(dwg, plan, a, *, ctx) -> int:
                 *plan.of_kind("boss"),
                 *plan.of_kind("polygonal_boss"),
                 *plan.of_kind("polygonal_stock"),
+                *plan.of_kind("pad"),
             ],
             key=lambda g: (g.facts.frame.axis, g.facts.frame.origin),
         )
     ):
         b = g.facts
-        role = "stock_length" if g.ref.kind == "polygonal_stock" else "boss_height"
+        role = {
+            "polygonal_stock": "stock_length",
+            "pad": "pad_height",
+        }.get(g.ref.kind, "boss_height")
         pd = next((d for d in g.dims if (d.role, d.kind) == (role, "length")), None)
         if pd is None or pd.span is None:
             continue
-        spec = specs.get(b.frame.axis)
+        # A Z-pad's direct height would otherwise compete with the mandatory overall
+        # height in the same right-hand profile corridor.  Keep the established boss/stock
+        # routes, but put the pad's nested axial extent on the opposite side where its
+        # endpoints remain equally visible (#1392).
+        spec = (
+            ("front", "left", a.fv_zones.left, "x")
+            if g.ref.kind == "pad" and b.frame.axis == "z"
+            else specs.get(b.frame.axis)
+        )
         if spec is None:
             continue
         view, side, strip, stack = spec
@@ -3393,7 +3407,10 @@ def render_boss_heights(dwg, plan, a, *, ctx) -> int:
         p2 = dwg.at(view, *pd.span[1])
         edge = max(p1[0], p2[0]) if side == "right" else max(p1[1], p2[1])
         label = pd.value_text + _tol_suffix(pd.tolerance, dwg.draft)
-        prefix = "m_stocklength" if g.ref.kind == "polygonal_stock" else "m_bossheight"
+        prefix = {
+            "polygonal_stock": "m_stocklength",
+            "pad": "m_padheight",
+        }.get(g.ref.kind, "m_bossheight")
         name = f"{prefix}_{b.frame.axis}{bi}"
 
         def build(pos, p1=p1, p2=p2, side=side, edge=edge, label=label):
@@ -3402,12 +3419,25 @@ def render_boss_heights(dwg, plan, a, *, ctx) -> int:
         def footprint(pos, p1=p1, p2=p2, side=side, edge=edge, label=label):
             return dim_footprint(p1, p2, side, abs(pos - edge), dwg.draft, label)
 
-        def dropped(_name, *, stock=g.ref.kind == "polygonal_stock", measurement=pd.id):
+        def dropped(
+            _name,
+            *,
+            stock=g.ref.kind == "polygonal_stock",
+            pad=g.ref.kind == "pad",
+            measurement=pd.id,
+        ):
             if stock:
                 ctx.record_issue(
                     "warning",
                     "polygonal_stock_length_dropped",
                     "polygonal stock axial length was not placed (profile strip full)",
+                    measurement=measurement,
+                )
+            elif pad:
+                ctx.record_issue(
+                    "warning",
+                    "pad_height_dropped",
+                    "rectangular pad height was not placed (profile strip full)",
                     measurement=measurement,
                 )
 

--- a/src/draftwright/evaluation/step_analysis.py
+++ b/src/draftwright/evaluation/step_analysis.py
@@ -2640,9 +2640,9 @@ def _default_observers() -> Mapping[str, Observer]:
             # recognises must still yield a scored non-answer rather than a traceback out
             # of the middle of a corpus run.
             try:
-                from b123d_recognisers import build_recognition_result
+                from b123d_recognisers import build_raw_recognition_result
 
-                holes = tuple(build_recognition_result(part).holes)  # type: ignore[arg-type]
+                holes = tuple(build_raw_recognition_result(part).holes)  # type: ignore[arg-type]
             except Exception:  # noqa: BLE001 — an unanalysable fixture observes nothing
                 return ()
             boundary_outcomes: dict[str, list[Outcome]] = {

--- a/src/draftwright/inspection_contract.py
+++ b/src/draftwright/inspection_contract.py
@@ -16,7 +16,7 @@ from b123d_recognisers.inspection import inspection_api_manifest
 CONSUMER_INSPECTION_FORMAT = "draftwright-inspection-api"
 CONSUMER_INSPECTION_FORMAT_VERSION = 1
 SUPPORTED_INSPECTION_API_MAJOR = 1
-SUPPORTED_RECOGNISER_VERSION = "0.4.6"
+SUPPORTED_RECOGNISER_VERSION = "0.4.8"
 _DISTRIBUTION = "b123d-recognisers"
 _PROVIDER_FORMAT = "b123d-recognisers-inspection-api"
 _NAMESPACE = "b123d_recognisers.inspection"

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -28,7 +28,7 @@ from b123d_recognisers import (
     RecognitionResult,
     TurnedProfile,
     analyse_cylinders,
-    build_recognition_result,
+    build_raw_recognition_result,
     feature_diameters,
     project_step_shoulders,
     recognise_double_d_bores,
@@ -1168,6 +1168,10 @@ def lint_prismatic_coverage(
     pairs_by_view: dict[str, list] = {}
     registry = getattr(dwg, "registry", None)
     satisfied_ids = satisfaction_ids(registry)
+    if registry is not None:
+        satisfied_ids.update(
+            identity for name in registry.names() for identity in registry.measurement_of(name)
+        )
 
     def satisfied(feature, parameter: str) -> bool:
         return any(
@@ -1181,9 +1185,19 @@ def lint_prismatic_coverage(
     issues = []
     pad_inventory = recognise_rectangular_pads(part) if pads is None else pads
     if pad_inventory:
+
+        def pad_bounds(feature) -> tuple[float, ...]:
+            half = feature.width / 2
+            by_axis = {
+                feature.long_axis: (feature.lo, feature.hi),
+                feature.width_axis: (feature.w_center - half, feature.w_center + half),
+                feature.frame.axis: (feature.z0, feature.z1),
+            }
+            return tuple(value for axis in "xyz" for value in by_axis[axis])
+
         bb = bbox if bbox is not None else part.bounding_box()
         undefined = 0
-        for pad in pad_inventory:
+        for occurrence, pad in enumerate(pad_inventory):
             yc = (pad.y0 + pad.y1) / 2
             xc = (pad.x0 + pad.x1) / 2
             x0, _, *_ = dwg.at("plan", pad.x0, yc, pad.z1)
@@ -1204,56 +1218,81 @@ def lint_prismatic_coverage(
                     f
                     for f in getattr(dwg.model(), "features", ())
                     if getattr(f, "kind", None) == "pad"
-                    and abs(f.lo - pad.x0) <= tol
-                    and abs(f.hi - pad.x1) <= tol
-                    and abs(f.w_center - yc) <= tol
-                    and abs(f.width - (pad.y1 - pad.y0)) <= tol
+                    and f.frame.axis == pad.axis
+                    and f.direction == pad.direction
+                    and f.occurrence == occurrence
+                    and all(
+                        abs(actual - expected) <= tol
+                        for actual, expected in zip(
+                            pad_bounds(f),
+                            (pad.x0, pad.x1, pad.y0, pad.y1, pad.z0, pad.z1),
+                            strict=True,
+                        )
+                    )
                 ),
                 None,
             )
-            parameter_by_axis = (
-                {
-                    owner.long_axis: "pad_length.length",
-                    owner.width_axis: "pad_width.length",
-                }
-                if owner is not None
-                else {}
+            footprint = owner is not None and all(
+                satisfied(owner, parameter)
+                for parameter in ("pad_length.length", "pad_width.length")
             )
-            size_x = owner is not None and (
-                _pair_covers(ps, 0, x0, x1, tol, owner=owner)
-                or satisfied(owner, parameter_by_axis["x"])
+            axis_i = "xyz".index(pad.axis)
+            centre = [xc, yc, (pad.z0 + pad.z1) / 2]
+            low = list(centre)
+            high = list(centre)
+            bounds = {
+                "x": (pad.x0, pad.x1),
+                "y": (pad.y0, pad.y1),
+                "z": (pad.z0, pad.z1),
+            }
+            low[axis_i], high[axis_i] = bounds[pad.axis]
+            height_view, page_axis = {
+                "x": ("front", 0),
+                "y": ("side", 0),
+                "z": ("front", 1),
+            }[pad.axis]
+            low_page = dwg.at(height_view, *low)[page_axis]
+            high_page = dwg.at(height_view, *high)[page_axis]
+            height = owner is not None and (
+                satisfied(owner, "pad_height.length")
+                or _pair_covers(pairs(height_view), page_axis, low_page, high_page, tol)
             )
-            size_y = owner is not None and (
-                _pair_covers(ps, 1, y0, y1, tol, owner=owner)
-                or satisfied(owner, parameter_by_axis["y"])
-            )
-            located_x = (
-                owner is not None
-                and satisfied(owner, "location")
-                or (
-                    abs(pad.x0 - bb.min.X) <= tol
-                    or abs(pad.x1 - bb.max.X) <= tol
-                    or any(
-                        _pair_covers(ps, 0, edge, bound, tol)
-                        for edge in (bx0, bx1)
-                        for bound in (x0, x1, xc_page)
-                    )
+            located = owner is not None and (
+                satisfied(owner, "location")
+                or all(
+                    satisfied(owner, f"location_pad.{axis}")
+                    for axis in (owner.long_axis, owner.width_axis)
                 )
             )
-            located_y = (
-                owner is not None
-                and satisfied(owner, "location")
-                or (
-                    abs(pad.y0 - bb.min.Y) <= tol
-                    or abs(pad.y1 - bb.max.Y) <= tol
-                    or any(
-                        _pair_covers(pairs("side"), 0, edge, bound, tol)
-                        for edge in (sby0, sby1)
-                        for bound in (sy0, sy1, syc)
+            if owner is not None and pad.axis == "z":
+                footprint = (
+                    _pair_covers(ps, 0, x0, x1, tol, owner=owner)
+                    or satisfied(owner, "pad_length.length")
+                ) and (
+                    _pair_covers(ps, 1, y0, y1, tol, owner=owner)
+                    or satisfied(owner, "pad_width.length")
+                )
+                located = located or (
+                    (
+                        abs(pad.x0 - bb.min.X) <= tol
+                        or abs(pad.x1 - bb.max.X) <= tol
+                        or any(
+                            _pair_covers(ps, 0, edge, bound, tol)
+                            for edge in (bx0, bx1)
+                            for bound in (x0, x1, xc_page)
+                        )
+                    )
+                    and (
+                        abs(pad.y0 - bb.min.Y) <= tol
+                        or abs(pad.y1 - bb.max.Y) <= tol
+                        or any(
+                            _pair_covers(pairs("side"), 0, edge, bound, tol)
+                            for edge in (sby0, sby1)
+                            for bound in (sy0, sy1, syc)
+                        )
                     )
                 )
-            )
-            if not (size_x and size_y and located_x and located_y):
+            if not (footprint and height and located):
                 undefined += 1
         if undefined:
             issues.append(
@@ -1261,8 +1300,8 @@ def lint_prismatic_coverage(
                     severity=severity,
                     code="pad_footprint_not_defined",
                     message=(
-                        f"{undefined} rectangular raised pad(s) lack footprint size "
-                        "or X/Y location dimensions"
+                        f"{undefined} rectangular raised pad(s) lack footprint, height, "
+                        "or in-plane location dimensions"
                     ),
                 )
             )
@@ -1408,7 +1447,7 @@ def lint_prismatic_coverage(
             f"{type(recognition).__name__}. A completeness check must not accept a "
             "caller-assembled inventory: an empty stand-in silences it."
         )
-    _rec = build_recognition_result(part) if recognition is None else recognition
+    _rec = build_raw_recognition_result(part) if recognition is None else recognition
     ladder_bounds = bbox if bbox is not None else part.bounding_box()
     source_shoulders = project_step_shoulders(
         _rec.risers,

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -58,6 +58,7 @@ from draftwright.model.ir import (
     Feature,
     HoleFeature,
     Note,
+    PadFeature,
     PartModel,
     PatternFeature,
     PocketFeature,
@@ -267,7 +268,7 @@ _FACTS: dict[str, tuple[str, ...]] = {
         "rows",
         "cols",
     ),
-    "pad": ("frame", "width_axis", "long_axis"),
+    "pad": ("frame", "width_axis", "long_axis", "direction", "occurrence"),
     "boss": ("frame", "thread", "knurl"),
     "polygonal_boss": ("frame", "side_count", "flat_directions", "flat_centres"),
     "polygonal_stock": ("frame", "side_count", "flat_directions", "flat_centres"),
@@ -1195,10 +1196,12 @@ def _compile_locations(model: PartModel) -> tuple[list[ApprovedDimension], list[
                     )
                 )
             continue
-        if isinstance(feature, PocketFeature) and axis != "z":
-            # A non-Z pocket's two in-plane coordinates are drawn as TWO dims in its end-on
-            # view (`render_slots`), so they are approved as two entries carrying their own
-            # values — the same shape `_compile_off_axis_hole_locations` uses.
+        if isinstance(feature, PadFeature) or (isinstance(feature, PocketFeature) and axis != "z"):
+            # A pad in every orientation, and a non-Z pocket, has two independently required
+            # in-plane coordinates.  They are drawn as TWO dims in the face-on/end-on view,
+            # so approve two entries carrying their own values — the same shape
+            # `_compile_off_axis_hole_locations` uses.  Keeping Z pads on the historical
+            # feature-level location id allowed either ordinate to falsely satisfy both.
             #
             # One entry with `value_text=""` made the renderer subtract the span's endpoints
             # itself to get each axis's number, which is the compiler's job done twice; the
@@ -1216,18 +1219,26 @@ def _compile_locations(model: PartModel) -> tuple[list[ApprovedDimension], list[
                             parameter_id,
                             value,
                             POCKET_LOCATION_DATUM_COINCIDENT,
-                            code="pocket_location_coincident_with_datum",
+                            code=f"{feature.kind}_location_coincident_with_datum",
                         )
                     )
                     continue
                 start = list(span[1])
                 start[index] = span[0][index]
+                approved_span = (
+                    span
+                    if isinstance(feature, PadFeature) and axis == "z"
+                    else ((start[0], start[1], start[2]), span[1])
+                )
                 approved.append(
                     ApprovedDimension(
                         id=_dim_id(feature, parameter_id),
                         value_text=_fmt(value),
                         value=value,
-                        span=((start[0], start[1], start[2]), span[1]),
+                        # `render_locations` groups Z-normal refs before it separates their
+                        # X/Y entries, so both copies must retain the full datum→centre span.
+                        # End-on rendering for non-Z features consumes the narrowed span.
+                        span=approved_span,
                         ref=FeatureRef(feature),
                         kind="location",
                         role=pd.param.role,
@@ -1253,7 +1264,7 @@ def _compile_locations(model: PartModel) -> tuple[list[ApprovedDimension], list[
         approved.append(
             ApprovedDimension(
                 id=_dim_id(feature, pd.param.parameter_id),
-                #: Pocket/pad Z-normal ladders remain one location entry with no per-axis value:
+                #: Pocket Z-normal ladders remain one location entry with no per-axis value:
                 #: `render_locations` groups refs ACROSS features and dedups per axis before
                 #: it knows which dims exist, so an entry per axis would be approving a mark
                 #: whose existence the renderer decides. Splitting it needs that grouping to

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -1495,12 +1495,16 @@ def pad(
     y1=None,
     z0=None,
     z1=None,
+    axis="z",
+    direction=1,
+    occurrence=0,
     at=None,
 ) -> PadFeature:
-    """A bounded rectangular raised pad, dimensioned by footprint and location.
+    """A signed principal-axis rectangular pad, dimensioned completely.
 
     ``pad(pad_solid)`` reads its axis-aligned bounding box; the explicit flavour
-    accepts the six bounds used by generated Sheet scripts.
+    accepts the six world-coordinate bounds plus its height ``axis`` and outward
+    ``direction`` used by generated Sheet scripts.
     """
     if obj is not None:
         bb = obj.bounding_box()
@@ -1514,20 +1518,33 @@ def pad(
         raise ValueError("pad() needs an object, or explicit x0=/x1=/y0=/y1=/z0=/z1=")
     if not (x0 < x1 and y0 < y1 and z0 < z1):
         raise ValueError("pad() bounds must increase on every axis")
+    if axis not in "xyz":
+        raise ValueError("pad() axis must be 'x', 'y', or 'z'")
+    if direction not in (-1, 1):
+        raise ValueError("pad() direction must be -1 or 1")
+    if type(occurrence) is not int or occurrence < 0:
+        raise ValueError("pad() occurrence must be a non-negative integer")
     if at is None:
         at = ((x0 + x1) / 2, (y0 + y1) / 2, (z0 + z1) / 2)
     _require_point("at", at)
+    bounds = {"x": (x0, x1), "y": (y0, y1), "z": (z0, z1)}
+    long_axis, width_axis = tuple(candidate for candidate in "xyz" if candidate != axis)
+    lo, hi = bounds[long_axis]
+    width_lo, width_hi = bounds[width_axis]
+    axis_lo, axis_hi = bounds[axis]
     return PadFeature(
-        frame=Frame(at, "z"),
-        width_axis="y",
-        long_axis="x",
-        width=y1 - y0,
-        length=x1 - x0,
-        w_center=(y0 + y1) / 2,
-        lo=x0,
-        hi=x1,
-        z0=z0,
-        z1=z1,
+        frame=Frame(at, axis),
+        width_axis=width_axis,
+        long_axis=long_axis,
+        width=width_hi - width_lo,
+        length=hi - lo,
+        w_center=(width_lo + width_hi) / 2,
+        lo=lo,
+        hi=hi,
+        z0=axis_lo,
+        z1=axis_hi,
+        direction=direction,
+        occurrence=occurrence,
     )
 
 

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, replace
-from typing import Any
+from typing import Any, cast
 
 from b123d_recognisers import (
     AngledStep,
@@ -56,7 +56,7 @@ from b123d_recognisers import (
     TurnedProfile,
     TurnedStep,
     analyse_cylinders,
-    build_recognition_result,
+    build_raw_recognition_result,
     has_multi_axis_plates,
     project_step_shoulders,
     recognise_bosses,
@@ -491,20 +491,31 @@ def _convert_channel(channel: Channel, ctx: ConvContext) -> ChannelFeature:
 
 def _convert_pad(pad: RaisedPad, ctx: ConvContext) -> PadFeature:
     """A recognised bounded island → the dimensioning IR."""
+    transverse = tuple(axis for axis in "xyz" if axis != pad.axis)
+    long_axis, width_axis = transverse
+    bounds = {
+        "x": (pad.x0, pad.x1),
+        "y": (pad.y0, pad.y1),
+        "z": (pad.z0, pad.z1),
+    }
+    lo, hi = bounds[long_axis]
+    width_lo, width_hi = bounds[width_axis]
+    axis_lo, axis_hi = bounds[pad.axis]
     return PadFeature(
         frame=Frame(
             ((pad.x0 + pad.x1) / 2, (pad.y0 + pad.y1) / 2, (pad.z0 + pad.z1) / 2),
-            "z",
+            pad.axis,
         ),
-        width_axis="y",
-        long_axis="x",
-        width=pad.y1 - pad.y0,
-        length=pad.x1 - pad.x0,
-        w_center=(pad.y0 + pad.y1) / 2,
-        lo=pad.x0,
-        hi=pad.x1,
-        z0=pad.z0,
-        z1=pad.z1,
+        width_axis=width_axis,
+        long_axis=long_axis,
+        width=width_hi - width_lo,
+        length=hi - lo,
+        w_center=(width_lo + width_hi) / 2,
+        lo=lo,
+        hi=hi,
+        z0=axis_lo,
+        z1=axis_hi,
+        direction=pad.direction,
     )
 
 
@@ -995,7 +1006,7 @@ def build_part_model(
             sizes=(bbox.size.X, bbox.size.Y, bbox.size.Z),
             centre=(centre.X, centre.Y, centre.Z),
         )
-        recognition = build_recognition_result(
+        recognition = build_raw_recognition_result(
             part,
             cylinders=cyls,
             rotational=(
@@ -1323,11 +1334,15 @@ def build_part_model(
             continue
         features.append(convert(pk, ctx))
 
-    # Bounded rectangular raised pads: footprint sizing + X/Y location; their
-    # height remains in the correlated StepLevelFeature ladder.
+    # Bounded rectangular raised pads retain their complete signed principal-axis
+    # occurrence.  The occurrence ordinal prevents equal records on distinct solids
+    # from collapsing at the structural FeatureRef boundary.
     if pads is None:
         pads = recognise_rectangular_pads(part)
-    features.extend(convert(pad, ctx) for pad in pads)
+    features.extend(
+        replace(cast(PadFeature, convert(pad, ctx)), occurrence=occurrence)
+        for occurrence, pad in enumerate(pads)
+    )
 
     # Bounded regular polygonal bosses own an across-flats callout and their direct axial
     # height. They are distinct from circular bosses (diameter semantics) and rectangular

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -315,6 +315,7 @@ DimensionParameterId = Literal[
     "od.diameter",
     "pad_length.length",
     "pad_width.length",
+    "pad_height.length",
     "pitch.length",
     "pocket_depth.length",
     "pocket_length.length",
@@ -1013,11 +1014,13 @@ class ChannelFeature:
 
 @dataclass(frozen=True)
 class PadFeature:
-    """A bounded rectangular raised island.
+    """A bounded, principal-axis rectangular raised island.
 
-    The footprint mirrors the slot vocabulary so the shared in-plane dimension
-    renderer can place its two sizes. Height remains owned by the correlated
-    prismatic level ladder, avoiding double-dimensioning the same Z rise.
+    ``long_axis`` and ``width_axis`` span the footprint; ``frame.axis`` is the
+    outward height axis.  ``z0``/``z1`` retain their historical public names but
+    are the ordered bounds on that height axis for every orientation.  Direction
+    preserves which bound is the attachment plane, and occurrence keeps equal-
+    valued pads on distinct solids independently addressable.
     """
 
     #: The compiled stem this feature's position is minted under — see
@@ -1034,12 +1037,25 @@ class PadFeature:
     hi: float
     z0: float
     z1: float
+    direction: int = 1
+    occurrence: int = 0
     kind: ClassVar[str] = "pad"
 
     def parameters(self) -> list[DimParameter]:
+        origin = list(self.frame.origin)
+        axis_i = "xyz".index(self.frame.axis)
+        origin[axis_i] = self.z0
+        tip = list(origin)
+        tip[axis_i] = self.z1
         return [
             DimParameter("length", "pad_width", self.width),
             DimParameter("length", "pad_length", self.length),
+            DimParameter(
+                "length",
+                "pad_height",
+                self.z1 - self.z0,
+                span=((origin[0], origin[1], origin[2]), (tip[0], tip[1], tip[2])),
+            ),
         ]
 
     def references(self) -> list[Datum]:

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -116,6 +116,7 @@ _CONVENTION = {
     ("slot_length", "length"): "linear",
     ("pad_width", "length"): "linear",
     ("pad_length", "length"): "linear",
+    ("pad_height", "length"): "linear",
 }
 
 
@@ -753,7 +754,9 @@ def location_datum(feature) -> str | None:
         return "datum_xy"  # every orientation: its two in-plane coordinates
     if isinstance(feature, HoleFeature):
         return "datum_xy" if feature.frame.axis == "z" else "bbox"
-    # Patterns, pocket/slot-patterns and pads: the plan-X / side-Y ladder only, so Z-normal
+    if isinstance(feature, PadFeature):
+        return "datum_xy"  # every orientation: two coordinates in the footprint plane
+    # Patterns and pocket/slot-patterns: the plan-X / side-Y ladder only, so Z-normal
     # only. A fall-through, not another `isinstance` + `return None`: membership above is by
     # exact type, so those four are all that can reach here and the extra arm was
     # unreachable — dead code that read as defensive and showed up as the one uncovered
@@ -1219,6 +1222,8 @@ def _parameter_view_preferences(feature: Feature, pd: PlannedDimension) -> tuple
         if role == "height":
             return ("front",)
     if role in {"boss_height", "stock_length"}:
+        return (_PROFILE.get(axis, "front"),)
+    if isinstance(feature, PadFeature) and role == "pad_height":
         return (_PROFILE.get(axis, "front"),)
     if kind == "step_level" and role == "step_height":
         return ("front",)

--- a/src/draftwright/recogniser_contract.py
+++ b/src/draftwright/recogniser_contract.py
@@ -126,6 +126,7 @@ _FAMILIES: dict[str, _FamilySpec] = {
 _RECORD_SCHEMA_VERSIONS: dict[tuple[str, str], tuple[int, ...]] = {
     ("chamfers", "Chamfer"): (2,),
     ("fillets", "Fillet"): (2,),
+    ("rectangular-pads", "RaisedPad"): (2,),
 }
 
 

--- a/src/draftwright/recognition_cache.py
+++ b/src/draftwright/recognition_cache.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from b123d_recognisers import RecognitionResult, build_recognition_result
+from b123d_recognisers import RecognitionResult, build_raw_recognition_result
 
 
 @dataclass
@@ -22,5 +22,5 @@ class RecognitionCache:
         """Return this drawing's result, recognising *part* only when still empty."""
 
         if self.result is None:
-            self.result = build_recognition_result(part)
+            self.result = build_raw_recognition_result(part)
         return self.result

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -1529,11 +1529,7 @@ class Sheet:
         return _Params(self, len(self._features) - 1)
 
     def pad(self, obj=None, **kw) -> _Params:
-        """Declare a bounded rectangular raised pad (footprint + X/Y location).
-
-        Its Z height is shared with the prismatic level ladder, so it is not
-        independently double-dimensioned.
-        """
+        """Declare a signed principal-axis rectangular raised pad."""
         self._features.append(_pad(obj, **kw))
         return _Params(self, len(self._features) - 1)
 

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -781,10 +781,16 @@ def _feature_line(
         )
     if k == "pad":
         half = f.width / 2
+        bounds = {
+            f.long_axis: (f.lo, f.hi),
+            f.width_axis: (f.w_center - half, f.w_center + half),
+            f.frame.axis: (f.z0, f.z1),
+        }
         return (
-            f"sheet.pad(x0={_n(f.lo)}, x1={_n(f.hi)}, "
-            f"y0={_n(f.w_center - half)}, y1={_n(f.w_center + half)}, "
-            f"z0={_n(f.z0)}, z1={_n(f.z1)})"
+            f"sheet.pad(x0={_n(bounds['x'][0])}, x1={_n(bounds['x'][1])}, "
+            f"y0={_n(bounds['y'][0])}, y1={_n(bounds['y'][1])}, "
+            f"z0={_n(bounds['z'][0])}, z1={_n(bounds['z'][1])}, "
+            f'axis="{f.frame.axis}", direction={f.direction}, occurrence={f.occurrence})'
         )
     if k == "pattern":
         # Defining dims for the furniture (BCD centreline / pitch / grid dims) PLUS the exact

--- a/tests/test_external_recognition_boundary.py
+++ b/tests/test_external_recognition_boundary.py
@@ -45,14 +45,16 @@ def test_embedded_implementation_is_gone_and_compatibility_is_identity_preservin
 
 def test_recognition_cache_is_consumer_owned_and_runs_once(monkeypatch) -> None:
     calls = 0
-    original = external.build_recognition_result
+    original = external.build_raw_recognition_result
 
     def counting_build(part):
         nonlocal calls
         calls += 1
         return original(part)
 
-    monkeypatch.setattr("draftwright.recognition_cache.build_recognition_result", counting_build)
+    monkeypatch.setattr(
+        "draftwright.recognition_cache.build_raw_recognition_result", counting_build
+    )
     cache = RecognitionCache()
     part = Box(10, 10, 10)
 

--- a/tests/test_inspection_contract.py
+++ b/tests/test_inspection_contract.py
@@ -26,7 +26,7 @@ def _manifest() -> dict:
 def test_installed_pypi_wheel_satisfies_the_inspection_contract() -> None:
     distribution = importlib.metadata.distribution("b123d-recognisers")
 
-    assert distribution.version == "0.4.6"
+    assert distribution.version == "0.4.8"
     assert distribution.read_text("direct_url.json") is None
     assert Path(inspect.getfile(inspection)).resolve().is_relative_to(ROOT / ".venv")
     validate_inspection_contract()

--- a/tests/test_issue_1058_wheel_profile.py
+++ b/tests/test_issue_1058_wheel_profile.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 
 import pytest
 from b123d_recognisers import (
-    build_recognition_result,
+    build_raw_recognition_result,
     recognise_double_d_bores,
     recognise_repeating_radial_profiles,
 )
@@ -570,7 +570,7 @@ def test_real_wheel_no_longer_gets_a_confident_envelope_only_result(wheel_drawin
 
 def test_synthetic_double_d_profile_is_recognised_without_lint_rescans():
     detected = detect_part_model(_double_d_bore())
-    with counting_calls({"orchestration": build_recognition_result}) as calls:
+    with counting_calls({"orchestration": build_raw_recognition_result}) as calls:
         drawing = build_drawing(_double_d_bore())
         assert tuple(detected.features) == tuple(drawing.model().features)
         assert calls == {"orchestration": 1}
@@ -715,7 +715,7 @@ def test_opposed_blind_recesses_do_not_prove_a_through_bore():
 def test_declared_object_and_explicit_forms_preserve_profile_and_skip_recognition():
     part = Box(30, 30, 10, align=_CENTER)
     cutter = _double_d_cutter()
-    with counting_calls({"orchestration": build_recognition_result}) as calls:
+    with counting_calls({"orchestration": build_raw_recognition_result}) as calls:
         sheet = Sheet(part)
         object_handle = sheet.double_d_bore(cutter)
         explicit_handle = sheet.double_d_bore(
@@ -793,7 +793,7 @@ def test_declared_model_cannot_omit_a_physical_double_d_bore_cleanly():
 
 def test_a_dropped_profile_only_suppresses_the_exact_physical_requirement():
     part = _double_d_bore()
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
     exact = ("double_d", "z", True, 10.0, 7.2, (1.0, 0.0, 0.0))
     wrong_af = ("double_d", "z", True, 10.0, 6.8, (1.0, 0.0, 0.0))
     assert (
@@ -831,7 +831,7 @@ def test_profile_coverage_rejects_unowned_results_and_canonicalises_directions()
         0.0,
     )
 
-    recognition = build_recognition_result(part)
+    recognition = build_raw_recognition_result(part)
     issues = lint_profiled_bore_coverage(part, [], recognition=recognition, assembly=True)
     assert [issue.severity for issue in issues] == ["info"]
 

--- a/tests/test_issue_1146_scale_completeness.py
+++ b/tests/test_issue_1146_scale_completeness.py
@@ -460,14 +460,14 @@ def test_sheet_fallback_reuses_lazy_physical_recognition(monkeypatch):
 
     sheet = Sheet.from_part(_scale_sensitive_plate(), page="A4", scale=1.0)
     calls = []
-    original = recognition_cache_module.build_recognition_result
+    original = recognition_cache_module.build_raw_recognition_result
 
     def counted(part):
         result = original(part)
         calls.append(result)
         return result
 
-    monkeypatch.setattr(recognition_cache_module, "build_recognition_result", counted)
+    monkeypatch.setattr(recognition_cache_module, "build_raw_recognition_result", counted)
     with pytest.warns(ScaleCompletenessWarning, match="fallback scale 0.5"):
         drawing = sheet.build()
 
@@ -501,7 +501,7 @@ def test_fallback_reuses_geometry_classification_and_recognition(monkeypatch):
 
     calls = {"classify": 0, "recognise": 0}
     original_classify = analysis._classify_geometry
-    original_recognise = analysis.build_recognition_result
+    original_recognise = analysis.build_raw_recognition_result
 
     def counted_classify(*args, **kwargs):
         calls["classify"] += 1
@@ -512,7 +512,7 @@ def test_fallback_reuses_geometry_classification_and_recognition(monkeypatch):
         return original_recognise(*args, **kwargs)
 
     monkeypatch.setattr(analysis, "_classify_geometry", counted_classify)
-    monkeypatch.setattr(analysis, "build_recognition_result", counted_recognise)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted_recognise)
     with pytest.warns(ScaleCompletenessWarning, match="fallback scale 0.5"):
         drawing = build_drawing(_scale_sensitive_plate(), page="A4", scale=1.0, repair=False)
 

--- a/tests/test_issue_1369_hole_completeness_evidence.py
+++ b/tests/test_issue_1369_hole_completeness_evidence.py
@@ -151,13 +151,13 @@ def test_deleting_provider_holes_cannot_shrink_the_independent_denominator(monke
     """
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def without_holes(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, holes=(), hole_patterns=())
 
-    monkeypatch.setattr(analysis, "build_recognition_result", without_holes)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_holes)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0

--- a/tests/test_issue_1370_hole_pattern_completeness_evidence.py
+++ b/tests/test_issue_1370_hole_pattern_completeness_evidence.py
@@ -293,13 +293,13 @@ def test_wrong_placed_group_count_ink_loses_drawing_credit(monkeypatch) -> None:
 def test_deleting_provider_patterns_cannot_shrink_the_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def without_patterns(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, hole_patterns=())
 
-    monkeypatch.setattr(analysis, "build_recognition_result", without_patterns)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_patterns)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -311,7 +311,7 @@ def test_deleting_provider_patterns_cannot_shrink_the_independent_denominator(mo
 def test_weakening_provider_arrangement_values_reduces_parameter_fidelity(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def weakened_patterns(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -325,7 +325,7 @@ def test_weakening_provider_arrangement_values_reduces_parameter_fidelity(monkey
                 changed.append(replace(pattern, diameter=pattern.diameter + 1.0))
         return replace(result, hole_patterns=tuple(changed))
 
-    monkeypatch.setattr(analysis, "build_recognition_result", weakened_patterns)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened_patterns)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0

--- a/tests/test_issue_1371_flat_completeness_evidence.py
+++ b/tests/test_issue_1371_flat_completeness_evidence.py
@@ -107,7 +107,7 @@ def test_every_flat_boundary_is_observed_supported_on_the_real_public_path() -> 
 def test_flat_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
     calls = 0
 
     def counted(*args, **kwargs):
@@ -115,7 +115,7 @@ def test_flat_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", counted)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted)
     assert _default_observers()["flats"](_double_d())
     assert calls == 1
 
@@ -252,13 +252,13 @@ def test_severing_flat_measurement_provenance_loses_drawing_credit(monkeypatch) 
 def test_deleting_provider_flats_cannot_shrink_the_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def without_flats(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, flats=())
 
-    monkeypatch.setattr(analysis, "build_recognition_result", without_flats)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_flats)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -270,14 +270,14 @@ def test_deleting_provider_flats_cannot_shrink_the_independent_denominator(monke
 def test_weakening_provider_across_values_reduces_parameter_fidelity(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def weakened_flats(*args, **kwargs):
         result = original(*args, **kwargs)
         flats = tuple(replace(flat, across=flat.across + 1.0) for flat in result.flats)
         return replace(result, flats=flats)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", weakened_flats)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened_flats)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0

--- a/tests/test_issue_1372_groove_completeness_evidence.py
+++ b/tests/test_issue_1372_groove_completeness_evidence.py
@@ -182,7 +182,7 @@ def test_every_groove_boundary_is_observed_supported_on_the_real_public_path() -
 def test_groove_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
     calls = 0
 
     def counted(*args, **kwargs):
@@ -190,7 +190,7 @@ def test_groove_observer_uses_one_build_owned_recognition_aggregate(monkeypatch)
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", counted)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted)
     assert _default_observers()["grooves"](_lone())
     assert calls == 1
 
@@ -488,13 +488,13 @@ def test_incomplete_compiler_group_cannot_certify_groove_ink(monkeypatch) -> Non
 def test_deleting_provider_grooves_cannot_shrink_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def without_grooves(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, grooves=())
 
-    monkeypatch.setattr(analysis, "build_recognition_result", without_grooves)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_grooves)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -507,7 +507,7 @@ def test_deleting_provider_grooves_cannot_shrink_independent_denominator(monkeyp
 def test_weakening_provider_measurements_reduces_parameter_fidelity(monkeypatch, field) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def weakened_grooves(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -516,7 +516,7 @@ def test_weakening_provider_measurements_reduces_parameter_fidelity(monkeypatch,
         )
         return replace(result, grooves=grooves)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", weakened_grooves)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened_grooves)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0
@@ -530,7 +530,7 @@ def test_weakening_provider_measurements_reduces_parameter_fidelity(monkeypatch,
 def test_weakening_provider_identity_reduces_detection_recall(monkeypatch, field) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def weakened_grooves(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -546,7 +546,7 @@ def test_weakening_provider_identity_reduces_detection_recall(monkeypatch, field
             )
         return replace(result, grooves=values)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", weakened_grooves)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened_grooves)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 0.0

--- a/tests/test_issue_1372_pocket_completeness_evidence.py
+++ b/tests/test_issue_1372_pocket_completeness_evidence.py
@@ -169,7 +169,7 @@ def test_every_pocket_boundary_is_observed_supported_on_the_real_public_path() -
 def test_pocket_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
     calls = 0
 
     def counted(*args, **kwargs):
@@ -177,7 +177,7 @@ def test_pocket_observer_uses_one_build_owned_recognition_aggregate(monkeypatch)
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", counted)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted)
     assert _default_observers()["pockets"](_lone())
     assert calls == 1
 
@@ -399,13 +399,13 @@ def test_side_opening_authored_location_omission_is_suppressed_not_missing() -> 
 def test_deleting_provider_pockets_cannot_shrink_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def without_pockets(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, pockets=(), pocket_patterns=())
 
-    monkeypatch.setattr(analysis, "build_recognition_result", without_pockets)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_pockets)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -417,14 +417,14 @@ def test_deleting_provider_pockets_cannot_shrink_independent_denominator(monkeyp
 def test_weakening_provider_widths_reduces_parameter_fidelity(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def weakened_pockets(*args, **kwargs):
         result = original(*args, **kwargs)
         pockets = tuple(replace(pocket, width=pocket.width + 1.0) for pocket in result.pockets)
         return replace(result, pockets=pockets)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", weakened_pockets)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened_pockets)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0

--- a/tests/test_issue_1372_pocket_pattern_completeness_evidence.py
+++ b/tests/test_issue_1372_pocket_pattern_completeness_evidence.py
@@ -284,7 +284,7 @@ def test_every_pocket_pattern_boundary_is_observed_on_the_real_public_path() -> 
 def test_pocket_pattern_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
     calls = 0
 
     def counted(*args, **kwargs):
@@ -292,7 +292,7 @@ def test_pocket_pattern_observer_uses_one_build_owned_recognition_aggregate(monk
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", counted)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted)
     assert _default_observers()["pocket-patterns"](_grid_part())
     assert calls == 1
 
@@ -823,13 +823,13 @@ def test_pitch_fallback_rejects_unverifiable_real_geometry(
 def test_deleting_provider_patterns_cannot_shrink_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def without_patterns(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, pocket_patterns=())
 
-    monkeypatch.setattr(analysis, "build_recognition_result", without_patterns)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_patterns)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -841,7 +841,7 @@ def test_deleting_provider_patterns_cannot_shrink_independent_denominator(monkey
 def test_weakening_provider_pitch_reduces_parameter_fidelity(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def weakened_patterns(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -853,7 +853,7 @@ def test_weakening_provider_pitch_reduces_parameter_fidelity(monkeypatch) -> Non
                 changed.append(replace(pattern, pitch=pattern.pitch + 1.0))
         return replace(result, pocket_patterns=tuple(changed))
 
-    monkeypatch.setattr(analysis, "build_recognition_result", weakened_patterns)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened_patterns)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0
@@ -866,7 +866,7 @@ def test_weakening_provider_pitch_reduces_parameter_fidelity(monkeypatch) -> Non
 def test_hardcoding_arrangement_orientation_reduces_parameter_fidelity(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def axis_aligned_patterns(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -878,7 +878,7 @@ def test_hardcoding_arrangement_orientation_reduces_parameter_fidelity(monkeypat
                 changed.append(replace(pattern, direction=(0.0, 1.0, 0.0)))
         return replace(result, pocket_patterns=tuple(changed))
 
-    monkeypatch.setattr(analysis, "build_recognition_result", axis_aligned_patterns)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", axis_aligned_patterns)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0

--- a/tests/test_issue_1374_chamfer_completeness_evidence.py
+++ b/tests/test_issue_1374_chamfer_completeness_evidence.py
@@ -283,7 +283,7 @@ def test_every_chamfer_boundary_is_observed_supported_on_the_real_public_path() 
 def test_chamfer_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
     calls = 0
 
     def counted(*args, **kwargs):
@@ -291,7 +291,7 @@ def test_chamfer_observer_uses_one_build_owned_recognition_aggregate(monkeypatch
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", counted)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted)
     assert _default_observers()["chamfers"](_lone())
     assert calls == 1
 
@@ -512,13 +512,13 @@ def test_severing_chamfer_measurement_provenance_loses_drawing_credit(monkeypatc
 def test_deleting_provider_chamfers_cannot_shrink_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def without_chamfers(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, chamfers=())
 
-    monkeypatch.setattr(analysis, "build_recognition_result", without_chamfers)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_chamfers)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -531,7 +531,7 @@ def test_deleting_provider_chamfers_cannot_shrink_independent_denominator(monkey
 def test_weakening_provider_chamfer_parameters_reduces_fidelity(monkeypatch, field) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def weakened(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -540,7 +540,7 @@ def test_weakening_provider_chamfer_parameters_reduces_fidelity(monkeypatch, fie
         )
         return replace(result, chamfers=values)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", weakened)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0

--- a/tests/test_issue_1374_fillet_completeness_evidence.py
+++ b/tests/test_issue_1374_fillet_completeness_evidence.py
@@ -256,7 +256,7 @@ def test_every_fillet_boundary_is_observed_supported_on_the_real_public_path() -
 def test_fillet_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
     calls = 0
 
     def counted(*args, **kwargs):
@@ -264,7 +264,7 @@ def test_fillet_observer_uses_one_build_owned_recognition_aggregate(monkeypatch)
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", counted)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted)
     assert _default_observers()["fillets"](_lone())
     assert calls == 1
 
@@ -483,13 +483,13 @@ def test_severing_fillet_measurement_provenance_loses_drawing_credit(monkeypatch
 def test_deleting_provider_fillets_cannot_shrink_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def without_fillets(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, fillets=())
 
-    monkeypatch.setattr(analysis, "build_recognition_result", without_fillets)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_fillets)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -501,14 +501,14 @@ def test_deleting_provider_fillets_cannot_shrink_independent_denominator(monkeyp
 def test_weakening_provider_fillet_radius_reduces_fidelity(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def weakened(*args, **kwargs):
         result = original(*args, **kwargs)
         values = tuple(replace(item, radius=item.radius + 0.5) for item in result.fillets)
         return replace(result, fillets=values)
 
-    monkeypatch.setattr(analysis, "build_recognition_result", weakened)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0

--- a/tests/test_issue_1382_circular_blind_step_semantics.py
+++ b/tests/test_issue_1382_circular_blind_step_semantics.py
@@ -213,13 +213,13 @@ def test_standalone_model_runs_one_aggregate_and_one_cylinder_scan(monkeypatch) 
     import draftwright.model.detect as detect
 
     rotational_flags = []
-    real_build = detect.build_recognition_result
+    real_build = detect.build_raw_recognition_result
 
     def recording_build(*args, **kwargs):
         rotational_flags.append(kwargs["rotational"])
         return real_build(*args, **kwargs)
 
-    monkeypatch.setattr(detect, "build_recognition_result", recording_build)
+    monkeypatch.setattr(detect, "build_raw_recognition_result", recording_build)
     with counting_calls(
         {"turned_steps": recognise_turned_steps, "cylinders": analyse_cylinders}
     ) as counts:

--- a/tests/test_issue_1382_through_step_semantics.py
+++ b/tests/test_issue_1382_through_step_semantics.py
@@ -372,7 +372,7 @@ def test_only_emittable_plates_may_preempt_the_aggregate_owner() -> None:
     assert len(tuple(compile_dimensions(model).of_kind("through_step"))) == 1
 
 
-def test_edge_pocket_floor_cannot_preempt_then_erase_the_aggregate_owner() -> None:
+def test_covariant_edge_pocket_keeps_the_complete_legacy_owner() -> None:
     base = Rot(90, 0, 0) * _through_step_part()
     edge_pocket = Pos(-20, -10, 0) * Box(
         8,
@@ -390,8 +390,13 @@ def test_edge_pocket_floor_cannot_preempt_then_erase_the_aggregate_owner() -> No
     )
 
     assert len(recognition.through_steps) == 1
-    assert [feature.kind for feature in drawing.model().features].count("through_step") == 1
-    assert [outcome.state for outcome in outcomes] == ["placed", "placed"]
+    # 0.4.8 correctly reports this post-rotation opening along Y.  Its floor therefore
+    # cannot erase the Z level + X shoulder that already state the two transverse legs;
+    # retaining a second ThroughStep owner would double-dimension the same section.
+    assert recognition.pockets[0].depth_axis == "y"
+    assert [feature.kind for feature in drawing.model().features].count("through_step") == 0
+    assert [feature.kind for feature in drawing.model().features].count("step_level") == 1
+    assert [outcome.state for outcome in outcomes] == ["inapplicable", "inapplicable"]
     assert not [issue for issue in drawing.lint() if "through_step" in issue.code]
 
 

--- a/tests/test_issue_1392_pad_covariance.py
+++ b/tests/test_issue_1392_pad_covariance.py
@@ -1,0 +1,189 @@
+"""End-to-end 0.4.8 adoption and RaisedPad schema-v2 covariance (#1392)."""
+
+import ast
+from importlib import metadata
+from pathlib import Path
+
+import pytest
+from b123d_recognisers import (
+    FramedRecognitionResult,
+    build_framed_recognition_result,
+    build_raw_recognition_result,
+)
+from build123d import Align, Axis, Box, Compound, Pos, RegularPolygon, Rot, extrude
+
+from draftwright import build_drawing
+from draftwright.builder import detect_part_model
+from draftwright.model import PadFeature, pad
+
+_MIN = (Align.MIN, Align.MIN, Align.MIN)
+
+
+def test_exact_wheel_and_production_raw_coordinate_boundary_are_explicit():
+    assert metadata.version("b123d-recognisers") == "0.4.8"
+    root = Path(__file__).parents[1] / "src" / "draftwright"
+    offenders = []
+    for path in root.rglob("*.py"):
+        tree = ast.parse(path.read_text(), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Name) and node.id == "build_recognition_result":
+                offenders.append(str(path.relative_to(root)))
+            if isinstance(node, ast.Attribute) and node.attr == "build_recognition_result":
+                offenders.append(str(path.relative_to(root)))
+    assert offenders == []
+
+
+def test_048_public_framed_contract_returns_exact_local_pad_working_solid():
+    source = Box(100, 70, 12, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    source += Pos(18, -10, 12) * Box(28, 16, 8, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    moved = Pos(17, -23, 9) * Rot(31, 47, 13) * source
+
+    framed = build_framed_recognition_result(moved, rotational=False)
+
+    assert isinstance(framed, FramedRecognitionResult)
+    assert framed.part is not moved
+    assert len(framed.part.solids()) == len(moved.solids()) == 1
+    (record,) = framed.result.pads
+    local_bb = framed.part.bounding_box()
+    tol = 1e-3  # public records are deterministically rounded to three decimals
+    assert local_bb.min.X - tol <= record.x0 < record.x1 <= local_bb.max.X + tol
+    assert local_bb.min.Y - tol <= record.y0 < record.y1 <= local_bb.max.Y + tol
+    assert local_bb.min.Z - tol <= record.z0 < record.z1 <= local_bb.max.Z + tol
+    spans = {
+        "x": record.x1 - record.x0,
+        "y": record.y1 - record.y0,
+        "z": record.z1 - record.z0,
+    }
+    assert spans.pop(record.axis) == pytest.approx(8, abs=1e-3)
+    assert sorted(spans.values()) == pytest.approx([16, 28], abs=1e-3)
+
+
+def test_048_public_framed_contract_preserves_polygonal_boss_covariance():
+    source = Box(100, 80, 10) + Pos(0, 0, 5) * extrude(RegularPolygon(20, 6), 30)
+    moved = Pos(17, -23, 9) * Rot(31, 47, 13) * source
+
+    framed = build_framed_recognition_result(moved, rotational=False)
+
+    assert isinstance(framed, FramedRecognitionResult)
+    (record,) = framed.result.polygonal_bosses
+    assert record.axis in "xyz"
+    assert record.side_count == 6
+    assert record.height == pytest.approx(30, abs=1e-3)
+    local_bb = framed.part.bounding_box()
+    axis_bounds = {
+        "x": (local_bb.min.X, local_bb.max.X),
+        "y": (local_bb.min.Y, local_bb.max.Y),
+        "z": (local_bb.min.Z, local_bb.max.Z),
+    }
+    assert (
+        axis_bounds[record.axis][0] - 1e-3
+        <= record.base
+        < record.top
+        <= axis_bounds[record.axis][1] + 1e-3
+    )
+
+
+def test_048_public_framed_contract_preserves_rolled_body_local_plates():
+    align = (Align.CENTER, Align.CENTER, Align.MIN)
+    member = Box(40, 10, 4, align=align) + Pos(0, 7, 4) * Box(1, 14, 20, align=align)
+    rolled = member.rotate(Axis.Z, 37)
+    moved = Pos(17, -23, 9) * Rot(31, 47, 13) * rolled
+
+    framed = build_framed_recognition_result(moved, rotational=False)
+
+    assert isinstance(framed, FramedRecognitionResult)
+    assert len(framed.result.plates) == 2
+    local_bb = framed.part.bounding_box()
+    local_bounds = {
+        "x": (local_bb.min.X, local_bb.max.X),
+        "y": (local_bb.min.Y, local_bb.max.Y),
+        "z": (local_bb.min.Z, local_bb.max.Z),
+    }
+    assert all(
+        local_bounds[plate.axis][0] <= plate.lo < plate.hi <= local_bounds[plate.axis][1]
+        for plate in framed.result.plates
+    )
+
+
+def _pad_part(axis: str, direction: int):
+    base = Pos(-30, -25, -10) * Box(60, 50, 20, align=_MIN)
+    if axis == "x":
+        origin = (30 if direction > 0 else -36, -15, -7)
+        island = Pos(*origin) * Box(6, 20, 12, align=_MIN)
+    elif axis == "y":
+        origin = (-15, 25 if direction > 0 else -31, -7)
+        island = Pos(*origin) * Box(20, 6, 12, align=_MIN)
+    else:
+        origin = (-15, -9, 10 if direction > 0 else -16)
+        island = Pos(*origin) * Box(20, 12, 6, align=_MIN)
+    return base + island
+
+
+def _bounds(feature: PadFeature):
+    half = feature.width / 2
+    by_axis = {
+        feature.long_axis: (feature.lo, feature.hi),
+        feature.width_axis: (feature.w_center - half, feature.w_center + half),
+        feature.frame.axis: (feature.z0, feature.z1),
+    }
+    return tuple(value for axis in "xyz" for value in by_axis[axis])
+
+
+@pytest.mark.parametrize("axis", "xyz")
+@pytest.mark.parametrize("direction", (-1, 1))
+def test_signed_pad_semantics_reach_ir_solver_and_critique(axis, direction):
+    part = _pad_part(axis, direction)
+    source = build_raw_recognition_result(part).pads
+    assert len(source) == 1
+    record = source[0]
+    assert (record.axis, record.direction) == (axis, direction)
+
+    feature = next(f for f in detect_part_model(part).features if isinstance(f, PadFeature))
+    assert (feature.frame.axis, feature.direction, feature.occurrence) == (axis, direction, 0)
+    assert _bounds(feature) == pytest.approx(
+        (record.x0, record.x1, record.y0, record.y1, record.z0, record.z1)
+    )
+    assert {parameter.parameter_id for parameter in feature.parameters()} == {
+        "pad_width.length",
+        "pad_length.length",
+        "pad_height.length",
+    }
+
+    rebuilt = pad(
+        x0=record.x0,
+        x1=record.x1,
+        y0=record.y0,
+        y1=record.y1,
+        z0=record.z0,
+        z1=record.z1,
+        axis=record.axis,
+        direction=record.direction,
+        occurrence=0,
+    )
+    assert rebuilt == feature
+
+    # The six-millimetre height needs enough paper span for inward arrows; at 1:1
+    # the correct outcome is an explicit placement drop, not a fabricated dimension.
+    drawing = build_drawing(part, page="A1", scale=5.0)
+    measurements = {
+        identity
+        for name in drawing.registry.names()
+        for identity in drawing.registry.measurement_of(name)
+        if identity.feature == feature
+    }
+    parameter_ids = {identity.parameter for identity in measurements}
+    assert {"pad_width.length", "pad_length.length", "pad_height.length"} <= parameter_ids
+    assert {f"location_pad.{candidate}" for candidate in "xyz" if candidate != axis} <= (
+        parameter_ids
+    )
+    assert "pad_footprint_not_defined" not in drawing.lint_summary()["by_code"]
+
+
+def test_equal_pad_values_keep_distinct_occurrence_identity():
+    first = _pad_part("z", 1)
+    second = Pos(80, 0, 0) * _pad_part("z", 1)
+    model = detect_part_model(Compound(children=[first, second]))
+    pads = [feature for feature in model.features if isinstance(feature, PadFeature)]
+    assert len(pads) == 2
+    assert [feature.occurrence for feature in pads] == [0, 1]
+    assert pads[0] != pads[1]

--- a/tests/test_issue_885_prismatic_coverage.py
+++ b/tests/test_issue_885_prismatic_coverage.py
@@ -90,12 +90,18 @@ def test_auto_drawing_defines_pad_footprints_and_pocket_locations():
     assert tuple(detected.features) == tuple(drawing.model().features)
     assert [f.kind for f in drawing.model().features].count("pad") == 4
     names = set(drawing.annotations())
-    assert len({name for name in names if name.startswith("m_pad")}) == 8
+    assert len({name for name in names if name.startswith("m_pad") and "height" not in name}) == 8
+    assert any(name.startswith("m_padheight_") for name in names)
     assert {"m_locy1", "m_locy3"} <= names  # pocket centres at Y=30 and Y=90
     summary = drawing.lint_summary()
     assert "pad_footprint_not_defined" not in summary["by_code"]
     assert "pocket_not_located" not in summary["by_code"]
-    assert summary["score"] == 1.0
+    # The default 1:1 layout has room for one of the four equal pad-height
+    # dimensions.  The other three must remain explicit placement outcomes;
+    # silently crediting them from a dimension attached to a different pad
+    # would violate per-occurrence measurement provenance.
+    assert summary["by_code"]["pad_height_dropped"] == 3
+    assert summary["score"] < 1.0
 
 
 def test_removing_one_pad_size_is_not_credited_from_an_aligned_sibling():

--- a/tests/test_issue_909_sloped_profile.py
+++ b/tests/test_issue_909_sloped_profile.py
@@ -55,7 +55,7 @@ def test_case_study_pad_reaches_the_drawing_with_complete_owned_footprint():
     } == {
         "pad_width.length",
         "pad_length.length",
-        "location_pad.location",
+        "location_pad.x",
     }
     detail_labels = Counter(
         annotation.label
@@ -100,7 +100,7 @@ def test_case_study_detail_rungs_keep_their_compiled_measurement_identity():
 
 @pytest.mark.parametrize(
     ("name_prefix", "parameter_id"),
-    [("m_pad", "pad_length.length"), ("m_locx", "location_pad.location")],
+    [("m_pad", "pad_length.length"), ("m_locx", "location_pad.x")],
 )
 def test_removing_a_required_pad_dimension_reports_the_real_requirement(name_prefix, parameter_id):
     drawing = build_drawing(_ISSUE_909, detail_view=True)

--- a/tests/test_issue_958_cross_solid_recognition.py
+++ b/tests/test_issue_958_cross_solid_recognition.py
@@ -74,14 +74,13 @@ def test_attached_pad_remains_recognised_once():
         name: drawing.get_annotation(name).label
         for name in drawing.annotations()
         if name.startswith("m_pad")
-    } == {"m_pad0_width": "20", "m_pad0_length": "30"}
+    } == {"m_pad0_width": "20", "m_pad0_length": "30", "m_padheight_z0": "4"}
     assert not [name for name in drawing.annotations() if name.startswith("m_slot")]
-    # The pad's own height above the plate is a `step_level` the compiler approves and the
-    # legibility floor discards — 9 mm of page against a 12.4 mm minimum — so this drawing gives
-    # the pad a width and a length and no height. That was invisible until `step_dim_withheld`
-    # (#1216); the assertion was `== []` and the missing dimension was part of what it blessed.
+    # The pad's direct height now occupies the left profile corridor, opposite the mandatory
+    # overall height.  The same short span remains part of the legacy step-level ladder, whose
+    # 12.4 mm legibility floor withholds that redundant route; pad completeness itself is met.
     assert [(issue.severity, issue.code) for issue in drawing.lint()] == [
-        ("info", "step_dim_withheld")
+        ("info", "step_dim_withheld"),
     ]
 
 

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -9492,11 +9492,14 @@ class TestTurnedDiameters:
             expected = 4 if dwg.get_annotation(name).label == "4× 2" else 1
             assert len(dwg.measurement_keys(name)) == expected
 
-        # The central Y-axis bore shares the detected turned-profile axis. Its
-        # centreline locates it; generic minimum-edge offsets would redundantly
-        # show half the 46 mm envelope in both X and Z (#881).
+        # The central Y-axis bore shares the detected turned-profile axis. Its side-view
+        # centreline locates it; generic minimum-edge offsets would redundantly show half
+        # the 46 mm envelope in both X and Z (#881).  With the corrected 0.4.8 inventory,
+        # automatic view selection can prove the plan projection redundant; #1262 requires
+        # furniture for an omitted view to be omitted with it.
         assert dwg.view_of("centerline_side") == "side"
-        assert dwg.view_of("centerline_plan") == "plan"
+        assert "plan" not in dwg.views
+        assert dwg.view_of("centerline_plan") is None
         assert not any(n.startswith("dim_loc_front_") for n in dwg.annotations())
         assert not any(n.startswith("dim_loc_side_") for n in dwg.annotations())
 
@@ -9717,7 +9720,7 @@ class TestTurnedDiameters:
 
         Retargeted onto the Sheet script by #940. This fixture also carries what
         `test_issue_881_generated_script_emits_y_step_intents` used to assert about the
-        imperative script's TEXT: that suite's executable half — side/plan centrelines, no
+        imperative script's TEXT: that suite's executable half — axis furniture, no
         front/side location dims, the step-length chain on the side view — is folded in
         below, since the source-text half described a file that no longer exists.
         """
@@ -9761,7 +9764,8 @@ class TestTurnedDiameters:
 
         # ── from #881: the Y-step furniture lands in the right views on the replay ──
         assert replayed.view_of("centerline_side") == "side"
-        assert replayed.view_of("centerline_plan") == "plan"
+        assert "plan" not in replayed.views
+        assert replayed.view_of("centerline_plan") is None
         assert not any(n.startswith(("dim_loc_front_", "dim_loc_side_")) for n in replay)
         assert {replayed.view_of(n) for n in replay if n.startswith("m_steplen")} == {"side"}
 

--- a/tests/test_parameter_id.py
+++ b/tests/test_parameter_id.py
@@ -240,7 +240,11 @@ _SAMPLE_BINDINGS = {
     ),
     "EnvelopeFeature": (("width.length", 80.0), ("height.length", 8.0), ("depth.length", 50.0)),
     "SlotFeature": (("slot_width.length", 8.0), ("slot_length.length", 30.0)),
-    "PadFeature": (("pad_width.length", 8.0), ("pad_length.length", 30.0)),
+    "PadFeature": (
+        ("pad_width.length", 8.0),
+        ("pad_length.length", 30.0),
+        ("pad_height.length", 8.0),
+    ),
     "PocketFeature": (
         ("pocket_width.length", 8.0),
         ("pocket_length.length", 30.0),

--- a/tests/test_part_model.py
+++ b/tests/test_part_model.py
@@ -298,7 +298,7 @@ def test_feature_detection_runs_once_per_build(monkeypatch):
     """ADR 0008 Amendment 5 / #244 — one aggregate inventory per build.
 
     The recogniser package owns its internal family orchestration; Draftwright's contract is
-    the single public ``build_recognition_result`` call whose result every consumer reuses.
+    the single public ``build_raw_recognition_result`` call whose result every consumer reuses.
     """
     from build123d import Cylinder, Pos, Rotation
 
@@ -306,14 +306,14 @@ def test_feature_detection_runs_once_per_build(monkeypatch):
     from draftwright import build_drawing
 
     calls = 0
-    original = amod.build_recognition_result
+    original = amod.build_raw_recognition_result
 
     def wrap(*args, **kwargs):
         nonlocal calls
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(amod, "build_recognition_result", wrap)
+    monkeypatch.setattr(amod, "build_raw_recognition_result", wrap)
 
     # A turned X shaft exercises the detected path, including a repack when required.
     build_drawing(Rotation(0, 90, 0) * (Cylinder(15, 30) + Pos(0, 0, 30) * Cylinder(8, 30)))

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -128,7 +128,7 @@ def test_installed_package_contract_validates_without_a_sibling_checkout() -> No
 def test_rich_passage_contract_has_an_explicit_unsupported_completeness_outcome() -> None:
     """Pin the 0.4 physical record and compatibility projection to one decision."""
 
-    assert INSTALLED_PACKAGE_VERSION == "0.4.6"
+    assert INSTALLED_PACKAGE_VERSION == "0.4.8"
     installed = tuple(int(component) for component in INSTALLED_PACKAGE_VERSION.split("."))
     assert (0, 4, 0) <= installed < (0, 5, 0)
     package = _families(recognition.capability_manifest())
@@ -982,16 +982,17 @@ def test_schema_format_fails_closed() -> None:
         _validate(package=package)
 
 
-def test_only_chamfer_and_fillet_accept_installed_schema_2() -> None:
-    """The pinned package uses schema 2 only for chamfers and fillets."""
+def test_only_reviewed_families_accept_installed_schema_2() -> None:
+    """The pinned package uses schema 2 only for reviewed chamfer, fillet, and pad records."""
     declaration = consumer_capability_declaration()
     families = _families(declaration)
     assert families["chamfers"]["record_schemas"] == {"Chamfer": [2]}
     assert families["fillets"]["record_schemas"] == {"Fillet": [2]}
+    assert families["rectangular-pads"]["record_schemas"] == {"RaisedPad": [2]}
     assert all(
         versions == [1]
         for family_id, family in families.items()
-        if family_id not in {"chamfers", "fillets"}
+        if family_id not in {"chamfers", "fillets", "rectangular-pads"}
         for versions in family["record_schemas"].values()
     )
 

--- a/tests/test_recognition_result.py
+++ b/tests/test_recognition_result.py
@@ -54,7 +54,7 @@ def test_built_drawing_exposes_its_recognition_result_without_private_state(monk
         raise AssertionError("Drawing.recognition() re-ran recognition instead of handing back")
 
     monkeypatch.setattr(result_module, "build_recognition_result", forbidden)
-    monkeypatch.setattr(analysis_module, "build_recognition_result", forbidden)
+    monkeypatch.setattr(analysis_module, "build_raw_recognition_result", forbidden)
     assert drawing.recognition() is result
 
 

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -2547,7 +2547,9 @@ class TestTheDimensionMirror:
     #: only an envelope) and "slot" (detected a pocket) until #947's review counted them.
     _EXPECTED_KINDS = {
         "plate+hole": {"hole"},
-        "flange (no envelope feature)": {"hole", "pattern", "pad", "step"},
+        # 0.4.8 no longer treats the flange's four box-ended lobes as attached rectangular
+        # pads after the part is rolled; the dedicated pad fixture below owns that route.
+        "flange (no envelope feature)": {"hole", "pattern", "step"},
         "stepped": {"step_level"},
         "slot": {"slot"},
         "pocket": {"pocket"},
@@ -2771,7 +2773,6 @@ class TestTheDimensionMirror:
 _SCRIPT_FURNITURE = {
     "m_cm": "centre marks — sized off the hole they mark, not a printed value (#875)",
     "centerline_front": "shows where the front view's axis is; no measurement",
-    "centerline_plan": "shows where the plan view's axis is; no measurement",
     "centerline_side": "shows where the side view's axis is; no measurement",
     "bc_": "a bolt circle's centreline — geometry, like a centre mark",
     "note_iso_nts": "the ISO NTS caption — a sheet-level statement, not a feature's",

--- a/uv.lock
+++ b/uv.lock
@@ -85,15 +85,15 @@ wheels = [
 
 [[package]]
 name = "b123d-recognisers"
-version = "0.4.6"
+version = "0.4.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c0/c7/ad6be406531a243bd416017c75659d455a6cb0f2f49202c354f0b7d8bbca/b123d_recognisers-0.4.6.tar.gz", hash = "sha256:ea4a0ca46eb97017594636d95b638ad19bea448f7d05a12428f7d33cd1071341", size = 2063844, upload-time = "2026-08-29T21:52:11.202Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/f9/69be5018fe16b53317502c67e9254e0373968bf6261f3dc9c873901d07ca/b123d_recognisers-0.4.8.tar.gz", hash = "sha256:c76edc640c3e4029ab2060a7a4e1e2743e27a479cec9147a08cdcfc827a2ac66", size = 3127513, upload-time = "2026-08-30T15:42:27.041Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/88/c74b9e350c833746987b3f53189a1fb33e0dc6dea98190f14000852d8061/b123d_recognisers-0.4.6-py3-none-any.whl", hash = "sha256:55dfff8510fc4c5aaf5f3783ec1e78ac82e4db152f6935b3e5dd2563fc5f2568", size = 375023, upload-time = "2026-08-29T21:52:09.945Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/ac/814f5d6ccdc07aba66bbfcbe8665d186e60eeb43ff4b10986202e4167254/b123d_recognisers-0.4.8-py3-none-any.whl", hash = "sha256:ec818b0c65922d8d6c4824c09563acc37542ac78f808e0d6af9e2ad2ddfa7785", size = 381313, upload-time = "2026-08-30T15:42:25.196Z" },
 ]
 
 [[package]]
@@ -746,7 +746,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "antlr4-python3-runtime", specifier = "<4.10" },
-    { name = "b123d-recognisers", specifier = "==0.4.6" },
+    { name = "b123d-recognisers", specifier = "==0.4.8" },
     { name = "build123d", marker = "python_full_version < '3.13'", specifier = ">=0.9.0,<0.11" },
     { name = "build123d", marker = "python_full_version >= '3.13'", specifier = ">=0.11,<0.12" },
     { name = "build123d-drafting-helpers", specifier = ">=0.14.2" },


### PR DESCRIPTION
Closes #1392

## Outcome

Adopts the exact PyPI `b123d-recognisers==0.4.8` contract while keeping Draftwright production explicitly in caller/world coordinates until #1357 owns the framed adapter.

- carries signed X/Y/Z `RaisedPad` axis, direction, and occurrence through IR, Sheet declarations, generated scripts, planning, rendering, and physical coverage
- adds independently addressable footprint, height, and two-axis location requirements
- places Z-pad height opposite the mandatory overall-height corridor, keeping representative stepped drawings complete
- accepts corrected caller-coordinate inventory transitions for a rotated edge pocket, rolled flange false pads, and redundant plan-view removal
- adds public framed-boundary tests for rectangular pads, polygonal bosses, and body-local Plates without adopting framed production piecemeal
- updates ADR 0017, architecture/capability docs, inspection metadata, changelog, and lockfile

## Architecture audit

Reviewed ADRs 0007, 0011, and 0013–0018 before implementation and against the final diff. The change retains one external aggregate/cache; makes the raw-coordinate boundary explicit; carries semantic identity in IR; lets the compiler mint parameter identities; registers placement through the shared corridor solver with explicit outcomes; keeps physical coverage corpus-independent; and leaves view selection requirement-driven.

## Evidence

- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run mypy src`
- focused consumer suite: 283 passed
- no-approved-tolerance-drop contract: 50 passed
- final pad/standards set: 13 passed
- both complete fast shards were exercised as discovery runs; they exposed and drove narrow fixes for stale raw/framed instrumentation, corrected inventory expectations, view omission, diagnostic completeness, and Z-pad corridor placement. Fresh exact-head hosted shards are the authoritative broad gate.
