### PR TITLE
docs: add docs, downloads, mypy and uv badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,15 @@
 </h1>
 
 [![CI](https://github.com/pzfreo/draftwright/actions/workflows/ci.yml/badge.svg)](https://github.com/pzfreo/draftwright/actions/workflows/ci.yml)
+[![Docs](https://github.com/pzfreo/draftwright/actions/workflows/docs.yml/badge.svg)](https://pzfreo.github.io/draftwright/)
 [![codecov](https://codecov.io/gh/pzfreo/draftwright/branch/main/graph/badge.svg)](https://codecov.io/gh/pzfreo/draftwright)
 [![PyPI](https://img.shields.io/pypi/v/draftwright.svg)](https://pypi.org/project/draftwright/)
 [![Python](https://img.shields.io/pypi/pyversions/draftwright.svg)](https://pypi.org/project/draftwright/)
+[![Downloads](https://img.shields.io/pypi/dm/draftwright.svg)](https://pypi.org/project/draftwright/)
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](LICENSE)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+[![mypy](https://img.shields.io/badge/mypy-checked-2a6db2.svg)](https://mypy-lang.org/)
+[![uv](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/uv/main/assets/badge/v0.json)](https://github.com/astral-sh/uv)
 
 **[API reference](https://pzfreo.github.io/draftwright/)** ·
 **[Examples and source](https://github.com/pzfreo/draftwright#readme)**


### PR DESCRIPTION
Adds four badges to the README block. Each is backed by something the repo already does, and every endpoint was fetched and confirmed to return 200 with the expected label before committing:

| Badge | Evidence | Renders as |
| --- | --- | --- |
| Docs | `.github/workflows/docs.yml` builds and deploys the mkdocs site | `Documentation - passing` |
| Downloads | `img.shields.io/pypi/dm/draftwright` | `downloads 4.6k/month` |
| mypy | `scripts/pr-check --static` runs `uv run mypy src/draftwright/`, and the static preflight is a required CI job — same standing as the Ruff badge already present | `mypy checked` |
| uv | every CI job installs through `astral-sh/setup-uv` | `uv` |

The Docs badge links to the published site rather than the workflow run, so it doubles as an entry point alongside the API-reference line just below.

Ordering groups the block: build/docs/coverage, then package (version, Python, downloads), then licence, then tooling.

## Considered and not included

- **OpenSSF Scorecard** — `api.securityscorecards.dev/projects/github.com/pzfreo/draftwright` returns 404; the repo is not enrolled. Would need `ossf/scorecard-action` added first. Worth a follow-up: CI already pins every action by SHA, so the score should be good.
- **`github/v/release`** (`v0.4.16`) — near-duplicate of the existing PyPI version badge.
- **`github/last-commit`** — goes stale-looking during any pause.
- **`pypi/status`** (`alpha`, from the `Development Status :: 3 - Alpha` classifier) — accurate but undersells a project with a 4700-test suite.

## Note for the reviewer

`readme = "README.md"` in `pyproject.toml`, so this block is also the PyPI long description — the monthly-downloads badge will render on the very page it counts. Swapping it for pepy's total (30k) is a one-line change if that reads better.

## Architectural fit

Documentation-only; no engine code, no ADR surface touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EwyQosK7GmDuD62rKW6vna