### PR TITLE
Remove lint provider-private profiled-bore coupling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,14 @@
 
 ### Changed
 
+- Principal-profile lint now correlates its independent extremal-face evidence with the cached
+  public `DoubleDBore` aggregate instead of importing provider-private profile helpers. Exact
+  axis/span, end-plane, centre, radius, A/F, chord, arc, and flat-direction checks fail closed;
+  occurrence mouths are consumed with matching multiplicity, and malformed records cannot earn
+  coverage. The exported low-level check now requires the aggregate projection explicitly so an
+  omitted inventory fails loudly; lint still owns its physical denominator and never reruns
+  recognition (#1411, ADRs 0013, 0015, 0017).
+
 - Whole polygonal-stock completeness is now backed by an independently authored, hash-pinned
   13-case STEP corpus covering all principal axes, in-plane rotation, translation, topology
   order and circular/rectangular/irregular/octagonal/attached/recessed/compound negatives. The

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -3628,6 +3628,7 @@ class Drawing:
                     lint_principal_profile_coverage(
                         working_part,
                         assembly=resolved_assembly,
+                        double_d_bores=recognition.double_d_bores,
                         prismatic_pockets=recognition.prismatic_pockets,
                         section_passages=recognition.section_passages,
                     )

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -21,7 +21,8 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable
-from math import atan2, pi, tau
+from math import asin, atan2, isfinite, pi, sqrt, tau
+from numbers import Real
 from typing import Literal
 
 from b123d_recognisers import (
@@ -37,11 +38,6 @@ from b123d_recognisers import (
     recognise_pockets,
     recognise_rectangular_pads,
     recognise_turned_steps,
-)
-from b123d_recognisers.profiled_bores import (
-    double_d_bores_from_openings,
-    double_d_profile,
-    principal_boundary_plane,
 )
 from build123d import GeomType
 from build123d_drafting.helpers import CenterMark, Dimension, TitleBlock
@@ -756,6 +752,204 @@ def _prismatic_pocket_matches_principal_wire(
     return not unmatched
 
 
+def _principal_boundary_plane(face, bbox) -> tuple[str, tuple[str, str], float] | None:
+    """Return a solid-extremal principal plane as independent lint evidence.
+
+    This is intentionally a small Draftwright-owned physical predicate rather than a
+    provider helper: principal boundary faces are part of lint's independent denominator,
+    while recognised occurrences arrive separately through the build-owned aggregate.
+    """
+    if face.geom_type != GeomType.PLANE:
+        return None
+    fbb = face.bounding_box()
+    extent = {axis: float(getattr(fbb.size, axis.upper())) for axis in "xyz"}
+    part_extent = (float(bbox.size.X), float(bbox.size.Y), float(bbox.size.Z))
+    tol = max(1e-5, max(part_extent) * 1e-5)
+    flat = [axis for axis, value in extent.items() if value <= tol]
+    if len(flat) != 1:
+        return None
+    axis = flat[0]
+    attr = axis.upper()
+    at = float(getattr(fbb.center(), attr))
+    if (
+        min(
+            abs(at - float(getattr(bbox.min, attr))),
+            abs(at - float(getattr(bbox.max, attr))),
+        )
+        > tol
+    ):
+        return None
+    plane_axes = tuple(candidate for candidate in "xyz" if candidate != axis)
+    return axis, (plane_axes[0], plane_axes[1]), at
+
+
+def _double_d_bore_matches_principal_wire(
+    bore,
+    wire,
+    axis: str,
+    plane_axes: tuple[str, str],
+    at: float,
+    bbox,
+    tol: float,
+) -> bool:
+    """Correlate one physical mouth with one public ``DoubleDBore`` occurrence.
+
+    The aggregate proves that the full profile prism is void. Lint independently proves
+    that this exact extremal wire is one of that occurrence's two mouths; neither side
+    alone can certify support. The metric checks reject topology-similar lenses, obrounds,
+    and arbitrary line/arc loops without importing the provider's private classifier.
+    """
+
+    def number(value) -> float:
+        if isinstance(value, bool) or not isinstance(value, Real):
+            raise TypeError("correspondence evidence must be a real number")
+        result = float(value)
+        if not isfinite(result):
+            raise ValueError("non-finite correspondence evidence")
+        return result
+
+    def coord(obj, name: str) -> float:
+        return number(getattr(obj, name.upper()))
+
+    try:
+        if type(bore.through) is not bool or not bore.through:
+            return False
+        axis_i = "xyz".index(axis)
+        axis_vector = tuple(number(value) for value in bore.axis)
+        if len(axis_vector) != 3:
+            return False
+        axis_component = axis_vector[axis_i]
+        if abs(abs(axis_component) - 1.0) > 1e-6 or any(
+            abs(component) > 1e-6 for i, component in enumerate(axis_vector) if i != axis_i
+        ):
+            return False
+
+        location = tuple(number(value) for value in bore.location)
+        if len(location) != 3:
+            return False
+        depth = number(bore.depth)
+        if depth <= tol:
+            return False
+        record_ends = sorted((location[axis_i], location[axis_i] - axis_component * depth))
+        solid_ends = sorted((coord(bbox.min, axis), coord(bbox.max, axis)))
+        span_tol = max(8 * tol, depth * 1e-5, 1e-4)
+        if any(
+            abs(actual - expected) > span_tol for actual, expected in zip(record_ends, solid_ends)
+        ):
+            return False
+        matching_ends = [
+            i for i, endpoint in enumerate(record_ends) if abs(at - endpoint) <= span_tol
+        ]
+        if len(matching_ends) != 1:
+            return False
+
+        major_diameter = number(bore.major_diameter)
+        across_flats = number(bore.across_flats)
+        radius = major_diameter / 2.0
+        half_af = across_flats / 2.0
+        if radius <= tol or half_af <= tol or half_af >= radius - tol:
+            return False
+
+        flat_direction = tuple(number(value) for value in bore.flat_direction)
+        if len(flat_direction) != 3 or abs(flat_direction[axis_i]) > 1e-6:
+            return False
+        flat_norm = sqrt(sum(flat_direction[i] ** 2 for i in range(3) if i != axis_i))
+        if abs(flat_norm - 1.0) > 1e-6:
+            return False
+
+        edges = tuple(wire.edges())
+        lines = tuple(edge for edge in edges if edge.geom_type == GeomType.LINE)
+        arcs = tuple(edge for edge in edges if edge.geom_type == GeomType.CIRCLE)
+        if len(edges) != 4 or len(lines) != 2 or len(arcs) != 2:
+            return False
+
+        centre_values = list(location)
+        centre_values[axis_i] = at
+        centre = (centre_values[0], centre_values[1], centre_values[2])
+        wire_scale = max(coord(wire.bounding_box().size, name) for name in plane_axes)
+        metric_tol = max(8 * tol, wire_scale * 1e-3, 1e-4)
+        for arc in arcs:
+            if abs(number(arc.radius) - radius) > metric_tol:
+                return False
+            if any(
+                abs(coord(arc.arc_center, name) - centre["xyz".index(name)]) > metric_tol
+                for name in plane_axes
+            ):
+                return False
+
+        expected_chord = 2.0 * sqrt(radius * radius - half_af * half_af)
+        offsets: list[float] = []
+        for line in lines:
+            vertices = tuple(line.vertices())
+            if len(vertices) != 2 or abs(number(line.length) - expected_chord) > metric_tol:
+                return False
+            ends = [
+                tuple(number(getattr(vertex, name.upper())) for name in "xyz")
+                for vertex in vertices
+            ]
+            if any(abs(end[axis_i] - at) > metric_tol for end in ends):
+                return False
+            if any(
+                abs(sqrt(sum((end[i] - centre[i]) ** 2 for i in range(3))) - radius) > metric_tol
+                for end in ends
+            ):
+                return False
+            delta = tuple(ends[1][i] - ends[0][i] for i in range(3))
+            length = sqrt(sum(component * component for component in delta))
+            if length <= tol:
+                return False
+            direction = tuple(component / length for component in delta)
+            if abs(sum(direction[i] * flat_direction[i] for i in range(3))) > 1e-4:
+                return False
+            midpoint = tuple((ends[0][i] + ends[1][i]) / 2.0 for i in range(3))
+            offsets.append(sum((midpoint[i] - centre[i]) * flat_direction[i] for i in range(3)))
+        offsets.sort()
+        if abs(offsets[0] + half_af) > metric_tol or abs(offsets[1] - half_af) > metric_tol:
+            return False
+
+        expected_arc = 2.0 * radius * asin(half_af / radius)
+        return all(abs(number(arc.length) - expected_arc) <= metric_tol for arc in arcs)
+    except (AttributeError, OverflowError, TypeError, ValueError):
+        return False
+
+
+def _claim_double_d_bore_mouth(
+    bores,
+    claimed: set[tuple[int, int]],
+    wire,
+    axis: str,
+    plane_axes: tuple[str, str],
+    at: float,
+    bbox,
+    tol: float,
+) -> bool:
+    """Claim one aggregate occurrence endpoint without reusing it for another mouth."""
+    axis_i = "xyz".index(axis)
+    for record_i, bore in enumerate(bores):
+        if not _double_d_bore_matches_principal_wire(
+            bore,
+            wire,
+            axis,
+            plane_axes,
+            at,
+            bbox,
+            tol,
+        ):
+            continue
+        axis_component = float(bore.axis[axis_i])
+        ends = (
+            float(bore.location[axis_i]),
+            float(bore.location[axis_i]) - axis_component * float(bore.depth),
+        )
+        mouth_i = min(range(2), key=lambda i: abs(at - ends[i]))
+        key = (record_i, mouth_i)
+        if key in claimed:
+            continue
+        claimed.add(key)
+        return True
+    return False
+
+
 def _supported_inner_profile(
     wire,
     plane_axes: tuple[str, str],
@@ -763,10 +957,11 @@ def _supported_inner_profile(
     *,
     axis: str | None = None,
     at: float | None = None,
+    solid_bbox=None,
     double_d_bores=(),
+    claimed_double_d_mouths: set[tuple[int, int]] | None = None,
     prismatic_pockets=(),
     section_passages=(),
-    profile=_UNSET,
 ) -> bool:
     """Whether an inner boundary loop has a specific semantic owner.
 
@@ -800,31 +995,22 @@ def _supported_inner_profile(
         )
     ):
         return True
-    profile = double_d_profile(wire, plane_axes, tol=tol) if profile is _UNSET else profile
-    if profile is not None and axis is not None:
-        axis_i = "xyz".index(axis)
-        for bore in double_d_bores:
-            bore_axis_i = max(range(3), key=lambda i: abs(float(bore.axis[i])))
-            if bore_axis_i != axis_i:
-                continue
-            if (
-                abs(float(bore.major_diameter) - profile.major_diameter) <= tol
-                and abs(float(bore.across_flats) - profile.across_flats) <= tol
-                and all(
-                    abs(float(bore.location[i]) - profile.centre[i]) <= tol
-                    for i in range(3)
-                    if i != axis_i
-                )
-                and all(
-                    abs(float(a) - b) <= max(tol, 1e-6)
-                    for a, b in zip(
-                        bore.flat_direction,
-                        profile.flat_direction,
-                        strict=True,
-                    )
-                )
-            ):
-                return True
+    if (
+        axis is not None
+        and at is not None
+        and solid_bbox is not None
+        and _claim_double_d_bore_mouth(
+            double_d_bores,
+            claimed_double_d_mouths if claimed_double_d_mouths is not None else set(),
+            wire,
+            axis,
+            plane_axes,
+            at,
+            solid_bbox,
+            tol,
+        )
+    ):
+        return True
     if all(kind == GeomType.CIRCLE for kind in types):
         try:
             first = edges[0]
@@ -985,6 +1171,8 @@ def _has_unsupported_principal_inner_profile(
     part,
     bbox,
     *,
+    double_d_bores=(),
+    claimed_double_d_mouths: set[tuple[int, int]] | None = None,
     prismatic_pockets=(),
     section_passages=(),
 ) -> bool:
@@ -992,18 +1180,13 @@ def _has_unsupported_principal_inner_profile(
     part_extent = (float(bbox.size.X), float(bbox.size.Y), float(bbox.size.Z))
     tol = max(1e-5, max(part_extent) * 1e-5)
     wires = []
-    openings = []
     for face in part.faces():
-        boundary = principal_boundary_plane(face, bbox)
+        boundary = _principal_boundary_plane(face, bbox)
         if boundary is None:
             continue
         axis, plane_axes, at = boundary
         for wire in face.inner_wires():
-            profile = double_d_profile(wire, plane_axes, tol=tol)
-            wires.append((axis, plane_axes, at, wire, profile))
-            if profile is not None:
-                openings.append((axis, at, profile, wire))
-    double_d_bores = double_d_bores_from_openings(openings, bbox, part=part, tol=tol)
+            wires.append((axis, plane_axes, at, wire))
     return any(
         not _supported_inner_profile(
             wire,
@@ -1011,12 +1194,13 @@ def _has_unsupported_principal_inner_profile(
             tol,
             axis=axis,
             at=at,
+            solid_bbox=bbox,
             double_d_bores=double_d_bores,
+            claimed_double_d_mouths=claimed_double_d_mouths,
             prismatic_pockets=prismatic_pockets,
             section_passages=section_passages,
-            profile=profile,
         )
-        for axis, plane_axes, at, wire, profile in wires
+        for axis, plane_axes, at, wire in wires
     )
 
 
@@ -1032,7 +1216,7 @@ def _radial_outer_arc_count(part, bbox) -> int | None:
     tol = max(1e-5, part_scale * 1e-5)
     best = None
     for face in part.faces():
-        boundary = principal_boundary_plane(face, bbox)
+        boundary = _principal_boundary_plane(face, bbox)
         if boundary is None:
             continue
         _axis, plane_axes, _at = boundary
@@ -1082,6 +1266,7 @@ def _radial_outer_arc_count(part, bbox) -> int | None:
 def lint_principal_profile_coverage(
     part,
     *,
+    double_d_bores,
     assembly=None,
     prismatic_pockets=(),
     section_passages=(),
@@ -1089,19 +1274,23 @@ def lint_principal_profile_coverage(
     """Report principal inner or outer profiles outside the current feature vocabulary.
 
     The scan owns its physical extent: there is deliberately no caller-supplied bounding box
-    that could narrow the answer. The double-D correspondence is the recogniser's shared pure
-    correspondence proof over openings collected during this scan; lint reruns no public
-    recogniser. ``section_passages`` and ``prismatic_pockets`` are explicit projections of the
-    drawing's cached authoritative result used only to replace a matched generic profile finding
-    with the corresponding specific unsupported-family finding. :class:`Drawing` caches the
-    returned issues against the source part identity so repeated lint does not rescan the B-rep.
+    that could narrow the answer. ``double_d_bores``, ``section_passages`` and
+    ``prismatic_pockets`` are explicit projections of the drawing's cached authoritative public
+    aggregate. The Double-D projection is required so an omitted inventory fails loudly instead
+    of changing the physical diagnosis. These records replace a generic profile finding only
+    when independent physical evidence matches the exact occurrence; lint neither imports
+    provider-private helpers nor reruns a recogniser. :class:`Drawing` caches the returned issues
+    against the source part identity so repeated lint does not rescan the B-rep.
     """
     solids = list(part.solids())
     sources = solids if len(solids) > 1 else [part]
+    claimed_double_d_mouths: set[tuple[int, int]] = set()
     unsupported_inner = any(
         _has_unsupported_principal_inner_profile(
             solid,
             solid.bounding_box(),
+            double_d_bores=double_d_bores,
+            claimed_double_d_mouths=claimed_double_d_mouths,
             prismatic_pockets=prismatic_pockets,
             section_passages=section_passages,
         )

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -46,8 +46,11 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
+import b123d_recognisers
+
 _SRC = Path(__file__).resolve().parent.parent / "src" / "draftwright"
 _MODEL_DIR = _SRC / "model"
+_RECOGNISER_PUBLIC = frozenset(b123d_recognisers.__all__)
 
 # ── The declared DAG (mirrors CLAUDE.md ## Architecture) ─────────────────────────────────
 # Rank each top-level submodule (and subpackage) by its layer; a file may import only names
@@ -512,3 +515,57 @@ def test_linting_does_not_import_model():
             f"{path.name} imports draftwright.model — the lint/coverage carve-out "
             "(ADR 0015) forbids IR coupling in linting/"
         )
+
+
+def _private_recogniser_imports(path: Path) -> list[str]:
+    offenders: list[str] = []
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            if (node.module or "").startswith("b123d_recognisers."):
+                offenders.append(f"{path.name}:{node.lineno} imports {node.module}")
+            elif node.module == "b123d_recognisers":
+                offenders.extend(
+                    f"{path.name}:{node.lineno} imports non-public {alias.name}"
+                    for alias in node.names
+                    if alias.name not in _RECOGNISER_PUBLIC
+                )
+        elif isinstance(node, ast.Import):
+            offenders.extend(
+                f"{path.name}:{node.lineno} imports {alias.name}"
+                for alias in node.names
+                if alias.name == "b123d_recognisers" or alias.name.startswith("b123d_recognisers.")
+            )
+    return offenders
+
+
+def test_linting_consumes_recognisers_only_through_the_public_root():
+    """Lint may project public aggregate records, never provider implementation modules."""
+    offenders = [
+        offender
+        for path in sorted((_SRC / "linting").glob("*.py"))
+        for offender in _private_recogniser_imports(path)
+    ]
+    assert not offenders, (
+        "linting/ must consume the released b123d-recognisers contract through its public "
+        f"package root (ADRs 0013/0017; #1411). Private submodule imports: {offenders}"
+    )
+
+
+def test_public_root_guard_rejects_module_alias_loopholes(tmp_path):
+    probe = tmp_path / "private_recogniser_imports.py"
+    probe.write_text(
+        "from b123d_recognisers import profiled_bores, _features\n"
+        "import b123d_recognisers.profiled_bores\n"
+        "import b123d_recognisers as br\n"
+        "private = br.profiled_bores.double_d_profile\n",
+        encoding="utf-8",
+    )
+
+    offenders = _private_recogniser_imports(probe)
+
+    assert len(offenders) == 4
+    assert any("non-public profiled_bores" in offender for offender in offenders)
+    assert any("non-public _features" in offender for offender in offenders)
+    assert any("b123d_recognisers.profiled_bores" in offender for offender in offenders)
+    assert any("imports b123d_recognisers" in offender for offender in offenders)

--- a/tests/test_issue_1058_wheel_profile.py
+++ b/tests/test_issue_1058_wheel_profile.py
@@ -32,6 +32,7 @@ from b123d_recognisers.repeating_profiles import (
 from build123d import (
     Align,
     Box,
+    Compound,
     Cylinder,
     GeomType,
     Plane,
@@ -49,7 +50,11 @@ from draftwright import Sheet, build_drawing
 from draftwright.annotations.from_model import callout_from_spec
 from draftwright.annotations.holes import _record_callout_drop
 from draftwright.builder import detect_part_model
-from draftwright.linting.coverage import CoverageState, lint_principal_profile_coverage
+from draftwright.linting.coverage import (
+    CoverageState,
+    _double_d_bore_matches_principal_wire,
+    lint_principal_profile_coverage,
+)
 from draftwright.linting.profiled_bore_coverage import (
     lint_profiled_bore_coverage,
     profiled_bore_key,
@@ -582,8 +587,73 @@ def test_synthetic_double_d_profile_is_recognised_without_lint_rescans():
 
 def test_physical_profile_scan_accepts_no_caller_extent():
     assert "bbox" not in signature(lint_principal_profile_coverage).parameters
-    issues = lint_principal_profile_coverage(_double_d_bore())
+    part = _double_d_bore()
+    issues = lint_principal_profile_coverage(
+        part,
+        double_d_bores=recognise_double_d_bores(part),
+    )
     assert issues == []
+
+
+def test_physical_profile_scan_requires_the_public_aggregate_projection():
+    with pytest.raises(TypeError, match="double_d_bores"):
+        lint_principal_profile_coverage(_double_d_bore())
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {"through": "yes"},
+        {"axis": (0.0, 0.0, float("nan"))},
+        {"axis": (False, False, True)},
+        {"axis": "001"},
+        {"axis": (1.0, 0.0, 0.0)},
+        {"location": (float("nan"), 0.0, 5.0)},
+        {"location": (0.0, 0.0, float("nan"))},
+        {"location": (0.0, 0.0, 4.0)},
+        {"depth": float("nan")},
+        {"depth": 10**10000},
+        {"major_diameter": float("nan")},
+        {"major_diameter": "10.0"},
+        {"major_diameter": 10**10000},
+        {"major_diameter": 9.0},
+        {"across_flats": float("nan")},
+        {"across_flats": 10**10000},
+        {"across_flats": 6.0},
+        {"flat_direction": (float("nan"), 0.0, 0.0)},
+        {"flat_direction": (True, False, False)},
+        {"flat_direction": (0.0, 1.0, 0.0)},
+    ],
+    ids=(
+        "through-type",
+        "axis-nan",
+        "axis-bool",
+        "axis-string",
+        "axis",
+        "location-nan-in-plane",
+        "location-nan-end",
+        "end-plane",
+        "depth-nan",
+        "depth-overflow",
+        "diameter-nan",
+        "diameter-string",
+        "diameter-overflow",
+        "diameter",
+        "across-flats-nan",
+        "across-flats-overflow",
+        "across-flats",
+        "flat-direction-nan",
+        "flat-direction-bool",
+        "flat-direction",
+    ),
+)
+def test_physical_profile_scan_requires_exact_public_double_d_correspondence(changes):
+    part = _double_d_bore()
+    bore = replace(recognise_double_d_bores(part)[0], **changes)
+
+    issues = lint_principal_profile_coverage(part, double_d_bores=(bore,))
+
+    assert [issue.code for issue in issues] == ["unrecognised_defining_geometry"]
 
 
 @pytest.mark.parametrize("part", [_lens_bore(), _l_bore()], ids=("circular-arcs", "linear-l"))
@@ -614,6 +684,101 @@ def test_edge_types_alone_do_not_certify_a_supported_profile(part):
 )
 def test_malformed_line_arc_evidence_fails_closed(case):
     assert double_d_profile(_profile_evidence(case), ("x", "y"), tol=1e-5) is None
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "not-through",
+        "short-axis",
+        "short-location",
+        "zero-depth",
+        "between-endpoints",
+        "invalid-profile-size",
+        "short-flat-direction",
+        "non-unit-flat-direction",
+        "wrong-topology",
+        "wrong-arc-centre",
+        "off-plane-line",
+        "off-circle-end",
+        "zero-line",
+        "same-side",
+        "malformed-record",
+    ],
+)
+def test_public_double_d_to_physical_mouth_correlation_fails_closed(case):
+    bore = SimpleNamespace(
+        axis=(0.0, 0.0, 1.0),
+        location=(0.0, 0.0, 10.0),
+        major_diameter=10.0,
+        across_flats=7.2,
+        depth=10.0,
+        through=True,
+        flat_direction=(1.0, 0.0, 0.0),
+    )
+    wire = _profile_evidence()
+    at = 0.0
+    bbox = SimpleNamespace(min=_point(-15, -15, 0), max=_point(15, 15, 10))
+
+    if case == "not-through":
+        bore.through = False
+    elif case == "short-axis":
+        bore.axis = (0.0, 1.0)
+    elif case == "short-location":
+        bore.location = (0.0, 0.0)
+    elif case == "zero-depth":
+        bore.depth = 0.0
+    elif case == "between-endpoints":
+        at = 5.0
+    elif case == "invalid-profile-size":
+        bore.across_flats = 10.0
+    elif case == "short-flat-direction":
+        bore.flat_direction = (1.0, 0.0)
+    elif case == "non-unit-flat-direction":
+        bore.flat_direction = (0.5, 0.0, 0.0)
+    elif case == "wrong-topology":
+        wire._edges.pop()
+    elif case == "wrong-arc-centre":
+        wire._edges[2].arc_center = _point(1.0, 0.0)
+    elif case == "off-plane-line":
+        wire._edges[0]._vertices[0].Z = 1.0
+    elif case in {"off-circle-end", "zero-line", "same-side"}:
+        wire = _profile_evidence(case)
+    elif case == "malformed-record":
+        bore = object()
+
+    assert not _double_d_bore_matches_principal_wire(
+        bore,
+        wire,
+        "z",
+        ("x", "y"),
+        at,
+        bbox,
+        1e-5,
+    )
+
+
+def test_public_double_d_to_physical_mouth_correlation_accepts_exact_evidence():
+    bore = SimpleNamespace(
+        axis=(0.0, 0.0, 1.0),
+        location=(0.0, 0.0, 10.0),
+        major_diameter=10.0,
+        across_flats=7.2,
+        depth=10.0,
+        through=True,
+        flat_direction=(1.0, 0.0, 0.0),
+    )
+    bbox = SimpleNamespace(min=_point(-15, -15, 0), max=_point(15, 15, 10))
+
+    assert _double_d_bore_matches_principal_wire(
+        bore,
+        _profile_evidence(),
+        "z",
+        ("x", "y"),
+        0.0,
+        bbox,
+        1e-5,
+    )
 
 
 def test_an_unpaired_opening_and_a_failed_void_proof_are_not_bores():
@@ -667,6 +832,23 @@ def test_double_d_orientation_is_not_limited_to_global_flat_axes():
 
 
 @pytest.mark.parametrize(
+    "part",
+    [
+        _double_d_bore(),
+        Rot(0, 0, 30) * _double_d_bore(),
+        Rot(0, 90, 0) * _double_d_bore(),
+        Rot(90, 0, 0) * _double_d_bore(),
+    ],
+    ids=("z", "z-roll-30", "x", "y"),
+)
+def test_lint_correlates_public_double_d_records_across_principal_axes(part):
+    bores = recognise_double_d_bores(part)
+
+    assert len(bores) == 1
+    assert lint_principal_profile_coverage(part, double_d_bores=bores) == []
+
+
+@pytest.mark.parametrize(
     ("part", "axis"),
     [
         (_double_d_bore(), (0.0, 0.0, 1.0)),
@@ -685,7 +867,17 @@ def test_assembly_components_own_their_bore_correspondence():
     bores = recognise_double_d_bores(part)
     assert len(bores) == 2
     assert [bore.depth for bore in bores] == pytest.approx([10, 10])
-    assert lint_principal_profile_coverage(part) == []
+    assert lint_principal_profile_coverage(part, double_d_bores=bores) == []
+
+
+def test_one_public_record_cannot_cover_two_coincident_assembly_occurrences():
+    part = Compound(children=[_double_d_bore(), _double_d_bore()])
+    bores = recognise_double_d_bores(part)
+
+    assert len(part.solids()) == len(bores) == 2
+    assert lint_principal_profile_coverage(part, double_d_bores=bores) == []
+    issues = lint_principal_profile_coverage(part, double_d_bores=bores[:1])
+    assert [issue.code for issue in issues] == ["unrecognised_defining_geometry"]
 
 
 def test_a_blind_double_d_recess_is_not_certified_as_a_through_bore():


### PR DESCRIPTION
## Summary

- consume the cached public `DoubleDBore` aggregate in principal-profile linting
- replace provider-private helpers with an independent physical mouth-to-record correspondence
- enforce the public recogniser import boundary for linting and fail closed on malformed evidence

This is the production-boundary slice of #1411. It does not close #1411; consumer-test cleanup and the broader 0.6.0 compatibility work remain.

## Architecture review

Audited against accepted ADRs 0007, 0013, 0015, and 0017. Lint continues to own its independent physical denominator, consumes one build-owned public aggregate, imports no provider-private module, imports no Draftwright IR, and does not rerun recognition.

No b123d-recognisers API change or upstream issue is required for this slice.

## Validation

- `scripts/pr-check --static`
- `uv run pytest tests/ -n 12 --dist loadscope -q` — 5,975 passed, 5 skipped, 2 xfailed
- changed-line coverage — 126/126, 100%
- three independent exact-head review tracks — clean, no nits, at `2a2837b8c51b04eeca8087ea26539d2c3372a85f`