### PR TITLE
Compile plural turned profiles independently

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,8 @@ Compact map, bottom to top:
   `_geometry.py` (page-plane maths + the ADR 0014 Amdt 3 material field; the DAG's
   bottom leaf), `fonts.py` (pinned IBM Plex, ADR 0006), `fits.py` (ISO 286),
   `intents.py` (deferred-edit low IR), `recognition_cache.py` (ADR 0017 one-result
-  lifecycle), `recognition_frame.py` (ADR 0020 prepared local-frame boundary),
+  lifecycle), `recognition_frame.py` (ADR 0020 prepared local-frame boundary and fail-closed
+  body-local occurrence joins),
   `_warnings.py`, `_pmi_part21.py`, and the `linting/` subpackage
   (draftwright owns lint, ADR 0007).
 - **`_core.py`** — shared primitives: the `Analysis` namespace, dim/format helpers,

--- a/docs/adr/0020-provider-owned-frame-boundary.md
+++ b/docs/adr/0020-provider-owned-frame-boundary.md
@@ -93,20 +93,71 @@ working solid, result, or guessed axes and never invokes the raw aggregate. If a
 later offers raw fallback, that is an explicit caller or top-level build-policy choice with a
 visible decision—not hidden recovery inside the frame adapter.
 
-### 5. Plural turned profiles fail explicitly at the current singular waist
+### 5. Plural turned profiles are one compiler input, never a selected body
 
-Recognisers 0.4.9 preserves body-local turned-profile membership. Draftwright's current `Analysis`
-stores one `TurnedProfile`, so selecting the first of several or merging disjoint bodies would be
-false. `single_turned_profile` consumes the public `RecognitionResult.turned_profiles` grouping
-and raises `MultipleTurnedProfilesError` when a caller requires one physical profile but receives
-several. A standalone `build_part_model` therefore fails explicitly instead of inventing global
-ownership.
+Recognisers 0.4.9 preserves body-local turned-profile membership. `Analysis.profiles` and
+`build_part_model(..., profiles=...)` now carry that public tuple through the record→IR waist;
+`Analysis.prof` and the compatible `prof=` input remain zero/one projections only for behavior
+that genuinely requires one coaxial stack. No production consumer selects the first profile or
+merges disjoint bodies. `single_turned_profile` remains an explicit legacy accessor and still
+raises `MultipleTurnedProfilesError` when a caller asks for one profile but the result owns several.
 
-The unchanged raw production path has an older supported compound behavior to preserve: parallel
-grooved shafts build without a global turned profile. `_raw_compatible_turned_profile` retains that
-no-global-profile result when 0.4.9 now exposes several body-local groups and logs the #1357
-deferral. It neither selects nor merges a profile. Framed activation must make the compiler input
-plural before consuming those new TurnedSteps; it may not inherit this compatibility projection.
+Each `TurnedStep` lowers against its `TurnedProfileKey.axis_origin`, so its `StepFeature.frame` and
+span stay on the physical body's axis line rather than the compound bounding-box centre; the
+immutable key also crosses the IR as structural body provenance. Grooves are joined only to the
+profile on the same line. The renderer groups step chains by exact profile identity, with an
+axis-line/disconnected-run fallback only for declared or legacy features without that provenance,
+before any repeated-run collapse. It anchors each chain to that body's silhouette; equal lengths
+on parallel shafts therefore retain separate marks and `DimensionId` provenance. The renderer
+matches overlapping physical occurrences of the same turning axis to conflict-free projected lanes
+across the two orthographic longitudinal views. Occurrences on the same projected axis line may
+reuse a lane only when their projected axial intervals are disjoint; perpendicular profile axes
+remain independent candidates for the common placement/overlap stages. If the available authored
+views or a dense profile grid provide no conflict-free assignment, that profile's chain is dropped
+with a required-outcome diagnostic instead of being drawn over a sibling. Physical axial lint searches
+the same pair of profile views and evaluates each profile independently, prioritising exact
+registry measurement provenance and rejecting tied unowned geometric witnesses. Structured
+claims, groove bands, drawing witnesses, and overall-drop contingency remain body-local; a sibling
+with equal shoulder stations cannot certify a missing chain. A deferred subset edit repeats view
+assignment against the complete physical-profile roster, then emits only the requested refs; a
+surviving sibling therefore keeps its auto-pass lane rather than being forgotten during replay.
+
+Declared `StepFeature` inputs follow the same plural compiler shape without detection. Their
+profiles are grouped in caller coordinates by axis line and disconnected axial run, preserving
+ADR 0011's coordinate authority. Generated scripts do not expose or serialize the provider's
+`TurnedProfileKey`; the emitter replaces each detected occurrence with a stable Draftwright-owned
+opaque `profile_group=` token, allocated outside every caller-authored token already present in the
+model. This preserves even adjacent or overlapping coaxial body partitions without making provider
+types part of the public `Sheet` surface. Synthetic declared profiles retain that opaque membership
+alongside their geometrically valid provider-shaped key, so lint can join placed measurements to
+the exact declaration group **and axis line** instead of relying on either ambiguous witness alone.
+Token-backed and provider-key axis lines are compared at their published/script precision, never
+with the generic 0.5 mm geometric-witness tolerance; a reused token therefore cannot merge two
+nearby physical axes. Ordinary declarations that omit a group still reconstruct physical grouping
+from axis lines, step spans, and intervening groove bands, with a tolerance limited to the script's
+documented 0.001 mm coordinate precision. Aggregate `PartModel.orientation` is derived from the
+set of declared step axes: one unique axis retains that orientation, while a mixed-axis inventory
+uses `None` regardless of declaration order. The legacy global-height misuse guard applies only to
+its single-solid domain and does not treat a caller-owned group token as evidence of another body;
+profiles in a multi-solid compound need not tile that compound's global axial envelope. Existing model,
+annotation, dimension, and lint round-trip parity tests guard that this provenance translation does
+not hide a drawing divergence.
+
+The released 0.4.9 `Groove` record does not carry `TurnedProfileKey`. A groove band that overlaps
+multiple nested coaxial profiles therefore has no exact public owner: position-only suppression can
+delete a sibling's legitimate step and position-only lint can falsely credit both bodies. The
+compiler refuses that ambiguous join rather than guessing or rescanning topology, and physical lint
+independently refuses to credit the groove to either profile if an external producer bypasses the
+compile gate. The missing provider contract is tracked upstream as
+[`b123d-recognisers#354`](https://github.com/pzfreo/b123d-recognisers/issues/354); independent plural
+work proceeds without treating the blocked case as supported. When the public records identify one
+owner unambiguously, the declared/emitted synthetic profile includes that groove's narrow physical
+band in the same denominator as the detected profile. Lint maps an evidenced groove-width claim to
+that exact band index rather than adding a scalar count. Removing either surrounding step therefore
+lowers direct and generated-program completeness identically; neither a groove nor a sibling profile
+can fill an unrelated missing band.
+The raw and explicit framed paths both compile 0.4.9's plural groups through this same waist; the
+framed path pairs them with the provider's exact local solid.
 
 ### 6. Activation is opt-in and source/working ownership stays visible
 
@@ -130,16 +181,15 @@ and representative corpus canaries remain release gates, not hidden conditions i
   cylinder scan or provider-private API.
 - The provider's exact local topology and body-local FaceLevel, RiserEvidence, and TurnedProfile
   identities stay paired with the records they justify.
-- Frame refusal and singular-IR limitations remain visible rather than changing coordinate
-  authority, selecting a body, or merging disjoint profiles.
+- Frame refusal remains visible, while plural turned bodies retain their own IR frames, rendered
+  chains, and completeness outcomes rather than selecting or merging a body.
 - AP242 points, vectors, AABBs, finite cylinders, and datum geometry can now share the provider's
   exact local coordinate system without altering the default caller-space API.
-- The framed boundary does not activate framed production. The 0.4.9 dependency does intentionally
-  correct one raw compound interpretation: disjoint coaxial bodies no longer form an invented
-  cross-body turned profile, so the existing raw path preserves them as independent bosses with no
-  global step chain.
-- Framed recognition is a supported explicit `build_drawing` option; raw remains the default while
-  canary evidence accumulates under #1357.
+- The 0.4.9 dependency and plural compiler intentionally correct raw compound interpretation:
+  disjoint turned bodies no longer form an invented cross-body profile or disappear behind a
+  singular projection; each body contributes its own step IR and chain.
+- Framed recognition is a supported explicit `build_drawing` option and uses the same plural
+  compiler waist; raw remains the default while canary evidence accumulates under #1357.
 
 ## Rejected alternatives
 
@@ -160,7 +210,8 @@ and representative corpus canaries remain release gates, not hidden conditions i
 
 `tests/test_issue_1357_framed_boundary.py` guards exact preparation/result pairing, cylinder reuse,
 all gauges and refusal reasons, local multi-diameter classification, body-local levels/risers/turned
-profiles, singular-waist refusal, and unchanged production selection. The fail-closed manifest join
+profiles, explicit singular-accessor refusal, and unchanged raw coordinate selection. The
+fail-closed manifest join
 in `tests/test_recogniser_capabilities.py` guards the 0.4.9 record schemas. Existing
 `tests/test_declared_recognition_gate.py` and `tests/test_part_model.py` retain declared no-recognition
 and one-aggregate lifecycle evidence; `tests/test_import_boundaries.py` keeps the boundary at the
@@ -171,6 +222,16 @@ GRM-03 fixtures.
 `tests/test_issue_1357_framed_activation.py` guards explicit selection/fallback, source versus
 working ownership, scale-retry reuse, rigid-motion build parity, cross-axis turned measurement
 completeness, arbitrary-frame PMI evidence, and off-axis pattern location completeness.
+`tests/test_issue_1357_plural_turned_profiles.py` proves aggregate/injected compiler
+equivalence, body-local IR origins, separate rendered chains and measurement identities, independent
+axial lint, generated-script reconstruction, orthographic profile-view selection, and declared
+caller-coordinate parity for parallel shafts, adjacent coaxial emission, ambiguous-grid drops,
+front-only fail-closed behavior, disjoint coaxial lane reuse and script replay, collision-free mixed
+token namespaces, group-plus-axis lint ownership, single-solid guard scope, perpendicular-axis lane
+independence, explicit refusal of the upstream-blocked groove ambiguity, exact emitted-group lint
+ownership, alternate-view detail ownership, and remove/deferred-replay lane preservation. The framed
+activation suite composes raw/framed plural compilation with a forced scale retry, proving that two
+profiles and four chains survive reuse while frame preparation still occurs once.
 
 ## Relationship to prior decisions
 
@@ -179,8 +240,8 @@ completeness, arbitrary-frame PMI evidence, and off-axis pattern location comple
   lifecycle, record→IR conversion, drafting policy, and lint.
 - **ADR 0011:** declarations remain caller-coordinate authority and recognition-free at build time.
 - **ADR 0013:** only public provider records cross the geometry→Draftwright adapter.
-- **ADR 0015:** future detected compilation changes its coherent input unit, not the PartModel
-  compiler waist.
+- **ADR 0015:** detected compilation changes its coherent input unit while the PartModel compiler
+  waist remains plural and coordinate-consistent.
 - **ADR 0017:** preparation and classification reuse one cylinder substrate and one aggregate;
   correspondence remains evidence-gated.
 - **ADRs 0004/0014:** no annotation placement API or raw page coordinate is introduced.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -509,7 +509,7 @@ policy) live in `CLAUDE.md`. This is the per-ADR status trail; each ADR's
   lives in the blocking issue.
   **#1022** landed the **ADR 0011 declared-path gate**: a declared build now recognises
   **nothing**. It was not one `if` — sizing sources the turned profile and step ladder from
-  the declaration (`_declared_turned_profile` / `_declared_step_zs` in `analysis.py`), and
+  the declaration (`_declared_turned_profiles` / `_declared_step_zs` in `analysis.py`), and
   the lint→repair loop stopped asking for the feature-coverage half it never used
   (`Drawing.lint(physical=False)`; repair acts on `dim_inside_part` alone, ADR 0002).
   Critique on that path still needs an inventory, so `BuildState.ensure_recognition()` builds

--- a/docs/multi-feature-object-reference-workflow.md
+++ b/docs/multi-feature-object-reference-workflow.md
@@ -100,9 +100,9 @@ part = features.body
 
 sheet = Sheet(part, title='DRAWING', number='DWG-001', scale=5.0, page=(297.0, 210.0))
 hole1 = sheet.hole(diameter=1.6, at=(0.8, 0, 0), axis="x").depth(8)   # ⌀1.6 blind 8
-step1 = sheet.step(diameter=3, length=5.3, at=(-5.85, 0, 0), axis="x")   # ⌀3 × 5.3 step
-step2 = sheet.step(diameter=4, length=3.2, at=(-1.6, 0, 0), axis="x")   # ⌀4 × 3.2 step
-step3 = sheet.step(diameter=6, length=0.5, at=(0.25, 0, 0), axis="x")   # ⌀6 × 0.5 step
+step1 = sheet.step(diameter=3, length=5.3, at=(-5.85, 0, 0), axis="x", profile_group='detected-profile-1')   # ⌀3 × 5.3 step
+step2 = sheet.step(diameter=4, length=3.2, at=(-1.6, 0, 0), axis="x", profile_group='detected-profile-1')   # ⌀4 × 3.2 step
+step3 = sheet.step(diameter=6, length=0.5, at=(0.25, 0, 0), axis="x", profile_group='detected-profile-1')   # ⌀6 × 0.5 step
 # ... step4, step5, boss1 ...
 envelope1 = sheet.envelope()   # envelope 20 × 10 × 10
 

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -342,11 +342,11 @@ recognition result. There is no hidden raw fallback.
 FULL frames establish a directed ordered basis. ORTHOGONAL representatives do not establish sign,
 axis interchange, or material identity. AXIAL representatives additionally do not establish roll,
 so only roll-invariant facts may be consumed until a particular asymmetric requirement is audited.
-The current singular `Analysis.prof` also rejects more than one body-local turned profile rather
-than selecting or merging one silently when the singular adapter is required. The legacy raw build
-keeps its supported compound behavior by recording no global profile and logging the #1357
-deferral; framed production cannot use that compatibility projection and must make the compiler
-input plural first.
+`Analysis.profiles` carries every body-local turned profile through the shared compiler waist on
+both the raw and explicit framed routes. Its compatible `Analysis.prof` projection is populated
+only for zero/one-profile consumers; `single_turned_profile()` likewise refuses plural cardinality
+without implying that plural compilation is unsupported. Neither route selects, merges, or discards
+a physical profile merely to satisfy that singular accessor.
 
 `analysis._analyse` activates this boundary only for explicit `framed_recognition=True`. The exact
 working solid then feeds detected compilation, projection and physical lint while caller geometry

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -1139,7 +1139,11 @@ class Analysis:
     z_diams: list[float]
     cross_diams: list[float]
     cyls: tuple[tuple, tuple]
-    prof: TurnedProfile | None  # turned step profile (recognise_turned_steps), detected once
+    prof: TurnedProfile | None  # compatible zero/one view for genuinely coaxial behavior
+    #: Every body-local turned profile. ``prof`` remains the compatible zero/one view used
+    #: only by behavior that genuinely requires one coaxial stack; compilation and
+    #: completeness consume this plural inventory (#1357).
+    profiles: tuple[TurnedProfile, ...]
     od_diam: float | None
     is_rotational: bool
     od_axis: str  # rotation/turning axis of a rotational part ("z" default; "x"/"y" #222)

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -21,6 +21,7 @@ from b123d_recognisers import (
     PartFrame,
     RecognitionResult,
     TurnedProfile,
+    TurnedProfileKey,
     TurnedStep,
     analyse_cylinders,
     build_raw_recognition_result,
@@ -60,19 +61,31 @@ from draftwright.compose import (
     choose_scale,
 )
 from draftwright.model import build_part_model
-from draftwright.model.ir import Datum, PartModel, StepFeature, StepLevelFeature
+from draftwright.model.ir import Datum, GrooveFeature, PartModel, StepFeature, StepLevelFeature
 from draftwright.model.planner import plan_dimensions
 from draftwright.recognition_frame import (
     FramedDetection,
     FramedDetectionRefusal,
     prepare_framed_detection,
-    single_turned_profile,
+    require_unambiguous_groove_owner,
 )
 from draftwright.view_plan import ViewConstraints, arrangement_of
 
 _log = logging.getLogger(__name__)
 
 _ScalePick = tuple[float, float, float, float]
+
+
+@dataclass(frozen=True)
+class _DeclaredTurnedProfile(TurnedProfile):
+    """A synthetic provider-shaped profile retaining Draftwright's opaque membership.
+
+    ``TurnedProfile.profile`` remains a geometrically valid provider key for projection and
+    body-local matching.  The additional token is the declared-program identity needed to
+    distinguish overlapping coaxial occurrences without leaking it into the provider API.
+    """
+
+    profile_group: str | None = None
 
 
 def _apply_principal_view_pins(
@@ -252,12 +265,21 @@ def _coerce_layout_model(model, part, decorations=None) -> PartModel | None:
     if model is None:
         return None
     if isinstance(model, PartModel):
+        turned_axes = {f.frame.axis for f in model.features if isinstance(f, StepFeature)}
+        orientation = next(iter(turned_axes)) if len(turned_axes) == 1 else None
+        out = model
         if decorations:
-            return replace(model, decorations={**model.decorations, **decorations})
-        return model
+            out = replace(out, decorations={**model.decorations, **decorations})
+        # ``orientation`` is derived compiler metadata, not caller authority. Normalise a
+        # hand-built PartModel as well as a feature sequence so mixed-axis meaning cannot
+        # depend on which StepFeature happened to be declared first.
+        if turned_axes and out.orientation != orientation:
+            out = replace(out, orientation=orientation)
+        return out
     features = list(model)
     bbox = part.bounding_box()
-    orientation = next((f.frame.axis for f in features if isinstance(f, StepFeature)), None)
+    turned_axes = {f.frame.axis for f in features if isinstance(f, StepFeature)}
+    orientation = next(iter(turned_axes)) if len(turned_axes) == 1 else None
     datum = Datum(id="datum_xy", kind="point", at=(bbox.min.X, bbox.min.Y, bbox.min.Z))
     return PartModel(
         bbox=bbox,
@@ -268,46 +290,173 @@ def _coerce_layout_model(model, part, decorations=None) -> PartModel | None:
     )
 
 
-def _declared_turned_profile(model: PartModel) -> TurnedProfile | None:
-    """The turned profile a DECLARED model states, or ``None`` if it declares no steps.
+def _declared_turned_profiles(model: PartModel) -> tuple[TurnedProfile, ...]:
+    """Return declared step profiles grouped by their body-local axis line.
 
-    The detected path aggregates ``recognise_turned_steps``; a declared model already carries
-    the same information as :class:`StepFeature`\\ s, so this reads it rather than scanning the
-    solid for it (#1022).  ``span`` is the pair of axial end-points the declaration fixed, so
-    ``lo``/``hi`` need no geometry — a declared step's extent is what the author said it is.
-
-    Mixed-axis steps are a malformed declaration, not a recoverable one:
-    :meth:`TurnedProfile.from_steps` raises, and it is allowed to reach the caller here for
-    the same reason it does on the detected path.
+    The axis letter plus the two perpendicular frame coordinates identify one line. A
+    synthetic provider key retains that ownership in caller coordinates, so parallel declared
+    shafts cannot be silently merged into one global profile (#1357).
     """
-    steps = [f for f in model.features if isinstance(f, StepFeature)]
-    if not steps:
-        return None
-    axis_i = "xyz".index(steps[0].frame.axis)
-    return TurnedProfile.from_steps(
-        [
-            TurnedStep(
-                axis=f.frame.axis,
-                lo=min(f.span[0][axis_i], f.span[1][axis_i]),
-                hi=max(f.span[0][axis_i], f.span[1][axis_i]),
-                diameter=f.diameter,
+    # Generated Sheet scripts round coordinates to 0.001 mm. Adjacent authored steps can
+    # therefore acquire a 0.0005 mm numerical seam even though they describe one body.
+    adjacency_tol = 1e-3 + 1e-9
+    steps = [feature for feature in model.features if isinstance(feature, StepFeature)]
+    grooves = [feature for feature in model.features if isinstance(feature, GrooveFeature)]
+    groups: dict[tuple[str, tuple[float, float], object | None], list[StepFeature]] = {}
+    for feature in steps:
+        axis = feature.frame.axis
+        axis_i = "xyz".index(axis)
+        line_values = [float(value) for i, value in enumerate(feature.frame.origin) if i != axis_i]
+        line = (line_values[0], line_values[1])
+        groups.setdefault((axis, line, feature.profile or feature.profile_group), []).append(
+            feature
+        )
+
+    body_groups: list[tuple[str, list[StepFeature], object | None]] = []
+    for (axis, _line, membership), line_members in sorted(
+        groups.items(), key=lambda item: (item[0][0], item[0][1], repr(item[0][2]))
+    ):
+        if membership is not None:
+            body_groups.append((axis, line_members, membership))
+            continue
+        axis_i = "xyz".index(axis)
+        line_members.sort(
+            key=lambda feature: min(float(feature.span[0][axis_i]), float(feature.span[1][axis_i]))
+        )
+        runs: list[list[StepFeature]] = []
+        run_hi = float("-inf")
+        for feature in line_members:
+            lo, hi = sorted((float(feature.span[0][axis_i]), float(feature.span[1][axis_i])))
+            gap_is_groove = any(
+                groove.frame.axis == axis
+                and all(
+                    abs(float(groove.frame.origin[index]) - float(feature.frame.origin[index]))
+                    <= adjacency_tol
+                    for index in range(3)
+                    if index != axis_i
+                )
+                and float(groove.frame.origin[axis_i]) - float(groove.width) / 2.0
+                <= run_hi + adjacency_tol
+                and float(groove.frame.origin[axis_i]) + float(groove.width) / 2.0
+                >= lo - adjacency_tol
+                for groove in grooves
             )
-            for f in steps
-        ]
-    )
+            if not runs or (lo > run_hi + adjacency_tol and not gap_is_groove):
+                runs.append([feature])
+                run_hi = hi
+            else:
+                runs[-1].append(feature)
+                run_hi = max(run_hi, hi)
+        body_groups.extend((axis, members, None) for members in runs)
+
+    profiles = []
+    for axis, members, membership in body_groups:
+        axis_i = "xyz".index(axis)
+        origin = [float(value) for value in members[0].frame.origin]
+        origin[axis_i] = 0.0
+        radius = max(float(feature.diameter) for feature in members) / 2.0
+        lo = min(float(point[axis_i]) for feature in members for point in feature.span)
+        hi = max(float(point[axis_i]) for feature in members for point in feature.span)
+        bounds: list[float] = []
+        for index, value in enumerate(origin):
+            bounds.extend((lo, hi) if index == axis_i else (value - radius, value + radius))
+        key = (
+            membership
+            if isinstance(membership, TurnedProfileKey)
+            else TurnedProfileKey(
+                axis,
+                (origin[0], origin[1], origin[2]),
+                (bounds[0], bounds[1], bounds[2], bounds[3], bounds[4], bounds[5]),
+            )
+        )
+        provider_profile = TurnedProfile.from_steps(
+            TurnedStep(
+                axis=axis,
+                lo=min(float(feature.span[0][axis_i]), float(feature.span[1][axis_i])),
+                hi=max(float(feature.span[0][axis_i]), float(feature.span[1][axis_i])),
+                diameter=float(feature.diameter),
+                profile=key,
+            )
+            for feature in members
+        )
+        assert provider_profile is not None
+        profiles.append(
+            _DeclaredTurnedProfile(
+                axis=provider_profile.axis,
+                steps=provider_profile.steps,
+                profile=provider_profile.profile,
+                profile_group=membership if isinstance(membership, str) else None,
+            )
+        )
+    declared_profiles = tuple(profiles)
+    grooves_by_profile: dict[int, list[GrooveFeature]] = {
+        id(profile): [] for profile in declared_profiles
+    }
+    for groove in grooves:
+        owners = require_unambiguous_groove_owner(groove, declared_profiles)
+        if owners:
+            grooves_by_profile[id(owners[0])].append(groove)
+
+    # Detection's TurnedProfile denominator includes the narrow groove band even though the
+    # IR deliberately gives that band to GrooveFeature rather than StepFeature. Reconstruct
+    # the same physical denominator for declared/emitted programs; otherwise one remaining
+    # step plus the groove could falsely certify a two-step synthetic profile (#1357).
+    augmented_profiles = []
+    for profile in declared_profiles:
+        profile_steps = list(profile.steps)
+        axis_index = "xyz".index(profile.axis)
+        for groove in grooves_by_profile[id(profile)]:
+            lo = float(groove.frame.origin[axis_index]) - float(groove.width) / 2.0
+            hi = float(groove.frame.origin[axis_index]) + float(groove.width) / 2.0
+            if any(
+                abs(float(step.lo) - lo) <= adjacency_tol
+                and abs(float(step.hi) - hi) <= adjacency_tol
+                for step in profile_steps
+            ):
+                continue
+            profile_steps.append(
+                TurnedStep(
+                    axis=profile.axis,
+                    lo=lo,
+                    hi=hi,
+                    diameter=float(groove.diameter),
+                    profile=profile.profile,
+                )
+            )
+        if len(profile_steps) == len(profile.steps):
+            augmented_profiles.append(profile)
+            continue
+        provider_profile = TurnedProfile.from_steps(profile_steps)
+        assert provider_profile is not None
+        augmented_profiles.append(
+            _DeclaredTurnedProfile(
+                axis=provider_profile.axis,
+                steps=provider_profile.steps,
+                profile=provider_profile.profile,
+                profile_group=profile.profile_group,
+            )
+        )
+    return tuple(augmented_profiles)
 
 
-def _declared_step_zs(model: PartModel, prof: TurnedProfile | None, bb) -> list[float]:
+def _declared_step_zs(model: PartModel, profiles: tuple[TurnedProfile, ...], bb) -> list[float]:
     """The step Z-levels page/scale selection converges on, sourced from the declaration.
 
-    Mirrors the detected path's two branches exactly — a Z-axis turned profile contributes its
-    interior shoulders, anything else the prismatic height ladder — with the ladder read off a
-    declared :class:`StepLevelFeature` instead of re-scanning face levels (#1022).  The 0.6 mm
-    end-exclusion is the detected path's, kept identical so a declared build selects the same
-    page as the equivalent detected one.
+    Mirrors the detected path's two branches exactly — Z-axis turned profiles contribute the
+    union of their interior shoulders, anything else the prismatic height ladder — with the
+    ladder read off a declared :class:`StepLevelFeature` instead of re-scanning face levels
+    (#1022). The 0.6 mm end-exclusion is the detected path's, kept identical so a declared build
+    selects the same page as the equivalent detected one.
     """
-    if prof is not None and prof.axis == "z":
-        return [z for z in prof.shoulders if bb.min.Z + 0.6 < z < bb.max.Z - 0.6]
+    if profiles and {profile.axis for profile in profiles} == {"z"}:
+        return sorted(
+            {
+                z
+                for profile in profiles
+                for z in profile.shoulders
+                if bb.min.Z + 0.6 < z < bb.max.Z - 0.6
+            }
+        )
     return sorted(
         {
             z
@@ -494,26 +643,6 @@ def _classify_geometry(part, x_size, y_size, z_size, cx, cy, cz) -> _GeomClass:
     if z_diams and not is_rotational:
         _log.info("Part classified prismatic; skipping OD/centreline/bore annotations")
     return _GeomClass(z_cyls, cross_cyls, z_diams, cross_diams, od_diam, od_axis, is_rotational)
-
-
-def _raw_compatible_turned_profile(recognition: RecognitionResult) -> TurnedProfile | None:
-    """Preserve the pre-0.4.9 raw path when the provider now exposes plural profiles.
-
-    The raw production path has no paired frame and ``Analysis.prof`` is singular. Selecting or
-    merging one of several physical profiles would be false; refusing the entire drawing would
-    regress supported compound groove drawings. Keep the historical no-global-profile behavior
-    until framed activation makes the compiler unit plural, and make the deferral visible.
-    """
-
-    profiles = recognition.turned_profiles
-    if len(profiles) > 1:
-        _log.warning(
-            "raw recognition found %d physical turned profiles; the singular Analysis waist "
-            "defers them to #1357 framed activation",
-            len(profiles),
-        )
-        return None
-    return profiles[0] if profiles else None
 
 
 def _validate_explicit_scale(
@@ -782,30 +911,41 @@ def _analyse(
     # here, ABOVE the aggregate, which is why `_coerce_layout_model` moved up from its old
     # place below — it is pure (IR in, IR out) and reads nothing this block computes.
     _turned: TurnedProfile | None
+    _profiles: tuple[TurnedProfile, ...]
     step_zs: list[float]
     if _reuse is not None:
         _turned = _reuse.prof
+        _profiles = _reuse.profiles
         step_zs = list(_reuse.step_zs)
     elif layout_model is not None:
-        # Sizing must source `prof` and `step_zs` from the DECLARATION here. Taking them from
+        # Sizing must source profiles and `step_zs` from the DECLARATION here. Taking them from
         # a recognition that has been gated away would silently change page/scale selection,
-        # and leaving `prof=None` would silently disable axial critique for a declared turned
-        # part — both are failures the gate must not introduce (#1022).
+        # and leaving the plural inventory empty would silently disable axial critique for a
+        # declared turned part — both are failures the gate must not introduce (#1022).
         recognition = None
-        _turned = _declared_turned_profile(layout_model)
-        step_zs = _declared_step_zs(layout_model, _turned, bb)
+        _profiles = _declared_turned_profiles(layout_model)
+        _turned = _profiles[0] if len(_profiles) == 1 else None
+        step_zs = _declared_step_zs(layout_model, _profiles, bb)
     else:
         assert recognition is not None
-        _turned = (
-            single_turned_profile(recognition)
-            if recognition_frame is not None
-            else _raw_compatible_turned_profile(recognition)
+        _profiles = recognition.turned_profiles
+        _turned = _profiles[0] if len(_profiles) == 1 else None
+        # Plural turned profiles own their body-local shoulders; the aggregate's compatible
+        # ladder projection intentionally returns prismatic FaceLevels unless exactly one
+        # Z-profile exists. Project the plural inventory explicitly so equal occurrences do
+        # not become a phantom global prismatic ladder during page sizing (#1357).
+        step_zs = (
+            sorted(
+                {
+                    station
+                    for profile in _profiles
+                    for station in profile.shoulders
+                    if bb.min.Z + 0.6 < station < bb.max.Z - 0.6
+                }
+            )
+            if len(_profiles) > 1 and {profile.axis for profile in _profiles} == {"z"}
+            else recognition.step_ladder_for_z_span(bb.min.Z, bb.max.Z)
         )
-        # The aggregate's own rule (#578 review; hoisted there by #1022, shared with critique
-        # by #1025). Both callers deriving this separately let lint project over a different
-        # ladder than the model was sized from — which is exactly the divergence one waist is
-        # supposed to prevent.
-        step_zs = recognition.step_ladder_for_z_span(bb.min.Z, bb.max.Z)
     # The aggregate owns the shared substrate from here on.  Rebind the local projection so
     # model construction, Analysis and the finished BuildState all consume the same inventory
     # object rather than parallel list/tuple wrappers that merely happen to contain equal data.
@@ -884,7 +1024,7 @@ def _analyse(
             pockets=pockets,
             pocket_patterns=pocket_patterns,
             pads=pads,
-            prof=_turned,
+            profiles=_profiles,
             step_zs=step_zs,
             face_levels=list(recognition.step_levels) if recognition else None,
             rotational=(od_diam, _bores, od_axis) if is_rotational else None,
@@ -1113,6 +1253,7 @@ def _analyse(
         cross_diams=cross_diams,
         cyls=shared_cyls,
         prof=_turned,
+        profiles=_profiles,
         od_diam=od_diam,
         is_rotational=is_rotational,
         od_axis=od_axis,

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass, replace
 from itertools import groupby, tee
-from typing import Any
+from typing import Any, Literal, cast
 
 from build123d_drafting import DatumFeature, FeatureControlFrame, SurfaceFinish, TextBlock
 from build123d_drafting.helpers import (
@@ -3298,7 +3298,7 @@ def render_boss_diameters(dwg, plan, a, *, ctx) -> int:
     Placement rides the shared :func:`place_machined_leader_jobs` adapter (#700 — never a sixth copy
     of the ray-exit loop, #637): rim-anchored :func:`_radial_candidates`, accepted with
     ``geom_clear`` (the full shaft, not just the label, must clear other annotations)."""
-    if a.is_rotational or a.prof is not None:
+    if a.is_rotational or a.profiles:
         # A turned profile means round stock — a band emitted as a boss (#298) belongs in the
         # OD diameter row/column, not an end-on plan leader. Only true prismatic parts qualify.
         return 0
@@ -3466,7 +3466,7 @@ def render_polygonal_stock(dwg, plan, a, *, ctx) -> int:
 
 def render_boss_heights(dwg, plan, a, *, ctx) -> int:
     """Queue prismatic boss heights and polygonal-stock lengths in a profile corridor."""
-    if a.is_rotational or a.prof is not None:
+    if a.is_rotational or a.profiles:
         return 0
     tier = dwg.draft.font_size + 2 * dwg.draft.pad_around_text
     specs = {
@@ -4171,7 +4171,16 @@ def _record_step_chain_drop(dwg, why: str, *, ctx, measurement=()) -> None:
 
 
 def _draw_step_chain(
-    dwg, view, segs, name_prefix, detail_scale=None, allow_collapse=True, *, ctx, start=0
+    dwg,
+    view,
+    segs,
+    name_prefix,
+    detail_scale=None,
+    allow_collapse=True,
+    *,
+    ctx,
+    start=0,
+    profile_bounds=None,
 ) -> int:
     """Place a turned step-length chain in *view* from structured *segs*, each already
     projected to *view*'s page coords in axis order. Orientation is
@@ -4183,10 +4192,11 @@ def _draw_step_chain(
     drawing inside a scaled detail view. ``allow_collapse=False`` disables the ``N× v``
     collapse — used when the chain mixes a synthetic head-*block* with real steps, where
     a uniform-staircase representative would be a false claim of N equal steps (#307
-    review). Returns the count placed."""
+    review). ``profile_bounds`` narrows the placement edge to one body's projected silhouette
+    when a compound contains multiple turned profiles. Returns the count placed."""
     if not segs:
         return 0
-    vb = dwg.view_bounds(view)
+    vb = profile_bounds or dwg.view_bounds(view)
     if vb is None:
         return 0
     trace = getattr(ctx, "trace", None)  # the immediate placers report to the trace too (#736)
@@ -4374,8 +4384,16 @@ def _next_steplen_start(ctx, prefix: str = "m_steplen") -> int:
     return max(idxs) + 1 if idxs else 0
 
 
-def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
-    """Unified turned step-length chain (ADR 0008 #223): each `StepFeature`'s length
+def render_step_lengths(
+    dwg,
+    plan,
+    *,
+    ctx,
+    only=None,
+    _profile_bounds_hint=None,
+    _profile_view_hint=None,
+) -> int:
+    """Unified turned step-length chains (ADR 0008 #223): each `StepFeature`'s length
     span projects into the profile view and joins the chain that tiles the turning
     axis so every shoulder is located. X-turned → horizontal chain above the front
     view; Z-turned → vertical chain to its right; Y-turned → horizontal chain above
@@ -4386,9 +4404,320 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
     in line: the main view locates that run as one *block* dim and an enlarged
     `DetailRequest` (#304/#307) is queued to break it down. If the detail later can't
     place, the block still locates the head extent and lint reports the un-located
-    interior shoulders — never worse than the prior skip. Returns the count placed."""
+    interior shoulders — never worse than the prior skip. Parallel or axially disconnected
+    profiles are grouped before collapse and rendered against their own silhouettes. Returns the
+    count placed."""
+    # One axial chain belongs to one physical axis line. Group BEFORE the repeat-run collapse:
+    # equal lengths on parallel shafts are separate requirements, not one global ``N×`` run.
+    # View assignment always sees the complete roster, even when ``only`` narrows a deferred
+    # edit. Otherwise re-adding one removed profile forgets a surviving sibling's lane and can
+    # place both chains on top of each other. Recursive per-profile placement carries an explicit
+    # view hint and narrows only the refs that actually receive ink (#1357).
+    # Emitted declarations round coordinates to 0.001 mm, so exact neighbours may return
+    # with a sub-micron numerical seam. This is declaration precision, not a physical gap.
+    adjacency_tol = 1e-3 + 1e-9
+    line_groups: dict[
+        tuple[str, tuple[float, float], object | None], list[tuple[float, float, object]]
+    ] = {}
+    for group in plan.of_kind("step"):
+        if group.facts.frame.axis not in ("x", "y", "z"):
+            continue
+        length = group.dim(kind="length")
+        if length is None or length.span is None:
+            continue
+        axis_index = "xyz".index(group.facts.frame.axis)
+        line_values = [
+            round(float(value), 6)
+            for index, value in enumerate(group.facts.frame.origin)
+            if index != axis_index
+        ]
+        line = (line_values[0], line_values[1])
+        axis_index = "xyz".index(group.facts.frame.axis)
+        lo, hi = sorted(float(point[axis_index]) for point in length.span)
+        membership = group.facts.profile or group.facts.profile_group
+        line_groups.setdefault((group.facts.frame.axis, line, membership), []).append(
+            (lo, hi, group.ref)
+        )
+    profile_groups: list[tuple[tuple[str, tuple[float, float], object | None], set[object]]] = []
+    for key, members in sorted(
+        line_groups.items(), key=lambda item: (item[0][0], item[0][1], repr(item[0][2]))
+    ):
+        if key[2] is not None:
+            profile_groups.append((key, {ref for _lo, _hi, ref in members}))
+            continue
+        axis, line, _membership = key
+        axis_index = "xyz".index(axis)
+        groove_intervals = []
+        for groove in plan.of_kind("groove"):
+            if groove.facts.frame.axis != axis:
+                continue
+            groove_line = tuple(
+                round(float(value), 6)
+                for index, value in enumerate(groove.facts.frame.origin)
+                if index != axis_index
+            )
+            width = groove.dim(kind="length")
+            if groove_line != line or width is None:
+                continue
+            centre = float(groove.facts.frame.origin[axis_index])
+            groove_intervals.append(
+                (centre - float(width.value) / 2.0, centre + float(width.value) / 2.0)
+            )
+        profile_runs: list[tuple[float, set[object]]] = []
+        for lo, hi, ref in sorted(members, key=lambda member: member[:2]):
+            run_hi = profile_runs[-1][0] if profile_runs else float("-inf")
+            gap_is_groove = any(
+                groove_lo <= run_hi + adjacency_tol and groove_hi >= lo - adjacency_tol
+                for groove_lo, groove_hi in groove_intervals
+            )
+            if not profile_runs or (lo > run_hi + adjacency_tol and not gap_is_groove):
+                profile_runs.append((hi, {ref}))
+            else:
+                run_hi, refs = profile_runs[-1]
+                refs.add(ref)
+                profile_runs[-1] = (max(run_hi, hi), refs)
+        profile_groups.extend((key, refs) for _hi, refs in profile_runs)
+    if len(profile_groups) > 1 and _profile_view_hint is None:
+        profile_views = {
+            "x": ("front", "plan"),
+            "y": ("side", "plan"),
+            "z": ("front", "side"),
+        }
+
+        def _point_for(profile_key):
+            profile_axis, profile_line, _profile_membership = profile_key
+            point = [0.0, 0.0, 0.0]
+            line_index = 0
+            for index in range(3):
+                if index != "xyz".index(profile_axis):
+                    point[index] = profile_line[line_index]
+                    line_index += 1
+            return point
+
+        def _projected_cross(profile_key, view) -> float:
+            axis, _line, _membership = profile_key
+            point = _point_for(profile_key)
+            px, py, *_ = dwg.at(view, *point)
+            axial_point = list(point)
+            axial_point["xyz".index(axis)] += 1.0
+            ax, ay, *_ = dwg.at(view, *axial_point)
+            axial_is_horizontal = abs(float(ax) - float(px)) >= abs(float(ay) - float(py))
+            return float(py if axial_is_horizontal else px)
+
+        refs_by_key = dict(profile_groups)
+        candidate_views = {
+            key: tuple(view for view in profile_views[key[0]] if dwg.view_bounds(view) is not None)
+            for key, _refs in profile_groups
+        }
+
+        def _projected_axial_interval(key, view) -> tuple[float, float]:
+            axis = key[0]
+            axis_index = "xyz".index(axis)
+            stations = [
+                float(point[axis_index])
+                for group in plan.of_kind("step")
+                if group.ref in refs_by_key[key]
+                for length in (group.dim(kind="length"),)
+                if length is not None and length.span is not None
+                for point in length.span
+            ]
+            point = _point_for(key)
+            projected = []
+            for station in (min(stations), max(stations)):
+                point[axis_index] = station
+                px, py, *_ = dwg.at(view, *point)
+                axial_point = list(point)
+                axial_point[axis_index] += 1.0
+                ax, ay, *_ = dwg.at(view, *axial_point)
+                projected.append(
+                    float(px if abs(float(ax) - float(px)) >= abs(float(ay) - float(py)) else py)
+                )
+            return (min(projected), max(projected))
+
+        def _conflict(left, right, view) -> bool:
+            if left[0] != right[0]:
+                # Perpendicular turning axes do not share a longitudinal lane. Their real
+                # page-ink interaction is resolved by the common placement/overlap stages.
+                return False
+            if round(_projected_cross(left, view), 6) != round(_projected_cross(right, view), 6):
+                return False
+            left_lo, left_hi = _projected_axial_interval(left, view)
+            right_lo, right_hi = _projected_axial_interval(right, view)
+            # A shared endpoint still shares witnesses/labels and therefore needs the other
+            # longitudinal view.  Truly separated silhouettes may safely reuse this lane.
+            return left_lo <= right_hi + 1e-6 and right_lo <= left_hi + 1e-6
+
+        profile_conflicts = {
+            (left, right, view): _conflict(left, right, view)
+            for left_index, (left, _left_refs) in enumerate(profile_groups)
+            for right, _right_refs in profile_groups[left_index + 1 :]
+            for view in set(candidate_views[left]) & set(candidate_views[right])
+        }
+
+        def _satisfiable(keys, forced=None) -> bool:
+            """Solve the two-view profile assignment as 2-SAT.
+
+            A profile chooses its conventional or alternate longitudinal view.  Two profiles
+            cannot make a particular joint choice only when both their projected cross line
+            *and* axial interval overlap.  This retains fail-closed ambiguity handling while
+            allowing any number of axially disjoint coaxial bodies to reuse a lane (#1357).
+            """
+            forced = forced or {}
+            index = {key: i for i, key in enumerate(keys)}
+            graph: list[list[int]] = [[] for _ in range(2 * len(keys))]
+            reverse: list[list[int]] = [[] for _ in graph]
+
+            def imply(source, target):
+                graph[source].append(target)
+                reverse[target].append(source)
+
+            for key, i in index.items():
+                choices = candidate_views[key]
+                if len(choices) == 1:
+                    imply(2 * i + 1, 2 * i)
+                if key in forced:
+                    choice = forced[key]
+                    imply(2 * i + (1 - choice), 2 * i + choice)
+            for left_i, left in enumerate(keys):
+                for right_i in range(left_i + 1, len(keys)):
+                    right = keys[right_i]
+                    for left_choice, left_view in enumerate(candidate_views[left]):
+                        for right_choice, right_view in enumerate(candidate_views[right]):
+                            if left_view != right_view or not profile_conflicts.get(
+                                (left, right, left_view), False
+                            ):
+                                continue
+                            # not(left=choice and right=choice): each selected literal implies
+                            # the negation of the other selected literal.
+                            imply(2 * left_i + left_choice, 2 * right_i + (1 - right_choice))
+                            imply(2 * right_i + right_choice, 2 * left_i + (1 - left_choice))
+
+            seen = set()
+            order = []
+
+            def visit(node):
+                if node in seen:
+                    return
+                seen.add(node)
+                for target in graph[node]:
+                    visit(target)
+                order.append(node)
+
+            for node in range(len(graph)):
+                visit(node)
+            components = [-1] * len(graph)
+
+            def assign(node, component):
+                if components[node] != -1:
+                    return
+                components[node] = component
+                for target in reverse[node]:
+                    assign(target, component)
+
+            component = 0
+            for node in reversed(order):
+                if components[node] == -1:
+                    assign(node, component)
+                    component += 1
+            return all(components[2 * i] != components[2 * i + 1] for i in range(len(keys)))
+
+        accepted: list[Any] = []
+        unassigned = []
+        for key, _refs in profile_groups:
+            if not candidate_views[key] or not _satisfiable([*accepted, key]):
+                unassigned.append(key)
+            else:
+                accepted.append(key)
+
+        # Prefer each axis's conventional view unless that would make the complete accepted
+        # roster unsatisfiable.  The forced-prefix solve makes the choice deterministic.
+        forced: dict[Any, int] = {}
+        for key in accepted:
+            trial = {**forced, key: 0}
+            if _satisfiable(accepted, trial):
+                forced = trial
+            else:
+                forced[key] = 1
+        assignments = {key: candidate_views[key][choice] for key, choice in forced.items()}
+
+        def _cell_bounds(key, view):
+            axis, _line, _membership = key
+            view_bounds = dwg.view_bounds(view)
+            if view_bounds is None:
+                return None
+
+            def _cross(profile_key) -> float:
+                return _projected_cross(profile_key, view)
+
+            cross = _cross(key)
+            siblings = sorted(
+                {
+                    _cross(profile_key)
+                    for profile_key, assigned_view in assignments.items()
+                    if profile_key[0] == axis and assigned_view == view
+                }
+            )
+            position = siblings.index(cross)
+            point = _point_for(key)
+            px, py, *_ = dwg.at(view, *point)
+            axial_point = list(point)
+            axial_point["xyz".index(axis)] += 1.0
+            ax, ay, *_ = dwg.at(view, *axial_point)
+            axial_is_horizontal = abs(float(ax) - float(px)) >= abs(float(ay) - float(py))
+            cross_lo_index, cross_hi_index = (1, 3) if axial_is_horizontal else (0, 2)
+            cross_lo = (
+                view_bounds[cross_lo_index]
+                if position == 0
+                else (siblings[position - 1] + cross) / 2.0
+            )
+            cross_hi = (
+                view_bounds[cross_hi_index]
+                if position == len(siblings) - 1
+                else (cross + siblings[position + 1]) / 2.0
+            )
+            if not axial_is_horizontal:
+                return (cross_lo, view_bounds[1], cross_hi, view_bounds[3])
+            return (view_bounds[0], cross_lo, view_bounds[2], cross_hi)
+
+        requested = None if only is None else set(only)
+        placed = 0
+        for key, refs in profile_groups:
+            refs_to_place = refs if requested is None else refs & requested
+            if key not in assignments or not refs_to_place:
+                continue
+            placed += render_step_lengths(
+                dwg,
+                plan,
+                ctx=ctx,
+                only=refs_to_place,
+                _profile_bounds_hint=_cell_bounds(key, assignments[key]),
+                _profile_view_hint=assignments[key],
+            )
+        for key in unassigned:
+            refs = refs_by_key[key]
+            if requested is not None:
+                refs &= requested
+            if not refs:
+                continue
+            measurements = tuple(
+                length.id
+                for group in plan.of_kind("step")
+                if group.ref in refs
+                for length in (group.dim(kind="length"),)
+                if length is not None and length.id is not None
+            )
+            _record_step_chain_drop(
+                dwg,
+                "no longitudinal view uniquely identifies this physical profile",
+                ctx=ctx,
+                measurement=measurements,
+            )
+        return placed
+
     rows: list[tuple[str, _StepChainSegment]] = []
     step_origins = []
+    step_geometry = []
+    step_profiles = []
     for g in plan.of_kind("step"):
         if g.facts.frame.axis not in ("x", "y", "z"):
             continue
@@ -4412,6 +4741,15 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
             )
         )
         step_origins.append(g.facts.frame.origin)
+        step_profiles.append(g.facts.profile)
+        diameter = g.dim(kind="diameter")
+        step_geometry.append(
+            (
+                g.facts.frame,
+                length.span,
+                None if diameter is None else float(diameter.value) / 2.0,
+            )
+        )
     if not rows:
         return 0
     draft = dwg.draft
@@ -4425,10 +4763,47 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
         )
         return 0
     turn_axis = next(iter(axes))
-    view = "side" if turn_axis == "y" else "front"
+    view = cast(
+        Literal["front", "plan", "side"],
+        _profile_view_hint or ("side" if turn_axis == "y" else "front"),
+    )
     bare_rows = [seg for _axis, seg in rows]
     fsegs = [replace(seg, pa=dwg.at(view, *seg.pa), pb=dwg.at(view, *seg.pb)) for seg in bare_rows]
     horizontal = abs(fsegs[0].pb[0] - fsegs[0].pa[0]) >= abs(fsegs[0].pb[1] - fsegs[0].pa[1])
+
+    # The principal view can contain several disjoint turned bodies. Anchor this chain at its
+    # own silhouette, not the compound's outer view edge, otherwise every vertical profile
+    # would draw the same dimension line and body ownership would be visually ambiguous.
+    radial_axis = {
+        ("front", "x"): "z",
+        ("front", "z"): "x",
+        ("plan", "x"): "y",
+        ("plan", "y"): "x",
+        ("side", "y"): "z",
+        ("side", "z"): "y",
+    }.get((view, turn_axis), "x" if turn_axis == "z" else "z")
+    radial_index = "xyz".index(radial_axis)
+    profile_points: list[tuple[float, ...]] = []
+    if _profile_bounds_hint is not None:
+        for frame, span, radius in step_geometry:
+            if radius is None:
+                profile_points = []
+                break
+            for endpoint in span:
+                for sign in (-1.0, 1.0):
+                    point = list(endpoint)
+                    point[radial_index] = float(frame.origin[radial_index]) + sign * radius
+                    profile_points.append(dwg.at(view, *point))
+    profile_bounds = (
+        (
+            min(point[0] for point in profile_points),
+            min(point[1] for point in profile_points),
+            max(point[0] for point in profile_points),
+            max(point[1] for point in profile_points),
+        )
+        if profile_points
+        else _profile_bounds_hint
+    )
 
     # A Y-turned chain that would need near/far staggering is ambiguous in the
     # narrow side view: an interior far-tier segment reads like an overall
@@ -4512,6 +4887,7 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
                 allow_collapse=False,
                 ctx=ctx,
                 start=start,
+                profile_bounds=profile_bounds,
             )
         if not (labels_clear and inside_arrows_fit):
             axis_lo = min(min(seg.pa[1], seg.pb[1]) for seg in bare_rows)
@@ -4538,7 +4914,15 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
             axis_zs = [origin[2] for origin in step_origins]
             coaxial = max(axis_xs) - min(axis_xs) <= 0.5 and max(axis_zs) - min(axis_zs) <= 0.5
             if not coaxial:
-                return _draw_step_chain(dwg, view, fsegs, "m_steplen", ctx=ctx, start=start)
+                return _draw_step_chain(
+                    dwg,
+                    view,
+                    fsegs,
+                    "m_steplen",
+                    ctx=ctx,
+                    start=start,
+                    profile_bounds=profile_bounds,
+                )
             axis_z = sum(axis_zs) / len(axis_zs)
 
             # Choose the same standard scale family as the detail renderer, then
@@ -4631,6 +5015,7 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
                 allow_collapse=False,
                 ctx=ctx,
                 start=start,
+                profile_bounds=profile_bounds,
             )
 
     # X-turned crowded-head detour (#307): split off each contiguous *run of ≥2*
@@ -4656,10 +5041,13 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
                 # absolute world→page scale). (#307 review)
                 scale_needed = _MIN_STEP_SEP_MM / minlen if minlen > 0 else float("inf")
                 # A head *block* is a synthetic span, not one toleranced step — carry no ± (None).
+                block_lo = list(step_origins[0])
+                block_hi = list(step_origins[0])
+                block_lo[0], block_hi[0] = hlo, hhi
                 blocks.append(
                     _StepChainSegment(
-                        dwg.at("front", hlo, 0, 0),
-                        dwg.at("front", hhi, 0, 0),
+                        dwg.at(view, *block_lo),
+                        dwg.at(view, *block_hi),
                         hhi - hlo,
                     )
                 )
@@ -4677,6 +5065,17 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
                         dwg, view, hsegs, f"dim_{view}_steplen", detail_scale, ctx=ctx
                     )
 
+                profile_key = next((key for key in step_profiles if key is not None), None)
+                cross_axis: Literal["x", "y", "z"] = "z" if view == "front" else "y"
+                cross_index = "xyz".index(cross_axis)
+                cross_bounds = (
+                    None
+                    if profile_key is None
+                    else (
+                        float(profile_key.body_bounds[2 * cross_index]),
+                        float(profile_key.body_bounds[2 * cross_index + 1]),
+                    )
+                )
                 ctx.detail_requests.append(
                     DetailRequest(
                         axis="x",
@@ -4686,6 +5085,10 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
                         redraw=_redraw,
                         pad_top=2 * (draft.font_size + 2 * draft.pad_around_text)
                         + draft.arrow_length,
+                        source_view=view,
+                        cross_axis=cross_axis if cross_bounds is not None else None,
+                        cross_lo=None if cross_bounds is None else cross_bounds[0],
+                        cross_hi=None if cross_bounds is None else cross_bounds[1],
                         kind="turned-head",
                     )
                 )
@@ -4695,10 +5098,25 @@ def render_step_lengths(dwg, plan, *, ctx, only=None) -> int:
             # The chain now mixes head-block(s) with real steps — never collapse it to a
             # uniform "N× v" representative (a block is not a repeated step, #307 review).
             return _draw_step_chain(
-                dwg, "front", main, "m_steplen", allow_collapse=False, ctx=ctx, start=start
+                dwg,
+                view,
+                main,
+                "m_steplen",
+                allow_collapse=False,
+                ctx=ctx,
+                start=start,
+                profile_bounds=profile_bounds,
             )
 
-    return _draw_step_chain(dwg, view, fsegs, "m_steplen", ctx=ctx, start=start)
+    return _draw_step_chain(
+        dwg,
+        view,
+        fsegs,
+        "m_steplen",
+        ctx=ctx,
+        start=start,
+        profile_bounds=profile_bounds,
+    )
 
 
 def ladder_plan_for(plan, *, step_height: bool, overall: bool):

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -380,7 +380,7 @@ def build_model(a: Analysis):
         pockets=a.recognition.pockets,
         pocket_patterns=a.recognition.pocket_patterns,
         pads=a.recognition.pads,
-        prof=a.prof,
+        profiles=a.profiles,
         step_zs=a.step_zs,
         face_levels=a.recognition.step_levels,
         rotational=(a.od_diam, _bores, a.od_axis) if a.is_rotational else None,
@@ -744,7 +744,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # cramming; the envelope dim along the turning axis was suppressed so the chain
         # does not double-dimension the length.
         nonlocal _runtime_plan
-        if a.prof is not None:
+        if a.profiles:
             placed = render_step_lengths(dwg, _compiled, ctx=ctx)
             if placed == 0:
                 released = _runtime_plan.release_contingency("step_length")

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -370,8 +370,9 @@ def _measure_blocks(dwg, a) -> dict:
 
 
 def _coerce_model(model, part, decorations=None, requested=None, authored=None) -> PartModel:
-    """Wrap a caller-supplied ``model=`` (ADR 0011) into a :class:`PartModel`. A
-    ``PartModel`` is used verbatim; a sequence of features is wrapped with the part's
+    """Wrap a caller-supplied ``model=`` (ADR 0011) into a :class:`PartModel`.
+    A ``PartModel`` retains its authored contents while derived turned orientation is
+    normalised; a sequence of features is wrapped with the part's
     bbox, a default corner location datum (matching ``detect.py``, so hole location
     dims measure from the min corner), and an orientation inferred from any turned
     ``StepFeature`` (so a declared shaft renders as turned).
@@ -405,7 +406,8 @@ def _coerce_model(model, part, decorations=None, requested=None, authored=None) 
     else:
         features = list(model)
         bbox = part.bounding_box()
-        orientation = next((f.frame.axis for f in features if isinstance(f, StepFeature)), None)
+        turned_axes = {f.frame.axis for f in features if isinstance(f, StepFeature)}
+        orientation = next(iter(turned_axes)) if len(turned_axes) == 1 else None
         datum = Datum(id="datum_xy", kind="point", at=(bbox.min.X, bbox.min.Y, bbox.min.Z))
         out = PartModel(
             bbox=bbox,
@@ -416,6 +418,13 @@ def _coerce_model(model, part, decorations=None, requested=None, authored=None) 
             requested_dimensions=tuple(requested or ()),
             authored_dimensions=None if authored is None else tuple(authored),
         )
+    turned_axes = {f.frame.axis for f in out.features if isinstance(f, StepFeature)}
+    orientation = next(iter(turned_axes)) if len(turned_axes) == 1 else None
+    if turned_axes and out.orientation != orientation:
+        # PartModel.orientation is the compiler's aggregate classification, not a caller
+        # override. Derive it from the complete set so list and PartModel front doors are
+        # equivalent and mixed-axis declarations are order-independent (#1357).
+        out = replace(out, orientation=orientation)
     _check_dimension_sources(out)
     return out
 
@@ -538,7 +547,16 @@ def _assemble(
         # (`axial_length_missing`). Guard on the tiling condition rather than a classifier
         # proxy (is_rotational / prof both have blind spots).
         z_steps = [f for f in pm.features if isinstance(f, StepFeature) and f.frame.axis == "z"]
-        if pm.orientation == "z" and z_steps:
+        # The global-envelope check is meaningful only in its legacy single-solid domain;
+        # caller-owned group strings cannot turn one solid into several physical bodies.
+        # Multiple solids can be parallel, axially disjoint, or accompanied by unrelated
+        # compound members, so their steps need not tile the compound bbox (#1357).
+        owns_global_envelope = any(feature.kind == "envelope" for feature in pm.features)
+        if (
+            z_steps
+            and len(a.part.solids()) == 1
+            and (pm.orientation == "z" or owns_global_envelope)
+        ):
             tol = 1e-3 * max(a.z_size, 1.0)  # small absolute float epsilon, floored
             # Tiling means the segments run end to end — a single reach to each end isn't
             # enough, since an interior gap is a stretch of part no declared step describes.
@@ -2035,11 +2053,12 @@ def build_drawing(
                 return (), (), "recovery_detail_retained"
             if require_axial_coverage:
                 assert latest_analysis is not None
-                if lint_axial_coverage(
-                    latest_analysis.part,
-                    candidate,
-                    prof=latest_analysis.prof,
-                ):
+                profile_kw = (
+                    {"profiles": latest_analysis.profiles}
+                    if hasattr(latest_analysis, "profiles")
+                    else {"prof": latest_analysis.prof}
+                )
+                if lint_axial_coverage(latest_analysis.part, candidate, **profile_kw):
                     return (), (), "axial_coverage_incomplete"
             issues, blockers = _automatic_assessment(candidate)
             if any(issue.severity == "error" for issue in issues):
@@ -2250,12 +2269,13 @@ def build_drawing(
             and "iso" in drawing.views
         ):
             assert latest_analysis is not None
+            profile_kw = (
+                {"profiles": latest_analysis.profiles}
+                if hasattr(latest_analysis, "profiles")
+                else {"prof": latest_analysis.prof}
+            )
             original_has_axial_gap = bool(
-                lint_axial_coverage(
-                    latest_analysis.part,
-                    drawing,
-                    prof=latest_analysis.prof,
-                )
+                lint_axial_coverage(latest_analysis.part, drawing, **profile_kw)
             )
             original_issues, original_blockers = _automatic_assessment(drawing)
             source_blockers = tuple(

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -2088,14 +2088,14 @@ class Drawing:
             and getattr(getattr(it.feature, "frame", None), "axis", None) in ("x", "y", "z")
         }
         # step LENGTH dimension intents (role="step") → render_step_lengths' chain (Phase 4b),
-        # but only on a TURNED part (a.prof is not None, mirroring the auto-pass guard) — else
+        # but only on a TURNED part (a.profiles is non-empty, mirroring the auto-pass guard) — else
         # they live-replay. Excludes the step's ø (a callout routed in dia_ids above).
         len_ids = {
             id(it)
             for it in self._intents
             if routable
             and a is not None
-            and a.prof is not None
+            and a.profiles
             and it.kind == "dimension"
             and getattr(it.feature, "kind", None) == "step"
             and getattr(getattr(it.feature, "frame", None), "axis", None) in ("x", "y", "z")
@@ -3487,7 +3487,7 @@ class Drawing:
                 # evidence over recognition's OWN levels, so no caller can narrow the
                 # shoulder inventory (#1025).
                 recognition = a.recognition
-                prof_kw = {"prof": a.prof}
+                prof_kw = {"profiles": a.profiles}
             elif a is not None:
                 # A DECLARED build recognised nothing (#1022), so `a.holes` and friends are
                 # empty because nothing looked — not because the part has none. Feeding that
@@ -3506,10 +3506,10 @@ class Drawing:
                 # forbids — it would make lint blind to exactly the geometry a sparse
                 # declaration omitted, the case `unrecognised_defining_geometry` reports.
                 recognition = rec
-                # `a.prof` IS declaration-sourced, and here that is right rather than a
-                # shortcut: axial critique judges the declared profile's dimensioning, so a
-                # declared turned part keeps it without the aggregate.
-                prof_kw = {"prof": a.prof}
+                # These profiles ARE declaration-sourced, and here that is right rather than a
+                # shortcut: axial critique judges each declared profile's dimensioning, so a
+                # declared turned part keeps them without importing detected coordinates.
+                prof_kw = {"profiles": a.profiles}
             else:
                 if self._cyl_cache is None:
                     self._cyl_cache = analyse_cylinders(working_part)
@@ -3553,7 +3553,7 @@ class Drawing:
                 dimension_plan = None
             # Turned bosses/bands remain in the OD + axial-step policy; this check is
             # specifically for a prismatic boss's independent projection height.
-            if model is not None and (a is None or (not a.is_rotational and a.prof is None)):
+            if model is not None and (a is None or (not a.is_rotational and not a.profiles)):
                 issues += lint_boss_height_coverage(
                     working_part,
                     self,

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -58,6 +58,7 @@ from draftwright._core import (
 from draftwright.linting._registry import annotation_owner, satisfaction_ids
 from draftwright.linting.issues import LintIssue
 from draftwright.linting.profiled_bore_coverage import profiled_bore_key
+from draftwright.recognition_frame import profiles_owning_axial_band
 from draftwright.view_plan import VIEW_AXES
 
 _UNSET = object()  # sentinel: distinguishes "not supplied" from a valid prof=None
@@ -68,6 +69,8 @@ _UNSET = object()  # sentinel: distinguishes "not supplied" from a valid prof=No
 _RECON_DIA_TOL = 0.2
 _RECON_POS_TOL = 0.5
 _LOCATION_AXIS_TOL = 1.0
+_GROOVE_STEP_POS_TOL = 0.1  # detect.py's groove-centre/turned-band reconciliation tolerance
+_GROOVE_STEP_LEN_PAD = 1.0  # detect.py's guard against treating a merged shaft run as a groove
 
 
 def _location_ref(owner, point) -> HoleRef:
@@ -1508,41 +1511,135 @@ def lint_prismatic_coverage(
     return issues
 
 
-def _axial_covered_from_drawing(part, dwg, prof, tol: float = 0.6) -> set[int]:
+def _turned_axis_origin(part, prof) -> tuple[float, float, float]:
+    """The profile's body-local axis line, with a legacy whole-part fallback."""
+    key = getattr(prof, "profile", None)
+    if key is not None:
+        return (
+            float(key.axis_origin[0]),
+            float(key.axis_origin[1]),
+            float(key.axis_origin[2]),
+        )
+    centre = part.bounding_box().center()
+    return (float(centre.X), float(centre.Y), float(centre.Z))
+
+
+def _feature_on_turned_axis(feature, prof, tol: float = 0.5) -> bool:
+    """Whether an IR feature belongs to this body-local turned axis line."""
+    profile_group = getattr(prof, "profile_group", None)
+    feature_group = getattr(feature, "profile_group", None)
+    if profile_group is not None and getattr(feature, "kind", None) == "step":
+        # Declared/emitted coaxial occurrences may share an axis, span, and even diameter.
+        # Their opaque declaration token is one exact ownership witness. Do not geometrically
+        # credit one group's placed measurement to another group (#1357).
+        if feature_group != profile_group:
+            return False
+        # Tokens are caller-chosen and may be reused on another physical axis line. Exact
+        # ownership requires both the opaque relationship and the geometry below.
+    key = getattr(prof, "profile", None)
+    if key is None:
+        return True
+    feature_profile = getattr(feature, "profile", None)
+    if feature_profile is not None:
+        return bool(feature_profile == key)
+    axis = getattr(feature, "axis", None) or getattr(getattr(feature, "frame", None), "axis", None)
+    origin = getattr(getattr(feature, "frame", None), "origin", None)
+    if axis != prof.axis or origin is None:
+        return False
+    axis_index = "xyz".index(prof.axis)
+    axis_tol = 1e-9 if profile_group is not None else tol
+    if not all(
+        abs(float(origin[index]) - float(key.axis_origin[index])) <= axis_tol
+        for index in range(3)
+        if index != axis_index
+    ):
+        return False
+    profile_lo, profile_hi = float(min(prof.shoulders)), float(max(prof.shoulders))
+    span = getattr(feature, "span", None)
+    if span is not None:
+        feature_lo, feature_hi = sorted(float(point[axis_index]) for point in span)
+        return feature_lo >= profile_lo - tol and feature_hi <= profile_hi + tol
+    if getattr(feature, "kind", None) == "groove":
+        centre = float(origin[axis_index])
+        half_width = float(feature.width) / 2.0
+        return centre - half_width >= profile_lo - tol and centre + half_width <= profile_hi + tol
+    return True
+
+
+def _turned_profile_views(axis: str) -> tuple[str, str]:
+    """The two principal views that show *axis* longitudinally."""
+    return {
+        "x": ("front", "plan"),
+        "y": ("side", "plan"),
+        "z": ("front", "side"),
+    }[axis]
+
+
+def _profile_projection(dwg, view: str, origin, axis: str) -> tuple[bool, float]:
+    """Whether the axis is horizontal on *view*, and the axis line's cross coordinate."""
+    point = list(origin)
+    px, py, *_ = dwg.at(view, *point)
+    point["xyz".index(axis)] += 1.0
+    ax, ay, *_ = dwg.at(view, *point)
+    horizontal = abs(float(ax) - float(px)) >= abs(float(ay) - float(py))
+    return horizontal, float(py if horizontal else px)
+
+
+def _step_length_owners(dwg, name: str) -> tuple[object, ...]:
+    """Exact step features whose compiled length claim produced annotation *name*."""
+    registry = getattr(dwg, "registry", None)
+    if registry is None:
+        return ()
+    return tuple(
+        identity.feature
+        for identity in registry.measurement_of(name)
+        if getattr(identity, "parameter", None) == "step.length"
+        and getattr(identity.feature, "kind", None) == "step"
+    )
+
+
+def _axial_covered_from_drawing(
+    part, dwg, prof, *, sibling_profiles=(), tol: float = 0.6
+) -> set[int]:
     """Which turned-profile step lengths are dimensioned **in the drawing**
     — a step counts as covered when some profile-view ``Dimension`` has witnesses
     at both of its shoulders' page positions. Drawing-derived, so it judges any
     producer (not the engine's :class:`CoverageState` side channel).
 
-    Works for every turning axis (orientation is data): X- and Y-turned chains
-    are horizontal in their respective front/side profile views, while a
-    Z-turned chain is vertical in the front view."""
-    bb = part.bounding_box()
-    c = bb.center()
+    Works for every turning axis (orientation is data) and both orthographic profile views,
+    so parallel bodies can use whichever projection visibly separates their axis lines."""
     idx = "xyz".index(prof.axis)
-    base = [c.X, c.Y, c.Z]
-    use_x = prof.axis in ("x", "y")
+    base = list(_turned_axis_origin(part, prof))
 
-    def shoulder_coord(view: str, s: float) -> float:
+    def profile_cross(profile, view: str) -> float:
+        _horizontal, cross = _profile_projection(
+            dwg, view, _turned_axis_origin(part, profile), profile.axis
+        )
+        return cross
+
+    def shoulder_coord(view: str, s: float, *, horizontal: bool) -> float:
         pt = list(base)
         pt[idx] = s
         px, py, *_ = dwg.at(view, *pt)
-        return float(px if use_x else py)
+        return float(px if horizontal else py)
 
     # A crowded X-turned head or Y-turned side chain can be dimensioned in an
     # enlarged detail view (#304/#307/#892), not the principal profile — so a
     # shoulder counts as located when matched in EITHER source or detail view.
-    views = ["side"] if prof.axis == "y" else ["front"]
+    views = [view for view in _turned_profile_views(prof.axis) if view in dwg.views]
     if prof.axis in ("x", "y"):
         views += sorted(v for v in dwg.views if v.startswith("detail_"))
     covered_steps: set[int] = set()
     for view in views:
-        shoulder_c = {s: shoulder_coord(view, s) for s in prof.shoulders}
+        horizontal, _own_cross = _profile_projection(dwg, view, base, prof.axis)
+        shoulder_c = {s: shoulder_coord(view, s, horizontal=horizontal) for s in prof.shoulders}
         dims = [
             (
                 name,
                 str(getattr(ann, "label", "") or ""),
-                {(x if use_x else y) for x, y in _dim_vertices(ann)},
+                {(x if horizontal else y) for x, y in _dim_vertices(ann)},
+                {(y if horizontal else x) for x, y in _dim_vertices(ann)},
+                _step_length_owners(dwg, name),
             )
             for name, ann in dwg.annotations_in_view(view)
             if isinstance(ann, Dimension)
@@ -1555,9 +1652,26 @@ def _axial_covered_from_drawing(part, dwg, prof, tol: float = 0.6) -> set[int]:
                 # shoulder), and this branch should be unreachable — but a lint pass must
                 # never crash on an unguarded lookup, so skip rather than KeyError.
                 continue
-            for name, label, cs in dims:
+            for name, label, cs, cross_coords, owners in dims:
                 if not cs:
                     continue
+                if owners and not any(_feature_on_turned_axis(owner, prof) for owner in owners):
+                    continue
+                # Parallel profiles can have identical axial ordinates. A dimension belongs to
+                # the nearest visible axis line in this profile view; without this gate one
+                # shaft's two witnesses would certify every sibling at the same stations.
+                if not owners and getattr(prof, "profile", None) is not None and cross_coords:
+                    dim_cross = sum(cross_coords) / len(cross_coords)
+                    own_distance = abs(dim_cross - profile_cross(prof, view))
+                    sibling_distances = [
+                        abs(dim_cross - profile_cross(sibling, view))
+                        for sibling in sibling_profiles
+                        if sibling is not prof and sibling.axis == prof.axis
+                    ]
+                    if any(distance < own_distance - tol for distance in sibling_distances) or any(
+                        abs(distance - own_distance) <= tol for distance in sibling_distances
+                    ):
+                        continue
                 # A plain dim locates the step when it has a witness at each shoulder.
                 if any(abs(v - clo) <= tol for v in cs) and any(abs(v - chi) <= tol for v in cs):
                     covered_steps.add(i)
@@ -1579,32 +1693,69 @@ def _axial_covered_from_drawing(part, dwg, prof, tol: float = 0.6) -> set[int]:
     return covered_steps
 
 
-def _overall_axial_extent_is_dimensioned(part, dwg, prof, tol: float = 0.6) -> bool:
+def _overall_axial_extent_is_dimensioned(
+    part, dwg, prof, *, sibling_profiles=(), tol: float = 0.6
+) -> bool:
     """Whether a profile-view dimension witnesses the turned profile's two outer ends."""
-    view = "side" if prof.axis == "y" else "front"
-    use_x = prof.axis in ("x", "y")
-
-    def projected(station: float) -> float:
-        c = part.bounding_box().center()
-        point = [c.X, c.Y, c.Z]
-        point["xyz".index(prof.axis)] = station
-        x, y, *_ = dwg.at(view, *point)
-        return float(x if use_x else y)
-
-    lo, hi = projected(min(prof.shoulders)), projected(max(prof.shoulders))
-    for _name, annotation in dwg.annotations_in_view(view):
-        if not isinstance(annotation, Dimension):
+    origin = _turned_axis_origin(part, prof)
+    for view in _turned_profile_views(prof.axis):
+        if view not in dwg.views:
             continue
-        coords = {(x if use_x else y) for x, y in _dim_vertices(annotation)}
-        if any(abs(value - lo) <= tol for value in coords) and any(
-            abs(value - hi) <= tol for value in coords
-        ):
-            return True
+        horizontal, own_cross = _profile_projection(dwg, view, origin, prof.axis)
+
+        def projected(station: float) -> float:
+            point = list(origin)
+            point["xyz".index(prof.axis)] = station
+            x, y, *_ = dwg.at(view, *point)
+            return float(x if horizontal else y)
+
+        lo, hi = projected(min(prof.shoulders)), projected(max(prof.shoulders))
+
+        def sibling_cross(profile) -> float:
+            _horizontal, cross = _profile_projection(
+                dwg, view, _turned_axis_origin(part, profile), profile.axis
+            )
+            return cross
+
+        for name, annotation in dwg.annotations_in_view(view):
+            if not isinstance(annotation, Dimension):
+                continue
+            vertices = _dim_vertices(annotation)
+            coords = {(x if horizontal else y) for x, y in vertices}
+            cross_coords = {(y if horizontal else x) for x, y in vertices}
+            owners = _step_length_owners(dwg, name)
+            if owners and not any(_feature_on_turned_axis(owner, prof) for owner in owners):
+                continue
+            if not owners and getattr(prof, "profile", None) is not None and cross_coords:
+                dim_cross = sum(cross_coords) / len(cross_coords)
+                own_distance = abs(dim_cross - own_cross)
+                sibling_distances = [
+                    abs(dim_cross - sibling_cross(sibling))
+                    for sibling in sibling_profiles
+                    if sibling is not prof and sibling.axis == prof.axis
+                ]
+                if any(distance < own_distance - tol for distance in sibling_distances) or any(
+                    abs(distance - own_distance) <= tol for distance in sibling_distances
+                ):
+                    continue
+            if any(abs(value - lo) <= tol for value in coords) and any(
+                abs(value - hi) <= tol for value in coords
+            ):
+                return True
     return False
 
 
-def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET, recognition=None) -> list:
-    """Report a stepped turned part whose axial step lengths are undimensioned.
+def _lint_one_axial_profile(
+    part,
+    dwg,
+    prof,
+    *,
+    assembly,
+    recognition,
+    sibling_profiles=(),
+    profile_label="",
+) -> list:
+    """Report missing axial coverage for one body-local turned profile.
 
     A turned part can have every diameter called out yet be unmanufacturable: with
     no shoulder located, the lengths are unknown (the drive-screw gap). A complete
@@ -1619,21 +1770,11 @@ def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET, recognition=None)
     chain (ADR 0008 #223), so a missing chain on any axis is a real gap
     (e.g. the chain skipped for want of page room). Severity mirrors
     :func:`lint_feature_coverage`: ``info`` for an assembly, else ``warning``.
-    *prof* may be supplied (the single inventory, #244) to skip re-detection;
-    omitted, it is detected here. A sentinel distinguishes "not supplied" from a
-    valid ``prof=None`` (non-turned part).
-
     ``recognition`` supplies the run-owned groove inventory used only to evidence-gate a
     structured ``groove.length`` claim; an unrelated declared groove cannot fill the count.
     """
-    if prof is _UNSET:
-        prof = TurnedProfile.from_steps(recognise_turned_steps(part))
-    if prof is None:
-        return []
-    if assembly is None:
-        assembly = len(part.solids()) > 1
     n = len(prof.steps)
-    covered_steps = _axial_covered_from_drawing(part, dwg, prof)
+    covered_steps = _axial_covered_from_drawing(part, dwg, prof, sibling_profiles=sibling_profiles)
     registry = getattr(dwg, "registry", None)
     placed_ids = (
         {identity for name in registry.names() for identity in registry.measurement_of(name)}
@@ -1653,25 +1794,18 @@ def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET, recognition=None)
         ):
             continue
         span = getattr(feature, "span", None)
-        if span is None:
+        if span is None or not _feature_on_turned_axis(feature, prof):
             continue
         lo, hi = sorted(float(point[axis_index]) for point in span)
         for index, step in enumerate(prof.steps):
             if abs(lo - float(step.lo)) <= 1e-3 and abs(hi - float(step.hi)) <= 1e-3:
                 covered_steps.add(index)
                 break
-    covered = len(covered_steps)
     # A groove band's axial extent is dimensioned by its width callout, not a step length, so
     # detect.py leaves it out of the step-length chain (#606). Count each *rendered* groove-width
     # callout on the turning axis as covering its band — so a fully-dimensioned grooved shaft
     # (N−1 step lengths + the groove width) is not flagged (#628); a *dropped* groove callout
     # leaves its band uncovered, so a genuine gap still fires (reconcile rendered, not intent).
-    covered += sum(1 for name in dwg.annotations() if name.startswith(f"m_groove_{prof.axis}"))
-    placed_grooves = {
-        identity.feature
-        for identity in placed_ids
-        if getattr(identity, "parameter", None) == "groove.length"
-    }
     physical_grooves = {
         (
             groove.axis,
@@ -1681,24 +1815,58 @@ def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET, recognition=None)
         )
         for groove in getattr(recognition, "grooves", ())
     }
+
+    def groove_key(feature):
+        return (
+            feature.axis,
+            round(float(feature.width), 3),
+            round(float(feature.diameter), 3),
+            tuple(round(float(value), 3) for value in feature.frame.origin),
+        )
+
+    def groove_belongs_exactly(feature) -> bool:
+        owners = profiles_owning_axial_band(
+            (prof, *(sibling for sibling in sibling_profiles if sibling is not prof)),
+            axis=feature.axis,
+            centre=feature.frame.origin,
+            width=feature.width,
+        )
+        return len(owners) == 1 and owners[0] is prof
+
+    placed_grooves = {
+        identity.feature
+        for identity in placed_ids
+        if getattr(identity, "parameter", None) == "groove.length"
+        and _feature_on_turned_axis(identity.feature, prof)
+        and groove_belongs_exactly(identity.feature)
+        and (recognition is None or groove_key(identity.feature) in physical_grooves)
+    }
     satisfied_grooves = {
         identity.feature
         for identity in satisfied_ids
         if getattr(identity, "parameter", None) == "groove.length"
         and getattr(identity.feature, "kind", None) == "groove"
         and identity.feature not in placed_grooves
+        and _feature_on_turned_axis(identity.feature, prof)
+        and groove_belongs_exactly(identity.feature)
     }
-    covered += sum(
-        1
-        for feature in satisfied_grooves
-        if (
-            feature.axis,
-            round(float(feature.width), 3),
-            round(float(feature.diameter), 3),
-            tuple(round(float(value), 3) for value in feature.frame.origin),
-        )
-        in physical_grooves
-    )
+    credited_grooves = placed_grooves | {
+        feature for feature in satisfied_grooves if groove_key(feature) in physical_grooves
+    }
+    for feature in credited_grooves:
+        centre = float(feature.frame.origin[axis_index])
+        for index, step in enumerate(prof.steps):
+            # Match the same physical narrow band detect.py delegates from StepFeature to
+            # GrooveFeature. The provider may report its wall OD, so diameter is not a join.
+            if (
+                float(step.lo) - _GROOVE_STEP_POS_TOL
+                <= centre
+                <= float(step.hi) + _GROOVE_STEP_POS_TOL
+                and float(step.hi) - float(step.lo) <= float(feature.width) + _GROOVE_STEP_LEN_PAD
+            ):
+                covered_steps.add(index)
+                break
+    covered = len(covered_steps)
     if covered >= n:
         return []
     # #955: when placement drops the complete chain, its specific warning already says the
@@ -1710,7 +1878,9 @@ def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET, recognition=None)
     chain_drop_reported = any(
         issue.code == "step_dim_dropped" for issue in getattr(registry, "issues", ())
     )
-    if chain_drop_reported and _overall_axial_extent_is_dimensioned(part, dwg, prof):
+    if chain_drop_reported and _overall_axial_extent_is_dimensioned(
+        part, dwg, prof, sibling_profiles=sibling_profiles
+    ):
         return []
     return [
         LintIssue(
@@ -1718,10 +1888,81 @@ def lint_axial_coverage(part, dwg, assembly=None, prof=_UNSET, recognition=None)
             code="axial_length_missing",
             message=(
                 f"turned part has {n} axial steps but only {covered} step length(s) "
-                f"dimensioned — shoulders cannot be located"
+                f"dimensioned{profile_label} — shoulders cannot be located"
             ),
         )
     ]
+
+
+def lint_axial_coverage(
+    part,
+    dwg,
+    assembly=None,
+    prof=_UNSET,
+    recognition=None,
+    *,
+    profiles=_UNSET,
+) -> list:
+    """Report every body-local turned profile whose axial chain is incomplete.
+
+    ``profiles`` is the plural compiler inventory. The compatible ``prof`` input remains for
+    callers with a known zero/one profile; supplying both is an error. If neither is supplied,
+    the run-owned recognition aggregate is preferred and standalone callers detect the same
+    grouped profiles directly. Each profile is judged independently, so one parallel shaft's dimensions cannot
+    certify another shaft with equal axial spans (#1357).
+    """
+    if prof is not _UNSET and profiles is not _UNSET:
+        raise ValueError("supply profiles= or the compatible singular prof=, not both")
+    if profiles is _UNSET:
+        if prof is _UNSET:
+            if recognition is not None:
+                profiles = recognition.turned_profiles
+            else:
+                profile_steps: dict[object, list] = {}
+                for step in recognise_turned_steps(part):
+                    profile_steps.setdefault(step.profile or (step.axis, None), []).append(step)
+                detected_profiles = []
+                for steps in profile_steps.values():
+                    detected = TurnedProfile.from_steps(steps)
+                    if detected is not None:
+                        detected_profiles.append(detected)
+                profiles = tuple(detected_profiles)
+        else:
+            profiles = () if prof is None else (prof,)
+    profiles = tuple(profiles)
+    if not profiles:
+        return []
+    if assembly is None:
+        assembly = len(part.solids()) > 1
+    plural = len(profiles) > 1
+    issues = []
+    for profile in profiles:
+        key = getattr(profile, "profile", None)
+        label = ""
+        if plural and key is not None:
+            axis_index = "xyz".index(profile.axis)
+            line = tuple(
+                round(float(value), 3)
+                for index, value in enumerate(key.axis_origin)
+                if index != axis_index
+            )
+            span = (
+                round(float(min(profile.shoulders)), 3),
+                round(float(max(profile.shoulders)), 3),
+            )
+            label = f" on {profile.axis}-axis line {line}, span {span}"
+        issues.extend(
+            _lint_one_axial_profile(
+                part,
+                dwg,
+                profile,
+                assembly=assembly,
+                recognition=recognition,
+                sibling_profiles=profiles,
+                profile_label=label,
+            )
+        )
+    return issues
 
 
 def lint_boss_height_coverage(part, dwg, features, assembly=None, omissions=()) -> list:

--- a/src/draftwright/model/__init__.py
+++ b/src/draftwright/model/__init__.py
@@ -99,6 +99,7 @@ from draftwright.model.ir import (
     ThreadRequirement,
     ThroughStepFeature,
     ToleranceDecoration,
+    TurnedProfileIdentity,
     display,
 )
 from draftwright.model.planner import (
@@ -161,6 +162,7 @@ __all__ = [
     "ThroughStepFeature",
     "ThreadOperation",
     "ThreadRequirement",
+    "TurnedProfileIdentity",
     "ToleranceDecoration",
     "measured_dimension",
     "build_part_model",

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -272,7 +272,9 @@ _FACTS: dict[str, tuple[str, ...]] = {
     "boss": ("frame", "thread", "knurl"),
     "polygonal_boss": ("frame", "side_count", "flat_directions", "flat_centres"),
     "polygonal_stock": ("frame", "side_count", "flat_directions", "flat_centres"),
-    "step": ("frame", "thread", "knurl"),
+    # ``profile`` is immutable body ownership (axis origin + body bounds), not a printable
+    # diameter/length. Renderers need it to keep parallel/disconnected chains separate (#1357).
+    "step": ("frame", "thread", "knurl", "profile", "profile_group"),
     "step_level": ("frame",),
     "envelope": ("frame",),
     "rotational": ("frame",),

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -503,6 +503,7 @@ def step(
     span=None,
     thread=None,
     knurl=None,
+    profile_group=None,
 ) -> StepFeature:
     """One axial segment of a turned profile — its OD + length. Either ``step(segment)``
     (⌀ from the cylindrical face, length + centre from the bbox along its axis) or
@@ -522,6 +523,10 @@ def step(
     axis = _norm_axis(axis)
     _require_positive(diameter=diameter, length=length)
     _require_point("at", at)
+    if profile_group is not None and (
+        not isinstance(profile_group, str) or not profile_group.strip()
+    ):
+        raise ValueError("profile_group must be a non-empty string when supplied")
     if span is None:
         span = _span(at, axis, length)
     return StepFeature(
@@ -531,6 +536,7 @@ def step(
         span=span,
         thread=thread,
         knurl=knurl,
+        profile_group=profile_group,
     )
 
 

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -53,7 +53,6 @@ from b123d_recognisers import (
     SlotGrid,
     StepShoulder,
     ThroughStep,
-    TurnedProfile,
     TurnedStep,
     analyse_cylinders,
     build_raw_recognition_result,
@@ -79,7 +78,6 @@ from b123d_recognisers import (
     recognise_slot_patterns,
     recognise_slots,
     recognise_through_steps,
-    recognise_turned_steps,
     step_level_records,
 )
 
@@ -125,7 +123,7 @@ from draftwright.model.ir import (
     StepLevelFeature,
     ThroughStepFeature,
 )
-from draftwright.recognition_frame import single_turned_profile
+from draftwright.recognition_frame import require_unambiguous_groove_owner
 
 
 def _member_hole(h, frame: Frame, members: tuple = (), count: int = 1) -> HoleFeature:
@@ -220,7 +218,17 @@ def _boss_is_groove_floor(b, grooves) -> bool:
     that floor. The groove callout already dimensions it, so it must not also get a boss ø
     (#148c review; applies whether or not the part read as a turned profile)."""
     ax = _axis_letter(b)
-    return any(abs(b.diameter - g.diameter) <= _DIA_TOL and g.axis == ax for g in grooves)
+    axis_index = "xyz".index(ax)
+    return any(
+        abs(b.diameter - g.diameter) <= _DIA_TOL
+        and g.axis == ax
+        and all(
+            abs(float(b.location[index]) - float(g.at[index])) <= 0.5
+            for index in range(3)
+            if index != axis_index
+        )
+        for g in grooves
+    )
 
 
 _DIA_TOL = 0.15  # two ø values within this (mm) are the same diameter (#298)
@@ -559,10 +567,13 @@ def _pocket_pattern_feature(pat, members) -> PocketPatternFeature:
 
 
 def _convert_step(s: TurnedStep, ctx: ConvContext) -> StepFeature:
-    assert ctx.orientation is not None  # only reached on the turned branch
-    idx = "xyz".index(ctx.orientation)
-    c = ctx.bbox.center()
-    base = [c.X, c.Y, c.Z]
+    axis = s.axis
+    idx = "xyz".index(axis)
+    if s.profile is None:
+        c = ctx.bbox.center()
+        base = [c.X, c.Y, c.Z]
+    else:
+        base = list(s.profile.axis_origin)
     s_mid = (s.lo + s.hi) / 2
     lo = list(base)
     hi = list(base)
@@ -571,10 +582,11 @@ def _convert_step(s: TurnedStep, ctx: ConvContext) -> StepFeature:
     mid = list(base)
     mid[idx] = s_mid
     return StepFeature(
-        frame=Frame(origin=(mid[0], mid[1], mid[2]), axis=ctx.orientation),
+        frame=Frame(origin=(mid[0], mid[1], mid[2]), axis=axis),
         length=s.length,
         diameter=s.diameter,
         span=((lo[0], lo[1], lo[2]), (hi[0], hi[1], hi[2])),
+        profile=s.profile,
     )
 
 
@@ -924,6 +936,7 @@ def build_part_model(
     pocket_patterns=None,
     pads=None,
     prof=_UNSET,
+    profiles=_UNSET,
     step_zs=None,
     face_levels=None,
     rotational=None,
@@ -936,8 +949,9 @@ def build_part_model(
     The detected feature sets may be **supplied** by the caller (from `_analyse`,
     which already ran them) so detection happens **once per build** — the single
     feature inventory (ADR 0008 Amendment 5, #244). Omitted sets are detected here,
-    so a standalone ``build_part_model(part)`` still works. ``prof`` uses a sentinel
-    because ``None`` is a valid value (a non-turned part).
+    so a standalone ``build_part_model(part)`` still works. ``profiles`` is the plural
+    body-local turned-profile input; the compatible singular ``prof`` remains accepted,
+    and both use a sentinel because ``None`` is a valid non-turned value.
 
     ``step_zs`` (prismatic horizontal face levels), their optional ``face_levels`` records
     carrying support bounds, and ``rotational`` (``(od, bores)`` or ``None``) are
@@ -955,8 +969,10 @@ def build_part_model(
     derive_hole_patterns = holes is not None and patterns is None
     derive_slot_patterns = slots is not None and slot_patterns is None
     derive_pocket_patterns = pockets is not None and pocket_patterns is None
+    if prof is not _UNSET and profiles is not _UNSET:
+        raise ValueError("supply profiles= or the compatible singular prof=, not both")
     needs_aggregate = (
-        prof is _UNSET
+        (prof is _UNSET and profiles is _UNSET)
         or step_zs is None
         or face_levels is None
         or any(
@@ -991,7 +1007,7 @@ def build_part_model(
 
     # Turned-profile classification up front so the shared convert-context carries the
     # part's turning axis (the StepFeature span axis). Pure detection — no feature is
-    # emitted here; the turned/boss branch below reads the same `prof`.
+    # emitted here; the turned/boss branch below reads the same plural inventory.
     #
     # Any omitted family or classification input is filled from one public RecognitionResult,
     # preserving cross-family ownership for documented partial-inventory calls.  Derive the
@@ -1011,6 +1027,7 @@ def build_part_model(
             cylinders=cyls,
             rotational=(
                 rotational is not None
+                or (profiles is not _UNSET and bool(profiles))
                 or (prof is not _UNSET and prof is not None)
                 or cylinder_class.is_rotational
             ),
@@ -1082,19 +1099,29 @@ def build_part_model(
             slot_patterns = recognise_slot_patterns(slots)
         if derive_pocket_patterns:
             pocket_patterns = recognise_pocket_patterns(pockets)
-        if prof is _UNSET:
-            prof = single_turned_profile(recognition)
+        if prof is _UNSET and profiles is _UNSET:
+            profiles = recognition.turned_profiles
         if step_zs is None:
             step_zs = recognition.step_ladder_for_z_span(bbox.min.Z, bbox.max.Z)
         if face_levels is None:
             face_levels = recognition.step_levels
         cyls = recognition.cylinders
-    if prof is _UNSET:
-        prof = TurnedProfile.from_steps(recognise_turned_steps(part, cyls=cyls))
+    if profiles is _UNSET:
+        assert prof is not _UNSET  # both omitted always took and populated the aggregate arm
+        profiles = () if prof is None else (prof,)
+    profiles = () if profiles is None else tuple(profiles)
+    if len(profiles) > 1 and any(profile.profile is None for profile in profiles):
+        raise ValueError("plural turned profiles require body-local profile identity")
     # ``rotational`` is the classification fallback for a single-diameter turned body whose
     # step profile is absent. It is already supplied by the one analysis orchestration, so
     # carrying its axis into conversion is not a geometry rescan (#1276 / ADR 0017).
-    orientation = prof.axis if prof is not None else (rotational[2] if rotational else None)
+    profile_axes = {profile.axis for profile in profiles}
+    if len(profile_axes) == 1:
+        orientation = next(iter(profile_axes))
+    elif profile_axes:
+        orientation = None
+    else:
+        orientation = rotational[2] if rotational else None
     # Standalone detection applies the same surface-family gate as RecognitionResult. Supplied
     # records carry the recogniser's explicit surface-family discriminator themselves.
     if chamfers is None:
@@ -1119,7 +1146,7 @@ def build_part_model(
     if polygonal_stock is None:
         polygonal_stock = recognise_polygonal_stock(part)
     envelope_emittable = bool(
-        prof is None and not _is_round(bbox, bosses_d) and not polygonal_stock
+        not profiles and not _is_round(bbox, bosses_d) and not polygonal_stock
     )
     if through_steps is None:
         # Match RecognitionResult applicability on the standalone path. A supplied aggregate
@@ -1134,7 +1161,7 @@ def build_part_model(
     # #917 channel scheme applies only where plate recognition proves a multi-axis
     # U-bracket: base + walls. Use the same evidence as the plate-emission gate below so
     # the two domains cannot both dimension one profile.
-    if prof is None and rotational is None and plates is None:
+    if not profiles and rotational is None and plates is None:
         plates = recognise_plates(part)
     multi_plate = has_multi_axis_plates(plates or ())
     # Ownership evidence must be eligible to cross the recognition→IR boundary.  A lone
@@ -1142,7 +1169,7 @@ def build_part_model(
     # multi-plate bracket grammar), so letting it preempt a ThroughStep would leave the claimed
     # leg with no IR owner at all.
     ownership_plates = (
-        tuple(plates or ()) if prof is None and rotational is None and multi_plate else ()
+        tuple(plates or ()) if not profiles and rotational is None and multi_plate else ()
     )
     # Pocket recognition is consumed later, but its edge-open floors participate in the
     # step-level emission gate. Detect once up front so aggregate takeover is decided against
@@ -1212,7 +1239,7 @@ def build_part_model(
             and not any(abs(z - owned) < 0.5 for owned in side_pad_level_zs)
             and not any(abs(z - floor) < 0.5 for floor in edge_floor_zs)
         )
-        if prof is None
+        if not profiles
         else ()
     )
     shoulders = project_step_shoulders(risers, levels=list(ownership_step_zs))
@@ -1281,7 +1308,7 @@ def build_part_model(
     through_leg_spans = _through_step_leg_spans(lowered_through_steps)
     through_level_zs = _through_step_level_zs(lowered_through_steps)
     through_shoulder_sites = _through_step_shoulder_sites(lowered_through_steps, bbox)
-    if prof is None and rotational is None and multi_plate:
+    if not profiles and rotational is None and multi_plate:
         features.extend(convert(channel, ctx) for channel in channels)
 
     # Holes and hole patterns. A recognised pattern becomes one PatternFeature
@@ -1393,24 +1420,32 @@ def build_part_model(
     if grooves is None:
         grooves = recognise_grooves(part, cyls=cyls)
 
-    # Turned profile → step segments; else external bosses → diameters. (`prof` and the
-    # convert-context were classified up front.)
-    if prof is not None:
-        idx = "xyz".index(prof.axis)
-        groove_bands = [(g.at[idx], g.width) for g in grooves if g.axis == prof.axis]
-        for s in prof.steps:
-            # Skip the band a groove owns (its callout dimensions width + floor ø). Match on
-            # axial POSITION, not diameter: a narrow groove's step is reported at the WALL OD
-            # (local_od's pad engulfs both walls when the groove is < ~1.4 mm), so a floor-ø
-            # match would silently miss the common circlip case. The groove centre lies within
-            # its own step span; the short-length guard keeps a merged shaft run from matching.
-            if any(
-                s.lo - _GROOVE_STEP_TOL <= gc <= s.hi + _GROOVE_STEP_TOL
-                and s.length <= gw + _STEP_LEN_PAD
-                for gc, gw in groove_bands
-            ):
-                continue
-            features.append(convert(s, ctx))
+    # Body-local turned profiles → step segments; else external bosses → diameters. Profile
+    # identity owns the axis line, so parallel shafts never inherit the part bbox centre or
+    # each other's groove bands (#1357).
+    if profiles:
+        grooves_by_profile: dict[int, list[Groove]] = {id(profile): [] for profile in profiles}
+        for groove in grooves:
+            owners = require_unambiguous_groove_owner(groove, profiles)
+            if owners:
+                grooves_by_profile[id(owners[0])].append(groove)
+        for profile in profiles:
+            idx = "xyz".index(profile.axis)
+            groove_bands = [(g.at[idx], g.width) for g in grooves_by_profile[id(profile)]]
+            for s in profile.steps:
+                # Skip the band a groove owns (its callout dimensions width + floor ø). Match
+                # on axial POSITION, not diameter: a narrow groove's step is reported at the
+                # WALL OD (local_od's pad engulfs both walls when the groove is < ~1.4 mm), so
+                # a floor-ø match would silently miss the common circlip case. The groove centre
+                # lies within its own step span; the short-length guard keeps a merged shaft run
+                # from matching.
+                if any(
+                    s.lo - _GROOVE_STEP_TOL <= gc <= s.hi + _GROOVE_STEP_TOL
+                    and s.length <= gw + _STEP_LEN_PAD
+                    for gc, gw in groove_bands
+                ):
+                    continue
+                features.append(convert(s, ctx))
         # A narrow external band nested under / beside a larger OD reads as that OD in
         # local_od's max(), so it never becomes a step diameter and goes silently
         # undimensioned (#298). Emit each band the silhouette steps miss as a boss, so
@@ -1418,11 +1453,34 @@ def build_part_model(
         # with the feature_diameters inventory the coverage lint checks against. A groove
         # floor is likewise a narrow reduced band, but the groove callout already carries its
         # ø, so it is suppressed here (_boss_is_groove_floor) to avoid a duplicate boss ø.
-        step_dias = [s.diameter for s in prof.steps]
-        for b in bosses_d:
-            if all(
-                abs(b.diameter - d) > _DIA_TOL for d in step_dias
-            ) and not _boss_is_groove_floor(b, grooves):
+        for b in bosses:
+            axis = _axis_letter(b)
+            axis_index = "xyz".index(axis)
+            b_lo, b_hi = sorted(
+                (
+                    float(b.location[axis_index]),
+                    float(b.location[axis_index] - b.axis[axis_index] * b.height),
+                )
+            )
+            owned = any(
+                profile.axis == axis
+                and (
+                    profile.profile is None
+                    or all(
+                        abs(float(b.location[index]) - profile.profile.axis_origin[index]) <= 0.5
+                        for index in range(3)
+                        if index != axis_index
+                    )
+                )
+                and any(
+                    abs(b.diameter - step.diameter) <= _DIA_TOL
+                    and abs(b_lo - step.lo) <= 0.5
+                    and abs(b_hi - step.hi) <= 0.5
+                    for step in profile.steps
+                )
+                for profile in profiles
+            )
+            if not owned and not _boss_is_groove_floor(b, grooves):
                 features.append(convert(b, ctx))
     else:
         for b in bosses_d:
@@ -1455,7 +1513,7 @@ def build_part_model(
     # stack (a base slab under a smaller stacked block) is a *staircase*, owned by the
     # step-height ladder; treating its base as a "plate" would wrongly suppress the step
     # dim (#559 review). This keeps the plate feature to the issue's stated domain.
-    if prof is None and rotational is None:
+    if not profiles and rotational is None:
         plates = recognise_plates(part) if plates is None else plates
         if multi_plate:
             for pl in plates:
@@ -1470,7 +1528,7 @@ def build_part_model(
 
     # Prismatic step-height ladder — horizontal face levels on a NON-turned part
     # (a turned part's steps are StepFeatures, dimensioned by the IR length chain).
-    if prof is None and step_zs:
+    if not profiles and step_zs:
         c = bbox.center()
         # FaceLevel v2 is an occurrence roster: disjoint bodies may establish the same scalar
         # Z height independently. The current StepLevelFeature is the global height-requirement

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -40,6 +40,19 @@ PLACEMENT_VIEWS = frozenset({"front", "plan", "side"})
 PLACEMENT_SIDES = frozenset({"above", "below", "left", "right"})
 
 
+class TurnedProfileIdentity(Protocol):
+    """Draftwright's structural view of a provider-owned turned-profile key."""
+
+    @property
+    def axis(self) -> str: ...
+
+    @property
+    def axis_origin(self) -> Point: ...
+
+    @property
+    def body_bounds(self) -> tuple[float, float, float, float, float, float]: ...
+
+
 def validate_placement_intent(view: str | None, side: str | None, *, owner: str) -> None:
     """Validate the shared declarative view/strip vocabulary.
 
@@ -800,6 +813,13 @@ class StepFeature:
     # are cosmetic and rarely modelled as geometry, so there is no recogniser — declare + render.
     thread: str | ThreadRequirement | None = None
     knurl: KnurlRequirement | None = None
+    #: Body-local recognition ownership. Structural provenance, not a printable quantity;
+    #: declared/legacy features may leave it absent and retain axis-line grouping (#1357).
+    profile: TurnedProfileIdentity | None = None
+    #: Draftwright-owned, serializable physical-profile identity. Generated Sheet programs use
+    #: this opaque token instead of exposing the provider's ``TurnedProfileKey``; ordinary
+    #: declarations may omit it and retain geometric grouping.
+    profile_group: str | None = None
     kind: ClassVar[str] = "step"
 
     def parameters(self) -> list[DimParameter]:

--- a/src/draftwright/recognition_frame.py
+++ b/src/draftwright/recognition_frame.py
@@ -1,13 +1,15 @@
-"""Owned boundary for provider-framed automatic recognition (#1357).
+"""Owned boundary for provider frames and body-local occurrence joins (#1357).
 
 The provider owns frame inference, topology-preserving normalisation, and the immutable
 recognition aggregate.  Draftwright owns the classification decision that selects the
 aggregate's rotational policy and the rule that the exact local working solid, cylinders,
-records, and frame travel as one unit.  This module deliberately provides no raw fallback.
+records, and frame travel as one unit. It also owns fail-closed joins between public provider
+records when an occurrence key is absent. This module deliberately provides no raw fallback.
 """
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
 
@@ -32,7 +34,67 @@ class FramedRecognitionContractError(RuntimeError):
 
 
 class MultipleTurnedProfilesError(ValueError):
-    """Draftwright's current Analysis waist cannot represent multiple turned profiles."""
+    """A caller requested the compatible singular view of a plural profile inventory."""
+
+
+class AmbiguousTurnedOwnershipError(RuntimeError):
+    """A released recognition record cannot identify one physical turned profile."""
+
+
+def profiles_owning_axial_band(
+    profiles: Iterable[Any],
+    *,
+    axis: str,
+    centre: tuple[float, float, float],
+    width: float,
+    axis_tol: float = 1e-6,
+    span_tol: float = 1e-3 + 1e-9,
+) -> tuple[Any, ...]:
+    """Profiles whose published axis line and axial span contain one record band."""
+
+    axis_index = "xyz".index(axis)
+    band_lo = float(centre[axis_index]) - float(width) / 2.0
+    band_hi = float(centre[axis_index]) + float(width) / 2.0
+    owners = []
+    for profile in profiles:
+        if profile.axis != axis:
+            continue
+        key = getattr(profile, "profile", None)
+        if key is not None and any(
+            abs(float(centre[index]) - float(key.axis_origin[index])) > axis_tol
+            for index in range(3)
+            if index != axis_index
+        ):
+            continue
+        shoulders = tuple(float(value) for value in profile.shoulders)
+        if (
+            shoulders
+            and min(shoulders) - span_tol <= band_lo
+            and band_hi <= max(shoulders) + span_tol
+        ):
+            owners.append(profile)
+    return tuple(owners)
+
+
+def require_unambiguous_groove_owner(groove: Any, profiles: Iterable[Any]) -> tuple[Any, ...]:
+    """Return the zero/one groove owner or refuse the missing provider contract."""
+
+    centre = getattr(groove, "at", None)
+    if centre is None:
+        centre = groove.frame.origin
+    owners = profiles_owning_axial_band(
+        profiles,
+        axis=groove.axis if hasattr(groove, "axis") else groove.frame.axis,
+        centre=centre,
+        width=groove.width,
+    )
+    if len(owners) > 1:
+        raise AmbiguousTurnedOwnershipError(
+            "a groove matches multiple body-local turned profiles, but "
+            "b123d-recognisers 0.4.9 Groove records carry no profile identity; "
+            "refusing to guess (https://github.com/pzfreo/b123d-recognisers/issues/354)"
+        )
+    return owners
 
 
 @dataclass(frozen=True, slots=True)
@@ -178,18 +240,19 @@ def prepare_framed_detection(part: Shape) -> FramedDetection | FramedDetectionRe
 
 
 def single_turned_profile(result: RecognitionResult) -> TurnedProfile | None:
-    """Return the only physical turned profile, refusing an unsupported plural result."""
+    """Return the zero/one compatible projection, refusing a plural inventory."""
 
     profiles = result.turned_profiles
     if len(profiles) > 1:
         raise MultipleTurnedProfilesError(
-            "Draftwright does not yet support multiple physical turned profiles in one "
-            f"detected part (recognised {len(profiles)})"
+            "single_turned_profile() requires zero or one physical profile, but the result "
+            f"contains {len(profiles)}; consume result.turned_profiles or Analysis.profiles"
         )
     return profiles[0] if profiles else None
 
 
 __all__ = [
+    "AmbiguousTurnedOwnershipError",
     "FramePolicy",
     "FramedDetection",
     "FramedDetectionRefusal",
@@ -199,5 +262,7 @@ __all__ = [
     "classify_geometry",
     "frame_policy",
     "prepare_framed_detection",
+    "profiles_owning_axial_band",
+    "require_unambiguous_groove_owner",
     "single_turned_profile",
 ]

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -592,6 +592,7 @@ def _feature_line(
     origin_ref: str | None = None,
     object_ref: str | None = None,
     exact_parameter: str | None = None,
+    profile_group: str | None = None,
 ) -> str:
     """The declaration for one feature.
 
@@ -735,13 +736,14 @@ def _feature_line(
             f", thread={_thread_arg(f.thread)}" if getattr(f, "thread", None) else ""
         )  # external thread (#859)
         knurl = f", knurl={_knurl_arg(f.knurl)}" if getattr(f, "knurl", None) else ""
+        group = f", profile_group={profile_group!r}" if profile_group is not None else ""
         if object_ref is not None:
-            return f"sheet.step({object_ref}{thr}{knurl})"
+            return f"sheet.step({object_ref}{thr}{knurl}{group})"
         return (
             "sheet.step("
             f"diameter={_parameter_n(f.diameter, 'step.diameter', exact_parameter)}, "
             f"length={_n(f.length)}, "
-            f'at={_pt(f.frame.origin)}, axis="{f.frame.axis}"{thr}{knurl})'
+            f'at={_pt(f.frame.origin)}, axis="{f.frame.axis}"{thr}{knurl}{group})'
         )
     if k == "slot":
         lo, hi = _n(f.lo), _n(f.hi)
@@ -1449,6 +1451,41 @@ def _feature_block(
     if not features:
         return ["# ── Features: none detected ──"], {}
     source_features = tuple(features)
+    detected_profile_groups: dict[object, str] = {}
+    profile_group_by_feature: dict[int, str] = {}
+    reserved_profile_groups = {
+        group
+        for feature in source_features
+        if feature.kind == "step"
+        for group in (getattr(feature, "profile_group", None),)
+        if group is not None
+    }
+
+    def detected_profile_token() -> str:
+        """Mint a stable generated token without entering the caller's namespace."""
+        index = len(detected_profile_groups) + 1
+        token = f"detected-profile-{index}"
+        while token in reserved_profile_groups:
+            index += 1
+            token = f"detected-profile-{index}"
+        reserved_profile_groups.add(token)
+        return token
+
+    for feature in source_features:
+        if feature.kind != "step":
+            continue
+        declared_group = getattr(feature, "profile_group", None)
+        if declared_group is not None:
+            profile_group_by_feature[id(feature)] = declared_group
+            continue
+        provider_group = getattr(feature, "profile", None)
+        if provider_group is None:
+            continue
+        token = detected_profile_groups.get(provider_group)
+        if token is None:
+            token = detected_profile_token()
+            detected_profile_groups[provider_group] = token
+        profile_group_by_feature[id(feature)] = token
     out = [f"# ── Features ({len(source_features)}): {_manifest(source_features)} ──"]
     features = tuple(f for f in source_features if f.kind != "note") + tuple(
         f for f in source_features if f.kind == "note"
@@ -1465,6 +1502,8 @@ def _feature_block(
         summary = _run_summary(run)
         out.append(f"#   {section}" + (f" · {summary}" if summary else "") + " ─────")
         for f in run:
+            profile_group = profile_group_by_feature.get(id(f))
+            profile_kw = {} if profile_group is None else {"profile_group": profile_group}
             gdt_with_origin = f.kind in ("control_frame", "datum_ref", "note")
             origin_ref = names.get(id(f.origin)) if gdt_with_origin else None
             if (
@@ -1506,28 +1545,45 @@ def _feature_block(
             object_ref = None if exact_parameter is not None else (object_refs or {}).get(id(f))
             if gdt_with_origin:
                 if exact_parameter is None:
-                    line = _feature_line(f, part_envelope, origin_ref=origin_ref)
+                    line = _feature_line(
+                        f,
+                        part_envelope,
+                        origin_ref=origin_ref,
+                        **profile_kw,
+                    )
                 else:
                     line = _feature_line(
                         f,
                         part_envelope,
                         origin_ref=origin_ref,
                         exact_parameter=exact_parameter,
+                        **profile_kw,
                     )
             elif object_ref is not None:
                 if exact_parameter is None:
-                    line = _feature_line(f, part_envelope, object_ref=object_ref)
+                    line = _feature_line(
+                        f,
+                        part_envelope,
+                        object_ref=object_ref,
+                        **profile_kw,
+                    )
                 else:
                     line = _feature_line(
                         f,
                         part_envelope,
                         object_ref=object_ref,
                         exact_parameter=exact_parameter,
+                        **profile_kw,
                     )
             elif exact_parameter is not None:
-                line = _feature_line(f, part_envelope, exact_parameter=exact_parameter)
+                line = _feature_line(
+                    f,
+                    part_envelope,
+                    exact_parameter=exact_parameter,
+                    **profile_kw,
+                )
             else:
-                line = _feature_line(f, part_envelope)
+                line = _feature_line(f, part_envelope, **profile_kw)
             diameter_role = {
                 "hole": "bore",
                 "pattern": "bore",

--- a/tests/test_issue_1351_structured_note_coverage.py
+++ b/tests/test_issue_1351_structured_note_coverage.py
@@ -432,8 +432,10 @@ def test_groove_length_authority_requires_exact_physical_band_correspondence():
         sheet = Sheet.from_part(part).take_over(
             dimensions="authored", principal_views="automatic", derived_views="authored"
         )
-        step = next(feature for feature in sheet.features if feature.kind == "step")
-        sheet.note("ONE AXIAL SEGMENT", step, satisfies=("step.length",))
+        # Both surrounding bands are independent requirements. The groove width supplies only
+        # the narrow middle band; one step plus one groove must not falsely certify all three.
+        for step in (feature for feature in sheet.features if feature.kind == "step"):
+            sheet.note("AXIAL SEGMENT", step, satisfies=("step.length",))
         if wrong_axis:
             groove = sheet.groove(axis="x", width=4, diameter=16, at=(0, 0, 0))
             groove.note("4 WIDE GROOVE", satisfies=("groove.length",))

--- a/tests/test_issue_1357_framed_activation.py
+++ b/tests/test_issue_1357_framed_activation.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+import pytest
 from b123d_recognisers import FrameRefusalReason
-from build123d import Align, Box, Cylinder, Pos, Rot
+from build123d import Align, Box, Compound, Cylinder, Pos, Rot
 
 from draftwright import build_drawing
 from draftwright.audit import diff_builds
@@ -22,6 +23,11 @@ def _part():
 
 def _x_stepped_shaft():
     return Rot(0, 90, 0) * (Cylinder(15, 40) + Pos(0, 0, 35) * Cylinder(8, 30))
+
+
+def _parallel_stepped_shafts():
+    shaft = Cylinder(15, 20) + Pos(0, 0, 20) * Cylinder(10, 20)
+    return Compound(children=[Pos(-50, 0, 0) * shaft, Pos(50, 0, 0) * shaft])
 
 
 def _pattern_part():
@@ -112,6 +118,56 @@ def test_scale_retries_reuse_one_framed_preparation(monkeypatch):
     monkeypatch.setattr(analysis, "prepare_framed_detection", counted)
     build_drawing(_part(), scale=5, framed_recognition=True)
     assert calls == 1
+
+
+@pytest.mark.parametrize("framed_recognition", (False, True))
+def test_plural_profiles_survive_raw_and_framed_scale_retries(monkeypatch, framed_recognition):
+    from draftwright import analysis
+
+    calls = 0
+    original = analysis.prepare_framed_detection
+
+    def counted(part):
+        nonlocal calls
+        calls += 1
+        return original(part)
+
+    monkeypatch.setattr(analysis, "prepare_framed_detection", counted)
+    drawing = build_drawing(
+        _parallel_stepped_shafts(),
+        scale=10,
+        framed_recognition=framed_recognition,
+    )
+
+    assert calls == int(framed_recognition)
+    assert drawing.recognition_frame_decision["status"] == (
+        "framed" if framed_recognition else "raw"
+    )
+    assert drawing.scale_decision["status"] == "fallback"
+    assert len(drawing.scale_decision["attempted_scales"]) > 1
+    steps = [feature for feature in drawing.model().features if feature.kind == "step"]
+    assert len(steps) == 4
+    profiles = {feature.profile for feature in steps}
+    assert len(profiles) == 2
+    assert len([name for name in drawing.annotations() if name.startswith("m_steplen")]) == 4
+    assert not [issue for issue in drawing.lint() if issue.code == "axial_length_missing"]
+
+    target_profile = next(iter(profiles))
+    target_names = {
+        name
+        for name in drawing.annotations()
+        if name.startswith("m_steplen")
+        and any(
+            identity.feature.profile == target_profile
+            for identity in drawing.registry.measurement_of(name)
+        )
+    }
+    assert len(target_names) == 2
+    for name in target_names:
+        drawing.remove(name)
+    issues = [issue for issue in drawing.lint() if issue.code == "axial_length_missing"]
+    assert len(issues) == 1
+    assert "only 0 step length(s) dimensioned" in issues[0].message
 
 
 def test_rigid_motion_preserves_requirements_and_build_diff():

--- a/tests/test_issue_1357_framed_boundary.py
+++ b/tests/test_issue_1357_framed_boundary.py
@@ -220,7 +220,7 @@ def test_equal_body_local_level_occurrences_project_to_one_global_height_rung() 
     assert support.x_span[1] - support.x_span[0] == pytest.approx(20.0)
 
 
-def test_multiple_body_local_turned_profiles_are_visible_but_fail_closed_at_the_singular_waist():
+def test_multiple_body_local_turned_profiles_are_visible_and_the_legacy_singular_accessor_refuses():
     source = Compound(
         children=[Pos(-50, 0, 0) * _stepped_shaft(), Pos(50, 0, 0) * _stepped_shaft()]
     )
@@ -228,10 +228,10 @@ def test_multiple_body_local_turned_profiles_are_visible_but_fail_closed_at_the_
 
     assert len(result.turned_profiles) == 2
     assert len({profile.profile for profile in result.turned_profiles}) == 2
-    with pytest.raises(MultipleTurnedProfilesError, match=r"recognised 2"):
+    with pytest.raises(MultipleTurnedProfilesError, match=r"contains 2"):
         single_turned_profile(result)
-    with pytest.raises(MultipleTurnedProfilesError, match=r"recognised 2"):
-        build_part_model(source)
+    model = build_part_model(source)
+    assert len([feature for feature in model.features if feature.kind == "step"]) == 4
 
 
 def test_framed_classifier_rejects_an_eccentric_parallel_cylinder_compound() -> None:
@@ -262,21 +262,20 @@ def test_framed_classifier_rejects_equal_diameter_eccentric_bands_on_one_body() 
     assert detection.result.rotational is False
 
 
-def test_raw_production_preserves_plural_compounds_without_selecting_or_merging(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
+def test_raw_production_compiles_plural_compounds_without_selecting_or_merging() -> None:
     from draftwright import build_drawing
 
     source = Compound(
         children=[Pos(-50, 0, 0) * _stepped_shaft(), Pos(50, 0, 0) * _stepped_shaft()]
     )
 
-    with caplog.at_level("WARNING", logger="draftwright.analysis"):
-        drawing = build_drawing(source)
+    drawing = build_drawing(source)
 
     assert len(drawing.recognition().turned_profiles) == 2
-    assert not [feature for feature in drawing.model().features if feature.kind == "step"]
-    assert "singular Analysis waist defers them to #1357" in caplog.text
+    steps = [feature for feature in drawing.model().features if feature.kind == "step"]
+    assert len(steps) == 4
+    assert {step.frame.origin[:2] for step in steps} == {(-50.0, 0.0), (50.0, 0.0)}
+    assert len({step.profile for step in steps}) == 2
 
 
 def test_zero_or_one_physical_turned_profile_preserves_the_existing_analysis_shape() -> None:

--- a/tests/test_issue_1357_plural_turned_profiles.py
+++ b/tests/test_issue_1357_plural_turned_profiles.py
@@ -1,0 +1,1013 @@
+"""Plural body-local turned-profile compiler waist for #1357."""
+
+from __future__ import annotations
+
+import typing
+from dataclasses import replace
+
+import pytest
+from build123d import Align, Axis, Box, Compound, Cylinder, Pos, Rot
+
+from draftwright import Sheet, build_drawing
+from draftwright.linting.coverage import _dim_vertices, lint_axial_coverage
+from draftwright.model.detect import build_part_model
+from draftwright.sheet_emit import emit_sheet_script
+
+
+def _stepped_shaft():
+    return Cylinder(15, 20) + Pos(0, 0, 20) * Cylinder(10, 20)
+
+
+def _parallel_shafts():
+    return Compound(children=[Pos(-50, 0, 0) * _stepped_shaft(), Pos(50, 0, 0) * _stepped_shaft()])
+
+
+def _depth_separated_shafts():
+    return Compound(children=[Pos(0, -50, 0) * _stepped_shaft(), Pos(0, 50, 0) * _stepped_shaft()])
+
+
+def _three_shaft_l():
+    return Compound(
+        children=[
+            _stepped_shaft(),
+            Pos(0, 100, 0) * _stepped_shaft(),
+            Pos(100, 0, 0) * _stepped_shaft(),
+        ]
+    )
+
+
+def _crowded_x_shaft():
+    shaft = None
+    z = 0.0
+    for diameter, length in ((4, 1.5), (6, 2.0), (4, 2.5), (3, 25.0)):
+        segment = Pos(0, 0, z) * Cylinder(
+            diameter / 2,
+            length,
+            align=(Align.CENTER, Align.CENTER, Align.MIN),
+        )
+        shaft = segment if shaft is None else shaft + segment
+        z += length
+    return Rot(0, 90, 0) * shaft
+
+
+def _three_axially_disjoint_shafts():
+    return Compound(children=[Pos(0, 0, z) * _stepped_shaft() for z in (0.0, 100.0, 200.0)])
+
+
+def test_standalone_compiler_keeps_every_body_local_turned_profile():
+    model = build_part_model(_parallel_shafts())
+    steps = [feature for feature in model.features if feature.kind == "step"]
+
+    assert len(steps) == 4
+    assert model.orientation == "z"
+    assert len({step.profile for step in steps}) == 2
+    assert all(step.profile is not None for step in steps)
+    assert {step.frame.origin[:2] for step in steps} == {(-50.0, 0.0), (50.0, 0.0)}
+    assert {(step.span[0][2], step.span[1][2], step.diameter) for step in steps} == {
+        (-10.0, 10.0, 30.0),
+        (10.0, 30.0, 20.0),
+    }
+    assert not [
+        feature for feature in model.features if feature.kind in ("envelope", "step_level")
+    ]
+
+
+def test_explicit_plural_input_is_the_same_compiler_contract_as_aggregate_discovery():
+    from b123d_recognisers import build_raw_recognition_result
+
+    part = _parallel_shafts()
+    recognition = build_raw_recognition_result(part, rotational=True)
+
+    detected = build_part_model(part)
+    injected = build_part_model(
+        part,
+        profiles=recognition.turned_profiles,
+        holes=recognition.holes,
+        double_d_bores=recognition.double_d_bores,
+        patterns=recognition.hole_patterns,
+        bosses=recognition.bosses,
+        polygonal_bosses=recognition.polygonal_bosses,
+        polygonal_stock=recognition.polygonal_stock,
+        channels=recognition.channels,
+        slots=recognition.slots,
+        slot_patterns=recognition.slot_patterns,
+        risers=recognition.risers,
+        chamfers=recognition.chamfers,
+        fillets=recognition.fillets,
+        circular_blind_steps=recognition.circular_blind_steps,
+        paired_ramp_steps=recognition.paired_ramp_steps,
+        through_steps=recognition.through_steps,
+        plates=recognition.plates,
+        grooves=recognition.grooves,
+        flats=recognition.flats,
+        pockets=recognition.pockets,
+        pocket_patterns=recognition.pocket_patterns,
+        pads=recognition.pads,
+        step_zs=recognition.step_ladder_for_z_span(
+            part.bounding_box().min.Z, part.bounding_box().max.Z
+        ),
+        face_levels=recognition.step_levels,
+        cyls=recognition.cylinders,
+    )
+
+    assert injected.orientation == detected.orientation
+    assert injected.features == detected.features
+    assert injected.datums == detected.datums
+    assert injected.decorations == detected.decorations
+
+    with pytest.raises(ValueError, match="supply profiles= or the compatible singular prof="):
+        build_part_model(part, prof=None, profiles=recognition.turned_profiles)
+
+
+def test_parallel_profiles_render_independent_chains_with_body_local_provenance():
+    drawing = build_drawing(_parallel_shafts(), title="PARALLEL SHAFTS", number="1357")
+    names = [name for name in drawing.annotations() if name.startswith("m_steplen")]
+
+    assert names == ["m_steplen0", "m_steplen1", "m_steplen2", "m_steplen3"]
+    assert [
+        tuple(identity.feature.frame.origin for identity in drawing.registry.measurement_of(name))
+        for name in names
+    ] == [
+        ((-50.0, 0.0, 0.0),),
+        ((-50.0, 0.0, 20.0),),
+        ((50.0, 0.0, 0.0),),
+        ((50.0, 0.0, 20.0),),
+    ]
+    assert not [issue for issue in drawing.lint() if issue.code == "axial_length_missing"]
+
+
+def test_one_parallel_profile_cannot_supply_another_profiles_axial_coverage():
+    drawing = build_drawing(_parallel_shafts(), title="PARALLEL SHAFTS", number="1357")
+    drawing.remove("m_steplen2")
+    drawing.remove("m_steplen3")
+
+    issues = [issue for issue in drawing.lint() if issue.code == "axial_length_missing"]
+
+    assert len(issues) == 1
+    assert "z-axis line (50.0, 0.0)" in issues[0].message
+    assert "only 0 step length(s) dimensioned" in issues[0].message
+
+
+def test_reused_declared_group_token_still_requires_the_same_physical_axis_line():
+    sheet = Sheet(_parallel_shafts(), title="REUSED GROUP", number="1357-RG")
+    for x in (-50.0, 50.0):
+        for diameter, z in ((30.0, 0.0), (20.0, 20.0)):
+            step = sheet.step(
+                diameter=diameter,
+                length=20,
+                at=(x, 0, z),
+                axis="z",
+                profile_group="same",
+            )
+            sheet.dimension(step, "step.length")
+    drawing = sheet.build()
+    far_names = [
+        name
+        for name in drawing.annotations()
+        if name.startswith("m_steplen")
+        and any(
+            identity.feature.frame.origin[0] == 50.0
+            for identity in drawing.registry.measurement_of(name)
+        )
+    ]
+    assert len(far_names) == 2
+    for name in far_names:
+        drawing.remove(name)
+
+    issues = [issue for issue in drawing.lint() if issue.code == "axial_length_missing"]
+    assert len(issues) == 1
+    assert "z-axis line (50.0, 0.0)" in issues[0].message
+
+
+def test_reused_group_token_does_not_merge_nearby_submillimetre_axis_lines():
+    tiny = Cylinder(0.05, 10) + Pos(0, 0, 10) * Cylinder(0.04, 10)
+    part = Compound(children=[tiny, Pos(0.4, 0, 0) * tiny])
+    sheet = Sheet(part, title="NEAR AXES", number="1357-NEAR")
+    for x in (0.0, 0.4):
+        for diameter, z in ((0.1, 0.0), (0.08, 10.0)):
+            step = sheet.step(
+                diameter=diameter,
+                length=10,
+                at=(x, 0, z),
+                axis="z",
+                profile_group="same",
+            )
+            sheet.dimension(step, "step.length")
+    drawing = sheet.build()
+    far_names = [
+        name
+        for name in drawing.annotations()
+        if name.startswith("m_steplen")
+        and any(
+            identity.feature.frame.origin[0] == pytest.approx(0.4)
+            for identity in drawing.registry.measurement_of(name)
+        )
+    ]
+    assert len(far_names) == 2
+    for name in far_names:
+        drawing.remove(name)
+
+    issues = [issue for issue in drawing.lint() if issue.code == "axial_length_missing"]
+    assert len(issues) == 1
+    assert "z-axis line (0.4, 0.0)" in issues[0].message
+
+
+def test_parallel_profiles_use_the_orthographic_view_that_separates_their_axis_lines():
+    drawing = build_drawing(_depth_separated_shafts(), title="DEPTH SHAFTS", number="1357-Y")
+
+    front = [
+        name
+        for name, _annotation in drawing.annotations_in_view("front")
+        if name.startswith("m_steplen")
+    ]
+    side = [
+        name
+        for name, _annotation in drawing.annotations_in_view("side")
+        if name.startswith("m_steplen")
+    ]
+
+    assert len(front) == 2
+    assert len(side) == 2
+    assert not [
+        issue
+        for issue in drawing.lint()
+        if issue.code in ("annotation_overlap", "annotation_ink_overlap", "axial_length_missing")
+    ]
+
+
+def test_deferred_profile_replay_keeps_surviving_sibling_in_view_assignment():
+    drawing = build_drawing(
+        _depth_separated_shafts(), title="DEFERRED PROFILE", number="1357-EDIT"
+    )
+    side_names = [
+        name
+        for name, _annotation in drawing.annotations_in_view("side")
+        if name.startswith("m_steplen")
+    ]
+    assert len(side_names) == 2
+    replay_features = {
+        identity.feature
+        for name in side_names
+        for identity in drawing.registry.measurement_of(name)
+    }
+    assert len(replay_features) == 2
+    for name in side_names:
+        drawing.remove(name)
+
+    with drawing.deferred():
+        for feature in replay_features:
+            drawing.dimension(feature, "length", role="step")
+
+    replayed_names = {
+        name
+        for name in drawing.annotations()
+        if name.startswith("m_steplen")
+        and any(
+            identity.feature in replay_features
+            for identity in drawing.registry.measurement_of(name)
+        )
+    }
+    assert len(replayed_names) == 2
+    assert {drawing.view_of(name) for name in replayed_names} == {"side"}
+    assert not [
+        issue
+        for issue in drawing.lint()
+        if issue.code in ("annotation_overlap", "annotation_ink_overlap", "axial_length_missing")
+    ]
+
+
+def test_profile_view_assignment_uses_both_views_and_lint_keeps_exact_body_ownership():
+    drawing = build_drawing(_three_shaft_l(), title="L SHAFTS", number="1357-L")
+    chain_views = {
+        name: drawing.view_of(name)
+        for name in drawing.annotations()
+        if name.startswith("m_steplen")
+    }
+
+    assert len(chain_views) == 6
+    assert set(chain_views.values()) == {"front", "side"}
+    assert not [
+        issue
+        for issue in drawing.lint()
+        if issue.code in ("annotation_overlap", "annotation_ink_overlap", "axial_length_missing")
+    ]
+
+    target_names = [
+        name
+        for name in chain_views
+        if any(
+            identity.feature.frame.origin[:2] == (0.0, 100.0)
+            for identity in drawing.registry.measurement_of(name)
+        )
+    ]
+    assert len(target_names) == 2
+    for name in target_names:
+        drawing.remove(name)
+
+    issues = [issue for issue in drawing.lint() if issue.code == "axial_length_missing"]
+    assert len(issues) == 1
+    assert "z-axis line (0.0, 100.0)" in issues[0].message
+
+
+def test_unassignable_profile_grid_drops_ambiguous_chains_and_lint_fails_closed():
+    part = Compound(
+        children=[
+            Pos(x, y, 0) * _stepped_shaft()
+            for x in (-100.0, 0.0, 100.0)
+            for y in (-100.0, 0.0, 100.0)
+        ]
+    )
+    drawing = build_drawing(part, title="SHAFT GRID", number="1357-G")
+    relevant = [
+        issue
+        for issue in drawing.lint()
+        if issue.code
+        in (
+            "step_dim_dropped",
+            "axial_length_missing",
+            "annotation_overlap",
+            "annotation_ink_overlap",
+        )
+    ]
+
+    assert len([name for name in drawing.annotations() if name.startswith("m_steplen")]) == 12
+    assert [issue.code for issue in relevant].count("step_dim_dropped") == 3
+    assert [issue.code for issue in relevant].count("axial_length_missing") == 3
+    assert not [issue for issue in relevant if issue.code.endswith("overlap")]
+
+
+def test_authored_front_only_view_drops_a_superimposed_profile_instead_of_overlapping():
+    sheet = Sheet(_depth_separated_shafts(), title="FRONT ONLY", number="1357-F")
+    for group, y in (("near", -50.0), ("far", 50.0)):
+        for diameter, length, z in ((30.0, 20.0, 0.0), (20.0, 20.0, 20.0)):
+            step = sheet.step(
+                diameter=diameter,
+                length=length,
+                at=(0.0, y, z),
+                axis="z",
+                profile_group=group,
+            )
+            sheet.dimension(step, "step.length")
+    sheet.view("front")
+    drawing = sheet.build()
+
+    relevant = [
+        issue
+        for issue in drawing.lint()
+        if issue.code in ("step_dim_dropped", "axial_length_missing", "annotation_overlap")
+    ]
+    assert len([name for name in drawing.annotations() if name.startswith("m_steplen")]) == 2
+    assert [issue.code for issue in relevant].count("step_dim_dropped") == 1
+    assert [issue.code for issue in relevant].count("axial_length_missing") == 1
+    assert not [issue for issue in relevant if issue.code == "annotation_overlap"]
+
+    # Deferred replay still solves against the complete roster. Requesting the hidden profile
+    # alone must not make it look assignable by forgetting the sibling that already owns this
+    # sole longitudinal view.
+    assigned_names = {name for name in drawing.annotations() if name.startswith("m_steplen")}
+    hidden_features = {
+        feature
+        for feature in drawing.model().features
+        if feature.kind == "step" and feature.frame.origin[1] == 50.0
+    }
+    assert len(assigned_names) == 2
+    assert len(hidden_features) == 2
+    with drawing.deferred():
+        for feature in hidden_features:
+            drawing.dimension(feature, "length", role="step")
+    assert {
+        name for name in drawing.annotations() if name.startswith("m_steplen")
+    } == assigned_names
+    post_replay = [
+        issue
+        for issue in drawing.lint()
+        if issue.code in ("axial_length_missing", "step_dim_dropped", "annotation_overlap")
+    ]
+    assert [issue.code for issue in post_replay].count("axial_length_missing") == 1
+    assert [issue.code for issue in post_replay].count("step_dim_dropped") == 2
+    assert not [issue for issue in post_replay if issue.code == "annotation_overlap"]
+    assert "z-axis line (0.0, 50.0)" in next(
+        issue.message for issue in post_replay if issue.code == "axial_length_missing"
+    )
+
+
+def test_declared_parallel_steps_keep_their_caller_coordinate_axis_lines():
+    part = _parallel_shafts()
+    drawing = build_drawing(
+        part,
+        model=build_part_model(part),
+        title="DECLARED PARALLEL SHAFTS",
+        number="1357-D",
+    )
+
+    steps = [feature for feature in drawing.model().features if feature.kind == "step"]
+    assert {step.frame.origin[:2] for step in steps} == {(-50.0, 0.0), (50.0, 0.0)}
+    assert len([name for name in drawing.annotations() if name.startswith("m_steplen")]) == 4
+    assert not [issue for issue in drawing.lint() if issue.code == "axial_length_missing"]
+
+
+def test_generated_script_reconstructs_plural_grouping_without_provider_keys():
+    part = _parallel_shafts()
+    source = emit_sheet_script(
+        build_part_model(part),
+        "part",
+        "plural",
+        title="SCRIPT PARALLEL SHAFTS",
+        number="1357-S",
+    )
+    namespace = {"part": part}
+    exec(  # noqa: S102 - the generated public Sheet source is the contract under test
+        compile(source[: source.index("drawing = sheet.build()")], "<issue-1357>", "exec"),
+        namespace,
+    )
+    drawing = namespace["sheet"].build()
+
+    assert "TurnedProfileKey" not in source
+    assert "profile_group='detected-profile-" in source
+    assert len([name for name in drawing.annotations() if name.startswith("m_steplen")]) == 4
+    assert not [issue for issue in drawing.lint() if issue.code == "axial_length_missing"]
+
+
+def test_emitted_groove_band_retains_detected_axial_denominator_after_mutation():
+    shaft = Cylinder(12, 100, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    shaft -= Pos(0, 0, 45) * (
+        Cylinder(12, 10, align=(Align.CENTER, Align.CENTER, Align.MIN))
+        - Cylinder(9, 10, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    )
+    model = build_part_model(shaft)
+    direct = build_drawing(shaft, title="GROOVED", number="1357-GROOVE-DIRECT")
+
+    source = emit_sheet_script(
+        model,
+        "part",
+        "grooved",
+        title="GROOVED",
+        number="1357-GROOVE-EMITTED",
+    )
+    namespace = {"part": shaft}
+    exec(  # noqa: S102 - the generated public Sheet source is the contract under test
+        compile(source[: source.index("drawing = sheet.build()")], "<issue-1357-groove>", "exec"),
+        namespace,
+    )
+    emitted = namespace["sheet"].build()
+
+    messages = []
+    for drawing in (direct, emitted):
+        step_name = next(name for name in drawing.annotations() if name.startswith("m_steplen"))
+        drawing.remove(step_name)
+        issues = [issue for issue in drawing.lint() if issue.code == "axial_length_missing"]
+        assert len(issues) == 1
+        messages.append(issues[0].message)
+
+    assert all("3 axial steps but only 2 step length(s) dimensioned" in msg for msg in messages)
+
+
+def test_generated_script_preserves_adjacent_coaxial_body_partition():
+    part = Compound(children=[_stepped_shaft(), Pos(0, 0, 40) * _stepped_shaft()])
+    source = emit_sheet_script(
+        build_part_model(part),
+        "part",
+        "coaxial",
+        title="COAXIAL SHAFTS",
+        number="1357-C",
+    )
+    namespace = {"part": part}
+    exec(  # noqa: S102 - the generated public Sheet source is the contract under test
+        compile(source[: source.index("drawing = sheet.build()")], "<issue-1357-coaxial>", "exec"),
+        namespace,
+    )
+    drawing = namespace["sheet"].build()
+
+    assert source.count("profile_group='detected-profile-1'") == 2
+    assert source.count("profile_group='detected-profile-2'") == 2
+    names = [name for name in drawing.annotations() if name.startswith("m_steplen")]
+    assert names == ["m_steplen0", "m_steplen1", "m_steplen2", "m_steplen3"]
+    assert not [issue for issue in drawing.lint() if issue.code == "axial_length_missing"]
+
+
+def test_axially_disjoint_coaxial_profiles_reuse_a_view_lane_and_round_trip():
+    part = _three_axially_disjoint_shafts()
+    direct = build_drawing(part, title="SEPARATED COAXIAL SHAFTS", number="1357-3C")
+
+    assert len([name for name in direct.annotations() if name.startswith("m_steplen")]) == 6
+    assert not [
+        issue
+        for issue in direct.lint()
+        if issue.code in ("step_dim_dropped", "axial_length_missing", "annotation_overlap")
+    ]
+
+    source = emit_sheet_script(
+        build_part_model(part),
+        "part",
+        "three_coaxial",
+        title="SEPARATED COAXIAL SHAFTS",
+        number="1357-3C",
+    )
+    namespace = {"part": part}
+    exec(  # noqa: S102 - the generated public Sheet source is the contract under test
+        compile(source[: source.index("drawing = sheet.build()")], "<issue-1357-3c>", "exec"),
+        namespace,
+    )
+    rebuilt = namespace["sheet"].build()
+
+    assert len([name for name in rebuilt.annotations() if name.startswith("m_steplen")]) == 6
+    assert not [issue for issue in rebuilt.lint() if issue.code == "axial_length_missing"]
+
+
+def test_global_step_misuse_guard_is_scoped_to_one_physical_solid():
+    compound = Compound(children=[_stepped_shaft(), Pos(0, 0, 100) * Box(10, 10, 10)])
+    drawing = build_drawing(compound, model=build_part_model(compound), number="1357-GUARD")
+    assert len([feature for feature in drawing.model().features if feature.kind == "step"]) == 2
+
+    solid = Pos(0, 0, 20) * Cylinder(10, 40)
+    sheet = Sheet(solid, number="1357-GUARD-ONE").auto_dimensions()
+    sheet.step(
+        diameter=20,
+        length=15,
+        at=(0, 0, 0),
+        axis="z",
+        profile_group="caller-a",
+    )
+    sheet.step(
+        diameter=20,
+        length=15,
+        at=(0, 0, 25),
+        axis="z",
+        profile_group="caller-b",
+    )
+    with pytest.raises(ValueError, match="don't span this part's full height"):
+        sheet.build()
+
+
+def test_generated_profile_tokens_cannot_collide_with_authored_group_namespace():
+    part = Compound(children=[_stepped_shaft(), Pos(0, 0, 40) * _stepped_shaft()])
+    detected = build_part_model(part)
+    provider_groups = {feature.profile for feature in detected.features if feature.kind == "step"}
+    authored_provider_group = min(provider_groups, key=repr)
+    mixed = replace(
+        detected,
+        features=[
+            replace(feature, profile=None, profile_group="detected-profile-1")
+            if feature.kind == "step" and feature.profile == authored_provider_group
+            else feature
+            for feature in detected.features
+        ],
+    )
+
+    source = emit_sheet_script(
+        mixed,
+        "part",
+        "mixed_groups",
+        title="MIXED PROFILE GROUPS",
+        number="1357-T",
+    )
+    namespace = {"part": part}
+    exec(  # noqa: S102 - the generated public Sheet source is the contract under test
+        compile(source[: source.index("drawing = sheet.build()")], "<issue-1357-token>", "exec"),
+        namespace,
+    )
+    rebuilt = namespace["sheet"].build()
+    rebuilt_steps = [feature for feature in rebuilt.model().features if feature.kind == "step"]
+
+    assert source.count("profile_group='detected-profile-1'") == 2
+    assert source.count("profile_group='detected-profile-2'") == 2
+    assert {feature.profile_group for feature in rebuilt_steps} == {
+        "detected-profile-1",
+        "detected-profile-2",
+    }
+    assert len([name for name in rebuilt.annotations() if name.startswith("m_steplen")]) == 4
+
+
+def test_emitted_coaxial_profiles_keep_exact_lint_ownership_after_chain_removal():
+    rod = Cylinder(5, 20) + Pos(0, 0, 20) * Cylinder(4, 20)
+    part = Compound(children=[_stepped_shaft(), rod])
+    source = emit_sheet_script(
+        build_part_model(part),
+        "part",
+        "coaxial_nested",
+        title="COAXIAL NESTED SHAFTS",
+        number="1357-LINT",
+    )
+    namespace = {"part": part}
+    exec(  # noqa: S102 - the generated public Sheet source is the contract under test
+        compile(source[: source.index("drawing = sheet.build()")], "<issue-1357-lint>", "exec"),
+        namespace,
+    )
+    drawing = namespace["sheet"].build()
+    rod_chains = [
+        name
+        for name in drawing.annotations()
+        if name.startswith("m_steplen")
+        and any(
+            identity.feature.diameter <= 10 for identity in drawing.registry.measurement_of(name)
+        )
+    ]
+    assert len(rod_chains) == 2
+    for name in rod_chains:
+        drawing.remove(name)
+
+    issues = [issue for issue in drawing.lint() if issue.code == "axial_length_missing"]
+    assert len(issues) == 1
+
+
+def test_ambiguous_nested_groove_ownership_refuses_missing_upstream_identity():
+    from b123d_recognisers import Groove, TurnedProfile, TurnedProfileKey, TurnedStep
+
+    from draftwright.recognition_frame import AmbiguousTurnedOwnershipError
+
+    def profile(radius, specs):
+        key = TurnedProfileKey(
+            "z",
+            (0, 0, 0),
+            (-radius, radius, -radius, radius, -10, 10),
+        )
+        return TurnedProfile.from_steps(
+            TurnedStep("z", lo, hi, diameter, key) for lo, hi, diameter in specs
+        )
+
+    outer = profile(15, [(-10, 0, 30), (0, 2, 30), (2, 10, 25)])
+    inner = profile(5, [(-10, 0, 10), (0, 2, 8), (2, 10, 10)])
+    groove = Groove(axis="z", width=2, diameter=20, at=(0, 0, 1))
+    part = Compound(children=[Cylinder(15, 20), Cylinder(5, 20)])
+
+    with pytest.raises(AmbiguousTurnedOwnershipError, match="issues/354"):
+        build_part_model(
+            part,
+            profiles=(outer, inner),
+            grooves=(groove,),
+            step_zs=(),
+            face_levels=(),
+        )
+
+
+def test_groove_owner_uses_published_axis_precision_for_nearby_profiles():
+    from b123d_recognisers import TurnedProfile, TurnedProfileKey, TurnedStep
+
+    from draftwright.recognition_frame import profiles_owning_axial_band
+
+    def profile(x):
+        key = TurnedProfileKey("z", (x, 0, 0), (x - 0.05, x + 0.05, -0.05, 0.05, 0, 20))
+        result = TurnedProfile.from_steps(
+            (
+                TurnedStep("z", 0, 9, 0.1, key),
+                TurnedStep("z", 9, 11, 0.08, key),
+                TurnedStep("z", 11, 20, 0.1, key),
+            )
+        )
+        assert result is not None
+        return result
+
+    near, neighbour = profile(0.0), profile(0.4)
+    owners = profiles_owning_axial_band(
+        (near, neighbour), axis="z", centre=(0.0, 0.0, 10.0), width=2.0
+    )
+
+    assert owners == (near,)
+
+
+def test_ambiguous_groove_cannot_lint_credit_both_profiles_if_compile_guard_is_bypassed(
+    monkeypatch,
+):
+    import draftwright.analysis as analysis
+
+    outer = Cylinder(15, 20) - Pos(0, 0, 1) * (Cylinder(15, 2) - Cylinder(10, 2))
+    inner = (
+        Pos(0, 0, -5) * Cylinder(5, 10)
+        + Pos(0, 0, 1) * Cylinder(4, 2)
+        + Pos(0, 0, 6) * Cylinder(5, 8)
+    )
+    part = Compound(children=[outer, inner])
+    sheet = Sheet(part, title="AMBIGUOUS GROOVE LINT", number="1357-GROOVE").auto_dimensions()
+    for group, specs in (
+        ("outer", ((30.0, 10.0, -5.0), (25.0, 8.0, 6.0))),
+        ("inner", ((10.0, 10.0, -5.0), (8.0, 2.0, 1.0), (10.0, 8.0, 6.0))),
+    ):
+        for diameter, length, z in specs:
+            sheet.step(
+                diameter=diameter,
+                length=length,
+                at=(0, 0, z),
+                axis="z",
+                profile_group=group,
+            )
+    sheet.groove(axis="z", width=2, diameter=20, at=(0, 0, 1))
+
+    # Simulate an external producer bypassing Draftwright's compile-time refusal. Lint is an
+    # independent consumer and must still refuse to credit one groove to both physical profiles.
+    monkeypatch.setattr(
+        analysis,
+        "require_unambiguous_groove_owner",
+        lambda _groove, profiles: tuple(profiles)[:1],
+    )
+    drawing = sheet.build()
+    inner_middle = next(
+        name
+        for name in drawing.annotations()
+        if name.startswith("m_steplen")
+        and any(
+            identity.feature.diameter == 8 for identity in drawing.registry.measurement_of(name)
+        )
+    )
+    drawing.remove(inner_middle)
+
+    assert [issue for issue in drawing.lint() if issue.code == "axial_length_missing"]
+
+
+def test_mixed_axis_profiles_remain_local_instead_of_inventing_one_orientation():
+    part = Compound(
+        children=[
+            Pos(-50, 0, 0) * _stepped_shaft(),
+            (Pos(50, 0, 0) * _stepped_shaft()).rotate(Axis.Y, 90),
+        ]
+    )
+    drawing = build_drawing(part, title="MIXED SHAFTS", number="1357-M")
+    steps = [feature for feature in drawing.model().features if feature.kind == "step"]
+
+    assert drawing.model().orientation is None
+    assert [step.frame.axis for step in steps].count("x") == 2
+    assert [step.frame.axis for step in steps].count("z") == 2
+    assert len([name for name in drawing.annotations() if name.startswith("m_steplen")]) == 4
+    assert not [issue for issue in drawing.lint() if issue.code == "axial_length_missing"]
+
+
+@pytest.mark.parametrize("order", (("x", "z"), ("z", "x")))
+def test_mixed_declared_orientation_and_step_misuse_are_order_independent(order):
+    lower = Pos(0, 0, 15) * Cylinder(35, 10)
+    upper = Pos(0, 0, 25) * Cylinder(25, 10)
+    part = Box(100, 100, 20) + lower + upper
+    assert len(part.solids()) == 1
+
+    sheet = Sheet(part, title="MIXED ORDER", number="1357-ORDER").auto_dimensions()
+    sheet.envelope()
+    for axis in order:
+        if axis == "x":
+            sheet.step(
+                diameter=10,
+                length=10,
+                at=(0, 0, 0),
+                axis="x",
+                profile_group="x-profile",
+            )
+        else:
+            sheet.step(lower, profile_group="z-profile")
+            sheet.step(upper, profile_group="z-profile")
+
+    model = sheet.model()
+    assert model.orientation is None
+    # Exercise the public PartModel front door with deliberately stale derived metadata too;
+    # both layout sizing and render-time coercion must derive the set, never trust first order.
+    stale = replace(model, orientation=order[0])
+    with pytest.raises(ValueError, match="don't span this part's full height"):
+        build_drawing(part, model=stale, number="1357-ORDER-PM")
+    with pytest.raises(ValueError, match="don't span this part's full height"):
+        sheet.build()
+
+
+def test_step_profile_annotation_is_runtime_resolvable_and_provider_neutral():
+    from draftwright.model import StepFeature, TurnedProfileIdentity
+
+    hint = typing.get_type_hints(StepFeature)["profile"]
+
+    assert set(typing.get_args(hint)) == {TurnedProfileIdentity, type(None)}
+
+
+def test_perpendicular_profile_axes_do_not_compete_for_one_longitudinal_lane():
+    part = Compound(children=[_stepped_shaft(), Rot(0, 90, 0) * _stepped_shaft()])
+    sheet = Sheet(part, title="PERPENDICULAR CHAINS", number="1357-PERP")
+    for axis in ("x", "z"):
+        for diameter, station in ((30.0, 0.0), (20.0, 20.0)):
+            at = (station, 0.0, 0.0) if axis == "x" else (0.0, 0.0, station)
+            step = sheet.step(
+                diameter=diameter,
+                length=20,
+                at=at,
+                axis=axis,
+                profile_group=axis,
+            )
+            sheet.dimension(step, "step.length")
+    sheet.view("front").pin((100, 100))
+    drawing = sheet.build()
+
+    assert len([name for name in drawing.annotations() if name.startswith("m_steplen")]) == 4
+    assert not [
+        issue
+        for issue in drawing.lint()
+        if issue.code in ("step_dim_dropped", "annotation_overlap", "axial_length_missing")
+    ]
+
+
+def test_alternate_plan_view_owns_crowded_x_profile_blocks_and_details():
+    part = Compound(
+        children=[
+            Pos(0, -50, 0) * _crowded_x_shaft(),
+            Pos(0, 50, 0) * _crowded_x_shaft(),
+        ]
+    )
+    drawing = build_drawing(
+        part,
+        page="A2",
+        scale=2.0,
+        title="CROWDED X SHAFTS",
+        number="1357-X",
+    )
+    principal_chains = {
+        name: drawing.view_of(name)
+        for name in drawing.annotations()
+        if name.startswith("m_steplen")
+    }
+
+    assert principal_chains
+    assert set(principal_chains.values()) == {"front", "plan"}
+    plan_names = [name for name, chain_view in principal_chains.items() if chain_view == "plan"]
+    assert plan_names
+    plan_owners = {
+        identity.feature.frame.origin[1]
+        for name in plan_names
+        for identity in drawing.registry.measurement_of(name)
+    }
+    detail_names = [
+        name
+        for name in drawing.annotations()
+        if name.startswith("dim_detail_") and "steplen" in name
+    ]
+    detail_owners = {
+        identity.feature.frame.origin[1]
+        for name in detail_names
+        for identity in drawing.registry.measurement_of(name)
+    }
+    assert {"detail_a", "detail_b"} <= set(drawing.views)
+    assert len(detail_names) == 6
+    assert plan_owners and plan_owners <= detail_owners
+    assert all(len(drawing.registry.measurement_of(name)) == 1 for name in detail_names)
+    assert not [
+        issue
+        for issue in drawing.lint()
+        if issue.code in ("annotation_overlap", "view_annotation_overlap", "axial_length_missing")
+    ]
+
+
+def test_authored_lengths_separate_parallel_chains_without_leaking_withheld_diameters():
+    sheet = Sheet(_parallel_shafts(), title="AUTHORED PARALLEL SHAFTS", number="1357-A")
+    steps = []
+    for x in (-50.0, 50.0):
+        steps.extend(
+            (
+                sheet.step(diameter=30, length=20, at=(x, 0, 0), axis="z"),
+                sheet.step(diameter=20, length=20, at=(x, 0, 20), axis="z"),
+            )
+        )
+    for step in steps:
+        sheet.dimension(step, "step.length")
+
+    drawing = sheet.build()
+    chains = [
+        annotation
+        for name, annotation in drawing.annotations_in_view("front")
+        if name.startswith("m_steplen")
+    ]
+
+    assert len(chains) == 4
+    assert len({round(_dim_vertices(chain)[0][0], 3) for chain in chains}) == 2
+    assert not [
+        name for name in drawing.annotations() if name.startswith(("m_dia", "dim_od", "ldr_"))
+    ]
+    assert not [issue for issue in drawing.lint() if issue.code == "annotation_overlap"]
+
+
+def test_authored_y_profiles_use_plan_cells_without_reading_withheld_diameters():
+    shaft = _stepped_shaft().rotate(Axis.X, 90)
+    part = Compound(children=[Pos(-50, 0, 0) * shaft, Pos(50, 0, 0) * shaft])
+    sheet = Sheet(part, title="AUTHORED Y SHAFTS", number="1357-YP")
+    steps = []
+    for x in (-50.0, 50.0):
+        steps.extend(
+            (
+                sheet.step(diameter=30, length=20, at=(x, 0, 0), axis="y"),
+                sheet.step(diameter=20, length=20, at=(x, 20, 0), axis="y"),
+            )
+        )
+    for step in steps:
+        sheet.dimension(step, "step.length")
+
+    drawing = sheet.build()
+
+    assert (
+        len(
+            [
+                name
+                for name in drawing.annotations_in_view("plan")
+                if name[0].startswith("m_steplen")
+            ]
+        )
+        == 2
+    )
+    assert (
+        len(
+            [
+                name
+                for name in drawing.annotations_in_view("side")
+                if name[0].startswith("m_steplen")
+            ]
+        )
+        == 2
+    )
+    assert not [
+        issue
+        for issue in drawing.lint()
+        if issue.code in ("annotation_overlap", "view_annotation_overlap")
+    ]
+
+
+def test_plural_none_and_positional_singular_lint_compatibility():
+    from b123d_recognisers import TurnedProfile, TurnedStep, build_raw_recognition_result
+
+    assert build_part_model(Box(1, 1, 1), profiles=None).orientation is None
+
+    part = _stepped_shaft()
+    recognition = build_raw_recognition_result(part, rotational=True)
+    drawing = build_drawing(part)
+    assert lint_axial_coverage(part, drawing, recognition=recognition) == []
+    assert (
+        lint_axial_coverage(
+            part,
+            drawing,
+            None,
+            recognition.turned_profiles[0],
+            recognition,
+        )
+        == []
+    )
+
+    legacy = TurnedProfile.from_steps(
+        (
+            TurnedStep("z", -10, 10, 30),
+            TurnedStep("z", 10, 30, 20),
+        )
+    )
+    assert legacy is not None and legacy.profile is None
+    legacy_model = build_part_model(part, profiles=(legacy,))
+    assert len([feature for feature in legacy_model.features if feature.kind == "step"]) == 2
+    legacy_drawing = build_drawing(part, model=legacy_model)
+    assert lint_axial_coverage(part, legacy_drawing, profiles=(legacy,)) == []
+    with pytest.raises(
+        ValueError, match="plural turned profiles require body-local profile identity"
+    ):
+        build_part_model(part, profiles=(legacy, legacy))
+
+
+@pytest.mark.parametrize("profile_group", ("", "   ", 7))
+def test_declared_profile_group_rejects_empty_or_non_string_tokens(profile_group):
+    sheet = Sheet(Box(2, 2, 2))
+    with pytest.raises(ValueError, match="profile_group must be a non-empty string"):
+        sheet.step(
+            diameter=2,
+            length=2,
+            at=(0, 0, 0),
+            axis="z",
+            profile_group=profile_group,
+        )
+
+
+def test_legacy_ungrouped_steps_join_a_real_gap_only_to_its_collinear_groove():
+    centre_min = (Align.CENTER, Align.CENTER, Align.MIN)
+    part = Cylinder(15, 200, align=centre_min)
+    part -= Pos(0, 0, 95) * (
+        Cylinder(15, 10, align=centre_min) - Cylinder(12, 10, align=centre_min)
+    )
+
+    def build_with_groove(at, *, axis="z"):
+        sheet = Sheet(part, title="UNGROUPED GROOVE", number="1357-UG")
+        steps = [
+            sheet.step(diameter=30, length=95, at=(0, 0, 47.5), axis="z"),
+            sheet.step(diameter=30, length=95, at=(0, 0, 152.5), axis="z"),
+        ]
+        for step in steps:
+            sheet.dimension(step, "step.length")
+        groove = sheet.groove(axis=axis, width=10, diameter=24, at=at)
+        sheet.dimension(groove, "groove.length")
+        sheet.dimension(groove, "groove.diameter")
+        return sheet.build()
+
+    collinear = build_with_groove((0, 0, 100))
+    off_line = build_with_groove((50, 0, 100))
+    with pytest.raises(ValueError, match="declared steps don't span this part's full height"):
+        build_with_groove((0, 0, 100), axis="x")
+
+    for drawing in (collinear, off_line):
+        assert len([name for name in drawing.annotations() if name.startswith("m_steplen")]) == 2
+        assert len([name for name in drawing.annotations() if name.startswith("m_groove_")]) == 1
+    assert not [
+        issue
+        for issue in collinear.lint()
+        if issue.code
+        in (
+            "axial_length_missing",
+            "step_dim_dropped",
+            "groove_requirement_unverifiable",
+        )
+    ]
+    unverifiable = [
+        issue for issue in off_line.lint() if issue.code == "groove_requirement_unverifiable"
+    ]
+    assert len(unverifiable) == 1
+    assert "groove at (0.0, 0.0, 100.0)" in unverifiable[0].message

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -9327,8 +9327,10 @@ class TestPrismaticBossDiameter:
         # cover only the boss, not the plate below, so the overall height would be dropped.
         from draftwright import Sheet
 
-        lower = Pos(0, 0, 25) * Cylinder(35, 10)
-        upper = Pos(0, 0, 35) * Cylinder(25, 10)
+        # Exact face contact makes this one physical solid: the old 25/35 placements left a
+        # 10 mm air gap above the plate and accidentally tested a valid multi-solid compound.
+        lower = Pos(0, 0, 15) * Cylinder(35, 10)
+        upper = Pos(0, 0, 25) * Cylinder(25, 10)
         part = Box(100, 100, 20) + lower + upper
         sheet = Sheet(part, title="C").auto_dimensions()
         sheet.envelope()

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -1244,8 +1244,8 @@ class TestObjectSpec:
         )
         assert result.exit_code == 0, result.output
         source = (tmp_path / "shaft.py").read_text(encoding="utf-8")
-        assert "sheet.step(features.large_step)" in source
-        assert "sheet.step(features.small_step)" in source
+        assert "sheet.step(features.large_step, profile_group='detected-profile-1')" in source
+        assert "sheet.step(features.small_step, profile_group='detected-profile-1')" in source
         assert "sheet.step(diameter=" not in source
 
     def test_axially_offset_construction_tool_fails_closed_to_numeric(self, tmp_path, monkeypatch):
@@ -3527,6 +3527,10 @@ class TestTheDeclaredModelMatchesTheDetectedOne:
         ("hole", "members"): "a single hole's member list is exactly its own frame origin",
         ("plate", "frame"): "detection fills a plate's frame with the PART centroid, so it "
         "carries no per-plate information and nothing reads it",
+        ("step", "profile"): "provider profile identity is recognition provenance; emitted "
+        "declarations reconstruct physical grouping from step axis lines, spans and grooves",
+        ("step", "profile_group"): "generated declarations replace the provider key with a "
+        "Draftwright-owned opaque group token",
     }
 
     def _exemption_holds(self, original, rebuilt, field):
@@ -3547,6 +3551,10 @@ class TestTheDeclaredModelMatchesTheDetectedOne:
                 and tuple(rebuilt.members) == ()
                 and tuple(map(tuple, original.members)) == (tuple(original.frame.origin),)
             )
+        if (original.kind, field) == ("step", "profile"):
+            return original.profile is not None and rebuilt.profile is None
+        if (original.kind, field) == ("step", "profile_group"):
+            return original.profile is not None and rebuilt.profile_group is not None
         return False
 
     @staticmethod


### PR DESCRIPTION
## Summary

- carry every provider-owned turned profile through the shared raw/framed compiler waist while preserving the compatible zero-or-one singular projection
- assign body-local profile ownership to steps and grooves, emit stable declared profile tokens, and solve independent chains across orthographic lanes
- make axial completeness and deferred replay profile-aware and fail closed for ambiguous nested groove ownership
- document the coordinate/ownership contract in ADR 0020 and the recogniser capability reference

## Verification

- `uv run pytest -q -n 18`: 5764 passed, 5 skipped, 2 xfailed
- focused recogniser/frame and architecture suites: green
- Ruff, mypy, import boundaries, private-read guard, and `git diff --check`: green
- three independent exact-head Google-style reviews: CLEAN with no nits
- ADR 0004, 0011, 0012, 0014, 0015, and 0020 audit: CLEAN

## Upstream boundary

Ambiguous nested groove ownership needs a provider contract and therefore fails closed. Tracked upstream in b123d-recognisers#354.

Contributes to #1365.