### PR TITLE
Use public recogniser symbols in consumer tests

### DIFF
--- a/tests/test_detect_once.py
+++ b/tests/test_detect_once.py
@@ -84,9 +84,9 @@ def cyls_counter():
     Yields a live dict, so the count is read AFTER the work — matching the previous
     fixture's ``calls["n"]`` shape.
     """
-    import b123d_recognisers._features as _features
+    from b123d_recognisers import analyse_cylinders
 
-    with counting_calls({"n": _features.analyse_cylinders}) as counts:
+    with counting_calls({"n": analyse_cylinders}) as counts:
         yield counts
 
 

--- a/tests/test_grid_lattice_convention.py
+++ b/tests/test_grid_lattice_convention.py
@@ -232,7 +232,7 @@ def test_a_reversed_axis_keeps_the_same_frame(axis):
 
 def _oblique_and_principal_lattices():
     """The same 2×3 lattice laid in an oblique plane and in the Z plane."""
-    from b123d_recognisers._features import HoleRecord
+    from b123d_recognisers import HoleRecord
 
     axis = (0.6, -0.48, 0.64)
     n = math.hypot(*axis)
@@ -264,7 +264,7 @@ def test_an_oblique_lattice_does_not_become_a_pattern_feature():
     recogniser returned nothing would codify the layering violation the first cut had
     (#983 review).
     """
-    from b123d_recognisers._features import recognise_hole_patterns
+    from b123d_recognisers import recognise_hole_patterns
     from build123d import Box
 
     from draftwright.model.detect import build_part_model


### PR DESCRIPTION
## Summary

- import `analyse_cylinders` from the released root contract in the detect-once guard
- import public `HoleRecord` and `recognise_hole_patterns` from the root contract in the lattice consumer tests
- leave provider-owned `_plane_uv` / `_rect_grid` implementation coverage untouched under pzfreo/b123d-recognisers#400

This is another independent consumer cleanup slice of #1411 and does not close the issue.

## Architecture review

Audited against accepted ADRs 0007, 0013, 0015, and 0017. All three public exports are object-identical to their former private-module bindings, preserving code-object counting and lattice semantics. No production behavior, recognition lifecycle, IR, or recogniser API changes.

## Validation

- `scripts/pr-check --static`
- `uv run pytest tests/ -n 12 --dist loadscope -q` — 5,975 passed, 5 skipped, 2 xfailed
- focused consumer tests — 175 passed
- three independent exact-head reviews — clean, no nits, at `5277f695fab1e9edcc4c023c34393e0062c1fb09`