### PR TITLE
Consume public recogniser profile evidence

### DIFF
--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -404,6 +404,9 @@ completeness slice. The remaining abstractions are evaluated separately after Ga
   recogniser is invoked outside the aggregate on guarded consumer paths.
 - [x] The released provider suite owns registry completeness, applicability, and exactly-once
   family execution; Draftwright does not duplicate those tests through private imports.
+- [x] Double-D, Passage, PrismaticPocket, and repeating-profile consumer tests read released
+  aggregate records and exercise Draftwright-owned physical correlation; the provider suite
+  owns its private profile predicates, attribution, and reconciliation algorithms.
 - [x] Declared build/render performs no recognition.
 - [x] Physical critique of a declared drawing obtains at most one cached aggregate.
 - [x] Repeated lint returns equivalent results without rerunning recognition.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -506,6 +506,9 @@ policy) live in `CLAUDE.md`. This is the per-ADR status trail; each ADR's
   private orchestration. Its consumer guard observes the public aggregate by code object and
   reports any public, part-taking recogniser invoked outside it, so a consumer cannot quietly
   grow a second scan while pure record projections remain reusable.
+  Double-D, Passage, PrismaticPocket, and repeating-profile consumer tests likewise read the
+  aggregate and test Draftwright's independent physical correlation; private profile predicates,
+  attribution, and family reconciliation remain provider-suite responsibilities.
   **#1022** landed the **ADR 0011 declared-path gate**: a declared build now recognises
   **nothing**. It was not one `if` — sizing sources the turned profile and step ladder from
   the declaration (`_declared_turned_profiles` / `_declared_step_zs` in `analysis.py`), and

--- a/docs/guard-audit.md
+++ b/docs/guard-audit.md
@@ -18,6 +18,7 @@ breaks its claimed contract (#1018 rule).
 | `test_compiled_plan_boundary.py` | **keep** | ADR 0016 Amdt 1: suppression-by-omission is unenforceable without it. |
 | `test_label_provenance.py` | **keep** | Active drawdown ratchet (#927, 26 sites). Re-audit when the budget reaches zero — at zero it becomes a simple boundary test. |
 | `recognition_consumer_calls` (`conftest.py`) | **keep** | ADR 0017 consumer ownership: counts the public aggregate and catches public physical-recogniser bypasses without inspecting provider internals. Provider registry completeness is owned by the released provider suite. |
+| `test_profile_consumer_tests_use_only_the_released_recogniser_root` | **keep** | #1411: the three consumer suites previously imported non-exported provider profile helpers and accumulated provider algorithm tests. The fixed file set is the regression boundary; provider-owned predicate coverage lives in released v0.4.9. |
 | `test_recogniser_contract.py` | **keep** | Cross-repository capability join; fail-closed by design. |
 | `test_detect_registry.py` | **keep** | Record→Feature completeness; a silently unadapted record family is invisible in output. |
 | `test_carve_free_position_callers.py` | **keep** | Two features (#555, #559) regressed onto the solver-invisible path before #636 — the failure mode recurred twice. Carries anti-tautology self-tests. |

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -552,6 +552,22 @@ def test_linting_consumes_recognisers_only_through_the_public_root():
     )
 
 
+def test_profile_consumer_tests_use_only_the_released_recogniser_root():
+    """Consumer evidence must not become a second home for provider implementation tests."""
+
+    tests = Path(__file__).resolve().parent
+    paths = (
+        tests / "test_issue_1058_wheel_profile.py",
+        tests / "test_issue_1245_passage_disposition.py",
+        tests / "test_issue_1246_prismatic_pocket_disposition.py",
+    )
+    offenders = [offender for path in paths for offender in _private_recogniser_imports(path)]
+    assert not offenders, (
+        "profile consumer tests must use released aggregate records and Draftwright-owned "
+        f"correlation evidence, not provider implementation modules: {offenders}"
+    )
+
+
 def test_public_root_guard_rejects_module_alias_loopholes(tmp_path):
     probe = tmp_path / "private_recogniser_imports.py"
     probe.write_text(

--- a/tests/test_issue_1058_wheel_profile.py
+++ b/tests/test_issue_1058_wheel_profile.py
@@ -11,23 +11,6 @@ from types import SimpleNamespace
 import pytest
 from b123d_recognisers import (
     build_raw_recognition_result,
-    recognise_double_d_bores,
-    recognise_repeating_radial_profiles,
-)
-from b123d_recognisers.profiled_bores import (
-    DoubleDProfile,
-    double_d_bores_from_openings,
-    double_d_profile,
-    principal_boundary_plane,
-)
-from b123d_recognisers.repeating_profiles import (
-    _CurveEvidence,
-    _cyclic_edge_orbits,
-    _distance,
-    _one_closed_cycle,
-    _polar_signature,
-    _rotate,
-    _sample_wire,
 )
 from build123d import (
     Align,
@@ -53,6 +36,7 @@ from draftwright.builder import detect_part_model
 from draftwright.linting.coverage import (
     CoverageState,
     _double_d_bore_matches_principal_wire,
+    _principal_boundary_plane,
     lint_principal_profile_coverage,
 )
 from draftwright.linting.profiled_bore_coverage import (
@@ -74,8 +58,6 @@ from draftwright.sheet_emit import _feature_line, _hole_line, emit_sheet_script
 _WHEEL = Path(__file__).parent / "fixtures" / "issue_1058_wheel_rh.step"
 _SHA256 = "4911c06426f0ceeedc198416e058aabc1c1a6a65e9e766eca7efed5484a27cda"
 _CENTER = (Align.CENTER, Align.CENTER, Align.CENTER)
-_RADIAL_REPEAT_COUNT = 13
-_CORRESPONDENCE_TOL = 1e-5
 
 
 def _double_d_bore():
@@ -193,13 +175,6 @@ def _profile_evidence(case="valid"):
     return _ProfileWire([*lines, *arcs], size=size)
 
 
-def _sample_outer_wire(face, *, samples=9) -> tuple[_CurveEvidence, ...]:
-    assert samples == 9
-    evidence = _sample_wire(face.outer_wire(), ("x", "y"))
-    assert evidence is not None
-    return evidence
-
-
 @pytest.fixture(scope="module")
 def wheel_part():
     return import_step(str(_WHEEL))
@@ -212,7 +187,13 @@ def wheel_drawing():
 
 def _wheel_end_faces(part):
     bbox = part.bounding_box()
-    return [face for face in part.faces() if principal_boundary_plane(face, bbox)]
+    return [face for face in part.faces() if _principal_boundary_plane(face, bbox)]
+
+
+def _recognised_double_d_bores(part):
+    """Read Double-D evidence through the released aggregate contract."""
+
+    return build_raw_recognition_result(part).double_d_bores
 
 
 def test_real_wheel_fixture_proves_the_double_d_profile(wheel_part):
@@ -244,10 +225,10 @@ def test_real_wheel_fixture_proves_the_double_d_profile(wheel_part):
         )
 
 
-def test_real_wheel_proves_complete_thirteen_sector_correspondence(wheel_part):
+def test_real_wheel_fixture_has_thirteen_sector_boundaries(wheel_part):
     end_faces = _wheel_end_faces(wheel_part)
     assert len(end_faces) == 2
-    boundaries = [principal_boundary_plane(face, wheel_part.bounding_box()) for face in end_faces]
+    boundaries = [_principal_boundary_plane(face, wheel_part.bounding_box()) for face in end_faces]
     assert [boundary[0] for boundary in boundaries if boundary] == ["z", "z"]
     assert sorted(boundary[2] for boundary in boundaries if boundary) == pytest.approx(
         [-3.8500001, 3.8500001]
@@ -264,22 +245,9 @@ def test_real_wheel_proves_complete_thirteen_sector_correspondence(wheel_part):
             abs=1e-6,
         )
 
-        evidence = _sample_outer_wire(face)
-        orbits = _cyclic_edge_orbits(
-            evidence,
-            centre=(0.0, 0.0),
-            repeat_count=_RADIAL_REPEAT_COUNT,
-            tol=_CORRESPONDENCE_TOL,
-        )
-        assert orbits is not None
-        assert [len(orbit) for orbit in orbits] == [13, 13, 13, 13]
-        assert Counter(evidence[orbit[0]].kind for orbit in orbits) == Counter(
-            {GeomType.BSPLINE.name: 3, GeomType.CIRCLE.name: 1}
-        )
-
 
 def test_production_recogniser_carries_complete_serialisable_profile_evidence(wheel_part):
-    (profile,) = recognise_repeating_radial_profiles(wheel_part)
+    (profile,) = build_raw_recognition_result(wheel_part).repeating_radial_profiles
 
     assert profile.axis == "z"
     assert profile.centre == pytest.approx((0.0, 0.0, 0.0), abs=1e-6)
@@ -290,25 +258,6 @@ def test_production_recogniser_carries_complete_serialisable_profile_evidence(wh
         {GeomType.BSPLINE.name: 3, GeomType.CIRCLE.name: 1}
     )
     assert len(profile.to_dict()["sector_signature"]) == 4
-
-
-def test_equal_profiles_on_distinct_bodies_remain_ambiguous(wheel_part, monkeypatch):
-    import b123d_recognisers.repeating_profiles as repeating_profiles
-
-    (profile,) = recognise_repeating_radial_profiles(wheel_part)
-    bodies = (object(), object())
-    part = SimpleNamespace(solids=lambda: bodies)
-    monkeypatch.setattr(
-        repeating_profiles,
-        "_recognise_solid",
-        lambda solid, **_kwargs: (
-            [repeating_profiles._RepeatingRadialProposal(profile, object(), object())]
-            if solid in bodies
-            else []
-        ),
-    )
-
-    assert repeating_profiles.recognise_repeating_radial_profiles(part) == [profile, profile]
 
 
 def test_declared_gear_reconciles_to_the_recognition_owned_profile(wheel_part):
@@ -341,190 +290,6 @@ def test_declared_gear_reconciles_to_the_recognition_owned_profile(wheel_part):
         & codes
     )
     assert "unrecognised_defining_geometry" in codes
-
-
-def test_full_profile_correspondence_ignores_start_and_traversal(wheel_part):
-    evidence = _sample_outer_wire(_wheel_end_faces(wheel_part)[0])
-    shifted = evidence[7:] + evidence[:7]
-    reversed_traversal = tuple(
-        replace(edge, points=tuple(reversed(edge.points))) for edge in reversed(evidence)
-    )
-
-    for candidate in (shifted, reversed_traversal):
-        assert (
-            _cyclic_edge_orbits(
-                candidate,
-                centre=(0.0, 0.0),
-                repeat_count=_RADIAL_REPEAT_COUNT,
-                tol=_CORRESPONDENCE_TOL,
-            )
-            is not None
-        )
-
-
-def test_common_circle_arcs_alone_do_not_prove_full_sector_correspondence(wheel_part):
-    evidence = _sample_outer_wire(_wheel_end_faces(wheel_part)[0])
-    arcs = tuple(edge for edge in evidence if edge.kind == GeomType.CIRCLE.name)
-    assert len(arcs) == 13
-    assert (
-        _cyclic_edge_orbits(
-            arcs,
-            centre=(0.0, 0.0),
-            repeat_count=_RADIAL_REPEAT_COUNT,
-            tol=_CORRESPONDENCE_TOL,
-        )
-        is None
-    )
-
-
-def test_empty_or_unsampleable_wire_evidence_fails_closed():
-    class _BadEdge:
-        geom_type = GeomType.BSPLINE
-        length = 1.0
-
-        def position_at(self, _fraction):
-            raise RuntimeError("malformed curve")
-
-    wire = SimpleNamespace(edges=lambda: [_BadEdge()])
-    assert not _one_closed_cycle((), tol=_CORRESPONDENCE_TOL)
-    assert _sample_wire(wire, ("x", "y")) is None
-
-
-def test_ambiguous_or_self_joined_endpoint_graph_fails_closed():
-    ambiguous = (
-        _CurveEvidence("line", 1.0, ((0.0, 0.0), (1.5e-5, 0.0))),
-        _CurveEvidence("line", 1.0, ((0.75e-5, 0.0), (1.0, 0.0))),
-    )
-    self_joined = (_CurveEvidence("line", 1.0, ((0.0, 0.0), (0.0, 0.0))),)
-
-    assert not _one_closed_cycle(ambiguous, tol=1e-5)
-    assert not _one_closed_cycle(self_joined, tol=1e-5)
-
-
-def test_polar_signature_is_stable_across_the_angle_branch_cut():
-    points = ((-1.0, 0.01), (-1.0, -0.01), (-0.9, -0.02))
-
-    assert _polar_signature(points, (0.0, 0.0)) == _polar_signature(
-        tuple(reversed(points)), (0.0, 0.0)
-    )
-
-
-def test_malformed_faces_and_a_shape_without_owned_solids_fail_closed(monkeypatch):
-    import b123d_recognisers.repeating_profiles as repeating_profiles
-
-    bbox = SimpleNamespace(
-        size=_point(1.0, 1.0, 1.0),
-        min=_point(0.0, 0.0, 0.0),
-        max=_point(1.0, 1.0, 1.0),
-    )
-    shape = SimpleNamespace(
-        bounding_box=lambda: bbox,
-        faces=lambda: [object()],
-        solids=lambda: [],
-    )
-
-    def malformed_boundary(*_args, **_kwargs):
-        raise RuntimeError("malformed face")
-
-    monkeypatch.setattr(repeating_profiles, "_prove_boundary", malformed_boundary)
-    assert repeating_profiles.recognise_repeating_radial_profiles(shape) == []
-
-
-def test_one_changed_intervening_curve_breaks_full_sector_correspondence(wheel_part):
-    evidence = list(_sample_outer_wire(_wheel_end_faces(wheel_part)[0]))
-    changed_index = next(
-        index for index, edge in enumerate(evidence) if edge.kind == GeomType.BSPLINE.name
-    )
-    changed = evidence[changed_index]
-    points = list(changed.points)
-    x, y = points[len(points) // 2]
-    points[len(points) // 2] = (x + 0.01, y)
-    evidence[changed_index] = replace(changed, points=tuple(points))
-
-    assert len([edge for edge in evidence if edge.kind == GeomType.CIRCLE.name]) == 13
-    assert (
-        _cyclic_edge_orbits(
-            evidence,
-            centre=(0.0, 0.0),
-            repeat_count=_RADIAL_REPEAT_COUNT,
-            tol=_CORRESPONDENCE_TOL,
-        )
-        is None
-    )
-
-
-def test_an_open_outer_cycle_cannot_prove_sector_correspondence(wheel_part):
-    evidence = list(_sample_outer_wire(_wheel_end_faces(wheel_part)[0]))
-    changed = evidence[0]
-    points = list(changed.points)
-    x, y = points[0]
-    points[0] = (x + 0.01, y)
-    evidence[0] = replace(changed, points=tuple(points))
-
-    assert not _one_closed_cycle(tuple(evidence), tol=_CORRESPONDENCE_TOL)
-    assert (
-        _cyclic_edge_orbits(
-            evidence,
-            centre=(0.0, 0.0),
-            repeat_count=_RADIAL_REPEAT_COUNT,
-            tol=_CORRESPONDENCE_TOL,
-        )
-        is None
-    )
-
-
-def test_one_unequal_sector_pitch_breaks_correspondence_even_when_closed(wheel_part):
-    evidence = list(_sample_outer_wire(_wheel_end_faces(wheel_part)[0]))
-    endpoint = evidence[0].points[0]
-    partners = [
-        (edge_index, point_index)
-        for edge_index, edge in enumerate(evidence[1:], start=1)
-        for point_index in (0, -1)
-        if _distance(endpoint, edge.points[point_index]) <= 1e-8
-    ]
-    assert len(partners) == 1
-
-    moved = _rotate(endpoint, 0.01, centre=(0.0, 0.0))
-    for edge_index, point_index in ((0, 0), partners[0]):
-        edge = evidence[edge_index]
-        points = list(edge.points)
-        points[point_index] = moved
-        evidence[edge_index] = replace(edge, points=tuple(points))
-
-    assert _one_closed_cycle(tuple(evidence), tol=_CORRESPONDENCE_TOL)
-    assert (
-        _cyclic_edge_orbits(
-            evidence,
-            centre=(0.0, 0.0),
-            repeat_count=_RADIAL_REPEAT_COUNT,
-            tol=_CORRESPONDENCE_TOL,
-        )
-        is None
-    )
-
-
-def test_non_bijective_sector_mapping_is_rejected_before_orbit_claim(wheel_part, monkeypatch):
-    import b123d_recognisers.repeating_profiles as repeating_profiles
-
-    evidence = _sample_outer_wire(_wheel_end_faces(wheel_part)[0])
-    assert _one_closed_cycle(evidence, tol=_CORRESPONDENCE_TOL)
-    targets = [(index + 4) % len(evidence) for index in range(len(evidence))]
-    targets[1] = targets[0]  # two source curves now claim the same physical target curve
-    target_for = {id(source): evidence[target] for source, target in zip(evidence, targets)}
-
-    def non_bijective(source, target, **_kwargs):
-        return target is target_for[id(source)]
-
-    monkeypatch.setattr(repeating_profiles, "_curves_match", non_bijective)
-    assert (
-        repeating_profiles._cyclic_edge_orbits(
-            evidence,
-            centre=(0.0, 0.0),
-            repeat_count=_RADIAL_REPEAT_COUNT,
-            tol=_CORRESPONDENCE_TOL,
-        )
-        is None
-    )
 
 
 def test_real_wheel_no_longer_gets_a_confident_envelope_only_result(wheel_drawing):
@@ -590,7 +355,7 @@ def test_physical_profile_scan_accepts_no_caller_extent():
     part = _double_d_bore()
     issues = lint_principal_profile_coverage(
         part,
-        double_d_bores=recognise_double_d_bores(part),
+        double_d_bores=_recognised_double_d_bores(part),
     )
     assert issues == []
 
@@ -649,7 +414,7 @@ def test_physical_profile_scan_requires_the_public_aggregate_projection():
 )
 def test_physical_profile_scan_requires_exact_public_double_d_correspondence(changes):
     part = _double_d_bore()
-    bore = replace(recognise_double_d_bores(part)[0], **changes)
+    bore = replace(_recognised_double_d_bores(part)[0], **changes)
 
     issues = lint_principal_profile_coverage(part, double_d_bores=(bore,))
 
@@ -658,32 +423,13 @@ def test_physical_profile_scan_requires_exact_public_double_d_correspondence(cha
 
 @pytest.mark.parametrize("part", [_lens_bore(), _l_bore()], ids=("circular-arcs", "linear-l"))
 def test_edge_types_alone_do_not_certify_a_supported_profile(part):
-    assert recognise_double_d_bores(part) == []
+    assert _recognised_double_d_bores(part) == ()
     issues = [
         issue
         for issue in build_drawing(part).lint()
         if issue.code in {"passage_requirement_unsupported", "unrecognised_defining_geometry"}
     ]
     assert len(issues) == 1
-
-
-@pytest.mark.parametrize(
-    "case",
-    [
-        "zero-radius",
-        "missing-radius",
-        "one-vertex",
-        "zero-line",
-        "off-circle-end",
-        "non-parallel",
-        "same-side",
-        "degenerate-flat",
-        "wrong-chord-length",
-        "wrong-arc-length",
-    ],
-)
-def test_malformed_line_arc_evidence_fails_closed(case):
-    assert double_d_profile(_profile_evidence(case), ("x", "y"), tol=1e-5) is None
 
 
 @pytest.mark.parametrize(
@@ -781,37 +527,8 @@ def test_public_double_d_to_physical_mouth_correlation_accepts_exact_evidence():
     )
 
 
-def test_an_unpaired_opening_and_a_failed_void_proof_are_not_bores():
-    bbox = SimpleNamespace(min=_point(-5, -5, -5), max=_point(5, 5, 5))
-    low = DoubleDProfile(
-        centre=(0.0, 0.0, -5.0),
-        major_diameter=10.0,
-        across_flats=7.2,
-        flat_direction=(1.0, 0.0, 0.0),
-    )
-    high = DoubleDProfile(
-        centre=(0.0, 0.0, 5.0),
-        major_diameter=10.0,
-        across_flats=7.2,
-        flat_direction=(1.0, 0.0, 0.0),
-    )
-    assert (
-        double_d_bores_from_openings([("z", -5.0, low, object())], bbox, part=object(), tol=1e-5)
-        == []
-    )
-    assert (
-        double_d_bores_from_openings(
-            [("z", -5.0, low, object()), ("z", 5.0, high, object())],
-            bbox,
-            part=object(),
-            tol=1e-5,
-        )
-        == []
-    )
-
-
 def test_recogniser_reports_the_complete_double_d_geometry():
-    assert recognise_double_d_bores(_double_d_bore())[0].to_dict() == {
+    assert _recognised_double_d_bores(_double_d_bore())[0].to_dict() == {
         "axis": (0.0, 0.0, 1.0),
         "location": (0.0, 0.0, 5.0),
         "major_diameter": 10.0,
@@ -825,7 +542,7 @@ def test_recogniser_reports_the_complete_double_d_geometry():
 def test_double_d_orientation_is_not_limited_to_global_flat_axes():
     cutter = Rot(0, 0, 30) * _double_d_cutter()
     part = Box(30, 30, 10, align=_CENTER) - cutter
-    bore = recognise_double_d_bores(part)[0]
+    bore = _recognised_double_d_bores(part)[0]
     assert bore.major_diameter == pytest.approx(10)
     assert bore.across_flats == pytest.approx(7.2)
     assert bore.flat_direction == pytest.approx((0.8660254, 0.5, 0.0), abs=1e-6)
@@ -842,7 +559,7 @@ def test_double_d_orientation_is_not_limited_to_global_flat_axes():
     ids=("z", "z-roll-30", "x", "y"),
 )
 def test_lint_correlates_public_double_d_records_across_principal_axes(part):
-    bores = recognise_double_d_bores(part)
+    bores = _recognised_double_d_bores(part)
 
     assert len(bores) == 1
     assert lint_principal_profile_coverage(part, double_d_bores=bores) == []
@@ -858,13 +575,13 @@ def test_lint_correlates_public_double_d_records_across_principal_axes(part):
     ids=("z", "x", "y"),
 )
 def test_recogniser_is_uniform_across_principal_bore_axes(part, axis):
-    assert recognise_double_d_bores(part)[0].axis == axis
+    assert _recognised_double_d_bores(part)[0].axis == axis
 
 
 def test_assembly_components_own_their_bore_correspondence():
     part = _double_d_bore() + Pos(0, 0, 30) * _double_d_bore()
     assert len(part.solids()) == 2
-    bores = recognise_double_d_bores(part)
+    bores = _recognised_double_d_bores(part)
     assert len(bores) == 2
     assert [bore.depth for bore in bores] == pytest.approx([10, 10])
     assert lint_principal_profile_coverage(part, double_d_bores=bores) == []
@@ -872,7 +589,7 @@ def test_assembly_components_own_their_bore_correspondence():
 
 def test_one_public_record_cannot_cover_two_coincident_assembly_occurrences():
     part = Compound(children=[_double_d_bore(), _double_d_bore()])
-    bores = recognise_double_d_bores(part)
+    bores = _recognised_double_d_bores(part)
 
     assert len(part.solids()) == len(bores) == 2
     assert lint_principal_profile_coverage(part, double_d_bores=bores) == []
@@ -882,7 +599,7 @@ def test_one_public_record_cannot_cover_two_coincident_assembly_occurrences():
 
 def test_a_blind_double_d_recess_is_not_certified_as_a_through_bore():
     part = _blind_double_d_recess()
-    assert recognise_double_d_bores(part) == []
+    assert _recognised_double_d_bores(part) == ()
     issues = [
         issue
         for issue in build_drawing(part).lint()
@@ -894,7 +611,7 @@ def test_a_blind_double_d_recess_is_not_certified_as_a_through_bore():
 
 def test_opposed_blind_recesses_do_not_prove_a_through_bore():
     part = _opposed_double_d_recesses_with_a_web()
-    assert recognise_double_d_bores(part) == []
+    assert _recognised_double_d_bores(part) == ()
     issues = [
         issue
         for issue in build_drawing(part).lint()
@@ -1178,7 +895,7 @@ def test_an_intermediate_double_d_boss_boundary_is_not_an_opening():
 )
 def test_supported_principal_profiles_remain_owned_and_clean(part, expected_kind):
     drawing = build_drawing(part)
-    assert recognise_double_d_bores(part) == []
+    assert _recognised_double_d_bores(part) == ()
     if expected_kind is not None:
         assert expected_kind in {feature.kind for feature in drawing.model().features}
     assert not [

--- a/tests/test_issue_1245_passage_disposition.py
+++ b/tests/test_issue_1245_passage_disposition.py
@@ -7,11 +7,13 @@ from types import SimpleNamespace
 
 import pytest
 from b123d_recognisers import build_raw_recognition_result
-from b123d_recognisers.profiled_bores import principal_boundary_plane
 from build123d import Box, Ellipse, GeomType, Pos, RegularPolygon, extrude
 
 from draftwright import build_drawing
-from draftwright.linting.coverage import _passage_matches_principal_wire
+from draftwright.linting.coverage import (
+    _passage_matches_principal_wire,
+    _principal_boundary_plane,
+)
 from draftwright.linting.passage_coverage import lint_passage_coverage
 from draftwright.linting.quality import quality_components
 from draftwright.registry import AnnotationRegistry
@@ -26,7 +28,7 @@ def _matched_mouth(part, passage):
     bbox = part.bounding_box()
     tol = max(1e-5, max(float(bbox.size.X), float(bbox.size.Y), float(bbox.size.Z)) * 1e-5)
     for face in part.faces():
-        boundary = principal_boundary_plane(face, bbox)
+        boundary = _principal_boundary_plane(face, bbox)
         if boundary is None:
             continue
         axis, plane_axes, at = boundary

--- a/tests/test_issue_1246_prismatic_pocket_disposition.py
+++ b/tests/test_issue_1246_prismatic_pocket_disposition.py
@@ -6,12 +6,7 @@ from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
-from b123d_recognisers import (
-    build_raw_recognition_result,
-    recognise_pockets,
-    recognise_prismatic_pockets,
-)
-from b123d_recognisers.profiled_bores import principal_boundary_plane
+from b123d_recognisers import build_raw_recognition_result
 from build123d import (
     Box,
     BuildPart,
@@ -26,7 +21,10 @@ from build123d import (
 )
 
 from draftwright import build_drawing
-from draftwright.linting.coverage import _prismatic_pocket_matches_principal_wire
+from draftwright.linting.coverage import (
+    _principal_boundary_plane,
+    _prismatic_pocket_matches_principal_wire,
+)
 from draftwright.linting.prismatic_pocket_coverage import lint_prismatic_pocket_coverage
 
 
@@ -54,7 +52,7 @@ def _matched_mouth(part, pocket):
     bbox = part.bounding_box()
     tol = max(1e-5, max(float(bbox.size.X), float(bbox.size.Y), float(bbox.size.Z)) * 1e-5)
     for face in part.faces():
-        boundary = principal_boundary_plane(face, bbox)
+        boundary = _principal_boundary_plane(face, bbox)
         if boundary is None:
             continue
         axis, plane_axes, at = boundary
@@ -159,8 +157,6 @@ def test_a_prismatic_pocket_is_an_explicit_unsupported_completeness_outcome() ->
 def test_aggregate_reconciliation_counts_the_rectangular_recess_only_as_pocket() -> None:
     part = _hexagonal_pocket_part(rectangular=True)
 
-    assert len(recognise_prismatic_pockets(part)) == 2, "direct calls precede reconciliation"
-    assert len(recognise_pockets(part)) == 1
     recognition = build_raw_recognition_result(part)
     assert len(recognition.prismatic_pockets) == 1
     assert len(recognition.pockets) == 1


### PR DESCRIPTION
Part of #1411.

## Summary

- move Double-D, Passage, PrismaticPocket, and repeating-profile consumer tests from provider-private helpers/direct family calls to the released `RecognitionResult` aggregate
- use Draftwright’s own independent principal-boundary and physical-correlation evidence in consumer checks
- remove 319 lines of provider predicate, topology sampling, attribution, ambiguity, and family-reconciliation re-certification after verifying equivalent or stronger tests in the released b123d-recognisers v0.4.9 tag
- add a scoped AST guard preventing these consumer suites from importing provider implementation modules again
- document the provider/consumer ownership split in ADR 0017, architecture, and the guard audit

No new or changed recogniser API is required.

## Architecture review

Reviewed against accepted ADRs 0007, 0013, 0015, and 0017. The provider owns recognition algorithms and family reconciliation. Draftwright owns aggregate consumption, independent physical correlation, IR/lint behavior, and downstream drawing semantics.

## Review evidence

Exact head `798ebb5b6cbda734e537dff815c53f17add7df14`, based directly on merged main `77b961664302369d1c4d2e1c1786071bed2b41d3`, received fresh independent ADR, public-contract, and quality reviews. All three report clean with no optional nits.

## Validation

- focused consumer/import/docs suite: 126 passed
- reviewer focused suites: 125–138 passed
- static: Ruff, format, mypy, and documentation build clean
- full 12-worker suite: 5,946 passed, 5 skipped, 2 xfailed

Merge remains gated on the exact-head hosted matrix, `ci-ok`, and Codecov project/patch.