### PR TITLE
Adopt provider-owned framed recognition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- Automatic builds can opt into a provider-owned part-relative recognition frame with
+  `framed_recognition=True`. One adapter keeps the exact normalized solid, classification,
+  aggregate, PMI evidence, IR, projection and physical lint in a single coordinate system while
+  preserving caller geometry on `Drawing.part`. All frame gauges, typed raw fallback, rigid
+  motion, compound ownership, and declared-build authority are explicit and tested (#1357).
+
 - Referential and measured Sheet dimensions accept optional `view=` / `side=` placement
   intent. Supported pairs survive IR/compiler and generated-script round trips, constrain
   ordinary corridor candidates without exposing page coordinates, and fail clearly when a
@@ -36,6 +42,11 @@
   it (#1334) (#1321, #1332).
 
 ### Changed
+
+- Updated the immutable `b123d-recognisers` pin to 0.4.9, including body-local FaceLevel, Riser,
+  and TurnedProfile contracts. Off-axis framed hole patterns retain their absolute location
+  requirements, and rectangular-grid pitch placement uses the recognised lattice basis rather
+  than floating-point member ordering (#1357).
 
 - Updated the immutable `b123d-recognisers` pin and lock to 0.4.8. Draftwright now names
   its existing caller/world-coordinate aggregate boundary explicitly with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,8 @@ Compact map, bottom to top:
   `_geometry.py` (page-plane maths + the ADR 0014 Amdt 3 material field; the DAG's
   bottom leaf), `fonts.py` (pinned IBM Plex, ADR 0006), `fits.py` (ISO 286),
   `intents.py` (deferred-edit low IR), `recognition_cache.py` (ADR 0017 one-result
-  lifecycle), `_warnings.py`, `_pmi_part21.py`, and the `linting/` subpackage
+  lifecycle), `recognition_frame.py` (ADR 0020's provider-frame selection boundary),
+  `_warnings.py`, `_pmi_part21.py`, and the `linting/` subpackage
   (draftwright owns lint, ADR 0007).
 - **`_core.py`** — shared primitives: the `Analysis` namespace, dim/format helpers,
   page/slot/margin constants.

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -235,6 +235,16 @@ critique because it logs its diagnostics. Therefore the observable call contract
 | first physical critique/export of a declared drawing | at most one aggregate |
 | subsequent lint of the same drawing | zero additional calls |
 
+## Amendment 5 — 0.4.9 makes Plate applicability body-local
+
+Plate discovery now depends on completed turned-step occurrences. It excludes only their
+owning solids and remains able to inspect independent prismatic solids in a mixed compound.
+Consequently Plate is no longer one of the whole-part classification-gated families: the four
+prismatic step inventories remain gated, while a turned automatic build runs 23 public families
+when no turned owner is established and 24 when Plate consumes established body ownership.
+The prismatic and declared-path counts remain 28 and zero respectively. This replaces the
+compound-global Plate wording and fixed 23-family turned count in Amendments 3–4 and section 6.
+
 The lazy result is evidence for critique. It does not replace the declared model or widen its
 authored dimension set.
 

--- a/docs/adr/0020-provider-owned-local-frame-for-automatic-recognition.md
+++ b/docs/adr/0020-provider-owned-local-frame-for-automatic-recognition.md
@@ -1,0 +1,104 @@
+# ADR 0020 — Provider-owned local frame for automatic recognition
+
+- **Status:** Accepted for explicit opt-in rollout
+- **Date:** 2026-08-30
+- **Deciders:** Paul Fremantle (pzfreo)
+
+## Context
+
+Recognition records contain positions, principal axes, spans, topology ownership, and finite
+geometry evidence. Historically they used caller/world coordinates. Arbitrary rigid rotation can
+therefore change detection and finished drawing meaning even though it does not change the part.
+
+`b123d-recognisers` 0.4.9 exposes a two-stage public seam: `prepare_framed_part` returns either a
+typed refusal or the exact topology-preserving local solid and frozen cylinders; Draftwright can
+classify that exact solid before requesting its one aggregate. Consuming local records beside the
+caller-space shape would mix coordinate systems. Recreating normalization in Draftwright would
+create a second authority. Transforming records back to world coordinates cannot fit the current
+principal-axis IR after arbitrary rotation.
+
+## Decision
+
+### One coordinate-coherent compiler unit
+
+`recognition_frame.adapt_recognition` is the sole selection boundary. A successful framed run
+classifies the provider's prepared solid and cylinders, requests exactly one aggregate, and keeps
+the resulting working solid, records, classification, and `PartFrame` inseparable. Bounding-box
+analysis, IR lowering, planning, projection, rendering, and physical lint all use working
+coordinates. Scale retries reuse that unit.
+
+The provider owns frame inference and topology-preserving normalization. Draftwright owns the
+selection and all drafting policy. No downstream stage imports frame internals or guesses which
+coordinates a record uses.
+
+### Source and working geometry have distinct meanings
+
+For a framed automatic build, `Drawing.part` remains caller-space source geometry;
+`Drawing.working_part` is the exact local compiler solid; `Drawing.recognition_frame` records the
+caller-to-working frame; and `Drawing.recognition_frame_decision` records status, gauge, and any
+refusal reason. Declared and raw builds use the same object for source and working geometry.
+
+### Declarations retain authority
+
+Supplying `model=` and every `Sheet` build remain in caller coordinates and perform no automatic
+recognition (ADR 0011). A caller deliberately re-declaring detected framed output must pair
+`drawing.working_part` with `drawing.model()`.
+
+### AP242 evidence crosses once
+
+Nominal values and source identities do not change. Correlation points, all eight support-bounds
+corners, exact datum directions, and finite cylindrical references move once into working
+coordinates before PMI lowering. Exact direction vectors are retained during extraction even
+when not world-principal, then projected to the local principal-axis vocabulary. The canonical
+extraction report remains a source-space census; the analysis stores a separate working-record
+projection for compilation and scale reuse.
+
+### Gauges, refusal, and rollout are explicit
+
+`FULL`, `ORTHOGONAL`, and `AXIAL` use the same paired-unit contract. AXIAL roll is a stable gauge,
+not inferred manufacturing intent. A typed `RefusedPartFrame` performs exactly one raw aggregate
+run and reports `raw_fallback` plus the provider reason. The comparison route reports `raw`.
+
+The public rollout begins as `framed_recognition=True`; raw remains the default until supported
+platform CI and representative real-part canaries enumerate and review raw-to-framed transitions.
+This is a staging gate, not an architectural preference for world coordinates.
+
+Frame-induced axis permutations do not erase requirements. In particular, X/Y-normal hole
+patterns compile their two bbox-referenced locations under the stable
+`location_pattern.location` identity and enter the existing shared placement solve. Rectangular
+grid pitch axes come from the recognised lattice frame, not floating-point member ordering.
+Audit identities canonicalize rounded signed zero.
+
+Multi-diameter X/Y round stock remains on Draftwright's measurement-complete boss/envelope path
+until #1402 supplies axis-covariant turned-length furniture. This is an explicit consumer rollout
+limit: prematurely classifying it rotational loses approved axial and boss measurements, as the
+display-completeness sweep proves. It does not narrow the provider's covariant evidence.
+
+## Consequences
+
+- Rigid rotation and translation can be assessed in one stable local coordinate system.
+- Body/face provenance survives because consumers use the provider's exact normalized topology.
+- Public source geometry remains inspectable without leaking into local projection or lint.
+- A framed build may intentionally select different principal views than a raw build; those are
+  rollout transitions requiring evidence, not byte-for-byte regressions.
+
+## Rejected alternatives
+
+- Transform local records back into caller coordinates: arbitrary directions do not fit the IR.
+- Normalize independently in Draftwright: this duplicates authority and weakens provenance.
+- Return a naked framed `PartModel`: it cannot prove which solid shares its coordinates.
+- Enable framing by default before matrix/canary evidence: covariance tests do not disposition
+  every raw-to-framed layout transition.
+- Treat refusal as a proved caller-axis frame: this erases a meaningful diagnostic.
+
+## Conformance
+
+`tests/test_issue_1357_framed_recognition.py` covers all gauges, typed refusal, source/working
+separation, compound locality, exact PMI direction transfer, off-axis pattern requirements,
+declared ownership, one-run scale reuse, and rigid-motion parity through requirements,
+annotations, suppressions, and lint. Existing declared-recognition, import-boundary, platform,
+and real-part suites remain rollout gates.
+
+This preserves ADRs 0011, 0013, 0014–0018: declarations remain authoritative; normalization stays
+in the provider; all dimensions remain compiled solve candidates; one aggregate feeds the shared
+IR and critique; and view planning reads requirements rather than inferring a second frame.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -36,6 +36,7 @@ architecture** table; open retired or superseded records only for design history
 | [0017](0017-recognition-inventory-correspondence-and-measurement-provenance.md) | One recognition result per run; correspondence is evidence-gated | Produce one external immutable recognition result held by Draftwright's per-run cache; require vertical-slice evidence before generalising correspondence, identity, requirements, outcomes, or reconciliation. | Accepted; external cache ownership clarified, extensions gated by #1018 | `test_external_recognition_boundary.py`, `test_recognition_manifest.py`, `test_declared_recognition_gate.py` |
 | [0018](0018-requirement-driven-view-planning-and-editable-sheet-layout.md) | Requirement-driven view planning and editable sheet layout | Use one `ViewSpec` vocabulary and planner with distinct authored `ViewConstraints` and immutable `ResolvedViewPlan`; jointly validate views, typography, convention, scale, paper and layout against requirement survival. Supersedes ADR 0004's fixed-topology assumption while retaining compose-then-pack. | Accepted 2026-08-16; partially implemented (`ViewSpec`, `ResolvedViewPlan`, `ViewCoverage`, arrangement choice and requirement gate); tracked by #1130/#1259-#1262 | Required guards are listed in the ADR |
 | [0019](0019-display-complete-labels-and-dimension-outcomes.md) | Display-complete labels and a dimension-outcome ledger | The compiled plan carries the full label text (tolerance and collapse wording included) so renderers render and never compose; dimension outcomes reconcile at one seam on both build routes; ladder rungs get per-mark identity. Finishes the ADR 0016 Amdt 1 boundary; supersedes Amdt 6's enforcement mechanism. | Proposed | `test_issue_1215_no_approved_tolerance_is_dropped.py` reduces to plan-equality when implemented |
+| [0020](0020-provider-owned-local-frame-for-automatic-recognition.md) | Provider-owned local frame for automatic recognition | Select one provider-prepared working solid, classification, aggregate, PMI projection and frame as a coordinate-coherent compiler unit; retain source geometry separately and roll out by explicit opt-in. | Accepted for explicit opt-in rollout | `test_issue_1357_framed_recognition.py`, `test_recognition_manifest.py`, `test_make_drawing.py` |
 
 ## Historical records
 
@@ -52,6 +53,6 @@ architecture** table; open retired or superseded records only for design history
 - Layout and placement: 0004 → 0014 → 0012 → 0018.
 - Declared intent and the editable surface: 0001 → 0011 → 0012 → 0016 → 0018 → 0019.
 - Quality and correction: 0002, with provenance from 0010.
-- Recognition correspondence and completeness: 0007 → 0013 → 0015 → 0017.
+- Recognition correspondence, framing and completeness: 0007 → 0013 → 0015 → 0017 → 0020.
 
 Tracking issue: #745.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,8 @@ keep that table, this document, and `CLAUDE.md`'s compact map in step. The
 
 The dependency graph is a DAG (the #138 / ADR 0005 split is complete). Bottom to
 top: leaf modules (`layout.py`, `registry.py`, `fonts.py`, `_geometry.py`,
-`fits.py`, `intents.py`, `recognition_cache.py`, and the `linting/` subpackage) →
+`fits.py`, `intents.py`, `recognition_cache.py`, `recognition_frame.py`, and the `linting/`
+subpackage) →
 `_core.py` → stage modules (`export.py`,
 `repair.py`, `projection.py`, `compose.py`, `analysis.py`, `drawing.py`, the
 `model/` IR subpackage, the `annotations/` subpackage) → `builder.py` → the
@@ -200,10 +201,11 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   repair loop) lives in `_core`.
 - **`recognition_cache.py`** — Draftwright's ADR 0017 one-result lifecycle owner. It calls
   external `build_raw_recognition_result(part)` at most once for a build/lazy-critique run.
-  The explicit name records that today's production IR consumes caller/world coordinates;
-  the package owns recognition, while Draftwright owns when the result is computed and reused.
-  The public framed route is exercised as release evidence but does not enter production until
-  #1357 supplies one reviewed frame-to-IR adapter.
+  The package owns recognition, while Draftwright owns when the result is computed and reused.
+- **`recognition_frame.py`** — ADR 0020's leaf selection boundary. It pairs the provider's exact
+  prepared local solid and cylinders with Draftwright's classification and one aggregate, or
+  records one typed-refusal raw fallback. Analysis consumes the resulting coherent unit; no
+  renderer or planner imports frame policy.
 - **`recogniser_contract.py`** — the fail-closed cross-repository capability join. It consumes
   only the installed `b123d-recognisers` public manifest, then validates Draftwright-owned IR,
   `Sheet`, generated-code, drawing, completeness, and documentation declarations. It is rank 7
@@ -532,13 +534,15 @@ policy) live in `CLAUDE.md`. This is the per-ADR status trail; each ADR's
   b123d-recognisers 0.2.9 chamfers and fillets became unconditional because the package now
   recognises their conical/toroidal turned forms. In 0.4.6, plates and the four prismatic step
   families (angled, circular blind, paired ramp, and through) remain classification-gated
-  (#1254/#1281/#1382).
+  (#1254/#1281/#1382). In 0.4.9 Plate discovery instead consumes completed turned-step
+  ownership and excludes only those solids, preserving prismatic plates in mixed compounds.
   **`DEFERRED` is now empty** — every public `recognise_*` family is owned by the one
   orchestration. The mechanism stays fail-closed (a new family must still be classified, and
   every `Deferral` member survives for a future one); what went was each deferral, as its
-  stated constraint stopped being true. Measured per family with the current 0.4.8 pin: a
+  stated constraint stopped being true. Measured per family with the current 0.4.9 pin: a
   prismatic build runs
-  28 once each, a turned build 23 (the five prismatic-only families excluded), and a declared
+  28 once each; a turned build runs 23 when no turned owner is established and 24 when Plate
+  consumes completed turned ownership (the four step families remain gated); and a declared
   build/render **zero**. Physical critique or export may then obtain one cached aggregate. The
   three 0.4.6 step inventories are owned by that aggregate and now have evidence-backed,
   scored consumer semantics under #1382. Their framed-coordinate parity remains a separate

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -286,15 +286,16 @@ channels, slots, slot patterns and polygonal stock; #1372 retains the independen
 and polygonal-boss benchmark corpora; #1373 covers plates, face levels and risers; and
 #1374 retains turned steps.
 
-## Recognisers 0.4.8 raw boundary and RaisedPad v2
+## Recognisers 0.4.9 framed boundary and RaisedPad v2
 
-Draftwright exactly pins the published `b123d-recognisers==0.4.8` wheel. Production deliberately
-calls `build_raw_recognition_result`: records remain in the caller/world coordinate system until
-#1357 introduces one reviewed framed-result adapter. Tests use the public framed API only as
-release evidence for upstream #331, #332, and #334, comparing each aggregate inventory with the
-corresponding public family call on the exact returned local solid. Production adds no fallback,
-second aggregate, or family rescan. Face levels, risers, and turned profiles remain outside framed
-production pending their separately released upstream fixes.
+Draftwright exactly pins the published `b123d-recognisers==0.4.9` wheel. The release includes the
+body-local FaceLevel, Riser, and TurnedProfile contracts as well as the earlier pad, polygonal-boss,
+and Plate covariance fixes. `framed_recognition=True` selects one Draftwright-owned boundary:
+prepare and normalize in the provider, classify the exact local solid, then build one aggregate
+against that same solid. IR, view planning, projection and physical lint remain in those working
+coordinates while `Drawing.part` retains caller coordinates. Typed frame refusal performs one
+explicit raw fallback. Raw remains the public default only through the platform/canary rollout
+required by #1357; neither route performs a second aggregate or family rescan.
 
 `RaisedPad` schema v2 makes a pad normal and its material-outward sign explicit. Draftwright maps
 the six signed principal orientations into one `PadFeature`: world bounds and direction survive
@@ -346,7 +347,7 @@ profile warning only for that occurrence, so an unrelated unrecognised profile r
 
 ## Passage compatibility boundary
 
-The installed `b123d-recognisers==0.4.8` release contains the `passages` family introduced
+The installed `b123d-recognisers==0.4.9` release contains the `passages` family introduced
 in 0.2.6. Version 0.4.0 makes `SectionPassage` the authoritative physical output and retains
 schema-v1 `Passage` as its compatibility projection. Draftwright declares all six public and nested
 record schemas exhaustively but deliberately keeps the family `unsupported`, with the drafting
@@ -364,7 +365,7 @@ The 0.4 contract is explicit:
 - rich split-junction passages can supersede a Slot claim, moving physical ownership to the
   unsupported Passage family through `SLOT_SUPERSEDED_BY_PASSAGE`.
 
-The exact 0.4.8 pin, manifest-v2 validator and explicit unsupported inventories make that limitation
+The exact 0.4.9 pin, manifest-v2 validator and explicit unsupported inventories make that limitation
 fail-visible rather than silently treating rich passages as supported. Draftwright deliberately
 does not claim that a regular-polygon `HEX … A/F THRU` callout covers the complete line/arc section
 schema. Each authoritative `RecognitionResult.section_passages` occurrence therefore emits

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "build123d>=0.9.0,<0.11 ; python_full_version < '3.13'",
     "build123d>=0.11,<0.12 ; python_full_version >= '3.13'",
     "build123d-drafting-helpers>=0.14.2",
-    "b123d-recognisers==0.4.8",
+    "b123d-recognisers==0.4.9",
     "numpy>=1.24",
     # PNG raster export (SVG→PDF→PNG). Both permissively licensed (Pillow HPND; pypdfium2
     # Apache-2.0 wrapping Google PDFium BSD-3) and ship pre-built wheels with NO native system

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -1237,10 +1237,21 @@ class Analysis:
     #: Immutable ADR 0018 authored input, retained for the resolver/diagnostics without making
     #: this low-level module depend on the view-planning leaf at runtime.
     view_constraints: object | None = None
+    #: Caller-coordinate source retained when ``part`` is a provider-normalized working solid.
+    source_part: Shape | None = None
+    #: Provider caller→working frame for a successful framed automatic build.
+    recognition_frame: object | None = None
+    #: JSON-friendly framed/raw/refusal selection outcome.
+    recognition_frame_decision: dict[str, object] | None = None
+    #: Coordinate-coherent PMI projection used by the compiler. ``None`` means the source
+    #: report's records are already in working coordinates (raw and declared builds).
+    pmi_working_records: tuple[object, ...] | None = None
 
     @property
     def pmi(self) -> list:
-        """Successful PMI records, derived from the canonical extraction report."""
+        """Successful PMI records in this analysis's working coordinates."""
+        if self.pmi_working_records is not None:
+            return list(self.pmi_working_records)
         return list(getattr(self.pmi_report, "records", ()))
 
 

--- a/src/draftwright/_geometry.py
+++ b/src/draftwright/_geometry.py
@@ -123,6 +123,10 @@ def _classify_rotational_cylinders(
                 for cylinder in cross_full
                 if cylinder.get("axis") == axis and cylinder["external"]
             ]
+            # Draftwright's X/Y rotational furniture currently owns a single-OD body.
+            # Multi-diameter horizontal stock remains on the complete boss/envelope path;
+            # classifying it rotational would suppress approved axial/boss measurements until
+            # the axis-covariant turned-length renderer is delivered (#1402).
             if len({round(cylinder["diameter"], 1) for cylinder in external}) != 1:
                 continue
             candidate = max(external, key=lambda cylinder: cylinder["diameter"], default=None)

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -64,6 +64,7 @@ from draftwright.compose import (
 from draftwright.model import build_part_model
 from draftwright.model.ir import Datum, PartModel, StepFeature, StepLevelFeature
 from draftwright.model.planner import plan_dimensions
+from draftwright.recognition_frame import Classification, adapt_recognition
 from draftwright.view_plan import ViewConstraints, arrangement_of
 
 _log = logging.getLogger(__name__)
@@ -467,11 +468,11 @@ class _GeomClass:
     is_rotational: bool
 
 
-def _classify_geometry(part, x_size, y_size, z_size, cx, cy, cz) -> _GeomClass:
+def _classify_geometry(part, x_size, y_size, z_size, cx, cy, cz, *, cylinders) -> _GeomClass:
     """Analyse *part*'s cylinders and classify its OD / rotational orientation (#590 split of
     :func:`_analyse`). Partial (fillet) faces are excluded — they would pollute the OD, the bore
     leaders, and the rotational test alike (#81)."""
-    z_cyls, cross_cyls = analyse_cylinders(part)
+    z_cyls, cross_cyls = cylinders
     classification = _classify_rotational_cylinders(
         (z_cyls, cross_cyls),
         sizes=(x_size, y_size, z_size),
@@ -591,6 +592,7 @@ def _analyse(
     _views: tuple[str, ...] | None = None,
     _include_iso: bool = True,
     _view_constraints=None,
+    _framed_recognition: bool = False,
 ) -> Analysis:
     """Load STEP or use a build123d Shape, analyse geometry, compute layout.
 
@@ -602,16 +604,25 @@ def _analyse(
     # placement both reserve room for the border. Computed up front so the choose_scale inside
     # step-count convergence sees it too.
     margin = _content_margin(frame)
+    recognition: RecognitionResult | None
+    recognition_frame = None
+    recognition_frame_decision: dict[str, object]
     if _reuse is not None:
         # Explicit-scale fallback changes only page-space layout. Reuse the immutable geometry,
         # STEP/PMI census, classification, and recognition waist from the requested trial rather
         # than importing and recognising the same part up to fifteen more times (#1146).
         part = _reuse.part
+        source_part = _reuse.source_part if _reuse.source_part is not None else part
+        recognition_frame = _reuse.recognition_frame
+        recognition_frame_decision = dict(
+            _reuse.recognition_frame_decision
+            or {"status": "not_evaluated", "gauge": None, "refusal_reason": None}
+        )
         src = str(_reuse.step_file)
         pmi_defaulted = _reuse.pmi_defaulted
         pmi_mode = _reuse.pmi_mode
         pmi_report = _reuse.pmi_report
-        pmi_records = list(getattr(pmi_report, "records", ())) if pmi_mode != "off" else []
+        pmi_records = _reuse.pmi if pmi_mode != "off" else []
         bb = _reuse.bb
         x_size, y_size, z_size = _reuse.x_size, _reuse.y_size, _reuse.z_size
         cx, cy, cz = _reuse.cx, _reuse.cy, _reuse.cz
@@ -621,6 +632,8 @@ def _analyse(
         od_diam = _reuse.od_diam
         od_axis = _reuse.od_axis
         is_rotational = _reuse.is_rotational
+        layout_model = _coerce_layout_model(model, part, decorations)
+        recognition = _reuse.recognition if layout_model is None else None
     else:
         if isinstance(step_file, Shape):
             part = step_file
@@ -629,6 +642,7 @@ def _analyse(
             part = _import_step(step_file)
             src = str(step_file)
         part = _solids_body(part, src)
+        source_part = part
 
         pmi_defaulted = pmi is None
         pmi_mode = "off" if pmi_defaulted else pmi
@@ -649,6 +663,60 @@ def _analyse(
                 _log.warning("PMI extraction failed: %s", exc)
                 pmi_report = PmiExtractionReport(error=f"{type(exc).__name__}: {exc}")
 
+        # A declaration stays entirely in caller coordinates and runs no aggregate (ADR 0011).
+        # Automatic builds instead select one coherent shape/result/classification unit here,
+        # above every bbox, IR, planner, projection, and lint consumer (#1357 / ADR 0017).
+        layout_model = _coerce_layout_model(model, part, decorations)
+
+        def classify_unit(working_part, cylinders):
+            working_bb = working_part.bounding_box()
+            working_sizes = (
+                working_bb.max.X - working_bb.min.X,
+                working_bb.max.Y - working_bb.min.Y,
+                working_bb.max.Z - working_bb.min.Z,
+            )
+            working_centre = (
+                (working_bb.min.X + working_bb.max.X) / 2,
+                (working_bb.min.Y + working_bb.max.Y) / 2,
+                (working_bb.min.Z + working_bb.max.Z) / 2,
+            )
+            classified = _classify_geometry(
+                working_part,
+                *working_sizes,
+                *working_centre,
+                cylinders=cylinders,
+            )
+            return Classification(classified, classified.is_rotational)
+
+        if layout_model is None:
+            adapted = adapt_recognition(
+                part,
+                framed=_framed_recognition,
+                classify=classify_unit,
+                # Keep analysis's established injectable aggregate seam: evaluation
+                # mutations prove their record→IR guards through this exact call.
+                raw_builder=build_raw_recognition_result,
+            )
+            part = adapted.working_part
+            recognition = adapted.result
+            _gc = adapted.classification
+            recognition_frame = adapted.frame
+            recognition_frame_decision = adapted.decision
+            if recognition_frame is not None and pmi_records:
+                from draftwright.pmi import reframe_pmi_records
+
+                pmi_records = reframe_pmi_records(pmi_records, recognition_frame)
+        else:
+            cylinders = analyse_cylinders(part)
+            classified = classify_unit(part, cylinders)
+            _gc = classified.value
+            recognition = None
+            recognition_frame_decision = {
+                "status": "declared",
+                "gauge": None,
+                "refusal_reason": None,
+            }
+
         bb = part.bounding_box()
         x_size = bb.max.X - bb.min.X
         y_size = bb.max.Y - bb.min.Y
@@ -660,7 +728,6 @@ def _analyse(
 
         _log.info("Loaded %s  bbox: %.2f × %.2f × %.2f mm", src, x_size, y_size, z_size)
 
-        _gc = _classify_geometry(part, x_size, y_size, z_size, cx, cy, cz)
         z_cyls, cross_cyls = _gc.z_cyls, _gc.cross_cyls
         z_diams, cross_diams = _gc.z_diams, _gc.cross_diams
         od_diam, od_axis, is_rotational = _gc.od_diam, _gc.od_axis, _gc.is_rotational
@@ -676,12 +743,9 @@ def _analyse(
     # ADR 0011 / ADR 0017 §6: a declared model skips detection (#1022).  The gate has to sit
     # here, ABOVE the aggregate, which is why `_coerce_layout_model` moved up from its old
     # place below — it is pure (IR in, IR out) and reads nothing this block computes.
-    layout_model = _coerce_layout_model(model, part, decorations)
-    recognition: RecognitionResult | None
     _turned: TurnedProfile | None
     step_zs: list[float]
     if _reuse is not None:
-        recognition = _reuse.recognition if layout_model is None else None
         _turned = _reuse.prof
         step_zs = list(_reuse.step_zs)
     elif layout_model is not None:
@@ -693,10 +757,14 @@ def _analyse(
         _turned = _declared_turned_profile(layout_model)
         step_zs = _declared_step_zs(layout_model, _turned, bb)
     else:
-        recognition = build_raw_recognition_result(
-            part, cylinders=(z_cyls, cross_cyls), rotational=is_rotational
-        )
-        _turned = TurnedProfile.from_steps(list(recognition.turned_steps))
+        assert recognition is not None
+        # A Draftwright Analysis still has one optional drawing-wide profile. 0.4.9 now
+        # exposes honest body-local memberships: a compound may contain several profiles,
+        # which must not be merged into one axis line across air. Keep the singular projection
+        # only when the aggregate proves exactly one physical owner; individual groove and
+        # cylinder inventories remain available for every body (#1357 / provider #337).
+        profiles = recognition.turned_profiles
+        _turned = profiles[0] if len(profiles) == 1 else None
         # The aggregate's own rule (#578 review; hoisted there by #1022, shared with critique
         # by #1025). Both callers deriving this separately let lint project over a different
         # ladder than the model was sized from — which is exactly the divergence one waist is
@@ -983,6 +1051,12 @@ def _analyse(
         planned_iso_scale=planned_iso_scale,
         view_constraints=_view_constraints,
         part=part,
+        source_part=source_part,
+        recognition_frame=recognition_frame,
+        recognition_frame_decision=recognition_frame_decision,
+        pmi_working_records=(
+            tuple(pmi_records) if recognition_frame is not None and pmi_mode != "off" else None
+        ),
         recognition=recognition,
         bb=bb,
         x_size=x_size,

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -674,6 +674,7 @@ class _OffHole(NamedTuple):
 
     axis: str
     location: tuple
+    feature: HoleFeature | PatternFeature
     approved: dict
 
 
@@ -705,14 +706,17 @@ def _approved_off_axis_holes(plan) -> list[_OffHole]:
         # Derived, not spelled: the role is a CONTRACT between the compiler that mints it
         # and this filter that reads it. A literal here is a second owner — renaming the
         # declaration would make every side-hole position dim vanish (#966).
-        if entry.role != HoleFeature.LOCATION_OFF_AXIS_STEM:
+        if entry.axis == "z" or entry.role not in {
+            HoleFeature.LOCATION_OFF_AXIS_STEM,
+            PatternFeature.LOCATION_STEM,
+        }:
             continue
         assert entry.span is not None  # off-axis entries always carry datum → member
         member = entry.span[1]
         key = (entry.ref, member)
         hole = holes.get(key)
         if hole is None:
-            hole = holes[key] = _OffHole(entry.axis, member, {})
+            hole = holes[key] = _OffHole(entry.axis, member, resolve_feature(entry.ref), {})
         hole.approved[entry.discriminator] = entry
     return list(holes.values())
 
@@ -819,12 +823,11 @@ def _off_axis_queue(
         )
 
 
-def _off_axis_owner(ctx, hole_locs):
+def _off_axis_owner(holes):
     # The IR hole feature owning a side-drilled location dim, or None when the dim's
     # offset is shared by >1 distinct feature (unowned, so drop can't over-strip a
     # sibling — mirrors the #398c shared-coordinate rule). Promoted (#638).
-    feats = {ctx.feature_of_hole_at(loc) for loc in hole_locs}
-    feats.discard(None)
+    feats = {hole.feature for hole in holes}
     return next(iter(feats)) if len(feats) == 1 else None
 
 
@@ -856,7 +859,7 @@ def _locate_across(dwg, ctx, a: Analysis, off):
         if yo * a.SCALE < 1.0:
             continue
         name = f"dim_loc_side_y{round(yo * 100)}"
-        loc_by_name.setdefault(name, []).append(h.location)
+        loc_by_name.setdefault(name, []).append(h)
         mids_by_name.setdefault(name, []).append(entry.id)
         coverage_by_name.setdefault(name, []).append(_hole_location_coverage_fact(entry))
         order_y[name] = yo
@@ -894,7 +897,7 @@ def _locate_across(dwg, ctx, a: Analysis, off):
                     )
                 ),
             )
-    feats = {nm: _off_axis_owner(ctx, locs) for nm, locs in loc_by_name.items()}
+    feats = {nm: _off_axis_owner(holes) for nm, holes in loc_by_name.items()}
     measurements = {name: tuple(ids) for name, ids in mids_by_name.items()}
 
     def _fallback(name):
@@ -979,7 +982,7 @@ def _locate_along_planar(dwg, ctx, a: Analysis, off):
         if xo * a.SCALE < 1.0:
             continue
         name = f"dim_loc_front_x{round(xo * 100)}"
-        x_loc_by_name.setdefault(name, []).append(h.location)
+        x_loc_by_name.setdefault(name, []).append(h)
         x_mids_by_name.setdefault(name, []).append(entry.id)
         x_coverage_by_name.setdefault(name, []).append(_hole_location_coverage_fact(entry))
         order_x[name] = xo
@@ -997,7 +1000,7 @@ def _locate_along_planar(dwg, ctx, a: Analysis, off):
                     ),
                 )
             )
-    x_feats = {nm: _off_axis_owner(ctx, locs) for nm, locs in x_loc_by_name.items()}
+    x_feats = {nm: _off_axis_owner(holes) for nm, holes in x_loc_by_name.items()}
     x_measurements = {name: tuple(ids) for name, ids in x_mids_by_name.items()}
     _off_axis_queue(
         dwg,
@@ -1035,7 +1038,7 @@ def _locate_along_z(dwg, ctx, a: Analysis, off):
     for h in off:
         entry = h.approved.get("z")
         if entry is not None and round(entry.value, 2) * a.SCALE >= 1.0:
-            z_locs.setdefault(round(entry.value, 2), []).append(h.location)
+            z_locs.setdefault(round(entry.value, 2), []).append(h)
             z_mids.setdefault(round(entry.value, 2), []).append(entry.id)
             z_coverage.setdefault(round(entry.value, 2), []).append(
                 _hole_location_coverage_fact(entry)
@@ -1050,7 +1053,7 @@ def _locate_along_z(dwg, ctx, a: Analysis, off):
             continue
         seen_z.add(zo)
         hz = h.location[2]
-        owner = _off_axis_owner(ctx, z_locs[zo])
+        owner = _off_axis_owner(z_locs[zo])
 
         def _zc(view, p_lo, p_hi, edge, _zo=zo, _lbl=entry.value_text):
             return (
@@ -1211,6 +1214,8 @@ def _locate_off_axis_holes(dwg, ctx, a: Analysis, *, which, plan):
         # prevents ``a.is_rotational``. Treat either classification as a valid
         # turning axis so the centreline, not redundant half-envelope offsets,
         # locates the bore (#881).
+        if isinstance(h.feature, PatternFeature):
+            return False
         turning_axis = a.od_axis if a.is_rotational else getattr(a.prof, "axis", None)
         if turning_axis is None or h.axis != turning_axis:
             return False
@@ -1387,49 +1392,8 @@ def _add_grid_pitch_dims(
     name_prefix="dim_pitch",
     drop_code=None,
 ):
-    """Both pitch dimensions of a rectangular grid — one along each lattice axis,
-    each labelled ``(n-1)× pitch`` (#92).  The two axes are recovered as the two
-    shortest near-orthogonal inter-hole page vectors (the recogniser's own
-    basis); this is used only to pick the dimension endpoints and the per-axis
-    count, not to re-recognise the grid (recognition stays upstream). *members* are
-    the grid's member locations; *nominals* is ``(row_pitch, col_pitch)``."""
+    """Both pitch dimensions of a rectangular grid from its recognised lattice frame."""
     pts = [to_page(m) for m in members]
-    diffs = []
-    for ia in range(len(pts)):
-        for ib in range(len(pts)):
-            if ia == ib:
-                continue
-            dx, dy = pts[ib][0] - pts[ia][0], pts[ib][1] - pts[ia][1]
-            length = math.hypot(dx, dy)
-            if length > 1e-6:
-                diffs.append((length, dx, dy))
-    if not diffs:
-        return
-    # Equal lattice edges are interchangeable geometry. b123d-recognisers 0.4.6 rounds member
-    # coordinates more consistently, which changed their last few floating-point bits and made
-    # the raw tuple sort select a different physical row. That row is later used as the placement
-    # witness, so a numerically meaningless tie could drop the second pitch dimension. Quantise
-    # only the ordering key (never the measured vector) at a scale far below drafting precision;
-    # stable sort then retains the recogniser's deterministic member order for equal edges.
-    diffs.sort(key=lambda vector: tuple(round(component, 6) for component in vector))
-    l1, ax, ay = diffs[0]
-    u1 = (ax / l1, ay / l1)
-    basis2 = next(
-        (
-            (length, dx, dy)
-            for length, dx, dy in diffs
-            if abs((dx * u1[0] + dy * u1[1]) / length) < 0.2
-        ),
-        None,
-    )
-    if basis2 is None:
-        return
-    l2, bx, by = basis2
-    u2 = (bx / l2, by / l2)
-
-    # The two pitch values are not identities: on a square-pitch grid they are equal. Map
-    # recovered page axes to the IR's row/column lattice basis instead. `angle` names the
-    # column direction in the plane_axes frame; the perpendicular direction is the row.
     actual_feature = resolve_feature(feature)
     by_discriminator = {
         entry.discriminator: entry
@@ -1439,14 +1403,35 @@ def _add_grid_pitch_dims(
     pu, pv = plane_axes(actual_feature.frame.axis)
     angle = math.radians(actual_feature.angle or 0.0)
     column_world = tuple(math.cos(angle) * pu[k] + math.sin(angle) * pv[k] for k in range(3))
+    row_world = tuple(-math.sin(angle) * pu[k] + math.cos(angle) * pv[k] for k in range(3))
     origin = actual_feature.frame.origin
     page_origin = to_page(origin)
-    page_column = to_page(tuple(origin[k] + column_world[k] for k in range(3)))
-    dx, dy = page_column[0] - page_origin[0], page_column[1] - page_origin[1]
-    norm = math.hypot(dx, dy)
-    column_page = (dx / norm, dy / norm)
 
-    def _axis_dim(u, pitch_page, sub):
+    def _page_axis(world, discriminator):
+        pitch = by_discriminator.get(discriminator)
+        if pitch is None:
+            return None
+        endpoint = to_page(tuple(origin[k] + world[k] for k in range(3)))
+        dx, dy = endpoint[0] - page_origin[0], endpoint[1] - page_origin[1]
+        unit_scale = math.hypot(dx, dy)
+        if unit_scale <= 1e-9:
+            return None
+        return ((dx / unit_scale, dy / unit_scale), abs(pitch.value) * unit_scale, pitch)
+
+    axes = [
+        axis
+        for axis in (
+            _page_axis(column_world, "col"),
+            _page_axis(row_world, "row"),
+        )
+        if axis is not None
+    ]
+    if len(axes) != 2:
+        return
+    axes.sort(key=lambda axis: (round(axis[1], 9), axis[2].discriminator or ""))
+    min_pitch_page = min(axis[1] for axis in axes)
+
+    def _axis_dim(u, pitch_page, pitch, sub):
         perp = (-u[1], u[0])
 
         def along(idx):
@@ -1490,9 +1475,9 @@ def _add_grid_pitch_dims(
         # (pitch_page * 0.25 fails on a high-aspect grid: for the long axis the
         # perpendicular lines are only the short pitch apart, and a quarter of
         # the long pitch can exceed that, merging two lines → diagonal again.)
-        lo_across = across(anchor)
-        line_tol = min(l1, l2) * 0.25
-        line = [idx for idx in range(len(pts)) if abs(across(idx) - lo_across) < line_tol]
+        anchor_across = across(anchor)
+        line_tol = min_pitch_page * 0.25
+        line = [idx for idx in range(len(pts)) if abs(across(idx) - anchor_across) < line_tol]
         lo = min(line, key=along)
         hi = max(line, key=along)
         # The holes this dim actually spans, in the order it spans them. `members[lo:hi+1]`
@@ -1503,10 +1488,6 @@ def _add_grid_pitch_dims(
         spanned = [members[idx] for idx in sorted(line, key=along)]
         span = along(hi) - along(lo)
         n = round(span / pitch_page) + 1
-        discriminator = (
-            "col" if abs(u[0] * column_page[0] + u[1] * column_page[1]) > 0.7 else "row"
-        )
-        pitch = by_discriminator[discriminator]
         _place_pitch_dim(
             dwg,
             a,
@@ -1523,8 +1504,8 @@ def _add_grid_pitch_dims(
             ctx=ctx,
         )
 
-    _axis_dim(u1, l1, 0)
-    _axis_dim(u2, l2, 1)
+    for sub, (unit, pitch_page, pitch) in enumerate(axes):
+        _axis_dim(unit, pitch_page, pitch, sub)
 
 
 def _pitch_text(pitch, members, draft, *, ctx) -> str:

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -491,7 +491,8 @@ def _assemble(
         dist=dist,
         centroid=(a.cx, a.cy, a.cz),
         out=out,
-        part=a.part,
+        part=a.source_part if a.source_part is not None else a.part,
+        working_part=a.part,
         cyls=a.cyls,
         assembly=assembly,
         reproducible=reproducible,
@@ -1092,6 +1093,7 @@ def _build_drawing_once(
     projection: str | None = None,
     zones: bool = False,
     reproducible: bool = False,
+    framed_recognition: bool = False,
     _analysis_base=None,
     _analysis_sink: Callable[[Analysis], None] | None = None,
     _critique_recognition=None,
@@ -1141,6 +1143,11 @@ def _build_drawing_once(
             because it is not free: settling the element order costs roughly a third
             of DXF export time again (one bounding box and one edge walk per part),
             while the metadata pinning it also turns on is ~1 ms.
+        framed_recognition: opt into provider-owned part-relative automatic recognition.
+            The caller solid remains :attr:`Drawing.part`; the exact normalized compiler solid,
+            frame, and typed selection decision are inspectable separately. A provider refusal
+            takes one explicit raw-coordinate fallback. Declared ``model=`` builds never frame
+            or recognise and remain in caller coordinates.
         model: a caller-supplied IR (ADR 0011) — a :class:`PartModel`, or a sequence
             of :class:`Feature`\\ s (declared with :func:`draftwright.model.hole`,
             ``boss``, ``step``, … from the objects you built). When given, **feature
@@ -1215,6 +1222,7 @@ def _build_drawing_once(
             _views=views,
             _include_iso=_include_iso,
             _view_constraints=_view_constraints,
+            _framed_recognition=framed_recognition,
         )
 
     a = analyse(reuse=_analysis_base, views=_views)
@@ -1746,6 +1754,7 @@ def build_drawing(
     zones: bool = False,
     scale_policy: Literal["strict", "fallback", "permissive"] = "fallback",
     reproducible: bool = False,
+    framed_recognition: bool = False,
     _post_build: Callable[[Drawing], Drawing] | None = None,
     _required_tables=(),
     _views: tuple[str, ...] | None = None,
@@ -1794,6 +1803,7 @@ def build_drawing(
         projection=projection,
         zones=zones,
         reproducible=reproducible,
+        framed_recognition=framed_recognition,
         _required_tables=_required_tables,
         _include_iso=_include_iso,
         _view_constraints=_view_constraints,
@@ -2634,6 +2644,7 @@ def make_drawing(
     zones: bool = False,
     scale_policy: Literal["strict", "fallback", "permissive"] = "fallback",
     reproducible: bool = False,
+    framed_recognition: bool = False,
 ) -> tuple[str, str]:
     """Generate a 4-view technical drawing from a STEP file or build123d object.
 
@@ -2662,6 +2673,8 @@ def make_drawing(
         reproducible: make repeated exports from the returned drawing byte-identical
             on the same Draftwright version. Off by default because canonical DXF
             ordering has a measurable export-time cost.
+        framed_recognition: opt into the provider-owned local recognition frame for an
+            automatically detected build. The raw route remains the rollout default.
 
     Returns:
         Tuple of ``(svg_path, dxf_path)`` for the generated files.
@@ -2698,6 +2711,7 @@ def make_drawing(
         projection=projection,
         zones=zones,
         reproducible=reproducible,
+        framed_recognition=framed_recognition,
         scale_policy=scale_policy,
     ).export(formats=("svg", "dxf"))
     assert isinstance(_paths, dict)  # formats=... always returns the {format: path} dict

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -389,9 +389,17 @@ def feature_key(f) -> str | None:
     axis = getattr(frame, "axis", "")
     if origin is None:
         return f"{kind}/{axis}" if axis else kind
-    x, y, z = (float(v) for v in (origin[0], origin[1], origin[2]))
+
+    # Canonicalise values that render as zero before formatting.  Provider-owned rigid
+    # transforms can legitimately leave ``-0.0``/sub-micron residue; spelling that sign in
+    # an audit identity makes an unchanged requirement look gained and lost (#1357).
+    def clean(value) -> float:
+        rounded = round(float(value), 3)
+        return 0.0 if rounded == 0 else rounded
+
+    x, y, z = (clean(v) for v in (origin[0], origin[1], origin[2]))
     sizes = [
-        f"{name}={float(v):.3f}"
+        f"{name}={clean(v):.3f}"
         for name in _KEY_SCALARS
         if isinstance(v := getattr(f, name, None), (int, float))
     ]
@@ -548,7 +556,9 @@ class Drawing:
         centroid: unscaled centroid ``(x, y, z)``.
         views: ``{name: (visible_compound, hidden_compound_or_None)}``.
         items: ordered list of annotation objects (mutable).
-        part: the source solid, when known — enables the feature-coverage lint.
+        part: the caller-coordinate source solid, when known.
+        working_part: the coordinate-coherent solid compiled, projected, and physically
+            critiqued. It differs from ``part`` only for framed automatic recognition.
         assembly: feature-coverage severity control — ``None`` auto-detects a
             multi-solid part as an assembly (per-part bores at ``info``),
             ``True``/``False`` forces it (#69).
@@ -575,6 +585,7 @@ class Drawing:
         centroid,
         out,
         part=None,
+        working_part=None,
         cyls=None,
         assembly=None,
         reproducible=False,
@@ -626,6 +637,7 @@ class Drawing:
             "detail": "the section pass has not run",
         }
         self.part = part
+        self._working_part = part if working_part is None else working_part
         self._cyl_cache = cyls
         # None → the coverage lint auto-detects a multi-solid part as an
         # assembly; True/False forces assembly/strict severity (#69).
@@ -684,6 +696,33 @@ class Drawing:
         prevent. Editing means converting it into constraints explicitly and resolving again.
         """
         return self._build.view_plan
+
+    @property
+    def working_part(self):
+        """The coordinate-coherent compiler/projection solid (read-only)."""
+
+        return self._working_part
+
+    @property
+    def recognition_frame(self):
+        """The provider caller→working frame, or ``None`` outside a framed build."""
+
+        return getattr(self._build.analysis, "recognition_frame", None)
+
+    @property
+    def recognition_frame_decision(self) -> dict[str, object]:
+        """Return the explicit framed/raw/refusal selection outcome."""
+
+        decision = getattr(self._build.analysis, "recognition_frame_decision", None)
+        return (
+            dict(decision)
+            if decision is not None
+            else {
+                "status": "not_evaluated",
+                "gauge": None,
+                "refusal_reason": None,
+            }
+        )
 
     @property
     def registry(self):
@@ -3434,7 +3473,8 @@ class Drawing:
             view_material_fields=self.material_fields(),
             _aggregation=aggregation,
         )
-        if self.part is not None and physical:
+        working_part = self._working_part
+        if working_part is not None and physical:
             # Reuse the single feature inventory from the build (#244) when present,
             # so lint does not re-detect holes/patterns/turned-steps; fall back to
             # detecting when there is no analysis (a manually-built Drawing, or lint
@@ -3461,7 +3501,7 @@ class Drawing:
                 # empty because nothing looked — not because the part has none. Feeding that
                 # emptiness to coverage would report every real hole as uncovered, so critique
                 # recognises here instead: once per drawing, owned by BuildState.
-                rec = self._build.ensure_recognition(self.part)
+                rec = self._build.ensure_recognition(working_part)
                 cyls = rec.cylinders
                 holes = list(rec.holes)
                 patterns = list(rec.hole_patterns)
@@ -3480,16 +3520,16 @@ class Drawing:
                 prof_kw = {"prof": a.prof}
             else:
                 if self._cyl_cache is None:
-                    self._cyl_cache = analyse_cylinders(self.part)
+                    self._cyl_cache = analyse_cylinders(working_part)
                 cyls = self._cyl_cache
                 holes = patterns = bosses = None
                 pads = pockets = recognition = None
                 prof_kw = {}
             if recognition is None:
-                recognition = self._build.ensure_recognition(self.part)
+                recognition = self._build.ensure_recognition(working_part)
             profiled_bores = list(recognition.double_d_bores)
             issues += lint_feature_coverage(
-                self.part,
+                working_part,
                 self.items,
                 cyls=cyls,
                 exclude=self._coverage.dropped_diams,
@@ -3499,7 +3539,7 @@ class Drawing:
                 registry=self._registry,
             )
             issues += lint_axial_coverage(
-                self.part,
+                working_part,
                 self,
                 assembly=self.assembly,
                 recognition=recognition,
@@ -3523,14 +3563,14 @@ class Drawing:
             # specifically for a prismatic boss's independent projection height.
             if model is not None and (a is None or (not a.is_rotational and a.prof is None)):
                 issues += lint_boss_height_coverage(
-                    self.part,
+                    working_part,
                     self,
                     getattr(model, "features", ()),
                     assembly=self.assembly,
                     omissions=self._build.omissions,
                 )
             issues += lint_location_coverage(
-                self.part,
+                working_part,
                 self,
                 cyls=cyls,
                 assembly=self.assembly,
@@ -3539,7 +3579,7 @@ class Drawing:
                 profiled_bores=profiled_bores,
             )
             issues += lint_prismatic_coverage(
-                self.part,
+                working_part,
                 self,
                 assembly=self.assembly,
                 pads=pads,
@@ -3553,26 +3593,26 @@ class Drawing:
             issues += lint_angled_step_coverage(recognition)
             resolved_assembly = self.assembly
             if resolved_assembly is None:
-                resolved_assembly = len(self.part.solids()) > 1
+                resolved_assembly = len(working_part.solids()) > 1
             profile_cache = self._build.principal_profile_cache
             if (
                 profile_cache is None
-                or profile_cache[0] is not self.part
+                or profile_cache[0] is not working_part
                 or profile_cache[1] != resolved_assembly
             ):
                 profile_issues = tuple(
                     lint_principal_profile_coverage(
-                        self.part,
+                        working_part,
                         assembly=resolved_assembly,
                         prismatic_pockets=recognition.prismatic_pockets,
                         section_passages=recognition.section_passages,
                     )
                 )
-                profile_cache = (self.part, resolved_assembly, profile_issues)
+                profile_cache = (working_part, resolved_assembly, profile_issues)
                 self._build.principal_profile_cache = profile_cache
             issues += list(profile_cache[2])
             issues += lint_profiled_bore_coverage(
-                self.part,
+                working_part,
                 self.items,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
@@ -3582,7 +3622,7 @@ class Drawing:
                 assembly=self.assembly,
             )
             issues += lint_flat_coverage(
-                self.part,
+                working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
                 registry=self._registry,
@@ -3590,7 +3630,7 @@ class Drawing:
                 assembly=self.assembly,
             )
             issues += lint_groove_coverage(
-                self.part,
+                working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
                 registry=self._registry,
@@ -3598,7 +3638,7 @@ class Drawing:
                 assembly=self.assembly,
             )
             issues += lint_chamfer_coverage(
-                self.part,
+                working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
                 registry=self._registry,
@@ -3606,7 +3646,7 @@ class Drawing:
                 assembly=self.assembly,
             )
             issues += lint_fillet_coverage(
-                self.part,
+                working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
                 registry=self._registry,
@@ -3614,7 +3654,7 @@ class Drawing:
                 assembly=self.assembly,
             )
             issues += lint_paired_ramp_step_coverage(
-                self.part,
+                working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
                 registry=self._registry,
@@ -3622,7 +3662,7 @@ class Drawing:
                 assembly=self.assembly,
             )
             issues += lint_circular_blind_step_coverage(
-                self.part,
+                working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
                 registry=self._registry,
@@ -3630,7 +3670,7 @@ class Drawing:
                 assembly=self.assembly,
             )
             issues += lint_through_step_coverage(
-                self.part,
+                working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
                 registry=self._registry,
@@ -3639,7 +3679,7 @@ class Drawing:
                 plan=dimension_plan,
             )
             issues += lint_slot_coverage(
-                self.part,
+                working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
                 registry=self._registry,
@@ -3647,7 +3687,7 @@ class Drawing:
                 assembly=self.assembly,
             )
             issues += lint_hole_coverage(
-                self.part,
+                working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
                 registry=self._registry,
@@ -3655,7 +3695,7 @@ class Drawing:
                 assembly=self.assembly,
             )
             issues += lint_channel_coverage(
-                self.part,
+                working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
                 registry=self._registry,
@@ -3663,7 +3703,7 @@ class Drawing:
                 assembly=self.assembly,
             )
             issues += lint_polygonal_stock_coverage(
-                self.part,
+                working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
                 registry=self._registry,
@@ -3671,7 +3711,7 @@ class Drawing:
                 assembly=self.assembly,
             )
             issues += lint_pocket_coverage(
-                self.part,
+                working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
                 registry=self._registry,
@@ -3679,7 +3719,7 @@ class Drawing:
                 assembly=self.assembly,
             )
             issues += lint_pocket_pattern_coverage(
-                self.part,
+                working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
                 registry=self._registry,

--- a/src/draftwright/inspection_contract.py
+++ b/src/draftwright/inspection_contract.py
@@ -16,7 +16,7 @@ from b123d_recognisers.inspection import inspection_api_manifest
 CONSUMER_INSPECTION_FORMAT = "draftwright-inspection-api"
 CONSUMER_INSPECTION_FORMAT_VERSION = 1
 SUPPORTED_INSPECTION_API_MAJOR = 1
-SUPPORTED_RECOGNISER_VERSION = "0.4.8"
+SUPPORTED_RECOGNISER_VERSION = "0.4.9"
 _DISTRIBUTION = "b123d-recognisers"
 _PROVIDER_FORMAT = "b123d-recognisers-inspection-api"
 _NAMESPACE = "b123d_recognisers.inspection"

--- a/src/draftwright/linting/hole_coverage.py
+++ b/src/draftwright/linting/hole_coverage.py
@@ -474,11 +474,9 @@ def _parameter_ids(
             in_plane = "y" if feature.frame.axis == "x" else "x"
             ids.extend((f"{stem}.{in_plane}", f"{stem}.z"))
     else:
-        # Pitch/direction/count define only relative arrangement. The current compiler has
-        # no off-axis pattern location producer, so retain both absolute in-plane physical
-        # requirements as explicit missing outcomes instead of deleting them from the
-        # recognition denominator. These stable ids extend the feature-owned location stem;
-        # a future compiler/renderer can make them placed without changing the ledger schema.
+        # Pitch/direction/count define only relative arrangement. Retain both absolute
+        # in-plane physical requirements independently; the compiler's one feature-level
+        # location unit can prove both without changing this physical ledger schema.
         stem = getattr(feature, "LOCATION_STEM", None)
         if stem is None:
             return None

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -1303,36 +1303,57 @@ def _compile_off_axis_hole_locations(
     for f in model.features:
         # Eligibility comes from `location_datum`, not a second orientation rule here —
         # that is the duplication this whole class of defect keeps coming from (#925).
-        if not isinstance(f, HoleFeature) or location_datum(f) != "bbox":
+        if not isinstance(f, HoleFeature | PatternFeature) or location_datum(f) != "bbox":
             continue
-        # An X-drilled hole is located across Y; a Y-drilled one across X. Both carry a
-        # height. (Pattern members are their own `PatternFeature`, so patterned holes are
-        # excluded by construction — as `_ir_off_axis_holes` documents.)
+        # An X-normal hole or pattern is located across Y; a Y-normal one across X. Both
+        # carry a height. Patterns compile one absolute address below, independently of
+        # their relative pitch/count requirements.
         measured = ("y" if f.frame.axis == "x" else "x", "z")
         omitted = authored_location_omitted(model, f)
-        for member in f.members or (f.frame.origin,):
+        references: tuple[Point, ...]
+        if isinstance(f, PatternFeature):
+            # One absolute address owns a pattern. A grid uses the member nearest the bbox
+            # datum so the two emitted offsets identify its near corner; a bolt circle uses
+            # its centre. Relative pitch/count remain separate requirements.
+            if f.pattern == "bolt_circle" or not f.members:
+                references = (f.frame.origin,)
+            else:
+                transverse = tuple(axis for axis in "xyz" if axis != f.frame.axis)
+                references = (
+                    min(
+                        f.members,
+                        key=lambda member: sum(
+                            (member["xyz".index(axis)] - float(getattr(bb.min, axis.upper()))) ** 2
+                            for axis in transverse
+                        ),
+                    ),
+                )
+            role = f.LOCATION_STEM
+        else:
+            references = f.members or (f.frame.origin,)
+            role = f.LOCATION_OFF_AXIS_STEM
+        for member in references:
             for meas in measured:
                 index = "xyz".index(meas)
                 datum = float(getattr(bb.min, meas.upper()))
                 value = abs(member[index] - datum)
+                parameter = (
+                    f"{role}.location" if isinstance(f, PatternFeature) else f"{role}.{meas}"
+                )
                 if omitted:
-                    omissions.append(
-                        Omission(
-                            f, f"{f.LOCATION_OFF_AXIS_STEM}.{meas}", value, _AUTHORED_OMISSION
-                        )
-                    )
+                    omissions.append(Omission(f, parameter, value, _AUTHORED_OMISSION))
                     continue
                 start = list(member)
                 start[index] = datum
                 approved.append(
                     ApprovedDimension(
-                        id=_dim_id(f, f"{f.LOCATION_OFF_AXIS_STEM}.{meas}"),
+                        id=_dim_id(f, parameter),
                         value_text=_fmt(value),
                         value=value,
                         span=((start[0], start[1], start[2]), member),
                         ref=FeatureRef(f),
                         kind="length",
-                        role=f.LOCATION_OFF_AXIS_STEM,  # the feature owns its name (#966)
+                        role=role,
                         discriminator=meas,
                         axis=f.frame.axis,
                     )

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -1471,14 +1471,28 @@ def build_part_model(
     # (a turned part's steps are StepFeatures, dimensioned by the IR length chain).
     if prof is None and step_zs:
         c = bbox.center()
+        supports_by_level: dict[float, list[FaceLevel]] = {}
+        for level in face_levels:
+            supports_by_level.setdefault(level.z, []).append(level)
         _levels = tuple(
             sorted(
-                z
-                for z in step_zs
-                if round(z, 3) not in plate_zs_at_base
-                and not any(abs(z - owned) < 0.5 for owned in side_pad_level_zs)
-                and not any(abs(z - owned) < 0.5 for owned in through_level_zs)
+                {
+                    z
+                    for z in step_zs
+                    # StepLevelFeature is a drawing-wide ladder. Equal ordinates on
+                    # separate body-local supports cannot be represented as one span without
+                    # joining across air, and duplicate values cannot round-trip through the
+                    # Sheet declaration. Decline that legacy projection (#1357 / #335).
+                    if len(supports_by_level.get(z, ())) <= 1
+                }
             )
+        )
+        _levels = tuple(
+            z
+            for z in _levels
+            if round(z, 3) not in plate_zs_at_base
+            and not any(abs(z - owned) < 0.5 for owned in side_pad_level_zs)
+            and not any(abs(z - owned) < 0.5 for owned in through_level_zs)
         )
         if _levels:
             # An edge-open blind interruption owns its floor through the pocket

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -757,7 +757,11 @@ def location_datum(feature) -> str | None:
         return "datum_xy"  # every orientation: its two in-plane coordinates
     if isinstance(feature, HoleFeature):
         return "datum_xy" if feature.frame.axis == "z" else "bbox"
-    # Patterns and pocket/slot-patterns: the plan-X / side-Y ladder only, so Z-normal only.
+    # Framing can make an otherwise ordinary hole pattern X/Y-normal. It remains the same
+    # locatable requirement and uses the bbox compiler/end-on renderer (#1357).
+    if isinstance(feature, PatternFeature):
+        return "datum_xy" if feature.frame.axis == "z" else "bbox"
+    # Pocket/slot-patterns: the plan-X / side-Y ladder only, so Z-normal only.
     # A fall-through, not another `isinstance` + `return None`: membership above is by exact
     # type, so those three are all that can reach here and the extra arm was
     # unreachable — dead code that read as defensive and showed up as the one uncovered

--- a/src/draftwright/pmi.py
+++ b/src/draftwright/pmi.py
@@ -231,12 +231,131 @@ class PmiRecord:
     datum_contexts: tuple[str, ...] = ()
     reference_item_ids: tuple[str, ...] = ()
     reference_axis: str = ""
+    # Exact source-space surface direction retained even when it is not world-principal.
+    # ``reference_axis`` remains the compact downstream projection; framed adoption can now
+    # rotate the evidence first and derive that projection without losing information.
+    reference_direction: tuple[float, float, float] | None = None
     semantic_name: str = ""
     shape_aspect_ids: tuple[str, ...] = ()
     # Kept separate from ``lowering_blockers``: an imported requirement may fail to enrich a
     # canonical owner yet remain a truthful standalone dimension (#1116/#1209).
     rendering_blockers: tuple[str, ...] = ()
     cylindrical_refs: tuple[CylindricalReference, ...] = ()
+
+
+def _local_direction(direction, frame) -> tuple[float, float, float]:
+    """Rotate a caller-space direction into *frame* without translating it."""
+
+    return cast(
+        tuple[float, float, float],
+        tuple(
+            sum(direction[i] * axis[i] for i in range(3)) for axis in (frame.x, frame.y, frame.z)
+        ),
+    )
+
+
+def _principal_axis(direction) -> str:
+    if direction is None:
+        return ""
+    magnitude = math.sqrt(sum(value * value for value in direction))
+    if magnitude <= 1e-12:
+        return "?"
+    unit = tuple(value / magnitude for value in direction)
+    dominant = max(range(3), key=lambda index: abs(unit[index]))
+    return "XYZ"[dominant] if abs(abs(unit[dominant]) - 1.0) <= 1e-6 else "?"
+
+
+def _axis_direction(axis: str) -> tuple[float, float, float] | None:
+    upper = axis.upper()
+    if upper not in {"X", "Y", "Z"}:
+        return None
+    return cast(
+        tuple[float, float, float],
+        tuple(1.0 if index == "XYZ".index(upper) else 0.0 for index in range(3)),
+    )
+
+
+def _dominant_direction(record: PmiRecord):
+    if record.cylindrical_refs:
+        directions = [reference.axis_direction for reference in record.cylindrical_refs]
+        first = directions[0]
+        if all(
+            abs(abs(sum(a * b for a, b in zip(first, other, strict=True))) - 1.0) < 1e-6
+            for other in directions[1:]
+        ):
+            return first
+    if len(record.ref_pts) >= 2:
+        start, finish = record.ref_pts[0], record.ref_pts[-1]
+        direction = tuple(b - a for a, b in zip(start, finish, strict=True))
+        if math.sqrt(sum(value * value for value in direction)) > 1e-9:
+            return direction
+    return _axis_direction(record.dominant_axis)
+
+
+def _frame_bbox(bbox, frame):
+    if bbox is None:
+        return None
+    corners = tuple(
+        frame.to_local((bbox[ix], bbox[iy], bbox[iz]))
+        for ix in (0, 3)
+        for iy in (1, 4)
+        for iz in (2, 5)
+    )
+    return cast(
+        tuple[float, float, float, float, float, float],
+        tuple(min(point[index] for point in corners) for index in range(3))
+        + tuple(max(point[index] for point in corners) for index in range(3)),
+    )
+
+
+def _frame_cylinder(reference: CylindricalReference, frame) -> CylindricalReference:
+    start = tuple(
+        reference.axis_origin[index]
+        + reference.axial_interval[0] * reference.axis_direction[index]
+        for index in range(3)
+    )
+    finish = tuple(
+        reference.axis_origin[index]
+        + reference.axial_interval[1] * reference.axis_direction[index]
+        for index in range(3)
+    )
+    local_start = frame.to_local(start)
+    local_finish = frame.to_local(finish)
+    direction = tuple(b - a for a, b in zip(local_start, local_finish, strict=True))
+    length = math.sqrt(sum(value * value for value in direction))
+    return CylindricalReference.canonical(
+        axis_point=local_start,
+        axis_direction=direction,
+        radius=reference.radius,
+        local_interval=(0.0, length),
+        sense=reference.sense,
+    )
+
+
+def reframe_pmi_records(records, frame) -> list[PmiRecord]:
+    """Move AP242 correlation geometry into the selected recognition coordinates."""
+
+    reframed = []
+    for record in records:
+        dominant = _dominant_direction(record)
+        reference = record.reference_direction or _axis_direction(record.reference_axis)
+        local_reference = _local_direction(reference, frame) if reference is not None else None
+        reframed.append(
+            replace(
+                record,
+                ref_pts=tuple(frame.to_local(point) for point in record.ref_pts),
+                ref_bbox=_frame_bbox(record.ref_bbox, frame),
+                dominant_axis=_principal_axis(
+                    _local_direction(dominant, frame) if dominant is not None else None
+                ),
+                reference_axis=_principal_axis(local_reference),
+                reference_direction=local_reference,
+                cylindrical_refs=tuple(
+                    _frame_cylinder(reference, frame) for reference in record.cylindrical_refs
+                ),
+            )
+        )
+    return reframed
 
 
 PmiExtractionOutcome = Literal[
@@ -650,10 +769,11 @@ def _diameter_reference_blockers(
 
 
 def _datum_geometry_from_shapes(shapes):
-    """Measure exact datum faces and require one compatible axis-aligned surface."""
+    """Measure exact datum faces and require one compatible planar/cylindrical surface."""
     points: list[tuple[float, float, float]] = []
     boxes: list[tuple[float, float, float, float, float, float]] = []
     axes: list[str] = []
+    directions: list[tuple[float, float, float]] = []
     surface_kinds: list[str] = []
     supports: list[tuple[float, ...]] = []
     reasons: list[str] = []
@@ -678,14 +798,9 @@ def _datum_geometry_from_shapes(shapes):
                 continue
             axis = geometry.Axis()
             direction = axis.Direction()
-            components = (abs(direction.X()), abs(direction.Y()), abs(direction.Z()))
+            direction_value = (direction.X(), direction.Y(), direction.Z())
+            components = tuple(abs(value) for value in direction_value)
             axis_index = max(range(3), key=components.__getitem__)
-            if (
-                components[axis_index] < 1e-6
-                or sum(components) - components[axis_index] > 0.1 * components[axis_index]
-            ):
-                reasons.append("one datum reference surface is not axis-aligned")
-                continue
             location = axis.Location()
             coordinates = (location.X(), location.Y(), location.Z())
             if kind == "plane":
@@ -694,7 +809,15 @@ def _datum_geometry_from_shapes(shapes):
                 support = tuple(
                     value for index, value in enumerate(coordinates) if index != axis_index
                 )
-            axes.append("XYZ"[axis_index])
+            axes.append(
+                "XYZ"[axis_index] if sum(components) - components[axis_index] <= 1e-6 else "?"
+            )
+            # Axis lines are unoriented for these uses. Canonicalise the sign so parallel
+            # faces with opposite topological orientations still compare equal.
+            sign = next(
+                (1.0 if value > 0 else -1.0 for value in direction_value if abs(value) > 1e-9), 1.0
+            )
+            directions.append(tuple(sign * value for value in direction_value))
             surface_kinds.append(kind)
             supports.append(support)
         except Exception as exc:
@@ -703,13 +826,17 @@ def _datum_geometry_from_shapes(shapes):
         reasons.append("referenced geometry is unavailable")
 
     ref_bbox = _merge_bboxes(boxes) if boxes else None
+    reference_direction = directions[0] if directions else None
     if not axes:
         reasons.append("datum reference surface is unavailable")
         reference_axis = ""
     elif len(set(surface_kinds)) != 1:
         reasons.append("datum reference faces mix planar and cylindrical surfaces")
         reference_axis = ""
-    elif len(set(axes)) != 1 or any(
+    elif any(
+        max(abs(a - b) for a, b in zip(direction, directions[0], strict=True)) > 1e-6
+        for direction in directions[1:]
+    ) or any(
         any(abs(value - supports[0][index]) > 1e-4 for index, value in enumerate(support))
         for support in supports[1:]
     ):
@@ -718,7 +845,13 @@ def _datum_geometry_from_shapes(shapes):
         reference_axis = ""
     else:
         reference_axis = axes[0]
-    return tuple(points), ref_bbox, reference_axis, tuple(dict.fromkeys(reasons))
+    return (
+        tuple(points),
+        ref_bbox,
+        reference_axis,
+        reference_direction,
+        tuple(dict.fromkeys(reasons)),
+    )
 
 
 def _datum_reference_geometry(label, shape_tool):
@@ -894,6 +1027,7 @@ def _coalesce_datum_records(records: list[PmiRecord]) -> list[PmiRecord]:
                 ),
                 reference_item_ids=group[0].reference_item_ids,
                 reference_axis=geometry.reference_axis,
+                reference_direction=geometry.reference_direction,
             )
         )
     return projected
@@ -1483,9 +1617,13 @@ def extract_pmi_report(step_file: str | Path) -> PmiExtractionReport:
             correspondence_reason = datum_part21_error
             if not correspondence_reason and not letter_reason and not context_reason:
                 fact, correspondence_reason = match_datum_occurrence(datum_facts, context, letter)
-            points, ref_bbox, reference_axis, geometry_reasons = _datum_reference_geometry(
-                label, shape_tool
-            )
+            (
+                points,
+                ref_bbox,
+                reference_axis,
+                reference_direction,
+                geometry_reasons,
+            ) = _datum_reference_geometry(label, shape_tool)
             if fact is not None and fact.reference_item_ids:
                 if datum_topology is None:
                     topology_shapes = ()
@@ -1495,9 +1633,13 @@ def extract_pmi_report(step_file: str | Path) -> PmiExtractionReport:
                         fact.datum_feature_id, fact.reference_item_ids
                     )
                 if topology_shapes:
-                    points, ref_bbox, reference_axis, geometry_reasons = (
-                        _datum_geometry_from_shapes(topology_shapes)
-                    )
+                    (
+                        points,
+                        ref_bbox,
+                        reference_axis,
+                        reference_direction,
+                        geometry_reasons,
+                    ) = _datum_geometry_from_shapes(topology_shapes)
                 else:
                     geometry_reasons = tuple(dict.fromkeys((*geometry_reasons, *topology_reasons)))
             blockers = tuple(
@@ -1529,6 +1671,7 @@ def extract_pmi_report(step_file: str | Path) -> PmiExtractionReport:
                     datum_contexts=(context,) if context else (),
                     reference_item_ids=fact.reference_item_ids if fact is not None else (),
                     reference_axis=reference_axis,
+                    reference_direction=reference_direction,
                 )
             )
         except Exception as exc:

--- a/src/draftwright/recogniser_contract.py
+++ b/src/draftwright/recogniser_contract.py
@@ -117,7 +117,10 @@ _FAMILIES: dict[str, _FamilySpec] = {
         ("ThroughStep",), "_convert_through_step", "through_step", "render_through_steps"
     ),
     "turned-steps": _FamilySpec(
-        ("TurnedProfile", "TurnedStep"), "_convert_step", "step", "render_step_lengths"
+        ("TurnedProfile", "TurnedProfileKey", "TurnedStep"),
+        "_convert_step",
+        "step",
+        "render_step_lengths",
     ),
 }
 
@@ -127,6 +130,9 @@ _RECORD_SCHEMA_VERSIONS: dict[tuple[str, str], tuple[int, ...]] = {
     ("chamfers", "Chamfer"): (2,),
     ("fillets", "Fillet"): (2,),
     ("rectangular-pads", "RaisedPad"): (2,),
+    ("risers", "RiserEvidence"): (2,),
+    ("turned-steps", "TurnedProfile"): (2,),
+    ("turned-steps", "TurnedStep"): (2,),
 }
 
 

--- a/src/draftwright/recognition_frame.py
+++ b/src/draftwright/recognition_frame.py
@@ -1,0 +1,115 @@
+"""Draftwright's single framed-recognition selection boundary (#1357).
+
+The provider owns frame inference and topology-preserving normalization. Draftwright owns
+classification and the decision to compile a framed or caller-coordinate unit.  This module
+keeps the selected shape, aggregate, classification, and frame inseparable so no downstream
+consumer can accidentally combine local records with caller-space geometry.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Generic, Literal, TypeVar
+
+from b123d_recognisers import (
+    FramedPreparation,
+    PartFrame,
+    RecognitionResult,
+    RefusedPartFrame,
+    analyse_cylinders,
+    build_raw_recognition_result,
+    prepare_framed_part,
+)
+from build123d import Shape
+
+ClassificationT = TypeVar("ClassificationT")
+RecognitionFrameStatus = Literal["framed", "raw_fallback", "raw"]
+
+
+@dataclass(frozen=True)
+class Classification(Generic[ClassificationT]):
+    """A caller-owned classification plus the aggregate's rotational gate."""
+
+    value: ClassificationT
+    rotational: bool
+
+
+@dataclass(frozen=True)
+class AdaptedRecognition(Generic[ClassificationT]):
+    """One coherent working-shape/result/classification unit plus source provenance."""
+
+    source_part: Shape
+    working_part: Shape
+    result: RecognitionResult
+    classification: ClassificationT
+    frame: PartFrame | None
+    status: RecognitionFrameStatus
+    refusal_reason: str | None = None
+
+    @property
+    def decision(self) -> dict[str, object]:
+        """Return the stable, JSON-friendly rollout decision."""
+
+        return {
+            "status": self.status,
+            "gauge": self.frame.gauge.value if self.frame is not None else None,
+            "refusal_reason": self.refusal_reason,
+        }
+
+
+def adapt_recognition(
+    part: Shape,
+    *,
+    framed: bool,
+    classify: Callable[[Shape, object], Classification[ClassificationT]],
+    prepare: Callable[[Shape], FramedPreparation] | None = None,
+    raw_builder: Callable[..., RecognitionResult] | None = None,
+) -> AdaptedRecognition[ClassificationT]:
+    """Select and recognise one coordinate-coherent automatic compiler unit.
+
+    A successful framed route classifies the provider's exact normalized solid from the
+    provider's frozen cylinder substrate *before* its only aggregate run.  A typed refusal
+    takes one explicit caller-coordinate run.  The raw rollout route does the same
+    classification/aggregate sequence in caller coordinates.  Declared builds never call this
+    function.
+    """
+
+    prepare = prepare_framed_part if prepare is None else prepare
+    raw_builder = build_raw_recognition_result if raw_builder is None else raw_builder
+
+    if framed:
+        prepared = prepare(part)
+        if not isinstance(prepared, RefusedPartFrame):
+            classified = classify(prepared.part, prepared.cylinders)
+            outcome = prepared.recognise(rotational=classified.rotational)
+            return AdaptedRecognition(
+                source_part=part,
+                working_part=outcome.part,
+                result=outcome.result,
+                classification=classified.value,
+                frame=outcome.frame,
+                status="framed",
+            )
+        refusal_reason = prepared.reason.value
+        status: RecognitionFrameStatus = "raw_fallback"
+    else:
+        refusal_reason = None
+        status = "raw"
+
+    cylinders = analyse_cylinders(part)
+    classified = classify(part, cylinders)
+    result = raw_builder(
+        part,
+        cylinders=cylinders,
+        rotational=classified.rotational,
+    )
+    return AdaptedRecognition(
+        source_part=part,
+        working_part=part,
+        result=result,
+        classification=classified.value,
+        frame=None,
+        status=status,
+        refusal_reason=refusal_reason,
+    )

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -591,24 +591,8 @@ class TestAPositionIsADimension:
     @pytest.mark.parametrize(
         "roles", [("location",), ("bore.diameter", "location")], ids=["alone", "with-bore"]
     )
-    def test_an_off_axis_pattern_location_is_refused_not_accepted_and_lost(self, axis, roles):
-        """Eligibility must match what a compiler will actually produce.
-
-        `_LOCATION_ROLE` said every pattern is locatable; `plan_locations` planned only
-        Z-normal ones and the bbox compiler handled only holes, so an X/Y pattern fell
-        between them — `dimension(pattern, "location")` was ACCEPTED and produced nothing,
-        with no diagnostic. That is precisely the blank-drawing failure
-        `_check_authored_targets` exists to prevent (#925 review).
-
-        The engine has never drawn an off-axis pattern position (the off-axis pass excluded
-        patterns by construction), so the honest fix is for the vocabulary to say so rather
-        than for the compiler to invent output. `location_datum` is now the single answer
-        that `plan_locations`, the bbox compiler and this check all read.
-
-        The `with-bore` case is the one that survived the first fix: the target check asked
-        whether the FEATURE matched anything, so a valid `bore.diameter` entry vouched for
-        the invalid `location` beside it.
-        """
+    def test_an_off_axis_pattern_location_compiles_two_bbox_components(self, axis, roles):
+        """The authored vocabulary and bbox compiler agree on framed X/Y patterns."""
         from draftwright.model.ir import Frame, HoleFeature, PatternFeature, RequestedDimension
 
         member = HoleFeature(Frame((10, 5, 2), axis), 4.0, depth=None, through=True)
@@ -621,12 +605,18 @@ class TestAPositionIsADimension:
             pitch=15,
             direction=(0, 1, 0),
         )
-        with pytest.raises(ValueError, match="draws no position"):
-            build_drawing(
-                Box(100, 60, 20),
-                model=[pattern],
-                authored=tuple(RequestedDimension(pattern, r) for r in roles),
-            )
+        drawing = build_drawing(
+            Box(100, 60, 20),
+            model=[pattern],
+            authored=tuple(RequestedDimension(pattern, r) for r in roles),
+        )
+        locations = [name for name in drawing.annotations() if name.startswith("dim_loc_")]
+        assert len(locations) == 2
+        assert {
+            key["parameter_id"]
+            for name in locations
+            for key in drawing.measurement_keys(name)
+        } == {"location_pattern.location"}
 
     def test_a_Z_normal_pattern_location_still_works(self):
         """The false-positive half: narrowing eligibility must not cost the case that works."""

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -73,6 +73,8 @@ _LAYERS: dict[str, int] = {
     "intents": 0,
     "recognition": 0,
     "recognition_cache": 0,
+    # ADR 0020 provider-frame selection; external geometry types only, below analysis.
+    "recognition_frame": 0,
     "score": 0,  # census over recognition/ only — a leaf beside the recognisers (#704)
     # audit: diffs two FINISHED drawings through their public reads (#996). A leaf by
     # construction — it imports nothing from the engine, so the thing it measures can never

--- a/tests/test_inspection_contract.py
+++ b/tests/test_inspection_contract.py
@@ -26,7 +26,7 @@ def _manifest() -> dict:
 def test_installed_pypi_wheel_satisfies_the_inspection_contract() -> None:
     distribution = importlib.metadata.distribution("b123d-recognisers")
 
-    assert distribution.version == "0.4.8"
+    assert distribution.version == "0.4.9"
     assert distribution.read_text("direct_url.json") is None
     assert Path(inspect.getfile(inspection)).resolve().is_relative_to(ROOT / ".venv")
     validate_inspection_contract()

--- a/tests/test_issue_1143_hole_completeness.py
+++ b/tests/test_issue_1143_hole_completeness.py
@@ -1749,12 +1749,12 @@ def test_off_axis_pattern_keeps_absolute_location_requirements_fail_closed():
         "bore.through": "placed",
         "grouping.count": "placed",
         "pitch.length": "placed",
-        "location_pattern.location.y": "missing",
-        "location_pattern.location.z": "missing",
+        "location_pattern.location.y": "placed",
+        "location_pattern.location.z": "placed",
     }
     completeness = _completeness(drawing)
     assert completeness["requirements"] == 6
-    assert completeness["audited_score"] == pytest.approx(4 / 6)
+    assert completeness["audited_score"] == 1.0
 
 
 def test_compound_countersink_callout_accounts_for_every_printed_measurement():

--- a/tests/test_issue_1357_framed_recognition.py
+++ b/tests/test_issue_1357_framed_recognition.py
@@ -1,0 +1,276 @@
+"""#1357: framed recognition is one explicit source-to-working boundary."""
+
+from __future__ import annotations
+
+import pytest
+from b123d_recognisers import FrameGauge, FrameRefusalReason, PartFrame, RefusedPartFrame
+from build123d import Align, Box, Compound, Cylinder, Pos, Rot, Sphere
+
+from draftwright import build_drawing
+from draftwright.audit import diff_builds
+from draftwright.model import CylindricalReference
+from draftwright.pmi import PmiRecord, reframe_pmi_records
+from draftwright.recognition_frame import Classification, adapt_recognition
+
+_C = (Align.CENTER, Align.CENTER, Align.CENTER)
+
+
+def _classify(part, cylinders):
+    del part
+    return Classification(None, bool(cylinders[0]))
+
+
+def _orthogonal_part():
+    return Box(60, 40, 20, align=_C) - Pos(10, 5, 0) * Cylinder(4, 30, align=_C)
+
+
+def _full_part():
+    return (
+        Box(80, 55, 20, align=_C)
+        - Pos(17, 8, 0) * Cylinder(4, 30, align=_C)
+        - Pos(-22, -11, 4) * Box(10, 8, 8, align=_C)
+    )
+
+
+def _pattern_part():
+    part = Box(80, 80, 10)
+    for x, y in ((25, 25), (-25, 25), (25, -25), (-25, -25)):
+        part -= Pos(x, y, 0) * Cylinder(3, 20)
+    return part
+
+
+def _requirements(drawing):
+    return sorted(
+        (
+            feature.kind,
+            feature.frame.axis,
+            tuple(
+                sorted(
+                    (parameter.parameter_id, round(float(parameter.value), 6), parameter.role)
+                    for parameter in feature.parameters()
+                )
+            ),
+        )
+        for feature in drawing.model().features
+    )
+
+
+@pytest.mark.parametrize(
+    ("part", "gauge"),
+    [
+        pytest.param(_full_part(), FrameGauge.FULL, id="full"),
+        pytest.param(_orthogonal_part(), FrameGauge.ORTHOGONAL, id="orthogonal"),
+        pytest.param(Cylinder(10, 40, align=_C), FrameGauge.AXIAL, id="axial"),
+    ],
+)
+def test_every_successful_gauge_binds_one_local_shape_and_result(part, gauge):
+    adapted = adapt_recognition(part, framed=True, classify=_classify)
+
+    assert adapted.status == "framed"
+    assert adapted.source_part is part
+    assert adapted.working_part is not part
+    assert adapted.frame is not None and adapted.frame.gauge is gauge
+    assert adapted.result.cylinders
+    assert adapted.decision == {
+        "status": "framed",
+        "gauge": gauge.value,
+        "refusal_reason": None,
+    }
+
+
+def test_refusal_is_explicit_and_falls_back_once():
+    calls = []
+    source = Sphere(10)
+
+    def refuse(part):
+        calls.append(("prepare", part))
+        return RefusedPartFrame(FrameRefusalReason.NO_ANALYTIC_DIRECTION)
+
+    def raw(part, *, cylinders, rotational):
+        calls.append(("raw", part, cylinders, rotational))
+        from b123d_recognisers import build_raw_recognition_result
+
+        return build_raw_recognition_result(part, cylinders=cylinders, rotational=rotational)
+
+    adapted = adapt_recognition(
+        source, framed=True, classify=_classify, prepare=refuse, raw_builder=raw
+    )
+
+    assert [call[0] for call in calls] == ["prepare", "raw"]
+    assert adapted.working_part is source and adapted.frame is None
+    assert adapted.decision == {
+        "status": "raw_fallback",
+        "gauge": None,
+        "refusal_reason": "no-analytic-direction",
+    }
+
+
+def test_default_route_never_prepares_a_frame(monkeypatch):
+    source = Pos(23, -17, 9) * _orthogonal_part()
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("default automatic build inferred a part frame")
+
+    monkeypatch.setattr("draftwright.recognition_frame.prepare_framed_part", forbidden)
+    drawing = build_drawing(source, auto_dims=False)
+
+    assert drawing.recognition_frame_decision["status"] == "raw"
+    assert drawing.recognition_frame is None
+    assert drawing.part is drawing.working_part
+
+    decision = drawing.recognition_frame_decision
+    decision["status"] = "mutated"
+    assert drawing.recognition_frame_decision["status"] == "raw"
+
+
+def test_drawing_exposes_source_and_local_working_part():
+    source = Pos(123, -47, 91) * Rot(17, 31, 23) * _full_part()
+    drawing = build_drawing(source, auto_dims=False, framed_recognition=True)
+
+    assert drawing.recognition_frame_decision["status"] == "framed"
+    assert drawing.recognition_frame is not None
+    assert drawing.part.wrapped.IsPartner(source.solids()[0].wrapped)
+    assert tuple(drawing.part.bounding_box().min) == pytest.approx(
+        tuple(source.bounding_box().min)
+    )
+    assert drawing.part is not drawing.working_part
+
+
+def test_compound_levels_and_risers_remain_body_local():
+    body = Box(20, 20, 10, align=_C) + Pos(0, 0, 8) * Box(10, 10, 6, align=_C)
+    source = Compound([Pos(-25, 0, 0) * body, Pos(25, 0, 0) * body])
+    adapted = adapt_recognition(source, framed=True, classify=_classify)
+
+    assert len(adapted.working_part.solids()) == 2
+    assert len(adapted.result.step_levels) == 4
+    assert len(adapted.result.risers) == 2
+    assert all(len(riser.body_levels) == 2 for riser in adapted.result.risers)
+    spans = {tuple(level.y_span) for level in adapted.result.step_levels}
+    assert len(spans) == 2
+    assert all(not (lo < 0 < hi) for lo, hi in spans), "a level crossed the air gap"
+
+
+def test_compound_turned_profiles_keep_distinct_axis_lines():
+    shaft = Cylinder(10, 20, align=_C) + Pos(0, 0, 15) * Cylinder(7, 10, align=_C)
+    source = Compound([Pos(-30, 0, 0) * shaft, Pos(30, 0, 0) * shaft])
+    adapted = adapt_recognition(source, framed=True, classify=_classify)
+
+    assert len(adapted.result.turned_profiles) == 2
+    assert len({profile.profile.axis_origin for profile in adapted.result.turned_profiles}) == 2
+    # Draftwright's current drawing-wide profile projection must decline this compound rather
+    # than joining its two shafts across air; family-specific inventories remain available.
+    drawing = build_drawing(source, framed_recognition=True)
+    assert not [feature for feature in drawing.model().features if feature.kind == "step"]
+
+
+def test_arbitrary_frame_preserves_pmi_direction_evidence():
+    frame = PartFrame(
+        origin=(10.0, 20.0, 30.0),
+        x=(0.0, 1.0, 0.0),
+        y=(0.0, 0.0, 1.0),
+        z=(1.0, 0.0, 0.0),
+        gauge=FrameGauge.FULL,
+    )
+    cylinder = CylindricalReference.canonical(
+        axis_point=(10.0, 22.0, 33.0),
+        axis_direction=(1.0, 0.0, 0.0),
+        radius=4.0,
+        local_interval=(0.0, 4.0),
+        sense="internal",
+    )
+    record = PmiRecord(
+        kind="diameter",
+        type_code=15,
+        value=8.0,
+        ref_pts=((10.0, 22.0, 33.0), (14.0, 22.0, 33.0)),
+        ref_bbox=(10.0, 20.0, 30.0, 14.0, 25.0, 36.0),
+        dominant_axis="?",
+        reference_axis="?",
+        reference_direction=(0.0, 1.0, 0.0),
+        cylindrical_refs=(cylinder,),
+        source_id="dimension:1",
+    )
+
+    local = reframe_pmi_records([record], frame)[0]
+
+    assert local.ref_pts == ((2.0, 3.0, 0.0), (2.0, 3.0, 4.0))
+    assert local.ref_bbox == (0.0, 0.0, 0.0, 5.0, 6.0, 4.0)
+    assert local.dominant_axis == "Z"
+    assert local.reference_axis == "X"
+    assert local.reference_direction == (1.0, 0.0, 0.0)
+    assert local.cylindrical_refs[0].principal_axis == "Z"
+    assert local.cylindrical_refs[0].midpoint == pytest.approx((2.0, 3.0, 2.0))
+
+
+def test_framed_off_axis_pattern_keeps_its_absolute_location():
+    drawing = build_drawing(_pattern_part(), framed_recognition=True)
+    pattern = next(feature for feature in drawing.model().features if feature.kind == "pattern")
+    location_ids = {
+        key["parameter_id"]
+        for name, _annotation in drawing.iter_annotations()
+        for key in drawing.measurement_keys(name)
+        if key["feature"].startswith("pattern") and key["parameter_id"].startswith("location")
+    }
+
+    assert pattern.frame.axis in {"x", "y"}
+    assert location_ids == {"location_pattern.location"}
+    assert drawing.lint() == []
+
+
+def test_declared_build_stays_in_caller_coordinates_and_skips_recognition(monkeypatch):
+    automatic = build_drawing(_full_part(), framed_recognition=True)
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("declared rendering performed recognition")
+
+    monkeypatch.setattr("draftwright.recognition_frame.prepare_framed_part", forbidden)
+    declared = build_drawing(automatic.working_part, model=automatic.model())
+
+    assert declared.recognition_frame_decision["status"] == "declared"
+    assert declared.recognition_frame is None
+    assert declared.part is declared.working_part
+    assert _requirements(declared) == _requirements(automatic)
+    assert declared.annotations() == automatic.annotations()
+
+
+def test_scale_convergence_reuses_one_framed_preparation(monkeypatch):
+    from draftwright import recognition_frame as boundary
+
+    calls = 0
+    original = boundary.prepare_framed_part
+
+    def counted(part):
+        nonlocal calls
+        calls += 1
+        return original(part)
+
+    monkeypatch.setattr(boundary, "prepare_framed_part", counted)
+    build_drawing(_full_part(), framed_recognition=True)
+
+    assert calls == 1
+
+
+@pytest.mark.parametrize(
+    "part",
+    [_full_part(), _orthogonal_part(), _pattern_part(), Cylinder(10, 40, align=_C)],
+    ids=("full", "orthogonal", "pattern", "axial"),
+)
+def test_rigid_motion_preserves_requirements_sheet_and_lint(part):
+    baseline = build_drawing(part, framed_recognition=True)
+    moved = build_drawing(Pos(123, -47, 91) * Rot(17, 31, 23) * part, framed_recognition=True)
+
+    assert baseline.recognition_frame_decision == moved.recognition_frame_decision
+    assert _requirements(baseline) == _requirements(moved)
+    assert baseline.annotations() == moved.annotations()
+    assert diff_builds(baseline, moved) == {
+        "dimensions_lost": {},
+        "dimensions_gained": {},
+        "dimensions_changed": {},
+        "measurements_substituted": {},
+        "suppressions_gained": [],
+        "suppressions_lost": [],
+        "candidate_explanations": {},
+    }
+    assert [(issue.severity, issue.code) for issue in baseline.lint()] == [
+        (issue.severity, issue.code) for issue in moved.lint()
+    ]

--- a/tests/test_location_vocabulary.py
+++ b/tests/test_location_vocabulary.py
@@ -384,7 +384,7 @@ def test_the_on_axis_bore_skip_reads_the_declaration_on_both_surfaces():
     )
 
 
-def test_location_role_answers_for_an_eligible_feature_and_none_for_an_ineligible_one():
+def test_location_role_answers_for_principal_axis_holes_and_patterns():
     """Both directions, unlike the first cut — which was named "...answers none where no
     location is planned" and then asserted the opposite on a feature that IS locatable,
     ending with `assert model is not None`, which cannot fail after ordinary construction."""
@@ -396,5 +396,5 @@ def test_location_role_answers_for_an_eligible_feature_and_none_for_an_ineligibl
 
     member = HoleFeature(Frame((0.0, 0.0, 0.0), "x"), 6.0, depth=None, through=True)
     off_axis = PatternFeature(Frame((0.0, 0.0, 0.0), "x"), "linear", 3, member)
-    assert location_datum(off_axis) is None, "an off-axis pattern has never been drawn"
-    assert location_role(off_axis) is None, "so the vocabulary must not accept it"
+    assert location_datum(off_axis) == "bbox"
+    assert location_role(off_axis) == "location_pattern"

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -9492,17 +9492,18 @@ class TestTurnedDiameters:
             expected = 4 if dwg.get_annotation(name).label == "4× 2" else 1
             assert len(dwg.measurement_keys(name)) == expected
 
-        # The central Y-axis bore shares the detected turned-profile axis. Its
-        # centreline locates it; generic minimum-edge offsets would redundantly
-        # show half the 46 mm envelope in both X and Z (#881).
+        # The central Y-axis bore shares the detected turned-profile axis and remains
+        # centreline-located. The bolt pattern is a distinct physical feature: pitch/count
+        # do not state its absolute centre, so #1357 now places those two locations.
         assert dwg.view_of("centerline_side") == "side"
         # RaisedPad v2 no longer misclassifies two rotated flange lugs as pads. With that
         # false requirement gone, ADR 0018 omits the redundant plan view and its furniture;
         # the front profile plus side end view still define the Y-axis stack completely.
         assert dwg.view_of("centerline_plan") is None
         assert "plan" not in dwg.views
-        assert not any(n.startswith("dim_loc_front_") for n in dwg.annotations())
-        assert not any(n.startswith("dim_loc_side_") for n in dwg.annotations())
+        locations = [n for n in dwg.annotations() if n.startswith("dim_loc_")]
+        assert {dwg.view_of(n) for n in locations} == {"front", "side"}
+        assert {dwg.registry.feature_of(n).kind for n in locations} == {"pattern"}
 
         codes = {issue.code for issue in dwg.lint()}
         assert "feature_not_dimensioned" not in codes
@@ -9744,10 +9745,8 @@ class TestTurnedDiameters:
         assert (
             auto.get_annotation("dim_height").label == replayed.get_annotation("dim_height").label
         )
-        # The off-axis four-hole pattern has relative pitch/count but no absolute X/Z
-        # location dimensions. The hole-family ledger added by #1143 reports those two
-        # physical requirements honestly on both paths; reconstruction must preserve the
-        # same critique as well as the same annotation set.
+        # The off-axis pattern's pitch/count do not state its absolute location. #1357 places
+        # both components on automatic and replay paths.
         # The `leader_crosses_silhouette` entry is the #798 bolt-circle cut described in
         # test_issue_881_...; it appears on BOTH paths, which is what this test is
         # actually about — the replay reproduces the same critique, defects included.
@@ -9757,17 +9756,16 @@ class TestTurnedDiameters:
         assert (
             auto.lint_summary()["by_code"]
             == replayed.lint_summary()["by_code"]
-            == {
-                "hole_requirement_missing": 2,
-                "leader_crosses_silhouette": 1,
-            }
+            == {"leader_crosses_silhouette": 1}
         )
 
         # ── from #881: the Y-step furniture lands in the right views on the replay ──
         assert replayed.view_of("centerline_side") == "side"
         assert replayed.view_of("centerline_plan") is None
         assert "plan" not in replayed.views
-        assert not any(n.startswith(("dim_loc_front_", "dim_loc_side_")) for n in replay)
+        locations = [n for n in replay if n.startswith("dim_loc_")]
+        assert {replayed.view_of(n) for n in locations} == {"front", "side"}
+        assert {replayed.registry.feature_of(n).kind for n in locations} == {"pattern"}
         assert {replayed.view_of(n) for n in replay if n.startswith("m_steplen")} == {"side"}
 
     @pytest.mark.parametrize(("axis_z", "rotation"), [(0.0, 90), (17.0, 90), (-11.0, -90)])
@@ -10519,12 +10517,9 @@ class TestTurnedLengths:
         assert dwg.lint_summary()["by_code"].get("axial_length_missing", 0) == 0
 
     def test_non_contiguous_turned_profile_lints_without_crashing(self):
-        # #797: a non-contiguous turned profile — two coaxial discs (ø30, then ø20)
-        # with an axial GAP between them — carries a step whose interior end face
-        # (10) `TurnedProfile.shoulders` used to drop, so the axial-coverage lookup
-        # KeyError'd and crashed the whole lint pass. shoulders now includes every
-        # endpoint, so both discs are locatable: no crash AND — since both lengths
-        # are dimensioned — no false `axial_length_missing` from a dropped face.
+        # #797/#1357: two disconnected coaxial discs are two physical profiles, not one
+        # non-contiguous shaft spanning the air gap. 0.4.9 gives them distinct membership;
+        # Draftwright's singular drawing-wide profile must decline rather than join them.
         from build123d import Align
 
         b = Align.MIN
@@ -10533,14 +10528,9 @@ class TestTurnedLengths:
             + Pos(0, 0, 20) * Cylinder(10, 10, align=(Align.CENTER, Align.CENTER, b))
         )
         dwg = build_drawing(part, number="X")
-        codes = dwg.lint_summary()["by_code"]  # must not raise KeyError
-        assert sorted(
-            str(o.label) for n, o in dwg.iter_annotations() if n.startswith("m_steplen")
-        ) == [
-            "10",
-            "10",
-        ]
-        assert codes.get("axial_length_missing", 0) == 0
+        assert dwg.recognition().turned_profiles == ()
+        assert not [n for n in dwg.annotations() if n.startswith("m_steplen")]
+        dwg.lint_summary()  # the former KeyError path still must not crash
 
 
 class TestStepLadderRecognition:

--- a/tests/test_part_model.py
+++ b/tests/test_part_model.py
@@ -298,22 +298,23 @@ def test_feature_detection_runs_once_per_build(monkeypatch):
     """ADR 0008 Amendment 5 / #244 — one aggregate inventory per build.
 
     The recogniser package owns its internal family orchestration; Draftwright's contract is
-    the single public ``build_raw_recognition_result`` call whose result every consumer reuses.
+    the single raw aggregate selected by the owned recognition-frame boundary, whose result
+    every consumer reuses.
     """
     from build123d import Cylinder, Pos, Rotation
 
-    import draftwright.analysis as amod
+    import draftwright.analysis as analysis
     from draftwright import build_drawing
 
     calls = 0
-    original = amod.build_raw_recognition_result
+    original = analysis.build_raw_recognition_result
 
     def wrap(*args, **kwargs):
         nonlocal calls
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(amod, "build_raw_recognition_result", wrap)
+    monkeypatch.setattr(analysis, "build_raw_recognition_result", wrap)
 
     # A turned X shaft exercises the detected path, including a repack when required.
     build_drawing(Rotation(0, 90, 0) * (Cylinder(15, 30) + Pos(0, 0, 30) * Cylinder(8, 30)))

--- a/tests/test_pmi_datum_lowering.py
+++ b/tests/test_pmi_datum_lowering.py
@@ -310,15 +310,21 @@ def test_datum_geometry_rejects_unusable_reference_shapes(monkeypatch):
     monkeypatch.setattr(pmi_module, "GeomAbs_Cylinder", "cylinder")
     shape_tool = SimpleNamespace(GetShape_s=lambda ref: ref)
 
+    points, bbox, axis, direction, reasons = pmi_module._datum_reference_geometry(
+        (((Shape(surface=Surface("plane", direction=(1.0, 0.2, 0.0))),), ())),
+        shape_tool,
+    )
+    assert points == ((1.0, 2.0, 3.0),)
+    assert bbox == (0.0, 1.0, 2.0, 2.0, 3.0, 4.0)
+    assert axis == "?"
+    assert direction == (1.0, 0.2, 0.0)
+    assert reasons == ()
+
     cases = (
         ((Shape(null=True),), "datum reference surface is unavailable"),
         (
             (Shape(surface=Surface("unsupported")),),
             "one datum reference is neither planar nor cylindrical",
-        ),
-        (
-            (Shape(surface=Surface("plane", direction=(1.0, 0.2, 0.0))),),
-            "one datum reference surface is not axis-aligned",
         ),
         (
             (Shape(broken=True),),
@@ -340,13 +346,14 @@ def test_datum_geometry_rejects_unusable_reference_shapes(monkeypatch):
         ),
     )
     for shapes, expected_reason in cases:
-        points, bbox, axis, reasons = pmi_module._datum_reference_geometry(
+        points, bbox, axis, direction, reasons = pmi_module._datum_reference_geometry(
             (shapes, ()), shape_tool
         )
         usable_shape_count = sum(not shape.null for shape in shapes)
         assert points == ((1.0, 2.0, 3.0),) * usable_shape_count
         assert bbox == ((0.0, 1.0, 2.0, 2.0, 3.0, 4.0) if usable_shape_count else None)
         assert axis == "", expected_reason
+        assert direction is None or len(direction) == 3
         assert expected_reason in reasons
 
 

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -128,7 +128,7 @@ def test_installed_package_contract_validates_without_a_sibling_checkout() -> No
 def test_rich_passage_contract_has_an_explicit_unsupported_completeness_outcome() -> None:
     """Pin the 0.4 physical record and compatibility projection to one decision."""
 
-    assert INSTALLED_PACKAGE_VERSION == "0.4.8"
+    assert INSTALLED_PACKAGE_VERSION == "0.4.9"
     installed = tuple(int(component) for component in INSTALLED_PACKAGE_VERSION.split("."))
     assert (0, 4, 0) <= installed < (0, 5, 0)
     package = _families(recognition.capability_manifest())
@@ -983,16 +983,26 @@ def test_schema_format_fails_closed() -> None:
 
 
 def test_only_reviewed_records_accept_installed_schema_2() -> None:
-    """The pinned package uses schema 2 only for the three reviewed records."""
+    """The pinned package uses schema 2 only for the reviewed adapter records."""
     declaration = consumer_capability_declaration()
     families = _families(declaration)
     assert families["chamfers"]["record_schemas"] == {"Chamfer": [2]}
     assert families["fillets"]["record_schemas"] == {"Fillet": [2]}
     assert families["rectangular-pads"]["record_schemas"] == {"RaisedPad": [2]}
+    assert families["risers"]["record_schemas"] == {
+        "RiserEvidence": [2],
+        "StepShoulder": [1],
+    }
+    assert families["turned-steps"]["record_schemas"] == {
+        "TurnedProfile": [2],
+        "TurnedProfileKey": [1],
+        "TurnedStep": [2],
+    }
     assert all(
         versions == [1]
         for family_id, family in families.items()
-        if family_id not in {"chamfers", "fillets", "rectangular-pads"}
+        if family_id
+        not in {"chamfers", "fillets", "rectangular-pads", "risers", "turned-steps"}
         for versions in family["record_schemas"].values()
     )
 

--- a/tests/test_recognition_manifest.py
+++ b/tests/test_recognition_manifest.py
@@ -358,14 +358,14 @@ def test_no_deferred_family_is_reachable_from_the_orchestration():
 #: Families the ORCHESTRATION runs only for the class that consumes them (#1028). Listed here
 #: rather than derived from DEFERRED because they are no longer deferred: they are MIGRATED
 #: *and* gated, which is the distinction #1028 established — owning a family and always
-#: running it are different things. Turned parts are the excluded class for plates and angled
-#: prismatic steps. Chamfers and fillets left this set in b123d-recognisers 0.2.9 because the
-#: aggregate now recognises their conical/toroidal turned forms (#1254/#1281).
+#: running it are different things.  Since b123d-recognisers 0.4.9, Plate discovery is not in
+#: this whole-part gate: it consumes completed turned-step ownership and excludes only those
+#: bodies, so a mixed compound can still expose independent prismatic plates. Chamfers and
+#: fillets likewise run for both classes because they recognise turned forms (#1254/#1281).
 _CLASSIFICATION_GATED = (
     "recognise_angled_steps",
     "recognise_circular_blind_steps",
     "recognise_paired_ramp_steps",
-    "recognise_plates",
     "recognise_through_steps",
 )
 
@@ -382,11 +382,9 @@ def test_a_classification_gated_family_does_not_run_for_the_excluded_class():
     every turned build scan for a prismatic-only result the model discards, which is the cost
     the deferral was protecting against — and this goes red.
 
-    Two turned fixtures, because plates gates on a CONJUNCTION (not rotational *and* no
-    turned profile) and the stepped shaft satisfies both — so on it alone, weakening the gate
-    to either half still passes. The plain cylinder has no shoulders, so its profile is
-    ``None`` while it is still rotational: it separates the two clauses and fails if the
-    rotational half is dropped.
+    Two turned fixtures ensure the global gate is independent of whether the part has
+    completed turned-step evidence. Plate is deliberately tested separately because 0.4.9
+    changed it from a whole-part classification gate to body-local exclusion.
     """
     assert _CLASSIFICATION_GATED, "no family is classification-gated — check vacuous"
     assert set(_CLASSIFICATION_GATED) <= MIGRATED, (
@@ -452,8 +450,8 @@ def _expected_inventory(part, *, rotational: bool = False) -> dict:
     the recognisers directly — the oracle the aggregate is judged against.
 
     The remaining classification-gated fields are ``()`` for a rotational part, mirroring
-    the orchestration's gate (#1028). Chamfers and fillets are deliberately unconditional
-    since b123d-recognisers 0.2.9 added turned edge treatments (#1254/#1281).
+    the orchestration's gate (#1028). Plate is discovered with completed turned bodies
+    excluded, a cross-family ownership operation covered as a subset below.
     """
     cyls = analyse_cylinders(part)
     csinks = recognise_countersinks(part)
@@ -486,11 +484,7 @@ def _expected_inventory(part, *, rotational: bool = False) -> dict:
         "rotational": rotational,
         "chamfers": tuple(recognise_chamfers(part)),
         "fillets": tuple(recognise_fillets(part)),
-        "plates": (
-            tuple(recognise_plates(part))
-            if not rotational and not recognise_turned_steps(part, cyls=cyls)
-            else ()
-        ),
+        "plates": tuple(recognise_plates(part)),
         # Recognised and carried, but never converted to inferred IR. The first family has a
         # reviewed unsupported outcome (#1247); the 0.4.6 families remain explicitly deferred
         # under #1382. The aggregate must still hold what its recognisers produced: an inventory
@@ -523,7 +517,7 @@ def _expected_inventory(part, *, rotational: bool = False) -> dict:
 #: another family, and may never invent one. Equality is still demanded everywhere else, so the
 #: "ran it and stored ()" failure this test exists for is still caught for every other field.
 _RECONCILED_FIELDS = frozenset(
-    {"chamfers", "fillets", "passages", "prismatic_pockets", "section_passages"}
+    {"chamfers", "fillets", "passages", "plates", "prismatic_pockets", "section_passages"}
 )
 
 
@@ -647,8 +641,8 @@ def test_an_automatic_build_runs_each_family_exactly_once_and_lint_runs_no_migra
             drawing.lint()
             after_lint = dict(counts)
 
-        # The remaining prismatic-only families are excluded for a turned part BY DESIGN
-        # (#1028/#1254) — owning a family and always running it are different things, and
+        # The four whole-part-gated families are excluded for a turned part BY DESIGN
+        # (#1028/#1254/#1382) — owning a family and always running it are different things, and
         # `test_a_classification_gated_family_does_not_run_for_the_excluded_class` owns that
         # claim. Everything else must run exactly once whatever the part class.
         expected_once = MIGRATED - (set(_CLASSIFICATION_GATED) if label == "turned" else set())

--- a/tests/test_recognition_result.py
+++ b/tests/test_recognition_result.py
@@ -6,10 +6,8 @@ import pytest
 from b123d_recognisers import (
     RecognitionResult,
     build_raw_recognition_result,
-    recognise_plates,
 )
-from build123d import Align, Axis, Box, Cylinder, Pos, chamfer, fillet
-from conftest import counting_calls
+from build123d import Align, Axis, Box, Compound, Cylinder, Pos, chamfer, fillet
 
 from draftwright import build_drawing
 from draftwright.model import build_part_model
@@ -177,14 +175,8 @@ def test_injecting_the_aggregate_builds_the_same_model_as_detecting(name, build)
     )
 
 
-def test_the_gate_is_the_orchestrations_not_the_call_sites():
-    """#1028's actual claim: a family can be MIGRATED *and* not always run.
-
-    Plates remain classification-gated because hoisting them unconditionally would scan every
-    turned build for a prismatic-only result `build_part_model` discards. Chamfers and fillets
-    deliberately stopped sharing this gate in b123d-recognisers 0.2.9, which recognises their
-    conical/toroidal turned forms (#1254/#1281).
-    """
+def test_plate_discovery_uses_body_ownership_not_a_compound_global_class_gate():
+    """0.4.9 may inspect plates in a mixed compound while excluding turned owners."""
     # An L-bracket: a base slab plus an upright wall, which is what `recognise_plates` looks
     # for. A plain box has no plates, so it would make the gate assertion below vacuous.
     prismatic = Box(80, 40, 8) + Pos(-36, 0, 24) * Box(8, 40, 40)
@@ -193,8 +185,7 @@ def test_the_gate_is_the_orchestrations_not_the_call_sites():
     assert build_raw_recognition_result(prismatic, rotational=False).rotational is False
     assert build_raw_recognition_result(turned, rotational=True).rotational is True
 
-    # Same solid, both classifications: only the gate differs, so the plate inventory change
-    # is the gate's doing and not the geometry's.
+    # A rotational classification without completed turned ownership still declines the scan.
     ungated = build_raw_recognition_result(prismatic, rotational=False)
     gated = build_raw_recognition_result(prismatic, rotational=True)
 
@@ -206,29 +197,14 @@ def test_the_gate_is_the_orchestrations_not_the_call_sites():
     assert ungated.step_levels == gated.step_levels
 
 
-def test_the_plates_gate_needs_both_halves_not_just_the_rotational_one():
-    """`plates` gates on a CONJUNCTION — not rotational AND no turned profile — and the
-    profile half needs its own counterexample.
-
-    The manifest's exclusion test drives both its turned fixtures through `build_drawing`,
-    where they classify rotational, so weakening the gate to `if prismatic` alone still
-    skipped plates on both and that guard stayed green (Codex #1033 r1). The half that was
-    untested is exactly the documented "caller has no classification" path: a stepped shaft
-    with `rotational=False`, where only the profile keeps the scan away.
-
-    Asserted by COUNTING the call, not by checking the inventory came back empty:
-    `recognise_plates` naturally finds nothing on a shaft, so an empty result proves the scan
-    was skipped only by coincidence. The cost this gate exists to avoid is the scan itself.
-    """
+def test_completed_turned_ownership_keeps_independent_compound_plates():
+    """Turned ownership excludes its body, not every plate in a mixed compound."""
     shaft = Cylinder(20, 30) + Pos(0, 0, 30) * Cylinder(14, 30)
+    bracket = Box(80, 40, 8) + Pos(-36, 0, 24) * Box(8, 40, 40)
+    part = Compound(children=[shaft, Pos(120, 0, 0) * bracket])
 
-    with counting_calls({"plates": recognise_plates}) as counts:
-        rec = build_raw_recognition_result(shaft, rotational=False)
+    rec = build_raw_recognition_result(part, rotational=True)
 
-    assert rec.turned_steps, "fixture stopped producing a turned profile — the gate's other half"
-    assert counts.get("plates", 0) == 0, (
-        "recognise_plates ran for a part with a turned profile even though the caller said "
-        "not-rotational — the conjunction has collapsed to its rotational half, and every "
-        "unclassified stepped-shaft aggregate now pays for a scan the model discards"
-    )
-    assert rec.plates == ()
+    assert rec.turned_steps, "fixture stopped establishing the shaft's turned ownership"
+    assert rec.plates, "the independent prismatic body's plates were compound-globally gated"
+    assert all(plate.lo > 60.0 for plate in rec.plates if plate.axis == "x")

--- a/tests/test_slanted_blind_step.py
+++ b/tests/test_slanted_blind_step.py
@@ -189,6 +189,10 @@ def test_oblique_degenerate_and_small_bounded_faces_are_rejected(monkeypatch):
         def faces(self):
             return [self._face]
 
+        def solids(self):
+            # b123d-recognisers 0.4.9 scopes riser evidence per owning body.
+            return [self]
+
     class PlaneSurface:
         @staticmethod
         def GetType():
@@ -199,6 +203,10 @@ def test_oblique_degenerate_and_small_bounded_faces_are_rejected(monkeypatch):
         "BRepAdaptor_Surface",
         lambda wrapped: PlaneSurface(),
     )
+    # This unit isolates the riser-face gates. Since 0.4.9 the public scan obtains body-local
+    # levels first; that independently covered prerequisite needs real OCP plane geometry and
+    # is deliberately outside this synthetic face stub.
+    monkeypatch.setattr(levels_module, "step_level_records", lambda part, tol=None: [])
 
     shallow = Face((1.0, 0.0, 0.02), _box(2, 3, 0, 10, 24.75, 25))
     small = Face((1.0, 0.0, 0.5), _box(2, 3, 0, 2, 20, 25))

--- a/tests/test_view_plan.py
+++ b/tests/test_view_plan.py
@@ -276,7 +276,7 @@ class TestPerViewRequirementCoverage:
             (
                 "stepped shaft",
                 lambda: Rot(0, 90, 0) * (Cylinder(10, 40) + Pos(0, 0, 40) * Cylinder(6, 30)),
-                ("plan", "side"),
+                (),
             ),
             (
                 "grooved shaft",
@@ -298,10 +298,11 @@ class TestPerViewRequirementCoverage:
     def test_a_turned_part_leaves_its_radial_views_empty(self, name, build, expected):
         """The redundancy is structural for turned parts, not a property of one plate.
 
-        A body of revolution looks the same from every radial direction, so the two views that
-        differ only in radial direction carry nothing between them — measured here on three
-        shafts, and the count is the drafting answer: a plain turned part is conventionally
-        dimensioned on one longitudinal view.
+        A classified body of revolution looks the same from every radial direction, so the two
+        views that differ only in radial direction carry nothing between them. The first
+        fixture is the counterexample introduced by 0.4.9: axis-covariant boss evidence on
+        multi-diameter X stock retains complete boss/envelope dimensions while Draftwright's
+        rotational furniture remains single-OD on X/Y, so all three views carry requirements.
 
         The contrast with the fixtures below is the useful part. A turned part carrying RADIAL
         features (a bolt circle, a hole pattern) needs its end view and only one candidate
@@ -347,17 +348,15 @@ class TestPerViewRequirementCoverage:
 
         Coverage was built by walking annotations, so a view with NO annotations never entered
         the map and could never be reported — silently dropping exactly the most redundant
-        views. On a stepped shaft the `side` view carries not one measurement, and only `plan`
+        views. On a grooved shaft the `side` view carries not one measurement, and only `plan`
         was reported. The map is seeded from the drawing's views now.
         """
         from draftwright.view_plan import view_coverage
 
-        drawing = build_drawing(
-            Rot(0, 90, 0) * (Cylinder(10, 40) + Pos(0, 0, 40) * Cylinder(6, 30)),
-            title="T",
-            number="N",
-            _views=("front", "plan", "side"),
+        part = (Rot(0, 90, 0) * Cylinder(12, 80)) - Rot(0, 90, 0) * Pos(0, 0, 20) * (
+            Cylinder(12, 6) - Cylinder(9, 6)
         )
+        drawing = build_drawing(part, title="T", number="N", _views=("front", "plan", "side"))
         coverage = view_coverage(drawing)
 
         assert {"front", "plan", "side"} <= set(coverage), (

--- a/uv.lock
+++ b/uv.lock
@@ -85,15 +85,15 @@ wheels = [
 
 [[package]]
 name = "b123d-recognisers"
-version = "0.4.8"
+version = "0.4.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ba/f9/69be5018fe16b53317502c67e9254e0373968bf6261f3dc9c873901d07ca/b123d_recognisers-0.4.8.tar.gz", hash = "sha256:c76edc640c3e4029ab2060a7a4e1e2743e27a479cec9147a08cdcfc827a2ac66", size = 3127513, upload-time = "2026-08-30T15:42:27.041Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/05/111821b5fa53c0f16cd1e208f6753efbed584364602164b1b28f261c1929/b123d_recognisers-0.4.9.tar.gz", hash = "sha256:16032465dc6a533d8a77d6a5d9b080f26ea500d0e9c6c6940cd55c64ba9ab7c1", size = 3409954, upload-time = "2026-08-30T19:35:41.357Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/ac/814f5d6ccdc07aba66bbfcbe8665d186e60eeb43ff4b10986202e4167254/b123d_recognisers-0.4.8-py3-none-any.whl", hash = "sha256:ec818b0c65922d8d6c4824c09563acc37542ac78f808e0d6af9e2ad2ddfa7785", size = 381313, upload-time = "2026-08-30T15:42:25.196Z" },
+    { url = "https://files.pythonhosted.org/packages/54/e0/afc0c3c0443b0fa1025e8217abeb508a73317d111f971a6fdf46213472ad/b123d_recognisers-0.4.9-py3-none-any.whl", hash = "sha256:4bbffe792e0c461091cf4f23746c91bb409c6dd4f5f5e3094ab15b7783ce576e", size = 385023, upload-time = "2026-08-30T19:35:38.756Z" },
 ]
 
 [[package]]
@@ -746,7 +746,7 @@ docs = [
 [package.metadata]
 requires-dist = [
     { name = "antlr4-python3-runtime", specifier = "<4.10" },
-    { name = "b123d-recognisers", specifier = "==0.4.8" },
+    { name = "b123d-recognisers", specifier = "==0.4.9" },
     { name = "build123d", marker = "python_full_version < '3.13'", specifier = ">=0.9.0,<0.11" },
     { name = "build123d", marker = "python_full_version >= '3.13'", specifier = ">=0.11,<0.12" },
     { name = "build123d-drafting-helpers", specifier = ">=0.14.2" },


### PR DESCRIPTION
## Outcome

Adds the first Draftwright-owned framed-recognition slice from #1357 against immutable `b123d-recognisers==0.4.9`. Automatic callers can opt in with `framed_recognition=True`; raw remains the rollout default.

- keeps provider preparation, exact working solid/cylinders, Draftwright classification, and one aggregate in one coordinate-coherent adapter
- retains caller geometry on `Drawing.part` and exposes the compiled `working_part`, frame, and typed decision separately
- preserves declared builds as caller-coordinate and recognition-free
- transforms AP242 correlation geometry once into the selected working frame while retaining the source extraction report
- consumes body-local FaceLevel/Riser/TurnedProfile v2 contracts without joining equal features across air
- places X/Y-normal pattern locations and derives grid pitch placement from the recognised lattice frame
- records ADR 0020 and updates capability/inspection contracts and orchestration counts for 0.4.9

Raw-to-framed default transition and representative canary disposition remain follow-up rollout work under #1357. Multi-diameter X/Y turned furniture remains deliberately on the complete boss/envelope path until #1402; the existing display-completeness sweep proves premature rotational classification loses approved measurements.

## Evidence

- `ruff check .`
- `mypy src` (79 files)
- 17 focused framed/covariance tests
- recognition manifest/result suites
- PMI suite and affected compiled/hole/turned suites
- broad local run: 2,252 passed before six related failures exposed the #1402 boundary; all six affected tests pass after restoring the complete consumer path
- hosted full/platform matrix is required before merge

Advances #1357 and #1365.
