### PR TITLE
Prove rectangular blind-slot completeness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,9 +51,12 @@
   `OPEN SLOT … DEEP` leader. Authored subsets retain every approved value with explicit
   `WIDE`/`LONG`/`DEEP` roles, and leaders target proved cap/side material rather than the open
   mouth. Native raw and rigidly moved framed builds retain the same three
-  measurement outcomes. Independent physical completeness scoring remains deferred under #1421,
-  and the distinct round-bottom family remains fully deferred (#1421; ADRs 0011, 0013–0017,
-  0020).
+  measurement outcomes. A seven-case independently authored corpus now pins all six run/open-side
+  orientations plus an independently sized specimen: each occurrence contributes separate width,
+  capped-run and depth requirements followed by exact structural correspondence and measurement
+  provenance to placed, structured-note, suppressed, dropped, missing or unverifiable outcomes.
+  Removing recognition cannot shrink that 21-requirement benchmark, and the distinct round-bottom
+  family remains fully deferred (#1421; ADRs 0011, 0013–0017, 0020).
 
 - Turned-step completeness is now backed by an independently authored, hash-pinned 11-case STEP
   corpus with 26 physical outside-diameter bands, 52 parameter checks and 104 downstream checks.

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -6,7 +6,8 @@
   prismatic step inventories incorporated by Amendment 4 (2026-08-30). Amendment 5
   (2026-09-01) incorporates the 0.4.10 prismatic blind-slot inventories; Amendment 6
   (2026-09-02) adopts the rectangular family's compiler semantics while retaining an
-  evidence gate around completeness.
+  evidence gate around completeness. Amendment 7 (2026-09-02) closes that rectangular
+  completeness gate with independent physical evidence and semantic outcomes.
 - **Date:** 2026-08-03
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -175,6 +176,29 @@ audited score on annotation presence. The round-bottom family remains fully defe
 separate flat-width and floor-radius semantics are delivered. Native raw and rigidly moved framed
 tests establish measurement/callout parity without treating an ORTHOGONAL frame representative as
 authored material-axis identity.
+
+## Amendment 7 — rectangular blind-slot completeness is evidence-backed
+
+Each aggregate rectangular blind-slot occurrence now contributes three independent physical
+requirements: U-section width, capped mouth-to-terminal run and flat-bottom depth. Correspondence
+uses the complete released structural record—axis, both opening signs, transverse axis roles, three
+sizes and centre—at the generated Sheet program's documented 0.001 mm precision. Duplicate sources,
+duplicate IR matches, malformed records, near neighbours and parameter/span disagreement are
+unverifiable rather than guessed.
+
+The requirements then follow their exact `DimensionId` values through the ADR 0010 registry seam to
+`placed`, `satisfied_by_structured_note`, authored `suppressed`, placement `dropped`, `missing`, or
+`unverifiable`. The ledger does not parse labels or names and does not use views, projected geometry,
+leader tips, page coordinates or the approved plan as its physical denominator. Compiler omissions
+are read only to distinguish authored suppression after source-to-IR correspondence is established.
+
+An independently authored seven-case corpus fixes all six principal run-axis/open-side orientations
+and a separately sized specimen: 7 physical occurrences, 21 parameters and 21 finished drawing
+outcomes. Removing the rectangular inventory produces zero observed outcomes while the authored
+21-requirement benchmark remains, so recognition loss cannot self-certify. Direct declarations and
+executed generated declarations earn the same outcomes, and all three approved identities must be
+present for a fully complete automatic callout. The rectangular family now enters the audited
+completeness denominator; round-bottom blind slots remain separately deferred.
 
 ## Accepted Contract
 

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -529,10 +529,15 @@ rigidly moved framed builds preserve the same three measurements and drawing sem
 
 This is intentionally not an ordinary through `SlotFeature`, which cannot state a blind terminal
 wall or section depth, and not a rectangular pocket, which cannot state the open end. Independent
-physical completeness scoring remains deferred under #1421, so live rectangular occurrences stay
-in `unscored_recognized_families` and do not silently earn ordinary slot/pocket coverage. The
-round-bottom family remains deferred at every semantic boundary: its separate flat width and floor
-radius still need their own IR, Sheet word, callout grammar and evidence.
+physical completeness is now supported by a seven-case authored corpus covering all six run/open
+orientations and a separately sized specimen. Each recognised occurrence contributes three
+requirements—width, capped run and flat-bottom depth—and exact released structural facts join it to
+one IR feature before measurement identities establish placed, structured-note, authored-
+suppressed, dropped, missing or unverifiable outcomes. Labels, annotation names, views, projections,
+leader tips and page coordinates cannot certify correspondence. The rectangular family therefore
+participates in `audited_score`; the distinct round-bottom family remains deferred at every semantic
+boundary because its flat width and floor radius still need their own IR, Sheet word, callout grammar
+and evidence.
 
 ## Recognisers 0.4.9 prepared frame boundary
 

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -123,6 +123,7 @@ from draftwright.linting import (
     lint_prismatic_coverage,
     lint_prismatic_pocket_coverage,
     lint_profiled_bore_coverage,
+    lint_rectangular_blind_slot_coverage,
     lint_slot_coverage,
     lint_through_step_coverage,
     pmi_stage_summary,
@@ -3695,6 +3696,14 @@ class Drawing:
                 assembly=self.assembly,
             )
             issues += lint_circular_blind_step_coverage(
+                working_part,
+                recognition=recognition,
+                features=getattr(model, "features", ()) if model is not None else (),
+                registry=self._registry,
+                omissions=self._build.omissions,
+                assembly=self.assembly,
+            )
+            issues += lint_rectangular_blind_slot_coverage(
                 working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),

--- a/src/draftwright/linting/__init__.py
+++ b/src/draftwright/linting/__init__.py
@@ -59,6 +59,9 @@ from draftwright.linting.polygonal_boss_coverage import lint_polygonal_boss_cove
 from draftwright.linting.polygonal_stock_coverage import lint_polygonal_stock_coverage
 from draftwright.linting.prismatic_pocket_coverage import lint_prismatic_pocket_coverage
 from draftwright.linting.profiled_bore_coverage import lint_profiled_bore_coverage
+from draftwright.linting.rectangular_blind_slot_coverage import (
+    lint_rectangular_blind_slot_coverage,
+)
 from draftwright.linting.slot_coverage import lint_slot_coverage
 from draftwright.linting.structural import is_dimension_like, lint_drawing
 from draftwright.linting.suggest import _suggest_fix
@@ -107,4 +110,5 @@ __all__ = [
     "lint_principal_profile_coverage",
     "lint_profiled_bore_coverage",
     "lint_prismatic_coverage",
+    "lint_rectangular_blind_slot_coverage",
 ]

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -49,6 +49,9 @@ from draftwright.linting.pocket_coverage import pocket_requirement_outcomes
 from draftwright.linting.pocket_pattern_coverage import pocket_pattern_requirement_outcomes
 from draftwright.linting.polygonal_boss_coverage import polygonal_boss_requirement_outcomes
 from draftwright.linting.polygonal_stock_coverage import polygonal_stock_outcomes
+from draftwright.linting.rectangular_blind_slot_coverage import (
+    rectangular_blind_slot_requirement_outcomes,
+)
 from draftwright.linting.slot_coverage import slot_requirement_outcomes
 from draftwright.linting.through_step_coverage import through_step_requirement_outcomes
 from draftwright.linting.turned_step_coverage import turned_step_requirement_outcomes
@@ -186,6 +189,7 @@ _AUDITED_FAMILIES = (
     "pockets",
     "pocket_patterns",
     "prismatic_pockets",
+    "rectangular_blind_slots",
     "slot_patterns",
     "slots",
     "through_steps",
@@ -418,6 +422,7 @@ _UNSCORED_CODE_PREFIXES = (
     "pocket_pattern_requirement_",
     "polygonal_boss_requirement_",
     "polygonal_stock_requirement_",
+    "rectangular_blind_slot_requirement_",
     "slot_requirement_",
 )
 
@@ -659,6 +664,9 @@ def _completeness_component(
         "polygonal_stock": polygonal_stock_outcomes(recognition, features, registry, omissions),
         "pockets": pocket_requirement_outcomes(recognition, features, registry, omissions),
         "pocket_patterns": pocket_pattern_requirement_outcomes(
+            recognition, features, registry, omissions
+        ),
+        "rectangular_blind_slots": rectangular_blind_slot_requirement_outcomes(
             recognition, features, registry, omissions
         ),
         "slots": [],

--- a/src/draftwright/linting/rectangular_blind_slot_coverage.py
+++ b/src/draftwright/linting/rectangular_blind_slot_coverage.py
@@ -1,0 +1,314 @@
+"""Semantic completeness for recognised rectangular blind slots (#1421).
+
+Each aggregate ``RectangularBlindSlot`` owns three independently auditable requirements:
+the U-section width, the capped mouth-to-terminal run and the flat-bottom depth.  Every
+released structural fact joins the provider record to one IR feature; exact parameter
+identities then follow those requirements to drawing outcomes.  Labels, annotation names,
+views, projected geometry, leader tips and page coordinates are never correspondence evidence.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from math import isfinite
+from numbers import Real
+from typing import Literal
+
+from b123d_recognisers import RecognitionResult, RectangularBlindSlot
+
+from draftwright.linting._registry import satisfaction_ids, satisfaction_of
+from draftwright.linting.issues import LintIssue, is_placement_drop
+
+RectangularBlindSlotRequirementState = Literal[
+    "placed",
+    "satisfied_by_structured_note",
+    "suppressed",
+    "dropped",
+    "missing",
+    "unverifiable",
+]
+
+_PARAMETERS = (
+    "rectangular_blind_slot_width.length",
+    "rectangular_blind_slot_length.length",
+    "rectangular_blind_slot_depth.length",
+)
+
+
+@dataclass(frozen=True)
+class RectangularBlindSlotRequirementOutcome:
+    """The observable engine outcome of one width, run or depth requirement."""
+
+    source_at: tuple[float, float, float]
+    parameter_id: str
+    state: RectangularBlindSlotRequirementState
+    requirement_count: int = 1
+    features: tuple = ()
+
+
+def _rounded(value) -> float:
+    try:
+        result = round(float(value), 3)
+    except (OverflowError, TypeError, ValueError) as exc:
+        raise ValueError from exc
+    if not isfinite(result):
+        raise ValueError
+    return result
+
+
+def _positive(value) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise ValueError
+    result = _rounded(value)
+    if result <= 0:
+        raise ValueError
+    return result
+
+
+def _point(value) -> tuple[float, float, float]:
+    if (
+        not isinstance(value, tuple)
+        or len(value) != 3
+        or any(
+            isinstance(component, bool) or not isinstance(component, Real) for component in value
+        )
+    ):
+        raise ValueError
+    return (_rounded(value[0]), _rounded(value[1]), _rounded(value[2]))
+
+
+def rectangular_blind_slot_key(slot, *, require_frame: bool = False) -> tuple:
+    """Return all public structural facts after validating their exact schema.
+
+    Rounding is limited to the generated Sheet program's documented 0.001 mm precision.
+    Ambiguous duplicate keys fail closed in :func:`rectangular_blind_slot_requirement_outcomes`.
+    """
+
+    axes = (slot.axis, slot.width_axis, slot.depth_axis)
+    if (
+        any(not isinstance(axis, str) or axis not in {"x", "y", "z"} for axis in axes)
+        or len(set(axes)) != 3
+    ):
+        raise ValueError
+    for sign in (slot.open_sign, slot.depth_sign):
+        if not isinstance(sign, int) or isinstance(sign, bool) or sign not in (-1, 1):
+            raise ValueError
+    if require_frame:
+        if slot.frame.axis != slot.axis:
+            raise ValueError
+        at = _point(slot.frame.origin)
+    else:
+        at = _point(slot.at)
+    return (
+        slot.axis,
+        slot.open_sign,
+        slot.width_axis,
+        slot.depth_axis,
+        slot.depth_sign,
+        _positive(slot.width),
+        _positive(slot.length),
+        _positive(slot.depth),
+        at,
+    )
+
+
+def _source_at(source) -> tuple[float, float, float]:
+    try:
+        return _point(source.at)
+    except (AttributeError, OverflowError, TypeError, ValueError):
+        return (float("nan"), float("nan"), float("nan"))
+
+
+def _span(at, axis: str, value: float) -> tuple[tuple[float, float, float], ...]:
+    lo = list(at)
+    hi = list(at)
+    index = "xyz".index(axis)
+    lo[index] -= value / 2
+    hi[index] += value / 2
+    return (_point(tuple(lo)), _point(tuple(hi)))
+
+
+def _parameter_ids(feature, source) -> tuple[str, ...] | None:
+    try:
+        parameters = tuple(feature.parameters())
+        observed = {}
+        for parameter in parameters:
+            parameter_id = parameter.parameter_id
+            if not isinstance(parameter_id, str) or parameter_id in observed:
+                return None
+            span = (
+                tuple(_point(point) for point in parameter.span)
+                if parameter.span is not None
+                else None
+            )
+            observed[parameter_id] = (_positive(parameter.value), span)
+        source_at = _point(source.at)
+        expected_values = (
+            _positive(source.width),
+            _positive(source.length),
+            _positive(source.depth),
+        )
+        expected_spans = (
+            _span(source_at, source.width_axis, expected_values[0]),
+            _span(source_at, source.axis, expected_values[1]),
+            _span(source_at, source.depth_axis, expected_values[2]),
+        )
+        expected = dict(zip(_PARAMETERS, zip(expected_values, expected_spans), strict=True))
+    except (AttributeError, IndexError, OverflowError, TypeError, ValueError):
+        return None
+    if observed != expected:
+        return None
+    return _PARAMETERS
+
+
+def _index_evidence(registry):
+    placed = {
+        (measurement.feature, measurement.parameter)
+        for name in registry.names()
+        for measurement in registry.measurement_of(name)
+    }
+    satisfied = {
+        (identity.feature, identity.parameter)
+        for identity in satisfaction_ids(registry)
+        if identity.feature is not None and isinstance(identity.parameter, str)
+    }
+    dropped = {
+        (measurement.feature, measurement.parameter)
+        for issue in registry.issues
+        if is_placement_drop(issue)
+        for measurement in getattr(issue, "measurement_ids", ())
+        if getattr(measurement, "feature", None) is not None
+        and isinstance(getattr(measurement, "parameter", None), str)
+    }
+    return placed, satisfied, dropped
+
+
+def rectangular_blind_slot_requirement_outcomes(
+    recognition: RecognitionResult | None,
+    features,
+    registry,
+    omissions=(),
+) -> list[RectangularBlindSlotRequirementOutcome]:
+    """Follow all three requirements of every recognised rectangular blind slot."""
+
+    if recognition is None:
+        return []
+    if not isinstance(recognition, RecognitionResult):
+        raise TypeError(
+            "rectangular_blind_slot_requirement_outcomes() requires the run's "
+            f"RecognitionResult; got {type(recognition).__name__}"
+        )
+    if not isinstance(recognition.rectangular_blind_slots, tuple):
+        raise TypeError("RecognitionResult.rectangular_blind_slots must be an immutable tuple")
+    sources = recognition.rectangular_blind_slots
+    if not sources:
+        return []
+
+    keyed_sources: list[tuple[RectangularBlindSlot, tuple | None]] = []
+    source_counts: dict[tuple, int] = defaultdict(int)
+    for source in sources:
+        try:
+            if not isinstance(source, RectangularBlindSlot):
+                raise TypeError
+            key = rectangular_blind_slot_key(source)
+        except (AttributeError, IndexError, OverflowError, TypeError, ValueError):
+            key = None
+        keyed_sources.append((source, key))
+        if key is not None:
+            source_counts[key] += 1
+
+    ir_by_key: dict[tuple, list] = defaultdict(list)
+    for feature in features:
+        if getattr(feature, "kind", None) != "rectangular_blind_slot":
+            continue
+        try:
+            ir_by_key[rectangular_blind_slot_key(feature, require_frame=True)].append(feature)
+        except (AttributeError, IndexError, OverflowError, TypeError, ValueError):
+            continue
+
+    placed, satisfied, dropped = _index_evidence(registry)
+    suppressed = {
+        (omission.feature, omission.parameter_id)
+        for omission in omissions
+        if omission.feature is not None and omission.authored
+    }
+    outcomes: list[RectangularBlindSlotRequirementOutcome] = []
+    for source, key in keyed_sources:
+        matches = ir_by_key.get(key, ()) if key is not None else ()
+        feature = (
+            matches[0] if key is not None and len(matches) == source_counts[key] == 1 else None
+        )
+        parameter_ids = _parameter_ids(feature, source) if feature is not None else None
+        if parameter_ids is None:
+            outcomes.extend(
+                RectangularBlindSlotRequirementOutcome(
+                    _source_at(source), parameter, "unverifiable"
+                )
+                for parameter in _PARAMETERS
+            )
+            continue
+        for parameter in parameter_ids:
+            identity = (feature, parameter)
+            if identity in placed:
+                state: RectangularBlindSlotRequirementState = "placed"
+            elif identity in satisfied:
+                state = "satisfied_by_structured_note"
+            elif identity in suppressed:
+                state = "suppressed"
+            elif identity in dropped:
+                state = "dropped"
+            else:
+                associated = registry.names_for_feature(feature)
+                state = (
+                    "unverifiable"
+                    if any(
+                        not registry.measurement_of(name) and not satisfaction_of(registry, name)
+                        for name in associated
+                    )
+                    else "missing"
+                )
+            outcomes.append(
+                RectangularBlindSlotRequirementOutcome(
+                    _source_at(source), parameter, state, features=(feature,)
+                )
+            )
+    return outcomes
+
+
+def lint_rectangular_blind_slot_coverage(
+    part,
+    *,
+    recognition: RecognitionResult | None,
+    features,
+    registry,
+    omissions=(),
+    assembly=None,
+) -> list[LintIssue]:
+    """Report uncovered rectangular blind-slot requirements without duplicate drops."""
+
+    if assembly is None:
+        assembly = len(part.solids()) > 1
+    severity: Literal["info", "warning"] = "info" if assembly else "warning"
+    messages = {
+        "suppressed": "was deliberately omitted by the authored dimension set",
+        "missing": "has no placed, suppressed, or dropped measurement outcome",
+        "unverifiable": "cannot be joined to measurement provenance without guessing",
+    }
+    issues = []
+    for outcome in rectangular_blind_slot_requirement_outcomes(
+        recognition, features, registry, omissions
+    ):
+        if outcome.state in {"placed", "satisfied_by_structured_note", "dropped"}:
+            continue
+        issues.append(
+            LintIssue(
+                severity=severity,
+                code=f"rectangular_blind_slot_requirement_{outcome.state}",
+                message=(
+                    f"rectangular blind slot {outcome.parameter_id} at {outcome.source_at} "
+                    f"{messages[outcome.state]}"
+                ),
+            )
+        )
+    return issues

--- a/src/draftwright/recogniser_contract.py
+++ b/src/draftwright/recogniser_contract.py
@@ -280,6 +280,12 @@ def _family_declaration(family_id: str, spec: _FamilySpec) -> dict[str, Any]:
             "draftwright.linting.circular_blind_step_coverage.lint_circular_blind_step_coverage",
             "tests/test_issue_1382_circular_blind_step_semantics.py",
         )
+    elif family_id == "rectangular-blind-slots":
+        completeness = _supported(
+            "draftwright.linting.rectangular_blind_slot_coverage."
+            "lint_rectangular_blind_slot_coverage",
+            "tests/test_issue_1421_rectangular_blind_slot_completeness.py",
+        )
     elif family_id == "through-steps":
         completeness = _supported(
             "draftwright.linting.through_step_coverage.lint_through_step_coverage",
@@ -756,6 +762,18 @@ def consumer_capability_declaration() -> dict[str, Any]:
                 "from": "deferred",
                 "release_notes": "CHANGELOG.md",
                 "to": "unsupported",
+                "version": distribution_version("draftwright"),
+            },
+            {
+                "boundary": "completeness",
+                "compatibility_evidence": [
+                    "tests/test_issue_1421_rectangular_blind_slot_completeness.py",
+                    "tests/test_recogniser_capabilities.py",
+                ],
+                "family": "rectangular-blind-slots",
+                "from": "deferred",
+                "release_notes": "CHANGELOG.md",
+                "to": "supported",
                 "version": distribution_version("draftwright"),
             },
             {

--- a/tests/test_issue_1143_hole_completeness.py
+++ b/tests/test_issue_1143_hole_completeness.py
@@ -280,6 +280,7 @@ def test_pattern_and_central_bore_have_a_complete_recognition_owned_ledger():
         "polygonal_stock": 0,
         "pockets": 0,
         "pocket_patterns": 0,
+        "rectangular_blind_slots": 0,
         "slots": 0,
         "slot_patterns": 0,
         "through_steps": 0,

--- a/tests/test_issue_1421_rectangular_blind_slot_completeness.py
+++ b/tests/test_issue_1421_rectangular_blind_slot_completeness.py
@@ -1,0 +1,589 @@
+"""#1421 — rectangular blind-slot completeness uses independent physical facts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from types import SimpleNamespace
+
+import pytest
+from b123d_recognisers import build_raw_recognition_result
+from build123d import Align, Axis, Box, Pos
+
+from draftwright import Sheet, build_drawing
+from draftwright.linting.issues import LintIssue
+from draftwright.linting.rectangular_blind_slot_coverage import (
+    lint_rectangular_blind_slot_coverage,
+    rectangular_blind_slot_key,
+    rectangular_blind_slot_requirement_outcomes,
+)
+from draftwright.model import DimensionId, Frame
+from draftwright.model.compiled import compile_dimensions
+from draftwright.registry import AnnotationRegistry
+from draftwright.sheet_emit import _feature_line
+
+_PARAMETERS = (
+    "rectangular_blind_slot_width.length",
+    "rectangular_blind_slot_length.length",
+    "rectangular_blind_slot_depth.length",
+)
+
+
+def _part(*, width=10, depth=5, length=20):
+    stock = Box(30, 20, 40, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    tool = Pos(0, 10 - depth, 0) * Box(
+        width, depth, length, align=(Align.CENTER, Align.MIN, Align.MIN)
+    )
+    return stock - tool
+
+
+@dataclass(frozen=True)
+class _Case:
+    name: str
+    part: object
+    axis: str
+    open_sign: int
+    width_axis: str
+    depth_axis: str
+    depth_sign: int
+    width: float
+    length: float
+    depth: float
+    at: tuple[float, float, float]
+
+    def declaration(self) -> dict:
+        return {
+            "axis": self.axis,
+            "open_sign": self.open_sign,
+            "length": self.length,
+            "width_axis": self.width_axis,
+            "depth_axis": self.depth_axis,
+            "depth_sign": self.depth_sign,
+            "width": self.width,
+            "depth": self.depth,
+            "at": self.at,
+        }
+
+
+class _FeatureProxy:
+    """Keep structural facts fixed while independently varying compiler parameters."""
+
+    def __init__(self, feature, parameters) -> None:
+        self._feature = feature
+        self._parameters = tuple(parameters)
+
+    def __getattr__(self, name):
+        return getattr(self._feature, name)
+
+    def parameters(self):
+        return list(self._parameters)
+
+
+# Every expected fact is authored here rather than derived from provider output or Draftwright
+# IR.  The six physical axis/open-side orientations plus an independently sized specimen make
+# recognition loss, sign swaps and parameter-role swaps visible to the benchmark.
+_CASES = (
+    _Case("z-negative", _part(), "z", -1, "x", "y", 1, 10, 20, 5, (0, 7.5, 10)),
+    _Case(
+        "z-sized", _part(width=6, depth=4, length=15), "z", -1, "x", "y", 1, 6, 15, 4, (0, 8, 7.5)
+    ),
+    _Case(
+        "z-positive",
+        _part().rotate(Axis.X, 180),
+        "z",
+        1,
+        "x",
+        "y",
+        -1,
+        10,
+        20,
+        5,
+        (0, -7.5, -10),
+    ),
+    _Case(
+        "x-negative",
+        _part().rotate(Axis.Y, 90),
+        "x",
+        -1,
+        "z",
+        "y",
+        1,
+        10,
+        20,
+        5,
+        (10, 7.5, 0),
+    ),
+    _Case(
+        "x-positive",
+        _part().rotate(Axis.Y, -90),
+        "x",
+        1,
+        "z",
+        "y",
+        1,
+        10,
+        20,
+        5,
+        (-10, 7.5, 0),
+    ),
+    _Case(
+        "y-positive",
+        _part().rotate(Axis.X, 90),
+        "y",
+        1,
+        "x",
+        "z",
+        1,
+        10,
+        20,
+        5,
+        (0, -10, 7.5),
+    ),
+    _Case(
+        "y-negative",
+        _part().rotate(Axis.X, -90),
+        "y",
+        -1,
+        "x",
+        "z",
+        -1,
+        10,
+        20,
+        5,
+        (0, 10, -7.5),
+    ),
+)
+
+
+def _source(case: _Case):
+    recognition = build_raw_recognition_result(case.part)
+    assert recognition.slots == recognition.pockets == recognition.channels == ()
+    assert len(recognition.rectangular_blind_slots) == 1
+    return recognition, recognition.rectangular_blind_slots[0]
+
+
+def _feature(drawing):
+    features = [
+        feature for feature in drawing.model().features if feature.kind == "rectangular_blind_slot"
+    ]
+    assert len(features) == 1
+    return features[0]
+
+
+@pytest.mark.parametrize("case", _CASES, ids=lambda case: case.name)
+def test_independent_corpus_reaches_recognition_ir_and_finished_measurements(case) -> None:
+    recognition, source = _source(case)
+    assert (
+        source.axis,
+        source.open_sign,
+        source.width_axis,
+        source.depth_axis,
+        source.depth_sign,
+        source.width,
+        source.length,
+        source.depth,
+        source.at,
+    ) == (
+        case.axis,
+        case.open_sign,
+        case.width_axis,
+        case.depth_axis,
+        case.depth_sign,
+        case.width,
+        case.length,
+        case.depth,
+        case.at,
+    )
+
+    drawing = build_drawing(case.part)
+    feature = _feature(drawing)
+    assert (
+        feature.axis,
+        feature.open_sign,
+        feature.width_axis,
+        feature.depth_axis,
+        feature.depth_sign,
+        feature.width,
+        feature.length,
+        feature.depth,
+        feature.frame.origin,
+    ) == (
+        case.axis,
+        case.open_sign,
+        case.width_axis,
+        case.depth_axis,
+        case.depth_sign,
+        case.width,
+        case.length,
+        case.depth,
+        case.at,
+    )
+    outcomes = rectangular_blind_slot_requirement_outcomes(
+        recognition, drawing.model().features, drawing.registry
+    )
+    assert [(outcome.parameter_id, outcome.state) for outcome in outcomes] == [
+        (parameter, "placed") for parameter in _PARAMETERS
+    ]
+    assert not [
+        issue
+        for issue in drawing.lint()
+        if issue.code.startswith("rectangular_blind_slot_requirement_")
+    ]
+    completeness = drawing.lint_summary()["quality"]["completeness"]
+    assert completeness["by_family"]["rectangular_blind_slots"] == 3
+    assert "rectangular_blind_slots" not in completeness["unscored_recognized_families"]
+
+
+def test_corpus_denominator_does_not_shrink_when_recognition_is_removed() -> None:
+    expected_physical_requirements = 3 * len(_CASES)
+    observed = 0
+    damaged = 0
+    for case in _CASES:
+        recognition, _source_record = _source(case)
+        observed += 3 * len(recognition.rectangular_blind_slots)
+        weakened = replace(recognition, rectangular_blind_slots=())
+        damaged += len(
+            rectangular_blind_slot_requirement_outcomes(weakened, (), AnnotationRegistry())
+        )
+
+    assert expected_physical_requirements == observed == 21
+    assert damaged == 0
+    assert damaged < expected_physical_requirements
+
+
+def test_declared_and_executed_generated_sheet_paths_earn_the_same_outcomes() -> None:
+    case = _CASES[1]
+    recognition, _source_record = _source(case)
+
+    declared = Sheet(case.part).authored_dimensions()
+    declared_handle = declared.rectangular_blind_slot(**case.declaration())
+    for parameter in _PARAMETERS:
+        declared.dimension(declared_handle, parameter)
+    declared_drawing = declared.build()
+
+    emitted = _feature_line(declared.model().features[0])
+    replay = Sheet(case.part).authored_dimensions()
+    replay_handle = eval(emitted, {"sheet": replay})  # noqa: S307
+    for parameter in _PARAMETERS:
+        replay.dimension(replay_handle, parameter)
+    replay_drawing = replay.build()
+
+    signatures = []
+    for drawing in (declared_drawing, replay_drawing):
+        feature = _feature(drawing)
+        outcomes = rectangular_blind_slot_requirement_outcomes(
+            recognition, drawing.model().features, drawing.registry
+        )
+        signatures.append(
+            (
+                feature,
+                tuple((outcome.parameter_id, outcome.state) for outcome in outcomes),
+                tuple(
+                    sorted(
+                        key["parameter_id"]
+                        for name in drawing.annotations_of(feature)
+                        for key in drawing.measurement_keys(name)
+                    )
+                ),
+            )
+        )
+    assert signatures[0] == signatures[1]
+    assert signatures[0][1] == tuple((parameter, "placed") for parameter in _PARAMETERS)
+    assert signatures[0][2] == tuple(sorted(_PARAMETERS))
+
+
+def test_authored_subset_is_suppressed_not_silently_complete() -> None:
+    case = _CASES[0]
+    recognition, _source_record = _source(case)
+    sheet = Sheet(case.part).authored_dimensions()
+    handle = sheet.rectangular_blind_slot(**case.declaration())
+    sheet.dimension(handle, _PARAMETERS[0])
+    drawing = sheet.build()
+
+    outcomes = rectangular_blind_slot_requirement_outcomes(
+        recognition,
+        drawing.model().features,
+        drawing.registry,
+        compile_dimensions(drawing.model()).diagnostics,
+    )
+    assert {outcome.parameter_id: outcome.state for outcome in outcomes} == {
+        _PARAMETERS[0]: "placed",
+        _PARAMETERS[1]: "suppressed",
+        _PARAMETERS[2]: "suppressed",
+    }
+    issues = [
+        issue
+        for issue in drawing.lint()
+        if issue.code.startswith("rectangular_blind_slot_requirement_")
+    ]
+    assert len(issues) == 2
+    assert {issue.code for issue in issues} == {"rectangular_blind_slot_requirement_suppressed"}
+    completeness = drawing.lint_summary()["quality"]["completeness"]
+    assert completeness["by_family"]["rectangular_blind_slots"] == 3
+    assert completeness["placed"] >= 1
+    assert completeness["suppressed"] >= 2
+
+
+def test_ledger_distinguishes_every_engine_outcome_and_duplicate_sources() -> None:
+    drawing = build_drawing(_CASES[0].part)
+    recognition = drawing.recognition()
+    assert recognition is not None
+    feature = _feature(drawing)
+
+    assert [
+        outcome.state
+        for outcome in rectangular_blind_slot_requirement_outcomes(
+            recognition, drawing.model().features, drawing.registry
+        )
+    ] == ["placed", "placed", "placed"]
+
+    empty = AnnotationRegistry()
+    assert [
+        outcome.state
+        for outcome in rectangular_blind_slot_requirement_outcomes(
+            recognition, drawing.model().features, empty
+        )
+    ] == ["missing", "missing", "missing"]
+
+    omission = SimpleNamespace(feature=feature, parameter_id=_PARAMETERS[0], authored=True)
+    assert [
+        outcome.state
+        for outcome in rectangular_blind_slot_requirement_outcomes(
+            recognition, drawing.model().features, empty, (omission,)
+        )
+    ] == ["suppressed", "missing", "missing"]
+
+    dropped = AnnotationRegistry()
+    dropped.record_issue(
+        LintIssue(
+            "warning",
+            "synthetic placement failure",
+            code="rectangular_blind_slot_dropped",
+            measurement_ids=(DimensionId(feature, _PARAMETERS[1]),),
+            outcome_stage="placement",
+        )
+    )
+    assert [
+        outcome.state
+        for outcome in rectangular_blind_slot_requirement_outcomes(
+            recognition, drawing.model().features, dropped
+        )
+    ] == ["missing", "dropped", "missing"]
+
+    satisfied = AnnotationRegistry()
+    satisfied.add(
+        object(),
+        "structured_note",
+        "front",
+        feature=feature,
+        satisfaction=DimensionId(feature, _PARAMETERS[2]),
+    )
+    assert [
+        outcome.state
+        for outcome in rectangular_blind_slot_requirement_outcomes(
+            recognition, drawing.model().features, satisfied
+        )
+    ] == ["missing", "missing", "satisfied_by_structured_note"]
+
+    manual = AnnotationRegistry()
+    manual.add(object(), "unowned_prose", "front", feature=feature)
+    assert {
+        outcome.state
+        for outcome in rectangular_blind_slot_requirement_outcomes(
+            recognition, drawing.model().features, manual
+        )
+    } == {"unverifiable"}
+
+    duplicated = replace(
+        recognition,
+        rectangular_blind_slots=(
+            recognition.rectangular_blind_slots[0],
+            recognition.rectangular_blind_slots[0],
+        ),
+    )
+    ambiguous = rectangular_blind_slot_requirement_outcomes(
+        duplicated, drawing.model().features, empty
+    )
+    assert len(ambiguous) == 6
+    assert {outcome.state for outcome in ambiguous} == {"unverifiable"}
+
+
+def test_parameter_correspondence_is_identity_based_not_sibling_order() -> None:
+    drawing = build_drawing(_CASES[0].part)
+    recognition = drawing.recognition()
+    assert recognition is not None
+    feature = _feature(drawing)
+    reordered = _FeatureProxy(feature, reversed(feature.parameters()))
+    registry = AnnotationRegistry()
+    registry.add(
+        object(),
+        "reordered-parameters",
+        "front",
+        feature=reordered,
+        measurement=tuple(DimensionId(reordered, parameter) for parameter in _PARAMETERS),
+    )
+
+    assert [
+        outcome.state
+        for outcome in rectangular_blind_slot_requirement_outcomes(
+            recognition, (reordered,), registry
+        )
+    ] == ["placed", "placed", "placed"]
+
+
+def test_correspondence_rejects_near_neighbours_and_malformed_ir_parameters() -> None:
+    drawing = build_drawing(_CASES[0].part)
+    recognition = drawing.recognition()
+    assert recognition is not None
+    feature = _feature(drawing)
+    shifted_origin = list(feature.frame.origin)
+    shifted_origin["xyz".index(feature.axis)] += 0.002
+    shifted = replace(feature, frame=Frame(tuple(shifted_origin), feature.axis))
+    registry = AnnotationRegistry()
+    registry.add(
+        object(),
+        "near-neighbour",
+        "front",
+        feature=shifted,
+        measurement=tuple(DimensionId(shifted, parameter) for parameter in _PARAMETERS),
+    )
+    assert {
+        outcome.state
+        for outcome in rectangular_blind_slot_requirement_outcomes(
+            recognition, (shifted,), registry
+        )
+    } == {"unverifiable"}
+
+    wrong_size = replace(feature, width=feature.width + 1)
+    assert {
+        outcome.state
+        for outcome in rectangular_blind_slot_requirement_outcomes(
+            recognition, (wrong_size,), AnnotationRegistry()
+        )
+    } == {"unverifiable"}
+
+    _recognition, source = _source(_CASES[0])
+    parameters = tuple(feature.parameters())
+    assert parameters[0].span is not None
+    shifted_span_start = list(parameters[0].span[0])
+    shifted_span_start[0] += 0.002
+    malformed_parameters = (
+        (
+            replace(parameters[0], role="rectangular_blind_slot_unknown"),
+            *parameters[1:],
+        ),
+        (replace(parameters[0], value=parameters[0].value + 1), *parameters[1:]),
+        (
+            replace(
+                parameters[0],
+                span=(tuple(shifted_span_start), parameters[0].span[1]),
+            ),
+            *parameters[1:],
+        ),
+        (*parameters, parameters[0]),
+    )
+    for malformed in malformed_parameters:
+        proxy = _FeatureProxy(feature, malformed)
+        assert rectangular_blind_slot_key(proxy, require_frame=True) == rectangular_blind_slot_key(
+            source
+        )
+        assert {
+            outcome.state
+            for outcome in rectangular_blind_slot_requirement_outcomes(
+                recognition, (proxy,), AnnotationRegistry()
+            )
+        } == {"unverifiable"}
+
+    assert {
+        outcome.state
+        for outcome in rectangular_blind_slot_requirement_outcomes(
+            recognition, (feature, feature), AnnotationRegistry()
+        )
+    } == {"unverifiable"}
+
+
+def test_lint_does_not_duplicate_a_recorded_placement_drop() -> None:
+    drawing = build_drawing(_CASES[0].part)
+    recognition = drawing.recognition()
+    assert recognition is not None
+    feature = _feature(drawing)
+    registry = AnnotationRegistry()
+    registry.record_issue(
+        LintIssue(
+            "warning",
+            "synthetic joint-solver drop",
+            code="rectangular_blind_slot_dropped",
+            measurement_ids=tuple(DimensionId(feature, parameter) for parameter in _PARAMETERS),
+            outcome_stage="placement",
+        )
+    )
+
+    assert (
+        lint_rectangular_blind_slot_coverage(
+            _CASES[0].part,
+            recognition=recognition,
+            features=drawing.model().features,
+            registry=registry,
+        )
+        == []
+    )
+
+
+def test_outcome_boundary_rejects_a_foreign_aggregate() -> None:
+    with pytest.raises(TypeError, match="run's RecognitionResult"):
+        rectangular_blind_slot_requirement_outcomes(
+            object(),
+            (),
+            AnnotationRegistry(),  # type: ignore[arg-type]
+        )
+
+    recognition, _source_record = _source(_CASES[0])
+    mutable = replace(
+        recognition,
+        rectangular_blind_slots=list(recognition.rectangular_blind_slots),  # type: ignore[arg-type]
+    )
+    with pytest.raises(TypeError, match="immutable tuple"):
+        rectangular_blind_slot_requirement_outcomes(mutable, (), AnnotationRegistry())
+
+
+def test_correspondence_key_rejects_every_malformed_released_fact() -> None:
+    _recognition, source = _source(_CASES[0])
+
+    class _BadFloat(float):
+        def __float__(self):
+            raise ValueError
+
+    malformed_sources = (
+        replace(source, width=_BadFloat(1)),
+        replace(source, width=float("inf")),
+        replace(source, width=True),
+        replace(source, width=0),
+        replace(source, at=list(source.at)),
+        replace(source, width_axis=source.axis),
+        replace(source, open_sign=True),
+    )
+    for malformed in malformed_sources:
+        with pytest.raises(ValueError):
+            rectangular_blind_slot_key(malformed)
+
+    malformed_recognition = replace(_recognition, rectangular_blind_slots=(malformed_sources[4],))
+    malformed_outcomes = rectangular_blind_slot_requirement_outcomes(
+        malformed_recognition, (), AnnotationRegistry()
+    )
+    assert len(malformed_outcomes) == 3
+    assert all(outcome.state == "unverifiable" for outcome in malformed_outcomes)
+
+    drawing = build_drawing(_CASES[0].part)
+    feature = _feature(drawing)
+    mismatched_frame = SimpleNamespace(
+        axis=feature.axis,
+        open_sign=feature.open_sign,
+        width_axis=feature.width_axis,
+        depth_axis=feature.depth_axis,
+        depth_sign=feature.depth_sign,
+        width=feature.width,
+        length=feature.length,
+        depth=feature.depth,
+        frame=Frame(feature.frame.origin, feature.width_axis),
+    )
+    with pytest.raises(ValueError):
+        rectangular_blind_slot_key(mismatched_frame, require_frame=True)

--- a/tests/test_issue_1421_rectangular_blind_slot_semantics.py
+++ b/tests/test_issue_1421_rectangular_blind_slot_semantics.py
@@ -190,7 +190,9 @@ def test_every_nonempty_authored_parameter_subset_survives_rendering(
     name, annotation = next(iter(annotations.items()))
     assert annotation.label == expected_label
     assert {key["parameter_id"] for key in drawing.measurement_keys(name)} == set(parameters)
-    assert drawing.lint() == []
+    issues = drawing.lint()
+    assert len(issues) == 3 - len(parameters)
+    assert {issue.code for issue in issues} <= {"rectangular_blind_slot_requirement_suppressed"}
 
 
 @pytest.mark.parametrize(

--- a/tests/test_issue_885_prismatic_coverage.py
+++ b/tests/test_issue_885_prismatic_coverage.py
@@ -132,7 +132,8 @@ def test_datum_starting_blind_slot_does_not_retain_the_superseded_pocket_callout
     assert "2 × 62.1 × 0.9 DEEP" not in labels
     assert len(drawing.recognition().rectangular_blind_slots) == 1
     completeness = drawing.lint_summary()["quality"]["completeness"]
-    assert "rectangular_blind_slots" in completeness["unscored_recognized_families"]
+    assert "rectangular_blind_slots" not in completeness["unscored_recognized_families"]
+    assert completeness["by_family"]["rectangular_blind_slots"] == 3
     assert "pocket_not_located" not in drawing.lint_summary()["by_code"]
 
 

--- a/tests/test_quality_components.py
+++ b/tests/test_quality_components.py
@@ -216,7 +216,7 @@ def test_an_undecided_inventory_names_a_real_open_issue():
         )
 
 
-def test_0410_blind_slot_occurrences_remain_visible_while_completeness_is_deferred():
+def test_0410_blind_slot_families_keep_independent_completeness_dispositions():
     inventories = {
         name: False if name == "rotational" else ()
         for name in RecognitionResult.__dataclass_fields__
@@ -260,9 +260,7 @@ def test_0410_blind_slot_occurrences_remain_visible_while_completeness_is_deferr
         has_asserted_content=True,
     )["completeness"]
 
-    assert {
-        "rectangular_blind_slots",
-        "round_bottom_blind_slots",
-    } <= set(completeness["unscored_recognized_families"])
-    assert "rectangular_blind_slots" not in completeness["by_family"]
+    assert completeness["unscored_recognized_families"] == ["round_bottom_blind_slots"]
+    assert completeness["by_family"]["rectangular_blind_slots"] == 3
+    assert completeness["requirements"] == completeness["unverifiable"] == 3
     assert "round_bottom_blind_slots" not in completeness["by_family"]

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -183,8 +183,7 @@ def test_0410_blind_slot_family_dispositions_are_explicit() -> None:
                     "drawing_consumer",
                 )
             } == {"supported"}
-            assert declaration["completeness"]["state"] == "deferred"
-            assert declaration["completeness"]["tracking"].endswith("/1421")
+            assert declaration["completeness"]["state"] == "supported"
         else:
             assert declaration["disposition"] == "deferred"
             assert declaration["tracking"] == ("https://github.com/pzfreo/draftwright/issues/1421")
@@ -511,6 +510,18 @@ def test_rich_passage_contract_has_an_explicit_unsupported_completeness_outcome(
             "from": "deferred",
             "release_notes": "CHANGELOG.md",
             "to": "unsupported",
+            "version": importlib.metadata.version("draftwright"),
+        },
+        {
+            "boundary": "completeness",
+            "compatibility_evidence": [
+                "tests/test_issue_1421_rectangular_blind_slot_completeness.py",
+                "tests/test_recogniser_capabilities.py",
+            ],
+            "family": "rectangular-blind-slots",
+            "from": "deferred",
+            "release_notes": "CHANGELOG.md",
+            "to": "supported",
             "version": importlib.metadata.version("draftwright"),
         },
         {


### PR DESCRIPTION
Advances #1421 and epic #1365 without closing either multi-slice tracker.

## Outcome

Proves rectangular blind-slot completeness end to end on the immutable `b123d-recognisers==0.4.10` public record:

- three independent physical requirements per occurrence: U-section width, capped mouth-to-terminal run, and flat-bottom depth
- one fail-closed source-to-IR correspondence over the complete released axis/sign/size/centre facts
- exact `DimensionId` provenance through automatic, declared `Sheet.rectangular_blind_slot(...)`, and executed generated-Sheet paths
- placed, structured-note, suppressed, dropped, missing, and unverifiable outcome states
- quality accounting and capability transition from deferred to supported

Round-bottom blind slots remain explicitly deferred for the next #1421 slice.

## Independent evidence

The authored seven-case corpus fixes 21 physical requirements independently of provider or IR output. It covers all six run-axis/open-side orientations plus a separately sized specimen. Removing recognition cannot shrink that authored denominator, and mutations cover sign/role loss, near neighbours, duplicate source or IR ownership, malformed released facts, wrong parameter IDs/values/spans, parameter reordering, foreign aggregates, and mutable inventory rejection.

## ADR audit

Reviewed against ADRs 0013, 0015, 0017, proposed 0019, and 0020. The implementation consumes one cached public aggregate, uses the existing IR/compiler/placement pipeline and sanctioned Sheet word, and relies only on semantic feature/parameter identity. It introduces no raw annotation coordinates, geometry rematch, provider-private API, or second engine. Proposed ADR 0019 is not treated as accepted.

The released `RectangularBlindSlot` v1 record contains every fact required by this slice. No recogniser API change or upstream issue is needed.

## Validation

- static, formatting, typing, and documentation gates: pass
- exact-head full suite: 6,267 passed, 5 skipped, 2 expected xfailed
- total coverage: 95.57%
- changed-line coverage: 96%
- two independent Google-style review rounds
- final exact-head ADR, contract, and code-quality reviews: clean with no optional nits
- reviewed exact head: `d1e834dbabe8e78a78f914db134b65785904c70d`
- reviewed tree: `14032c447232bbc04d656e6e38c952e8227ef9d9`

## Contributor License Agreement

- [x] I have read the CLA and agree to it. If I am contributing on behalf of an organisation, I am authorised to agree on its behalf.
