### PR TITLE
Verify public recogniser record contract structurally

### DIFF
--- a/tests/_recogniser_public_contract.py
+++ b/tests/_recogniser_public_contract.py
@@ -1,0 +1,99 @@
+"""Test helpers for the released public b123d-recognisers record contract."""
+
+from __future__ import annotations
+
+import dataclasses
+import inspect
+import types
+import typing
+
+import b123d_recognisers as recognition
+
+
+def _is_record_like_class(value: object) -> bool:
+    """Whether *value* has the released record shape, independent of publication."""
+
+    if not isinstance(value, type):
+        return False
+    params = getattr(value, "__dataclass_params__", None)
+    return bool(
+        dataclasses.is_dataclass(value)
+        and params is not None
+        and params.frozen
+        and callable(getattr(value, "to_dict", None))
+    )
+
+
+def is_public_record_class(value: object) -> bool:
+    """Whether *value* is a record class published at the package root."""
+
+    if not _is_record_like_class(value):
+        return False
+    name = getattr(value, "__name__", "")
+    return name in recognition.__all__ and getattr(recognition, name, None) is value
+
+
+def _nested_record_like_classes(annotation: object) -> set[type]:
+    """Find structurally record-like classes anywhere in an annotation."""
+
+    if _is_record_like_class(annotation):
+        return {annotation}
+    found: set[type] = set()
+    for member in typing.get_args(annotation):
+        found |= _nested_record_like_classes(member)
+    return found
+
+
+def public_record_return_types(annotation: object, *, source: str) -> set[type]:
+    """Validate and return the records in one public emitter's return annotation.
+
+    Non-record returns are outside this contract and contribute nothing. Once a public record
+    occurs anywhere in the annotation, however, ADR 0013's emitter grammar is strict: the
+    top-level shape is ``list[...]`` and every list member is a public record class.
+    """
+
+    nested = _nested_record_like_classes(annotation)
+    if not nested:
+        return set()
+
+    origin = typing.get_origin(annotation)
+    args = typing.get_args(annotation)
+    assert origin is list and len(args) == 1, (
+        f"{source} returns public record(s) in {annotation!r}; expected list[PublicRecord]"
+    )
+    element = args[0]
+    element_origin = typing.get_origin(element)
+    members = (
+        typing.get_args(element)
+        if element_origin in (typing.Union, types.UnionType)
+        else (element,)
+    )
+    invalid = [member for member in members if not is_public_record_class(member)]
+    assert not invalid, (
+        f"{source} has non-public-record list member(s) {invalid!r} in {annotation!r}"
+    )
+    return set(members)
+
+
+def public_record_universe() -> set[type]:
+    """Every record type returned by every released public package function."""
+
+    universe: set[type] = set()
+    for name in recognition.__all__:
+        fn = getattr(recognition, name)
+        if inspect.isclass(fn) or not callable(fn):
+            continue
+        try:
+            hints = typing.get_type_hints(fn)
+        except Exception as exc:
+            raise AssertionError(
+                f"could not resolve return hints for recognition.{name}: {exc!r}"
+            ) from exc
+        found = public_record_return_types(hints.get("return"), source=f"recognition.{name}")
+        if name.startswith(("recognise_", "project_")) or name == "step_level_records":
+            assert found, (
+                f"recognition.{name} has no public-record return annotation "
+                f"(got {hints.get('return')!r})"
+            )
+        universe |= found
+    return universe

--- a/tests/test_detect_registry.py
+++ b/tests/test_detect_registry.py
@@ -14,12 +14,17 @@ typed registry seam. These tests are the fail-closed guard on that seam:
 
 from __future__ import annotations
 
+import dataclasses
 import inspect
 import typing
 
 import b123d_recognisers as recognition
 import pytest
-from b123d_recognisers._record import Record
+from _recogniser_public_contract import (
+    public_record_return_types,
+    public_record_universe,
+)
+from b123d_recognisers import HoleRecord
 from build123d import Box, Cylinder, Pos
 
 from draftwright.model.detect import (
@@ -31,70 +36,55 @@ from draftwright.model.detect import (
     build_part_model,
     convert,
 )
-from draftwright.model.ir import Feature
-
-
-def _record_types_in(annot) -> set[type]:
-    """Every `Record` subclass reachable in a return annotation — unwrapping
-    ``list[...]``, unions/``| None`` and nesting.
-
-    Decompose parameterised generics (``get_args``) BEFORE the bare-class check: on
-    Python 3.10 ``isinstance(list[X], type)`` is ``True`` (a GenericAlias quirk fixed in
-    3.11), so an ``isinstance``-first order would treat ``list[BossRecord]`` as a plain
-    class and never reach its args — silently dropping the record type on 3.10."""
-    args = typing.get_args(annot)
-    if args:
-        out: set[type] = set()
-        for arg in args:
-            out |= _record_types_in(arg)
-        return out
-    if isinstance(annot, type):
-        return {annot} if issubclass(annot, Record) else set()
-    return set()
-
-
-#: Prefixes of the public functions that emit records into the IR. ``project_`` joined
-#: ``recognise_`` in #1025: ``project_step_shoulders`` produces ``StepShoulder``, which reaches
-#: ``StepLevelFeature.shoulders`` exactly as a recogniser's record would. Deriving the universe
-#: from ``recognise_`` alone would have quietly dropped that type from the completeness guard
-#: the moment it moved behind a projection — and left a future ``project_*`` record type with
-#: no home and no test saying so.
-_RECORD_EMITTING_PREFIXES = ("recognise_", "project_")
+from draftwright.model.ir import Feature, Frame
 
 
 def _recogniser_record_universe() -> set[type]:
-    """The authoritative set of record types, derived MECHANICALLY from the public
-    record-emitting functions' return annotations (not a hand-maintained list). This is what
-    makes the completeness guard genuinely fail-closed: add ``recognise_threads() ->
-    list[ThreadRecord]`` and ``ThreadRecord`` enters this universe automatically, so the
-    partition test below fails until it is given a home — matching the ADR 0013 claim
-    that a new recogniser cannot silently emit features with no converter."""
-    universe: set[type] = set()
-    for name in dir(recognition):
-        if not name.startswith(_RECORD_EMITTING_PREFIXES):
-            continue
-        fn = getattr(recognition, name)
-        # Fail loud, not open: an unresolvable return annotation must surface as a test
-        # failure naming the recogniser, never be silently skipped (which would let a new
-        # record type escape the universe and defeat the completeness guard below).
-        try:
-            hints = typing.get_type_hints(fn)
-        except Exception as exc:
-            raise AssertionError(
-                f"could not resolve return hints for recognition.{name}: {exc!r}"
-            ) from exc
-        # Every recogniser must *declare* a Record-typed return (all 14 today do:
-        # `list[<Record...>]`). A missing annotation (`get_type_hints` → no "return")
-        # or a non-Record return contributes nothing to the universe — which would let a
-        # new recogniser's record type escape the completeness guard. Reject it here so
-        # the fail-closed property survives a recogniser added with a bad/absent annotation.
-        found = _record_types_in(hints.get("return"))
-        assert found, (
-            f"recognition.{name} has no Record-typed return annotation "
-            f"(got {hints.get('return')!r}) — the record→Feature completeness guard needs one"
+    """The mechanically derived public record universe (kept as the historical test seam)."""
+
+    return public_record_universe()
+
+
+def test_record_return_grammar_rejects_private_mixed_or_non_list_shapes(monkeypatch):
+    """Finding one public record cannot bless unrelated members or an arbitrary container."""
+
+    @dataclasses.dataclass(frozen=True)
+    class _UnpublishedRecord:
+        value: int
+
+        def to_dict(self):
+            return {"value": self.value}
+
+    with pytest.raises(AssertionError, match="non-public-record list member"):
+        public_record_return_types(
+            list[_UnpublishedRecord], source="recognition.recognise_private"
         )
-        universe |= found
-    return universe
+    with pytest.raises(AssertionError, match=r"expected list\[PublicRecord\]"):
+        public_record_return_types(tuple[HoleRecord, int], source="recognition.recognise_bad")
+    with pytest.raises(AssertionError, match="non-public-record list member"):
+        public_record_return_types(list[HoleRecord | int], source="recognition.recognise_bad")
+    with pytest.raises(AssertionError, match="non-public-record list member"):
+        public_record_return_types(list[list[HoleRecord]], source="recognition.recognise_bad")
+
+    def recognise_private():
+        return []
+
+    recognise_private.__annotations__ = {"return": list[_UnpublishedRecord]}
+    with monkeypatch.context() as patch:
+        patch.setattr(recognition, "recognise_private", recognise_private, raising=False)
+        patch.setattr(recognition, "__all__", [*recognition.__all__, "recognise_private"])
+        with pytest.raises(AssertionError, match="non-public-record list member"):
+            public_record_universe()
+
+    def recognise_bad():
+        return []
+
+    recognise_bad.__annotations__ = {"return": list[int]}
+    with monkeypatch.context() as patch:
+        patch.setattr(recognition, "recognise_bad", recognise_bad, raising=False)
+        patch.setattr(recognition, "__all__", [*recognition.__all__, "recognise_bad"])
+        with pytest.raises(AssertionError, match="has no public-record return annotation"):
+            public_record_universe()
 
 
 def test_registry_tiers_partition_every_record_type():
@@ -186,6 +176,83 @@ def test_convert_fails_closed_on_unregistered_record():
         convert(_NotARecord(), ctx)
 
 
+def test_every_uniform_converter_lowers_a_representative_public_record_to_ir():
+    """The no-leak guard executes every registered 1:1 converter, not a lucky subset."""
+
+    from test_recogniser_contract import _records_from_recognisers
+
+    records = {type(record): record for _, record in _records_from_recognisers()}
+    missing = set(_CONVERTERS) - records.keys()
+    assert not missing, (
+        f"no representative record for converters: {sorted(t.__name__ for t in missing)}"
+    )
+
+    ctx = ConvContext(bbox=Box(200, 200, 200).bounding_box(), orientation="z")
+    provider_types = _recogniser_record_universe()
+    for record_type in _CONVERTERS:
+        converted = convert(records[record_type], ctx)
+        assert type(converted) not in provider_types, (
+            f"{record_type.__name__} converter leaked {type(converted).__name__}"
+        )
+        assert isinstance(converted, Feature), (
+            f"{record_type.__name__} converter returned {type(converted).__name__}, not IR"
+        )
+
+
+def test_every_derived_converter_lowers_representative_public_records_to_ir():
+    """Every grouped converter is called with real provider records and member evidence."""
+
+    from b123d_recognisers import (
+        HoleRecord,
+        recognise_hole_patterns,
+        recognise_holes,
+        recognise_pocket_patterns,
+        recognise_pockets,
+        recognise_slot_patterns,
+        recognise_slots,
+    )
+    from test_recogniser_contract import (
+        _bolt_circle_plate,
+        _csk_plate,
+        _grid_plate,
+        _linear_array_plate,
+        _pocket_array_plate,
+        _pocket_grid_plate,
+        _slot_array_plate,
+        _slot_grid_plate,
+    )
+
+    hole = recognise_holes(_csk_plate())[0]
+    converted: list[Feature] = [
+        _DERIVED_CONVERTERS[HoleRecord](hole, Frame(tuple(hole.location), "z"))
+    ]
+    cases = (
+        (recognise_holes, recognise_hole_patterns, _bolt_circle_plate),
+        (recognise_holes, recognise_hole_patterns, _linear_array_plate),
+        (recognise_holes, recognise_hole_patterns, _grid_plate),
+        (recognise_pockets, recognise_pocket_patterns, _pocket_array_plate),
+        (recognise_pockets, recognise_pocket_patterns, _pocket_grid_plate),
+        (recognise_slots, recognise_slot_patterns, _slot_array_plate),
+        (recognise_slots, recognise_slot_patterns, _slot_grid_plate),
+    )
+    exercised = {HoleRecord}
+    for recognise_members, recognise_patterns, build_part in cases:
+        members = recognise_members(build_part())
+        patterns = recognise_patterns(members)
+        assert len(patterns) == 1, build_part.__name__
+        pattern = patterns[0]
+        exercised.add(type(pattern))
+        converted.append(_DERIVED_CONVERTERS[type(pattern)](pattern, members))
+
+    assert exercised == set(_DERIVED_CONVERTERS), (
+        "derived converter corpus mismatch: "
+        f"missing={sorted(t.__name__ for t in set(_DERIVED_CONVERTERS) - exercised)}"
+    )
+    provider_types = _recogniser_record_universe()
+    assert all(type(feature) not in provider_types for feature in converted)
+    assert all(isinstance(feature, Feature) for feature in converted)
+
+
 def _rich_parts():
     """Parts spanning the feature families detect.py emits — holes, prismatic
     envelope, a turned profile (steps/boss), and a chamfer."""
@@ -196,13 +263,14 @@ def _rich_parts():
 
 def test_build_part_model_never_leaks_a_recognition_record():
     """The seam always lowers to the IR: no `build_part_model` output is a
-    recognition-layer `Record`; every feature satisfies the IR `Feature` shape."""
+    provider object; every feature satisfies the IR `Feature` shape."""
+    provider_types = _recogniser_record_universe()
     for part in _rich_parts():
         model = build_part_model(part)
         assert model.features, "expected the drive part to yield features"
         for f in model.features:
-            assert not isinstance(f, Record), (
-                f"recognition record leaked into IR: {type(f).__name__}"
+            assert type(f) not in provider_types, (
+                f"recognition-layer object leaked into IR: {type(f).__name__}"
             )
             # IR Feature shape (kind + frame + parameters), incl. the PMI/authored features.
             assert hasattr(f, "kind") and hasattr(f, "frame") and hasattr(f, "parameters")

--- a/tests/test_recogniser_contract.py
+++ b/tests/test_recogniser_contract.py
@@ -3,8 +3,8 @@
 Enforces the uniform contract mechanically (epic #584 WP3):
 
 - **Immutable records** — every recogniser returns frozen dataclasses.
-- **Uniform serialization** — each record has ``.to_dict()`` (the :class:`Record`
-  mixin) that yields a *JSON-serializable* nested dict. This is the invariant with
+- **Uniform serialization** — each public record has ``.to_dict()`` that yields a
+  *JSON-serializable* nested dict. This is the invariant with
   teeth: a leaked build123d / OCP object would make ``json.dumps`` raise, so the
   test proves the "geometry-only records, no build123d type leaks out" rule.
 - **Signature shape** — a part-based recogniser takes ``part`` then keyword-only
@@ -18,37 +18,17 @@ import inspect
 import json
 from pathlib import Path
 
+import b123d_recognisers as recognition
 import pytest
+from _recogniser_public_contract import public_record_universe
 from b123d_recognisers import (
-    BoltCircle,
-    BossRecord,
-    Chamfer,
-    Channel,
-    CounterSink,
-    DoubleDBore,
-    FaceLevel,
-    Fillet,
-    Flat,
-    Groove,
-    HoleRecord,
-    LinearArray,
-    Plate,
-    Pocket,
-    PocketArray,
-    PocketGrid,
-    PolygonalBoss,
-    RectGrid,
-    RepeatingRadialProfile,
-    Slot,
-    SlotArray,
-    SlotGrid,
-    StepShoulder,
-    TurnedStep,
     analyse_cylinders,
     project_step_shoulders,
+    recognise_angled_steps,
     recognise_bosses,
     recognise_chamfers,
     recognise_channels,
+    recognise_circular_blind_steps,
     recognise_countersinks,
     recognise_double_d_bores,
     recognise_face_levels,
@@ -57,50 +37,41 @@ from b123d_recognisers import (
     recognise_grooves,
     recognise_hole_patterns,
     recognise_holes,
+    recognise_paired_ramp_steps,
+    recognise_passages,
     recognise_plates,
     recognise_pocket_patterns,
     recognise_pockets,
     recognise_polygonal_bosses,
+    recognise_polygonal_stock,
+    recognise_prismatic_pockets,
+    recognise_rectangular_pads,
     recognise_repeating_radial_profiles,
     recognise_risers,
+    recognise_section_passages,
     recognise_slot_patterns,
     recognise_slots,
+    recognise_through_steps,
     recognise_turned_steps,
+    step_level_records,
 )
-from b123d_recognisers._record import Record
-from build123d import Align, Axis, Box, Cylinder, Pos, Rot, chamfer, fillet, import_step
-
-# Every record class a recogniser returns. The coverage test asserts the drive-parts
-# below actually emit one of each — so a record type that silently stops being produced
-# (or a new recogniser added without contract coverage) fails the test loudly, rather
-# than slipping through a bare count. (CounterBore/HoleSpec/TurnedProfile are sub-records
-# / aggregates, not recogniser returns, so they are exercised nested, not listed here.)
-_EXPECTED_RECORD_TYPES = {
-    HoleRecord,
-    DoubleDBore,
-    CounterSink,
-    BossRecord,
-    BoltCircle,
-    LinearArray,
-    RectGrid,
-    Chamfer,
-    Channel,
-    Fillet,
-    Flat,
-    Groove,
-    Slot,
-    SlotArray,
-    SlotGrid,
-    Pocket,
-    PocketArray,
-    PocketGrid,
-    PolygonalBoss,
-    Plate,
-    FaceLevel,
-    StepShoulder,
-    TurnedStep,
-    RepeatingRadialProfile,
-}
+from build123d import (
+    Align,
+    Axis,
+    Box,
+    BuildPart,
+    BuildSketch,
+    Cylinder,
+    Plane,
+    Polygon,
+    Pos,
+    RegularPolygon,
+    Rot,
+    chamfer,
+    extrude,
+    fillet,
+    import_step,
+)
 
 
 def _csk_plate():
@@ -204,6 +175,52 @@ def _polygonal_boss_plate():
     return Box(100, 80, 10) + Pos(0, 0, 5) * extrude(RegularPolygon(20, 6), 30)
 
 
+def _angled_step_part():
+    return import_step(
+        str(Path(__file__).parent / "fixtures" / "issue_1247_angled_blind_step.step")
+    )
+
+
+def _circular_blind_step_part():
+    return Box(40, 30, 20) - Pos(7.5, 15, 10) * Rot(0, 90, 0) * Cylinder(4, 25)
+
+
+def _paired_ramp_step_part():
+    profile = Polygon((0, -8), (0, 8), (-10, 0))
+    cutter = Pos(20, 20, 0) * extrude(Plane.XZ * profile, 25)
+    return Box(40, 40, 30) - cutter
+
+
+def _through_step_part():
+    return Box(40, 30, 20) - Pos(15, 10, 0) * Box(20, 20, 30)
+
+
+def _hexagonal_passage_plate():
+    plate = Box(120, 80, 20)
+    with BuildPart() as tool:
+        with BuildSketch(Plane.XY.offset(-20)):
+            RegularPolygon(12, 6)
+        extrude(amount=60)
+    return plate - Pos(-30, 0, 0) * tool.part
+
+
+def _hexagonal_pocket_plate():
+    plate = Box(120, 80, 20)
+    with BuildPart() as tool:
+        with BuildSketch(Plane.XY.offset(4)):
+            RegularPolygon(12, 6)
+        extrude(amount=20)
+    return plate - Pos(-30, 0, 0) * tool.part
+
+
+def _polygonal_stock():
+    return extrude(RegularPolygon(20, 6), 30)
+
+
+def _raised_pad_plate():
+    return Box(120, 90, 16) + Pos(0, -30, 10) * Box(30, 20, 4)
+
+
 def _records_from_recognisers():
     """(name, record) pairs across every recogniser, on parts that actually trigger them."""
     csk = _csk_plate()
@@ -256,6 +273,28 @@ def _records_from_recognisers():
         ("recognise_plates", recognise_plates(_l_bracket())),
         ("recognise_face_levels", recognise_face_levels(stepped)),
         ("recognise_risers", recognise_risers(stepped)),
+        ("step_level_records", step_level_records(stepped)),
+        ("recognise_angled_steps", recognise_angled_steps(_angled_step_part())),
+        (
+            "recognise_circular_blind_steps",
+            recognise_circular_blind_steps(_circular_blind_step_part()),
+        ),
+        (
+            "recognise_paired_ramp_steps",
+            recognise_paired_ramp_steps(_paired_ramp_step_part()),
+        ),
+        ("recognise_through_steps", recognise_through_steps(_through_step_part())),
+        ("recognise_passages", recognise_passages(_hexagonal_passage_plate())),
+        (
+            "recognise_section_passages",
+            recognise_section_passages(_hexagonal_passage_plate()),
+        ),
+        (
+            "recognise_prismatic_pockets",
+            recognise_prismatic_pockets(_hexagonal_pocket_plate()),
+        ),
+        ("recognise_polygonal_stock", recognise_polygonal_stock(_polygonal_stock())),
+        ("recognise_rectangular_pads", recognise_rectangular_pads(_raised_pad_plate())),
         (
             "recognise_repeating_radial_profiles",
             recognise_repeating_radial_profiles(
@@ -279,14 +318,22 @@ def _records_from_recognisers():
 
 
 def test_records_are_frozen_and_json_serializable():
-    """Every record from every recogniser is a frozen, JSON-serializable ``Record``."""
+    """Every result is a public, frozen, JSON-serializable record."""
     records = _records_from_recognisers()
 
     for name, rec in records:
-        assert isinstance(rec, Record), f"{name}: {type(rec).__name__} is not a Record"
-        assert dataclasses.is_dataclass(rec) and rec.__dataclass_params__.frozen, (
-            f"{name}: {type(rec).__name__} must be a frozen dataclass"
+        record_type = type(rec)
+        type_name = record_type.__name__
+        assert type_name in recognition.__all__, (
+            f"{name}: {type_name} is not published in b123d_recognisers.__all__"
         )
+        assert getattr(recognition, type_name, None) is record_type, (
+            f"{name}: root export {type_name} is not the returned record class"
+        )
+        assert dataclasses.is_dataclass(rec) and rec.__dataclass_params__.frozen, (
+            f"{name}: {type_name} must be a frozen dataclass"
+        )
+        assert callable(getattr(rec, "to_dict", None)), f"{name}: {type_name} has no to_dict()"
         d = rec.to_dict()
         assert isinstance(d, dict)
         # The teeth: a leaked build123d/OCP object makes this raise.
@@ -299,9 +346,13 @@ def test_every_record_type_is_actually_exercised():
     Guards against the count-only trap: a record type whose drive-part stops producing it
     (or a new record added without coverage) fails here instead of passing on a bare tally.
     """
+    expected = public_record_universe()
     seen = {type(rec) for _, rec in _records_from_recognisers()}
-    missing = _EXPECTED_RECORD_TYPES - seen
-    assert not missing, f"contract test never exercised these record types: {missing}"
+    assert seen == expected, (
+        "runtime contract roster disagrees with the mechanically derived public universe: "
+        f"missing={sorted(t.__name__ for t in expected - seen)}, "
+        f"unexpected={sorted(t.__name__ for t in seen - expected)}"
+    )
 
 
 def test_frozen_records_reject_mutation():


### PR DESCRIPTION
Part of #1411.

## Summary

- derive the released b123d-recognisers record universe structurally from public root exports and annotated emitter returns
- fail closed on unpublished records, malformed/nested return shapes, and required emitters without public records
- exercise all 34 current public record types and every uniform/derived Draftwright converter with real provider output

## ADR audit

- ADR 0013: preserves the public typed record-to-IR seam and makes converter completeness mechanical
- ADR 0017: keeps recognition provider-owned and tests Draftwright's consumer contract without private imports
- no production behavior changes and no new or changed recogniser API is required

## Independent exact-head review

Exact head `f470ae9195f4a664e7ee0b483062d1f557e52937` was independently reviewed for ADR alignment, contract correctness, and code quality. All three reviews are clean with no optional nits after four review/fix rounds.

## Validation

- `uv run pytest tests/test_detect_registry.py tests/test_recogniser_contract.py -q`: 16 passed
- `scripts/pr-check --static`: Ruff, formatting, mypy, and docs clean
- `uv run pytest tests/ -n 12 --dist loadscope`: 5,978 passed, 5 skipped, 2 xfailed
- `git diff --check`: clean
