### PR TITLE
Retain raw recognition evidence per drawing (#1438)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- Raw automatic recognition now retains the provider's run-scoped `RecognitionEvidence` beside
+  its exact `RecognitionResult`, exposed through the experimental read-only
+  `Drawing.recognition_evidence()`. Declared drawings acquire the pair lazily on first physical
+  critique; bare and framed results remain evidence-less, and Draftwright never rescans merely to
+  backfill evidence. This is a non-visual reporting foundation and changes no rendered artefact
+  (#1438, ADRs 0015, 0017, 0020).
+
 - Automatic drawings can opt into the provider-owned local recognition frame with
   `framed_recognition=True`. The returned drawing exposes caller provenance, the exact downstream
   working solid, frame, and a copied framed/raw/refusal decision. PMI correlation, off-axis pattern

--- a/docs/adr/0015-part-drawing-compiler-as-built.md
+++ b/docs/adr/0015-part-drawing-compiler-as-built.md
@@ -13,6 +13,10 @@
   `b123d-recognisers` `v0.1.0`. Draftwright owns the one per-build/lazy-critique
   `RecognitionCache`, record→IR conversion, and all drafting policy. The former embedded
   implementation is deleted; compatibility re-exports expire in 0.6.0.
+- **Amendment 4** (2026-09-02): raw recognition retains the released provider's run-scoped
+  `RecognitionEvidence` beside its exact aggregate in the same consumer-owned cache. This is
+  report/correspondence evidence below the IR waist; it does not enter the compiler or make the
+  plan a completeness denominator (ADR 0017 Amendment 11).
 - **Date:** 2026-07-18
 - **Deciders:** Paul Fremantle (pzfreo)
 

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -10,6 +10,8 @@
   completeness gate with independent physical evidence and semantic outcomes; Amendment 8 does
   the same independently for the round-bottom family. Amendment 9 (2026-09-02) adopts the 0.4.12
   additive inventories fail closed while retaining the existing paired-ramp consumer meaning.
+  Amendment 11 (2026-09-02) retains the provider's raw accepted-occurrence evidence in the same
+  consumer-owned cache without adding a second recognition run.
 - **Date:** 2026-08-03
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -277,6 +279,29 @@ occurrence multiplicity, and joins only the complete released value before follo
 missing or unverifiable. Raw-default and provider-framed arbitrary rigid-motion tests preserve the
 same radius requirements. `blends` therefore moves from deferred to supported and joins the
 audited denominator. Unreleased concave, toroidal and path schemas are not latent support.
+
+## Amendment 11 — Raw accepted-occurrence evidence shares the one run-owned cache
+
+The released `b123d_recognisers.evidence.build_recognition_evidence` entry point returns one
+run-scoped `RecognitionEvidence` whose `.result` is the existing immutable aggregate and whose
+opaque feature/face references authorise provider-owned accepted-occurrence queries. Raw automatic
+analysis and lazy physical critique now acquire recognition through that entry point once and keep
+the evidence beside its exact result in `RecognitionCache`. Scale, page and view retries carry the
+complete cache forward; they do not retain the aggregate while orphaning its reference authority.
+
+`Drawing.recognition()` remains the established result view, and
+`Drawing.recognition_evidence()` is the matching experimental read-only evidence view. A bare
+injected result is valid but has no evidence. Draftwright never reruns recognition to backfill one,
+and rejects a result/evidence pair that did not come from the same run. The explicit framed path is
+also evidence-less until the provider exposes framed accepted-occurrence evidence; that contract is
+tracked upstream by
+[`b123d-recognisers#463`](https://github.com/pzfreo/b123d-recognisers/issues/463) rather than
+reconstructed from a second raw scan.
+
+This amendment extends the accepted ownership unit, not the completeness denominator. It adds no
+persistent topology identifier, report schema, record-to-IR inference, manufacturing intent,
+compiled-plan dependency, placement path, or visual output. Later #1438 slices must demonstrate the
+consumer disposition rules independently before this evidence can support an authoritative report.
 
 ## Accepted Contract
 

--- a/docs/adr/0020-provider-owned-frame-boundary.md
+++ b/docs/adr/0020-provider-owned-frame-boundary.md
@@ -177,6 +177,13 @@ correct rotational-envelope requirement for such a shaft; its step diameters and
 equal to raw, so that extra requirement is intentional rather than a lost measurement. Platform
 and representative corpus canaries remain release gates, not hidden conditions in the adapter.
 
+The provider's released accepted-occurrence evidence API is raw-coordinate-only. A successful
+framed build therefore exposes its established `RecognitionResult` but no `RecognitionEvidence`;
+Draftwright does not run a second raw acquisition or synthesize references across authority
+universes. Public framed evidence is tracked upstream by
+[`b123d-recognisers#463`](https://github.com/pzfreo/b123d-recognisers/issues/463), and independent
+raw/report work proceeds without claiming that framed occurrence ownership is already available.
+
 ## Consequences
 
 - Draftwright can now exercise the correct normalize→classify→recognise ordering without a second

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -485,11 +485,12 @@ physical corpora.
 ## Historical: recognisers 0.4.8 raw boundary and RaisedPad v2
 
 Draftwright pinned the published `b123d-recognisers==0.4.8` wheel in the preceding release.
-The default route deliberately calls `build_raw_recognition_result`; records remain in the
-caller/world coordinate system. #1357 now provides a reviewed explicit framed-result activation
-added with 0.4.9. The 0.4.8 tests used the public framed API as release evidence for upstream #331, #332,
-and #334, comparing each aggregate inventory with the corresponding public family call on the exact
-returned local solid. Production added no fallback, second aggregate, or family rescan. Face levels,
+At that time the default route deliberately called `build_raw_recognition_result`; records
+remained in the caller/world coordinate system. #1357 now provides a reviewed explicit
+framed-result activation added with 0.4.9. The 0.4.8 tests used the public framed API as release
+evidence for upstream #331, #332, and #334, comparing each aggregate inventory with the
+corresponding public family call on the exact returned local solid. Production added no fallback,
+second aggregate, or family rescan. Face levels,
 risers, and turned profiles remained outside framed production pending their subsequently released
 upstream fixes.
 

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -581,6 +581,15 @@ requirements, one solver-owned compound leader, and the established completeness
 raw and provider-framed contract suites continue to guard the ADR 0020 boundary. Draftwright uses no
 provider-private geometry or sibling checkout for any of these claims.
 
+#1438 now consumes the release's public raw `b123d_recognisers.evidence` acquisition. One
+`RecognitionEvidence` owns the accepted physical occurrence/face references and projects the same
+`RecognitionResult` the existing compiler and lint consumers already read. Draftwright retains
+both in its per-drawing `RecognitionCache`, including across scale/view retries; declared builds
+remain recognition-free until physical critique, and a bare result is never rescanned merely to
+backfill evidence. The framed route remains evidence-less pending upstream
+[`b123d-recognisers#463`](https://github.com/pzfreo/b123d-recognisers/issues/463). This foundation
+does not yet claim a report disposition or change any rendered artefact.
+
 ## Recognisers 0.4.9 prepared frame boundary
 
 Draftwright's 0.4.9 boundary accepted `RiserEvidence` v2,

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -26,6 +26,7 @@ from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from b123d_recognisers import RecognitionResult, TurnedProfile
+    from b123d_recognisers.evidence import RecognitionEvidence
 
     from draftwright.compose import StripDepths
 
@@ -1219,6 +1220,11 @@ class Analysis:
     # declared a model (ADR 0011) or on a manually-built Analysis — consumers fall
     # back to build_model(a).
     model: object | None = None
+    #: Run-scoped accepted-occurrence/face authority for a raw recognition acquisition.
+    #: ``None`` for declared builds before physical critique, for framed recognition until the
+    #: provider exposes framed evidence, and for a deliberately injected bare aggregate.  It is
+    #: never reconstructed from ``recognition`` because that would create a second run universe.
+    recognition_evidence: RecognitionEvidence | None = None
     #: The relational arrangement the sheet was composed under — ADR 0018 §5's fourth
     #: dimension, decided once by `compose.choose_scale` and carried here so that placement
     #: and the repack loop compose under the arrangement whose feasibility was actually

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -24,9 +24,9 @@ from b123d_recognisers import (
     TurnedProfileKey,
     TurnedStep,
     analyse_cylinders,
-    build_raw_recognition_result,
     full_cylinders,
 )
+from b123d_recognisers.evidence import RecognitionEvidence, build_recognition_evidence
 from build123d import Compound, Shape
 from build123d_drafting.helpers import draft_preset
 from OCP.IFSelect import IFSelect_ReturnStatus
@@ -63,6 +63,7 @@ from draftwright.compose import (
 from draftwright.model.detect import _build_part_model_from_recognition
 from draftwright.model.ir import Datum, GrooveFeature, PartModel, StepFeature, StepLevelFeature
 from draftwright.model.planner import plan_dimensions
+from draftwright.recognition_cache import _result_from_evidence
 from draftwright.recognition_frame import (
     FramedDetection,
     FramedDetectionRefusal,
@@ -74,6 +75,21 @@ from draftwright.view_plan import ViewConstraints, arrangement_of
 _log = logging.getLogger(__name__)
 
 _ScalePick = tuple[float, float, float, float]
+
+
+def _raw_recognition(
+    part,
+    *,
+    cylinders,
+    rotational: bool,
+) -> tuple[RecognitionResult, RecognitionEvidence | None]:
+    evidence = build_recognition_evidence(
+        part,
+        cylinders=cylinders,
+        rotational=rotational,
+    )
+    result = _result_from_evidence(evidence)
+    return result, evidence if result is evidence.result else None
 
 
 @dataclass(frozen=True)
@@ -757,6 +773,7 @@ def _analyse(
     # step-count convergence sees it too.
     margin = _content_margin(frame)
     recognition: RecognitionResult | None
+    recognition_evidence: RecognitionEvidence | None = None
     recognition_frame: PartFrame | None = None
     recognition_frame_decision: dict[str, object]
     if _reuse is not None:
@@ -786,6 +803,7 @@ def _analyse(
         is_rotational = _reuse.is_rotational
         layout_model = _coerce_layout_model(model, part, decorations)
         recognition = _reuse.recognition if layout_model is None else None
+        recognition_evidence = _reuse.recognition_evidence if layout_model is None else None
     else:
         if isinstance(step_file, Shape):
             part = step_file
@@ -843,7 +861,7 @@ def _analyse(
                     raw_centre.Y,
                     raw_centre.Z,
                 )
-                recognition = build_raw_recognition_result(
+                recognition, recognition_evidence = _raw_recognition(
                     part,
                     cylinders=(_gc.z_cyls, _gc.cross_cyls),
                     rotational=_gc.is_rotational,
@@ -863,7 +881,7 @@ def _analyse(
                 "refusal_reason": None,
             }
             if layout_model is None:
-                recognition = build_raw_recognition_result(
+                recognition, recognition_evidence = _raw_recognition(
                     part,
                     cylinders=(_gc.z_cyls, _gc.cross_cyls),
                     rotational=_gc.is_rotational,
@@ -1242,6 +1260,7 @@ def _analyse(
             tuple(pmi_records) if recognition_frame is not None and pmi_mode != "off" else None
         ),
         recognition=recognition,
+        recognition_evidence=recognition_evidence,
         bb=bb,
         x_size=x_size,
         y_size=y_size,

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -84,6 +84,7 @@ from draftwright.projection import (
     _fit_iso_view,
     _project_iso,
 )
+from draftwright.recognition_cache import RecognitionCache
 from draftwright.view_plan import (
     ARRANGEMENTS,
     UncoveredViewRequirement,
@@ -479,7 +480,7 @@ def _assemble(
     authored=None,
     trace=None,
     shape=None,
-    critique_recognition=None,
+    critique_recognition_cache=None,
     reproducible=False,
 ) -> Drawing:
     """Project the 4 views for analysis *a*, run the automatic annotation
@@ -627,7 +628,14 @@ def _assemble(
     # ADR 0005 §2 (#639): the ONE build-context attachment — analysis + finished model
     # in a single typed BuildState; the compat properties on Drawing read through it.
     dwg._build.analysis = a
-    dwg._build.recognition = a.recognition if a.recognition is not None else critique_recognition
+    # A scale/view fallback is still the same build run. Preserve the exact lazy acquisition
+    # rather than copying only its aggregate and orphaning provider-issued occurrence/face
+    # references from their authority universe.
+    dwg._build.attach_recognition(
+        a.recognition,
+        evidence=a.recognition_evidence,
+        cache=critique_recognition_cache if a.recognition is None else None,
+    )
     dwg._build.part_model = pm
     # Persist the caller's detail-view setting: on the auto_dims=False path the flag
     # reaches no pass here, but the finalize drain gates the prismatic detail
@@ -834,7 +842,7 @@ def _repack(
     requested=None,
     authored=None,
     trace=None,
-    critique_recognition=None,
+    critique_recognition_cache=None,
     reproducible=False,
 ):
     """Measure the laid-out drawing's *real* per-view annotation footprints and,
@@ -1005,7 +1013,7 @@ def _repack(
         requested=requested,
         authored=authored,
         trace=trace,
-        critique_recognition=critique_recognition,
+        critique_recognition_cache=critique_recognition_cache,
         reproducible=reproducible,
     )
     return a2, dwg2
@@ -1024,7 +1032,7 @@ def _repack_to_fixed_point(
     requested=None,
     authored=None,
     trace=None,
-    critique_recognition=None,
+    critique_recognition_cache=None,
     reproducible=False,
 ):
     """Iterate measure→repack→assemble until stable or bounded (#302)."""
@@ -1043,7 +1051,7 @@ def _repack_to_fixed_point(
             requested=requested,
             authored=authored,
             trace=trace,
-            critique_recognition=critique_recognition,
+            critique_recognition_cache=critique_recognition_cache,
             reproducible=reproducible,
         )
         if repacked is None:
@@ -1114,7 +1122,7 @@ def _build_drawing_once(
     framed_recognition: bool = False,
     _analysis_base=None,
     _analysis_sink: Callable[[Analysis], None] | None = None,
-    _critique_recognition=None,
+    _critique_recognition_cache=None,
     _arrangements: tuple[str, ...] | None = None,
     _views: tuple[str, ...] | None = None,
     _include_iso: bool = True,
@@ -1366,7 +1374,7 @@ def _build_drawing_once(
         requested=requested,
         authored=authored,
         trace=tracer,
-        critique_recognition=_critique_recognition,
+        critique_recognition_cache=_critique_recognition_cache,
         reproducible=reproducible,
     )
     if auto_dims:
@@ -1383,7 +1391,7 @@ def _build_drawing_once(
             requested=requested,
             authored=authored,
             trace=tracer,
-            critique_recognition=_critique_recognition,
+            critique_recognition_cache=_critique_recognition_cache,
             reproducible=reproducible,
         )
         if repacked is not None:
@@ -1829,7 +1837,7 @@ def build_drawing(
     )
     analysis_base = None
     latest_analysis = None
-    critique_recognition = None
+    critique_recognition_cache = None
 
     built_arrangement = ARRANGEMENTS[0]
 
@@ -1876,7 +1884,7 @@ def build_drawing(
             page=page if page_override is None else page_override,
             _analysis_base=analysis_base,
             _analysis_sink=retain_analysis,
-            _critique_recognition=critique_recognition,
+            _critique_recognition_cache=critique_recognition_cache,
             _arrangements=arrangements,
             _views=views,
             _include_iso=_include_iso if include_iso is None else include_iso,
@@ -1887,10 +1895,14 @@ def build_drawing(
         return _post_build(built) if _post_build is not None else built
 
     def scale_blockers_for(built: Drawing) -> tuple[dict, ...]:
-        nonlocal critique_recognition
+        nonlocal critique_recognition_cache
         found = _scale_blockers(built)
-        if critique_recognition is None:
-            critique_recognition = built.recognition()
+        if critique_recognition_cache is None:
+            evidence_reader = getattr(built, "recognition_evidence", None)
+            critique_recognition_cache = RecognitionCache(
+                result=built.recognition(),
+                evidence=evidence_reader() if callable(evidence_reader) else None,
+            )
         return found
 
     views_are_automatic = _view_constraints is None or (

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -969,7 +969,8 @@ class Drawing:
         after the first physical critique of a declared drawing. It is ``None`` before that
         lazy critique, for a bare drawing, and for framed recognition while the provider lacks
         a public framed-evidence contract. Draftwright never reruns recognition merely to fill
-        this value.
+        this value. The returned evidence borrows exact faces from the source part, so callers
+        must not mutate that part while using the evidence view.
         """
 
         return self._build.recognition_evidence

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 
 if TYPE_CHECKING:
     from b123d_recognisers import RecognitionResult
+    from b123d_recognisers.evidence import RecognitionEvidence
 
 # PEP 702 @deprecated. A `sys.version_info` guard (not try/except) so the type checker,
 # which targets the 3.10 floor, resolves the backport branch instead of `warnings.deprecated`
@@ -496,7 +497,34 @@ class BuildState:
 
     @recognition.setter
     def recognition(self, value: RecognitionResult | None) -> None:
-        self.recognition_cache.result = value
+        self.recognition_cache.seed(value)
+
+    def attach_recognition(
+        self,
+        result: RecognitionResult | None,
+        *,
+        evidence: RecognitionEvidence | None = None,
+        cache: RecognitionCache | None = None,
+    ) -> None:
+        """Attach one coherent acquisition at the builder's single fill site.
+
+        A rebuilt drawing either receives the prior run's complete cache or a result/evidence
+        pair from its current analysis. Mixing both sources would make run ownership ambiguous
+        and therefore fails closed.
+        """
+
+        if cache is not None:
+            if result is not None or evidence is not None:
+                raise ValueError("cannot attach both a recognition cache and a new acquisition")
+            self.recognition_cache = cache
+            return
+        self.recognition_cache.seed(result, evidence=evidence)
+
+    @property
+    def recognition_evidence(self) -> RecognitionEvidence | None:
+        """Run-scoped provider evidence paired with :attr:`recognition`, when available."""
+
+        return self.recognition_cache.evidence
 
     def clear_geometry_caches(self) -> None:
         """The one invalidation seam (finalize rollback): view edges + annotation
@@ -933,6 +961,18 @@ class Drawing:
         """
 
         return self._build.recognition
+
+    def recognition_evidence(self) -> RecognitionEvidence | None:
+        """The run-scoped provider evidence paired with :meth:`recognition`.
+
+        This experimental, read-only view is available for raw automatic recognition and
+        after the first physical critique of a declared drawing. It is ``None`` before that
+        lazy critique, for a bare drawing, and for framed recognition while the provider lacks
+        a public framed-evidence contract. Draftwright never reruns recognition merely to fill
+        this value.
+        """
+
+        return self._build.recognition_evidence
 
     # --- build-context compat properties (#639): one BuildState, thin views.
     # _part_model and the two caches are GETTER-ONLY by design (#691 review):

--- a/src/draftwright/recognition_cache.py
+++ b/src/draftwright/recognition_cache.py
@@ -9,18 +9,70 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from b123d_recognisers import RecognitionResult, build_raw_recognition_result
+from b123d_recognisers import RecognitionResult
+from b123d_recognisers.evidence import RecognitionEvidence, build_recognition_evidence
+
+
+def _result_from_evidence(evidence: RecognitionEvidence) -> RecognitionResult:
+    """Project the established aggregate from one evidence acquisition.
+
+    Keeping this as one tiny seam lets semantic mutation tests replace the provider result
+    without fabricating provider-issued references.  Callers discard the now-unpaired evidence
+    when that happens, preserving the same-run invariant instead of attaching stale authority to
+    a deliberately altered aggregate.
+    """
+
+    return evidence.result
 
 
 @dataclass
 class RecognitionCache:
-    """One drawing's optional recognition result, built at most once on demand."""
+    """One drawing's optional recognition run, built at most once on demand.
+
+    ``result`` remains the established geometry inventory consumed by Draftwright.  When the
+    run entered through the provider's raw evidence API, ``evidence`` retains that same run's
+    accepted-occurrence/face authority for later reporting.  A cache may still be seeded with a
+    bare result (notably framed recognition); it must not rerun recognition merely to backfill
+    evidence from a different authority universe.
+    """
 
     result: RecognitionResult | None = None
+    evidence: RecognitionEvidence | None = None
 
-    def ensure(self, part) -> RecognitionResult:
+    def __post_init__(self) -> None:
+        if self.evidence is None:
+            return
+        if self.result is None:
+            self.result = self.evidence.result
+        elif self.result is not self.evidence.result:
+            raise ValueError("recognition evidence and result must come from the same run")
+
+    def seed(
+        self,
+        result: RecognitionResult | None,
+        *,
+        evidence: RecognitionEvidence | None = None,
+    ) -> None:
+        """Replace the cache atomically with one coherent recognition acquisition."""
+
+        if evidence is not None:
+            if result is None:
+                result = evidence.result
+            elif result is not evidence.result:
+                raise ValueError("recognition evidence and result must come from the same run")
+        self.result = result
+        self.evidence = evidence
+
+    def ensure(self, part, *, cylinders=None, rotational: bool = False) -> RecognitionResult:
         """Return this drawing's result, recognising *part* only when still empty."""
 
         if self.result is None:
-            self.result = build_raw_recognition_result(part)
+            evidence = build_recognition_evidence(
+                part,
+                cylinders=cylinders,
+                rotational=rotational,
+            )
+            result = _result_from_evidence(evidence)
+            self.seed(result, evidence=evidence if result is evidence.result else None)
+        assert self.result is not None
         return self.result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,7 +89,7 @@ def counting_calls(functions: Mapping[str, Callable[..., object]]):
 
 @contextmanager
 def recognition_consumer_calls():
-    """Count aggregate calls and public physical recogniser calls made outside it.
+    """Count aggregate acquisitions and public physical recogniser calls made outside them.
 
     Draftwright owns whether and when a build requests recognition, and must not bypass the
     aggregate by invoking a public, ``part``-taking recogniser itself. Part-less pattern
@@ -100,9 +100,13 @@ def recognition_consumer_calls():
     private registry.
     """
     import b123d_recognisers as recognition
+    import b123d_recognisers.evidence as recognition_evidence
     from _recogniser_public_contract import public_recogniser_member, public_recogniser_names
 
-    aggregate = recognition.build_raw_recognition_result
+    aggregates = {
+        recognition.build_raw_recognition_result.__code__: "build_raw_recognition_result",
+        recognition_evidence.build_recognition_evidence.__code__: "build_recognition_evidence",
+    }
     functions = {}
     for name in public_recogniser_names():
         if name != "step_level_records" and not name.startswith("recognise_"):
@@ -131,14 +135,12 @@ def recognition_consumer_calls():
     def hook(frame, event, arg):
         nonlocal aggregate_depth
         if event == "call":
-            if frame.f_code is aggregate.__code__:
-                counts["build_raw_recognition_result"] = (
-                    counts.get("build_raw_recognition_result", 0) + 1
-                )
+            if (aggregate_name := aggregates.get(frame.f_code)) is not None:
+                counts[aggregate_name] = counts.get(aggregate_name, 0) + 1
                 aggregate_depth += 1
             elif aggregate_depth == 0 and (name := by_code.get(frame.f_code)) is not None:
                 counts[name] = counts.get(name, 0) + 1
-        elif event == "return" and frame.f_code is aggregate.__code__:
+        elif event == "return" and frame.f_code in aggregates:
             aggregate_depth -= 1
         if previous is not None:
             previous(frame, event, arg)

--- a/tests/test_declared_recognition_gate.py
+++ b/tests/test_declared_recognition_gate.py
@@ -99,7 +99,7 @@ def test_exporting_a_declared_drawing_pays_for_one_aggregate_and_no_more(tmp_pat
         drawing.export(str(tmp_path / "second"), formats=("svg",))
         second = dict(counts)
 
-    assert first == {"build_raw_recognition_result": 1}, (
+    assert first == {"build_recognition_evidence": 1}, (
         f"the first export must request one aggregate and no bypass, got {first}"
     )
     assert dict(second) == {}, f"a second export re-recognised {dict(second)}"
@@ -112,7 +112,7 @@ def test_a_detected_build_still_requests_one_aggregate():
     with recognition_consumer_calls() as counts:
         build_drawing(_prismatic_plate())
 
-    assert counts == {"build_raw_recognition_result": 1}, (
+    assert counts == {"build_recognition_evidence": 1}, (
         f"the detected build must request one aggregate and no bypass, got {counts}"
     )
 
@@ -136,7 +136,7 @@ def test_critique_on_a_declared_drawing_recognises_once_and_then_never_again():
         third_issues = _issue_keys(drawing.lint())
         later = dict(counts)
 
-    assert first == {"build_raw_recognition_result": 1}, (
+    assert first == {"build_recognition_evidence": 1}, (
         f"the first physical lint must request one aggregate and no bypass, got {first} — "
         "without it coverage judges against an empty inventory"
     )
@@ -152,6 +152,8 @@ def test_critique_on_a_declared_drawing_recognises_once_and_then_never_again():
         f"nothing new: {sorted(set(first_issues) ^ set(second_issues))}"
     )
     assert third_issues == first_issues, "the third lint disagreed with the first"
+    assert drawing.recognition_evidence() is not None
+    assert drawing.recognition_evidence().result is drawing.recognition()
 
 
 #: Every way ``export`` can reject a call outright, with the message it rejects it by.

--- a/tests/test_detect_once.py
+++ b/tests/test_detect_once.py
@@ -44,13 +44,27 @@ def test_detectors_run_once_per_build(aggregate_counter, framed_recognition):
     dwg = build_drawing(_filleted(), framed_recognition=framed_recognition)
 
     assert dwg.recognition_frame_decision["status"] == ("framed" if framed_recognition else "raw")
-    assert aggregate_counter == {"build_raw_recognition_result": 1}, (
+    expected = (
+        {"build_raw_recognition_result": 1}
+        if framed_recognition
+        else {"build_recognition_evidence": 1}
+    )
+    assert aggregate_counter == expected, (
         f"unexpected recognition activity in one "
         f"{'framed' if framed_recognition else 'raw'} build: {aggregate_counter} — the "
         "sizing and render paths must share one inventory with no consumer bypass (ADR 0008)"
     )
     # The drawing's render model IS the stored sizing model — one object, one inventory.
     assert dwg.model() is dwg._analysis.model
+    if framed_recognition:
+        assert dwg.recognition_evidence() is None
+    else:
+        evidence = dwg.recognition_evidence()
+        assert evidence is not None
+        assert evidence.result is dwg.recognition()
+        fillets = tuple(ref for ref in evidence.features if evidence.family(ref) == "fillets")
+        assert len(fillets) == 1
+        assert evidence.record(fillets[0]) in dwg.recognition().fillets
 
 
 def test_generate_script_detects_once(aggregate_counter, tmp_path):
@@ -61,7 +75,7 @@ def test_generate_script_detects_once(aggregate_counter, tmp_path):
     step = str(tmp_path / "filleted.step")
     export_step(_filleted(), step)
     generate_sheet_script(step, out=str(tmp_path / "s"))
-    assert aggregate_counter == {"build_raw_recognition_result": 1}, (
+    assert aggregate_counter == {"build_recognition_evidence": 1}, (
         f"unexpected recognition activity in generate_sheet_script: {aggregate_counter} — "
         "the emitter must reuse one inventory without a consumer bypass"
     )

--- a/tests/test_drawing_encapsulation.py
+++ b/tests/test_drawing_encapsulation.py
@@ -500,9 +500,9 @@ def test_build_state_has_a_single_construction_and_fill_site():
         # and these guards caught it.
         "builder.py": [
             "_build.analysis",
-            # ADR 0017's recognition aggregate is filled beside analysis/model at this
-            # same single construction site; Drawing.recognition() is read-only.
-            "_build.recognition",
+            # ADR 0017's result/evidence pair is attached through the typed
+            # BuildState.attach_recognition() method at this same construction site;
+            # Drawing.recognition()/recognition_evidence() are read-only.
             "_build.part_model",
             "_build.detail_view",
             "_build.trace",
@@ -535,3 +535,17 @@ def test_build_state_has_a_single_construction_and_fill_site():
             "_build.principal_profile_cache",
         ],
     }, writers
+
+    builder_tree = ast.parse((src / "builder.py").read_text(encoding="utf-8"))
+    recognition_attachments = [
+        node
+        for node in ast.walk(builder_tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "attach_recognition"
+        and isinstance(node.func.value, ast.Attribute)
+        and node.func.value.attr == "_build"
+    ]
+    assert len(recognition_attachments) == 1, (
+        "BuildState.attach_recognition must have exactly one builder fill site"
+    )

--- a/tests/test_external_recognition_boundary.py
+++ b/tests/test_external_recognition_boundary.py
@@ -6,6 +6,8 @@ import re
 from pathlib import Path
 
 import b123d_recognisers as external
+import b123d_recognisers.evidence as external_evidence
+import pytest
 from _recogniser_public_contract import public_recogniser_member, public_recogniser_names
 from build123d import Box
 
@@ -15,6 +17,7 @@ except ModuleNotFoundError:  # Python 3.10
     import tomli as tomllib
 
 import draftwright.recognition as compatibility
+from draftwright.drawing import BuildState
 from draftwright.recognition_cache import RecognitionCache
 from draftwright.score import feature_census
 
@@ -36,6 +39,16 @@ def test_dependency_is_pinned_to_the_published_stable_release() -> None:
     assert "git+" not in package
 
 
+def test_consumed_evidence_api_is_the_released_public_major() -> None:
+    manifest = external_evidence.evidence_api_manifest()
+
+    assert manifest["format"] == "b123d-recognisers-evidence-api"
+    assert manifest["format_version"] == 1
+    assert manifest["api"]["major"] == 1
+    assert manifest["api"]["namespace"] == "b123d_recognisers.evidence"
+    assert {"RecognitionEvidence", "build_recognition_evidence"} <= set(manifest["api"]["symbols"])
+
+
 def test_embedded_implementation_is_gone_and_compatibility_is_identity_preserving() -> None:
     assert {path.name for path in RECOGNITION_DIR.glob("*.py")} == {"__init__.py"}
     assert frozenset(compatibility.__all__) == public_recogniser_names()
@@ -46,20 +59,69 @@ def test_embedded_implementation_is_gone_and_compatibility_is_identity_preservin
 
 def test_recognition_cache_is_consumer_owned_and_runs_once(monkeypatch) -> None:
     calls = 0
-    original = external.build_raw_recognition_result
+    original = external_evidence.build_recognition_evidence
 
-    def counting_build(part):
+    def counting_build(part, *, cylinders=None, rotational=False):
         nonlocal calls
         calls += 1
-        return original(part)
+        return original(part, cylinders=cylinders, rotational=rotational)
 
-    monkeypatch.setattr(
-        "draftwright.recognition_cache.build_raw_recognition_result", counting_build
-    )
+    monkeypatch.setattr("draftwright.recognition_cache.build_recognition_evidence", counting_build)
     cache = RecognitionCache()
     part = Box(10, 10, 10)
 
     first = cache.ensure(part)
     assert cache.ensure(part) is first
     assert cache.result is first
+    assert cache.evidence is not None
+    assert cache.evidence.result is first
     assert calls == 1
+
+
+def test_bare_seed_never_reruns_to_backfill_evidence(monkeypatch) -> None:
+    part = Box(10, 10, 10)
+    result = external.build_raw_recognition_result(part)
+    cache = RecognitionCache(result=result)
+
+    def forbidden(*args, **kwargs):
+        raise AssertionError("a bare result must not create a second recognition universe")
+
+    monkeypatch.setattr("draftwright.recognition_cache.build_recognition_evidence", forbidden)
+
+    assert cache.ensure(part) is result
+    assert cache.evidence is None
+
+
+def test_cache_rejects_result_and_evidence_from_different_runs() -> None:
+    part = Box(10, 10, 10)
+    first = external_evidence.build_recognition_evidence(part)
+    second = external_evidence.build_recognition_evidence(part)
+
+    with pytest.raises(ValueError, match="same run"):
+        RecognitionCache(result=first.result, evidence=second)
+
+    cache = RecognitionCache(evidence=first)
+    assert cache.result is first.result
+    with pytest.raises(ValueError, match="same run"):
+        cache.seed(first.result, evidence=second)
+
+    seeded = RecognitionCache()
+    seeded.seed(None, evidence=first)
+    assert seeded.result is first.result
+    assert seeded.evidence is first
+
+
+def test_build_state_attaches_one_recognition_source_atomically() -> None:
+    evidence = external_evidence.build_recognition_evidence(Box(10, 10, 10))
+    state = BuildState()
+
+    state.recognition = evidence.result
+    assert state.recognition is evidence.result
+    assert state.recognition_evidence is None
+
+    with pytest.raises(ValueError, match="both a recognition cache and a new acquisition"):
+        state.attach_recognition(
+            evidence.result,
+            evidence=evidence,
+            cache=RecognitionCache(evidence=evidence),
+        )

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -854,6 +854,24 @@ def test_consumer_recogniser_contract_guard_covers_static_provider_seams(tmp_pat
         "from b123d_recognisers.inspection import _FaceGraph\n",
         encoding="utf-8",
     )
+    (tmp_path / "private_evidence_import.py").write_text(
+        "from b123d_recognisers.evidence import _PrivateEvidence\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "private_evidence_alias.py").write_text(
+        "import b123d_recognisers.evidence as evidence\nprivate = evidence._private_builder\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "private_evidence_getattr.py").write_text(
+        "import b123d_recognisers.evidence as evidence\n"
+        "private = getattr(evidence, '_private_builder')\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "private_evidence_patch.py").write_text(
+        "import b123d_recognisers.evidence as evidence\n"
+        "monkeypatch.setattr(evidence, '_private_builder', replacement)\n",
+        encoding="utf-8",
+    )
     (tmp_path / "private_getattr.py").write_text(
         "import b123d_recognisers as br\nprivate = getattr(br, 'polygonal_bosses')\n",
         encoding="utf-8",
@@ -901,8 +919,13 @@ def test_consumer_recogniser_contract_guard_covers_static_provider_seams(tmp_pat
     (tmp_path / "public_and_unrelated_controls.py").write_text(
         "import importlib.util\n"
         "import b123d_recognisers as br\n"
+        "import b123d_recognisers.evidence as evidence\n"
         "from b123d_recognisers import Flat\n"
+        "from b123d_recognisers.evidence import RecognitionEvidence\n"
         "public = br.Flat\n"
+        "public_evidence = evidence.build_recognition_evidence\n"
+        "also_public_evidence = getattr(evidence, 'RecognitionEvidence')\n"
+        "monkeypatch.setattr(evidence, 'build_recognition_evidence', replacement)\n"
         "also_public = getattr(br, 'Flat')\n"
         "monkeypatch.setattr(br, 'Flat', 'replacement')\n"
         "assert_context(br, 'consumer fixture')\n"
@@ -921,6 +944,10 @@ def test_consumer_recogniser_contract_guard_covers_static_provider_seams(tmp_pat
         ("test_grid_lattice_convention.py", "b123d_recognisers._features", "_new_private"),
         ("private_static.py", _PROVIDER_ROOT, "profiled_bores"),
         ("private_inspection.py", _PROVIDER_INSPECTION, "_FaceGraph"),
+        ("private_evidence_import.py", _PROVIDER_EVIDENCE, "_PrivateEvidence"),
+        ("private_evidence_alias.py", _PROVIDER_EVIDENCE, "_private_builder"),
+        ("private_evidence_getattr.py", _PROVIDER_EVIDENCE, "_private_builder"),
+        ("private_evidence_patch.py", _PROVIDER_EVIDENCE, "_private_builder"),
         ("private_getattr.py", _PROVIDER_ROOT, "polygonal_bosses"),
         ("private_literal_target.py", _PROVIDER_ROOT, "profiled_bores"),
         ("private_unbound_patch.py", _PROVIDER_ROOT, "profiled_bores"),

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -47,12 +47,14 @@ import ast
 from pathlib import Path
 
 import b123d_recognisers
+import b123d_recognisers.evidence as recogniser_evidence
 import b123d_recognisers.inspection as recogniser_inspection
 import pytest
 
 _SRC = Path(__file__).resolve().parent.parent / "src" / "draftwright"
 _MODEL_DIR = _SRC / "model"
 _RECOGNISER_PUBLIC = frozenset(b123d_recognisers.__all__)
+_RECOGNISER_EVIDENCE_PUBLIC = frozenset(recogniser_evidence.__all__)
 _RECOGNISER_INSPECTION_PUBLIC = frozenset(recogniser_inspection.__all__)
 
 # ── The declared DAG (mirrors CLAUDE.md ## Architecture) ─────────────────────────────────
@@ -582,7 +584,9 @@ _ALLOWED_PRIVATE_RECOGNISER_REFERENCES = {
 }
 _RECOGNISER_POLICY_MODULE = "b123d_recognisers.<policy>"
 _PROVIDER_ROOT = "b123d_recognisers"
+_PROVIDER_EVIDENCE = "b123d_recognisers.evidence"
 _PROVIDER_INSPECTION = "b123d_recognisers.inspection"
+_PROVIDER_PUBLIC_MODULES = {_PROVIDER_ROOT, _PROVIDER_EVIDENCE, _PROVIDER_INSPECTION}
 _LITERAL_PREDICATES = {"endswith", "removeprefix", "removesuffix", "startswith"}
 _PROVIDER_MEMBER_CALLS = {"delattr", "object", "setattr"}
 
@@ -617,6 +621,15 @@ def _recogniser_contract_references(path: Path, *, relative_to: Path) -> set[tup
         if actual == _PROVIDER_ROOT or not actual.startswith(f"{_PROVIDER_ROOT}."):
             return
         components = actual.removeprefix(f"{_PROVIDER_ROOT}.").split(".")
+        if components[0] == "evidence":
+            if len(components) == 1:
+                return
+            member = components[1]
+            if member == "__all__":
+                references.add((relative, _PROVIDER_EVIDENCE, member))
+            elif member not in _RECOGNISER_EVIDENCE_PUBLIC:
+                references.add((relative, _PROVIDER_EVIDENCE, member))
+            return
         if components[0] == "inspection":
             if len(components) == 1:
                 return
@@ -658,6 +671,12 @@ def _recogniser_contract_references(path: Path, *, relative_to: Path) -> set[tup
                     for alias in node.names
                     if alias.name not in _RECOGNISER_INSPECTION_PUBLIC | {"*"}
                 )
+            elif module == _PROVIDER_EVIDENCE:
+                references.update(
+                    (relative, module, alias.name)
+                    for alias in node.names
+                    if alias.name not in _RECOGNISER_EVIDENCE_PUBLIC | {"*"}
+                )
             elif module.startswith(f"{_PROVIDER_ROOT}."):
                 references.update((relative, module, alias.name) for alias in node.names)
         elif isinstance(node, ast.Import):
@@ -665,6 +684,9 @@ def _recogniser_contract_references(path: Path, *, relative_to: Path) -> set[tup
                 module = alias.name
                 if module == _PROVIDER_ROOT:
                     module_aliases[alias.asname or module] = module
+                elif module == _PROVIDER_EVIDENCE:
+                    binding = alias.asname or _PROVIDER_ROOT
+                    module_aliases[binding] = module if alias.asname else binding
                 elif module == _PROVIDER_INSPECTION:
                     binding = alias.asname or _PROVIDER_ROOT
                     module_aliases[binding] = module if alias.asname else binding
@@ -736,7 +758,7 @@ def _recogniser_contract_references(path: Path, *, relative_to: Path) -> set[tup
 
         if terminal == "getattr" and len(node.args) >= 2:
             provider = resolve_expr(node.args[0])
-            if provider in {_PROVIDER_ROOT, _PROVIDER_INSPECTION}:
+            if provider in _PROVIDER_PUBLIC_MODULES:
                 member = literal(node.args[1])
                 if member is None:
                     policy("dynamic-provider-member")
@@ -754,13 +776,13 @@ def _recogniser_contract_references(path: Path, *, relative_to: Path) -> set[tup
             for provider_node, member_node in zip(node.args, node.args[1:]):
                 provider = resolve_expr(provider_node)
                 member = literal(member_node)
-                if provider in {_PROVIDER_ROOT, _PROVIDER_INSPECTION} and member is not None:
+                if provider in _PROVIDER_PUBLIC_MODULES and member is not None:
                     record(f"{provider}.{member}")
 
             providers = {
                 provider
                 for value in [*node.args, *target_keywords]
-                if (provider := resolve_expr(value)) in {_PROVIDER_ROOT, _PROVIDER_INSPECTION}
+                if (provider := resolve_expr(value)) in _PROVIDER_PUBLIC_MODULES
             }
             members = {
                 member for value in member_keywords if (member := literal(value)) is not None
@@ -773,9 +795,9 @@ def _recogniser_contract_references(path: Path, *, relative_to: Path) -> set[tup
             target = target_argument(node)
             provider = resolve_expr(target) if target is not None else None
             target_name = literal(target)
-            if provider is None and target_name in {_PROVIDER_ROOT, _PROVIDER_INSPECTION}:
+            if provider is None and target_name in _PROVIDER_PUBLIC_MODULES:
                 provider = target_name
-            if provider in {_PROVIDER_ROOT, _PROVIDER_INSPECTION}:
+            if provider in _PROVIDER_PUBLIC_MODULES:
                 for item in node.keywords:
                     if item.arg not in {None, "create", "spec", "spec_set", "target"}:
                         record(f"{provider}.{item.arg}")

--- a/tests/test_issue_1058_wheel_profile.py
+++ b/tests/test_issue_1058_wheel_profile.py
@@ -12,6 +12,7 @@ import pytest
 from b123d_recognisers import (
     build_raw_recognition_result,
 )
+from b123d_recognisers.evidence import build_recognition_evidence
 from build123d import (
     Align,
     Box,
@@ -340,7 +341,7 @@ def test_real_wheel_no_longer_gets_a_confident_envelope_only_result(wheel_drawin
 
 def test_synthetic_double_d_profile_is_recognised_without_lint_rescans():
     detected = detect_part_model(_double_d_bore())
-    with counting_calls({"orchestration": build_raw_recognition_result}) as calls:
+    with counting_calls({"orchestration": build_recognition_evidence}) as calls:
         drawing = build_drawing(_double_d_bore())
         assert tuple(detected.features) == tuple(drawing.model().features)
         assert calls == {"orchestration": 1}

--- a/tests/test_issue_1146_scale_completeness.py
+++ b/tests/test_issue_1146_scale_completeness.py
@@ -460,20 +460,21 @@ def test_sheet_fallback_reuses_lazy_physical_recognition(monkeypatch):
 
     sheet = Sheet.from_part(_scale_sensitive_plate(), page="A4", scale=1.0)
     calls = []
-    original = recognition_cache_module.build_raw_recognition_result
+    original = recognition_cache_module.build_recognition_evidence
 
-    def counted(part):
-        result = original(part)
-        calls.append(result)
-        return result
+    def counted(part, *, cylinders=None, rotational=False):
+        evidence = original(part, cylinders=cylinders, rotational=rotational)
+        calls.append(evidence)
+        return evidence
 
-    monkeypatch.setattr(recognition_cache_module, "build_raw_recognition_result", counted)
+    monkeypatch.setattr(recognition_cache_module, "build_recognition_evidence", counted)
     with pytest.warns(ScaleCompletenessWarning, match="fallback scale 0.5"):
         drawing = sheet.build()
 
     assert drawing.scale_decision["attempted_scales"] == (1.0, 0.5)
     assert len(calls) == 1
-    assert drawing.recognition() is calls[0]
+    assert drawing.recognition_evidence() is calls[0]
+    assert drawing.recognition() is calls[0].result
 
 
 @pytest.mark.timeout(120)
@@ -501,7 +502,7 @@ def test_fallback_reuses_geometry_classification_and_recognition(monkeypatch):
 
     calls = {"classify": 0, "recognise": 0}
     original_classify = analysis._classify_geometry
-    original_recognise = analysis.build_raw_recognition_result
+    original_recognise = analysis.build_recognition_evidence
 
     def counted_classify(*args, **kwargs):
         calls["classify"] += 1
@@ -512,7 +513,7 @@ def test_fallback_reuses_geometry_classification_and_recognition(monkeypatch):
         return original_recognise(*args, **kwargs)
 
     monkeypatch.setattr(analysis, "_classify_geometry", counted_classify)
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted_recognise)
+    monkeypatch.setattr(analysis, "build_recognition_evidence", counted_recognise)
     with pytest.warns(ScaleCompletenessWarning, match="fallback scale 0.5"):
         drawing = build_drawing(_scale_sensitive_plate(), page="A4", scale=1.0, repair=False)
 

--- a/tests/test_issue_1357_framed_activation.py
+++ b/tests/test_issue_1357_framed_activation.py
@@ -90,7 +90,7 @@ def test_provider_refusal_has_one_visible_top_level_raw_fallback(monkeypatch):
         drawing = build_drawing(source, auto_dims=False, framed_recognition=True)
 
     assert calls == 1
-    assert recognition_calls == {"build_raw_recognition_result": 1}
+    assert recognition_calls == {"build_recognition_evidence": 1}
     assert drawing.part is drawing.working_part
     assert drawing.recognition_frame is None
     assert drawing.recognition_frame_decision == {

--- a/tests/test_issue_1357_framed_boundary.py
+++ b/tests/test_issue_1357_framed_boundary.py
@@ -286,20 +286,20 @@ def test_zero_or_one_physical_turned_profile_preserves_the_existing_analysis_sha
     assert single_turned_profile(one) == one.turned_profiles[0]
 
 
-def test_production_remains_on_the_explicit_raw_boundary(
+def test_default_production_uses_the_explicit_raw_evidence_boundary(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     from draftwright import analysis as analysis_module
     from draftwright import build_drawing
 
     raw_calls = []
-    raw_builder = analysis_module.build_raw_recognition_result
+    raw_builder = analysis_module.build_recognition_evidence
 
     def tracked_raw_builder(*args, **kwargs):
         raw_calls.append((args, kwargs))
         return raw_builder(*args, **kwargs)
 
-    monkeypatch.setattr(analysis_module, "build_raw_recognition_result", tracked_raw_builder)
+    monkeypatch.setattr(analysis_module, "build_recognition_evidence", tracked_raw_builder)
     monkeypatch.setattr(
         frame_module,
         "prepare_framed_part",

--- a/tests/test_issue_1369_hole_completeness_evidence.py
+++ b/tests/test_issue_1369_hole_completeness_evidence.py
@@ -151,13 +151,13 @@ def test_deleting_provider_holes_cannot_shrink_the_independent_denominator(monke
     """
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def without_holes(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, holes=(), hole_patterns=())
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_holes)
+    monkeypatch.setattr(analysis, "_result_from_evidence", without_holes)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0

--- a/tests/test_issue_1370_countersink_completeness_evidence.py
+++ b/tests/test_issue_1370_countersink_completeness_evidence.py
@@ -395,14 +395,14 @@ def test_deleting_provider_seats_cannot_shrink_the_independent_denominator(
 ) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def without_countersinks(*args, **kwargs):
         result = original(*args, **kwargs)
         holes = tuple(replace(hole, csink=None) for hole in result.holes)
         return replace(result, countersinks=(), holes=holes, hole_patterns=())
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_countersinks)
+    monkeypatch.setattr(analysis, "_result_from_evidence", without_countersinks)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0

--- a/tests/test_issue_1370_double_d_completeness_evidence.py
+++ b/tests/test_issue_1370_double_d_completeness_evidence.py
@@ -129,7 +129,7 @@ def test_an_ordinary_hole_on_the_same_span_invalidates_only_double_d_credit(
 
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def with_overlapping_hole(*args, **kwargs):
         recognition = original(*args, **kwargs)
@@ -156,7 +156,7 @@ def test_an_ordinary_hole_on_the_same_span_invalidates_only_double_d_credit(
         )
         return replace(recognition, holes=(*recognition.holes, overlap))
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", with_overlapping_hole)
+    monkeypatch.setattr(analysis, "_result_from_evidence", with_overlapping_hole)
     observed = _default_observers()["double-d-bores"](_double_d_part(depth))
 
     assert len(observed) == 1
@@ -591,13 +591,13 @@ def test_missing_or_corrupt_across_flats_unit_loses_drawing_credit(
 def test_deleting_provider_records_cannot_shrink_the_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def without_double_d(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, double_d_bores=())
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_double_d)
+    monkeypatch.setattr(analysis, "_result_from_evidence", without_double_d)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0

--- a/tests/test_issue_1370_hole_pattern_completeness_evidence.py
+++ b/tests/test_issue_1370_hole_pattern_completeness_evidence.py
@@ -293,13 +293,13 @@ def test_wrong_placed_group_count_ink_loses_drawing_credit(monkeypatch) -> None:
 def test_deleting_provider_patterns_cannot_shrink_the_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def without_patterns(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, hole_patterns=())
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_patterns)
+    monkeypatch.setattr(analysis, "_result_from_evidence", without_patterns)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -311,7 +311,7 @@ def test_deleting_provider_patterns_cannot_shrink_the_independent_denominator(mo
 def test_weakening_provider_arrangement_values_reduces_parameter_fidelity(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def weakened_patterns(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -325,7 +325,7 @@ def test_weakening_provider_arrangement_values_reduces_parameter_fidelity(monkey
                 changed.append(replace(pattern, diameter=pattern.diameter + 1.0))
         return replace(result, hole_patterns=tuple(changed))
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened_patterns)
+    monkeypatch.setattr(analysis, "_result_from_evidence", weakened_patterns)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0

--- a/tests/test_issue_1371_flat_completeness_evidence.py
+++ b/tests/test_issue_1371_flat_completeness_evidence.py
@@ -107,7 +107,7 @@ def test_every_flat_boundary_is_observed_supported_on_the_real_public_path() -> 
 def test_flat_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis.build_recognition_evidence
     calls = 0
 
     def counted(*args, **kwargs):
@@ -115,7 +115,7 @@ def test_flat_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted)
+    monkeypatch.setattr(analysis, "build_recognition_evidence", counted)
     assert _default_observers()["flats"](_double_d())
     assert calls == 1
 
@@ -252,13 +252,13 @@ def test_severing_flat_measurement_provenance_loses_drawing_credit(monkeypatch) 
 def test_deleting_provider_flats_cannot_shrink_the_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def without_flats(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, flats=())
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_flats)
+    monkeypatch.setattr(analysis, "_result_from_evidence", without_flats)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -270,14 +270,14 @@ def test_deleting_provider_flats_cannot_shrink_the_independent_denominator(monke
 def test_weakening_provider_across_values_reduces_parameter_fidelity(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def weakened_flats(*args, **kwargs):
         result = original(*args, **kwargs)
         flats = tuple(replace(flat, across=flat.across + 1.0) for flat in result.flats)
         return replace(result, flats=flats)
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened_flats)
+    monkeypatch.setattr(analysis, "_result_from_evidence", weakened_flats)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0

--- a/tests/test_issue_1371_polygonal_stock_completeness_evidence.py
+++ b/tests/test_issue_1371_polygonal_stock_completeness_evidence.py
@@ -853,7 +853,7 @@ def test_polygonal_stock_ledger_distinguishes_suppressed_dropped_structured_and_
 def test_polygonal_stock_observer_uses_one_build_owned_aggregate(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis.build_recognition_evidence
     calls = 0
 
     def counted(*args, **kwargs):
@@ -861,7 +861,7 @@ def test_polygonal_stock_observer_uses_one_build_owned_aggregate(monkeypatch) ->
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted)
+    monkeypatch.setattr(analysis, "build_recognition_evidence", counted)
     assert _default_observers()["polygonal-stock"](_stock())
     assert calls == 1
 
@@ -1080,13 +1080,13 @@ def test_drawing_consumer_requires_both_compiler_approved_stock_dimensions(monke
 def test_deleting_provider_stock_cannot_shrink_the_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def without_stock(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, polygonal_stock=())
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_stock)
+    monkeypatch.setattr(analysis, "_result_from_evidence", without_stock)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -1099,7 +1099,7 @@ def test_deleting_provider_stock_cannot_shrink_the_independent_denominator(monke
 def test_weakening_provider_parameters_reduces_parameter_fidelity(monkeypatch, parameter) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def weakened(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -1140,7 +1140,7 @@ def test_weakening_provider_parameters_reduces_parameter_fidelity(monkeypatch, p
                 raise AssertionError(parameter)
         return replace(result, polygonal_stock=tuple(values))
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened)
+    monkeypatch.setattr(analysis, "_result_from_evidence", weakened)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0
@@ -1152,7 +1152,7 @@ def test_weakening_provider_parameters_reduces_parameter_fidelity(monkeypatch, p
 def test_constant_canonical_values_cannot_pass_the_varied_positive_oracle(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
     canonical_af = 40 * cos(pi / 6)
 
     def hard_coded(*args, **kwargs):
@@ -1176,7 +1176,7 @@ def test_constant_canonical_values_cannot_pass_the_varied_positive_oracle(monkey
             )
         return replace(result, polygonal_stock=tuple(values))
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", hard_coded)
+    monkeypatch.setattr(analysis, "_result_from_evidence", hard_coded)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0

--- a/tests/test_issue_1372_groove_completeness_evidence.py
+++ b/tests/test_issue_1372_groove_completeness_evidence.py
@@ -282,7 +282,7 @@ def test_every_groove_boundary_is_observed_supported_on_the_real_public_path() -
 def test_groove_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis.build_recognition_evidence
     calls = 0
 
     def counted(*args, **kwargs):
@@ -290,7 +290,7 @@ def test_groove_observer_uses_one_build_owned_recognition_aggregate(monkeypatch)
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted)
+    monkeypatch.setattr(analysis, "build_recognition_evidence", counted)
     assert _default_observers()["grooves"](_lone())
     assert calls == 1
 
@@ -588,13 +588,13 @@ def test_incomplete_compiler_group_cannot_certify_groove_ink(monkeypatch) -> Non
 def test_deleting_provider_grooves_cannot_shrink_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def without_grooves(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, grooves=())
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_grooves)
+    monkeypatch.setattr(analysis, "_result_from_evidence", without_grooves)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -607,7 +607,7 @@ def test_deleting_provider_grooves_cannot_shrink_independent_denominator(monkeyp
 def test_weakening_provider_measurements_reduces_parameter_fidelity(monkeypatch, field) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def weakened_grooves(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -616,7 +616,7 @@ def test_weakening_provider_measurements_reduces_parameter_fidelity(monkeypatch,
         )
         return replace(result, grooves=grooves)
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened_grooves)
+    monkeypatch.setattr(analysis, "_result_from_evidence", weakened_grooves)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0
@@ -630,7 +630,7 @@ def test_weakening_provider_measurements_reduces_parameter_fidelity(monkeypatch,
 def test_weakening_provider_identity_reduces_detection_recall(monkeypatch, field) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def weakened_grooves(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -646,7 +646,7 @@ def test_weakening_provider_identity_reduces_detection_recall(monkeypatch, field
             )
         return replace(result, grooves=values)
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened_grooves)
+    monkeypatch.setattr(analysis, "_result_from_evidence", weakened_grooves)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 0.0

--- a/tests/test_issue_1372_pad_completeness_evidence.py
+++ b/tests/test_issue_1372_pad_completeness_evidence.py
@@ -423,7 +423,7 @@ def test_pad_coverage_does_not_duplicate_a_placement_drop() -> None:
 def test_pad_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis.build_recognition_evidence
     calls = 0
 
     def counted(*args, **kwargs):
@@ -431,7 +431,7 @@ def test_pad_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) ->
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted)
+    monkeypatch.setattr(analysis, "build_recognition_evidence", counted)
     assert _default_observers()["rectangular-pads"](_lone())
     assert calls == 1
 
@@ -675,13 +675,13 @@ def test_severing_one_pad_measurement_claim_loses_drawing_credit(monkeypatch) ->
 def test_deleting_provider_pads_cannot_shrink_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def without_pads(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, pads=())
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_pads)
+    monkeypatch.setattr(analysis, "_result_from_evidence", without_pads)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -714,7 +714,7 @@ def test_weakening_provider_measurements_reduces_parameter_fidelity(
 ) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def weakened_pads(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -723,7 +723,7 @@ def test_weakening_provider_measurements_reduces_parameter_fidelity(
             pads=tuple(_weaken_parameter(pad, parameter) for pad in result.pads),
         )
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened_pads)
+    monkeypatch.setattr(analysis, "_result_from_evidence", weakened_pads)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0
@@ -736,7 +736,7 @@ def test_weakening_provider_measurements_reduces_parameter_fidelity(
 def test_weakening_provider_identity_reduces_detection_recall(monkeypatch, field) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def weakened_pads(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -757,7 +757,7 @@ def test_weakening_provider_identity_reduces_detection_recall(monkeypatch, field
             )
         return replace(result, pads=tuple(values))
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened_pads)
+    monkeypatch.setattr(analysis, "_result_from_evidence", weakened_pads)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 0.0

--- a/tests/test_issue_1372_pocket_completeness_evidence.py
+++ b/tests/test_issue_1372_pocket_completeness_evidence.py
@@ -171,7 +171,7 @@ def test_every_pocket_boundary_is_observed_supported_on_the_real_public_path() -
 def test_pocket_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis.build_recognition_evidence
     calls = 0
 
     def counted(*args, **kwargs):
@@ -179,7 +179,7 @@ def test_pocket_observer_uses_one_build_owned_recognition_aggregate(monkeypatch)
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted)
+    monkeypatch.setattr(analysis, "build_recognition_evidence", counted)
     assert _default_observers()["pockets"](_lone())
     assert calls == 1
 
@@ -401,13 +401,13 @@ def test_side_opening_authored_location_omission_is_suppressed_not_missing() -> 
 def test_deleting_provider_pockets_cannot_shrink_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def without_pockets(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, pockets=(), pocket_patterns=())
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_pockets)
+    monkeypatch.setattr(analysis, "_result_from_evidence", without_pockets)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -419,14 +419,14 @@ def test_deleting_provider_pockets_cannot_shrink_independent_denominator(monkeyp
 def test_weakening_provider_widths_reduces_parameter_fidelity(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def weakened_pockets(*args, **kwargs):
         result = original(*args, **kwargs)
         pockets = tuple(replace(pocket, width=pocket.width + 1.0) for pocket in result.pockets)
         return replace(result, pockets=pockets)
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened_pockets)
+    monkeypatch.setattr(analysis, "_result_from_evidence", weakened_pockets)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0

--- a/tests/test_issue_1372_pocket_pattern_completeness_evidence.py
+++ b/tests/test_issue_1372_pocket_pattern_completeness_evidence.py
@@ -284,7 +284,7 @@ def test_every_pocket_pattern_boundary_is_observed_on_the_real_public_path() -> 
 def test_pocket_pattern_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis.build_recognition_evidence
     calls = 0
 
     def counted(*args, **kwargs):
@@ -292,7 +292,7 @@ def test_pocket_pattern_observer_uses_one_build_owned_recognition_aggregate(monk
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted)
+    monkeypatch.setattr(analysis, "build_recognition_evidence", counted)
     assert _default_observers()["pocket-patterns"](_grid_part())
     assert calls == 1
 
@@ -823,13 +823,13 @@ def test_pitch_fallback_rejects_unverifiable_real_geometry(
 def test_deleting_provider_patterns_cannot_shrink_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def without_patterns(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, pocket_patterns=())
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_patterns)
+    monkeypatch.setattr(analysis, "_result_from_evidence", without_patterns)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -841,7 +841,7 @@ def test_deleting_provider_patterns_cannot_shrink_independent_denominator(monkey
 def test_weakening_provider_pitch_reduces_parameter_fidelity(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def weakened_patterns(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -853,7 +853,7 @@ def test_weakening_provider_pitch_reduces_parameter_fidelity(monkeypatch) -> Non
                 changed.append(replace(pattern, pitch=pattern.pitch + 1.0))
         return replace(result, pocket_patterns=tuple(changed))
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened_patterns)
+    monkeypatch.setattr(analysis, "_result_from_evidence", weakened_patterns)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0
@@ -866,7 +866,7 @@ def test_weakening_provider_pitch_reduces_parameter_fidelity(monkeypatch) -> Non
 def test_hardcoding_arrangement_orientation_reduces_parameter_fidelity(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def axis_aligned_patterns(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -878,7 +878,7 @@ def test_hardcoding_arrangement_orientation_reduces_parameter_fidelity(monkeypat
                 changed.append(replace(pattern, direction=(0.0, 1.0, 0.0)))
         return replace(result, pocket_patterns=tuple(changed))
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", axis_aligned_patterns)
+    monkeypatch.setattr(analysis, "_result_from_evidence", axis_aligned_patterns)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0

--- a/tests/test_issue_1372_polygonal_boss_completeness_evidence.py
+++ b/tests/test_issue_1372_polygonal_boss_completeness_evidence.py
@@ -242,7 +242,7 @@ def test_malformed_source_record_fails_closed_through_drawing_lint(
     import draftwright.recognition_cache as recognition_cache
     from draftwright import Sheet
 
-    original = recognition_cache.build_raw_recognition_result
+    original = recognition_cache._result_from_evidence
 
     def malformed_recognition(*args, **kwargs):
         recognition = original(*args, **kwargs)
@@ -260,7 +260,7 @@ def test_malformed_source_record_fails_closed_through_drawing_lint(
             source = replace(boss, flat_directions=boss.flat_directions[:-1])
         return replace(recognition, polygonal_bosses=(source,))
 
-    monkeypatch.setattr(recognition_cache, "build_raw_recognition_result", malformed_recognition)
+    monkeypatch.setattr(recognition_cache, "_result_from_evidence", malformed_recognition)
     sheet = Sheet(_boss_part()).authored_dimensions()
     envelope = sheet.envelope()
     sheet.dimension(envelope, "width.length")
@@ -508,7 +508,7 @@ def test_polygonal_boss_coverage_does_not_duplicate_a_placement_drop() -> None:
 def test_polygonal_boss_observer_uses_one_build_owned_aggregate(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis.build_recognition_evidence
     calls = 0
 
     def counted(*args, **kwargs):
@@ -516,7 +516,7 @@ def test_polygonal_boss_observer_uses_one_build_owned_aggregate(monkeypatch) -> 
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted)
+    monkeypatch.setattr(analysis, "build_recognition_evidence", counted)
     assert _default_observers()["polygonal-bosses"](_boss_part())
     assert calls == 1
 
@@ -677,13 +677,13 @@ def test_deleting_provider_bosses_cannot_shrink_the_independent_denominator(
 ) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def without_bosses(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, polygonal_bosses=())
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_bosses)
+    monkeypatch.setattr(analysis, "_result_from_evidence", without_bosses)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -699,7 +699,7 @@ def test_deleting_provider_bosses_cannot_shrink_the_independent_denominator(
 def test_weakening_provider_parameters_reduces_parameter_fidelity(monkeypatch, parameter) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def weakened(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -767,7 +767,7 @@ def test_weakening_provider_parameters_reduces_parameter_fidelity(monkeypatch, p
                 raise AssertionError(parameter)
         return replace(result, polygonal_bosses=tuple(values))
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened)
+    monkeypatch.setattr(analysis, "_result_from_evidence", weakened)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0
@@ -779,7 +779,7 @@ def test_weakening_provider_parameters_reduces_parameter_fidelity(monkeypatch, p
         import draftwright.recognition_cache as recognition_cache
         from draftwright import build_drawing
 
-        monkeypatch.setattr(recognition_cache, "build_raw_recognition_result", weakened)
+        monkeypatch.setattr(recognition_cache, "_result_from_evidence", weakened)
         drawing = build_drawing(_boss_part())
         summary = drawing.lint_summary()
         issues = summary["by_code"]
@@ -795,7 +795,7 @@ def test_weakening_provider_parameters_reduces_parameter_fidelity(monkeypatch, p
 def test_shifting_provider_identity_reduces_detection_recall(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def shifted(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -817,7 +817,7 @@ def test_shifting_provider_identity_reduces_detection_recall(monkeypatch) -> Non
             )
         return replace(result, polygonal_bosses=tuple(values))
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", shifted)
+    monkeypatch.setattr(analysis, "_result_from_evidence", shifted)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 0.0

--- a/tests/test_issue_1373_plate_completeness_evidence.py
+++ b/tests/test_issue_1373_plate_completeness_evidence.py
@@ -1159,7 +1159,7 @@ def test_derived_plate_drawing_credit_requires_verified_dependency_ink() -> None
 def test_plate_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis.build_recognition_evidence
     calls = 0
 
     def counted(*args, **kwargs):
@@ -1167,7 +1167,7 @@ def test_plate_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) 
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted)
+    monkeypatch.setattr(analysis, "build_recognition_evidence", counted)
     assert _default_observers()["plates"](_tee())
     assert calls == 1
 
@@ -1292,13 +1292,13 @@ def test_deleting_provider_plates_cannot_shrink_the_independent_denominator(
 ) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def without_plates(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, plates=())
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_plates)
+    monkeypatch.setattr(analysis, "_result_from_evidence", without_plates)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -1310,7 +1310,7 @@ def test_deleting_provider_plates_cannot_shrink_the_independent_denominator(
 def test_malformed_provider_plate_cannot_pass_or_shrink_the_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def malformed(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -1318,7 +1318,7 @@ def test_malformed_provider_plate_cannot_pass_or_shrink_the_denominator(monkeypa
             return result
         return replace(result, plates=(object(), *result.plates[1:]))
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", malformed)
+    monkeypatch.setattr(analysis, "_result_from_evidence", malformed)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.missed > 0
@@ -1331,7 +1331,7 @@ def test_symmetric_provider_interval_damage_preserves_identity_but_loses_fidelit
 ) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def weakened(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -1340,7 +1340,7 @@ def test_symmetric_provider_interval_damage_preserves_identity_but_loses_fidelit
         )
         return replace(result, plates=plates)
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened)
+    monkeypatch.setattr(analysis, "_result_from_evidence", weakened)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0
@@ -1352,7 +1352,7 @@ def test_symmetric_provider_interval_damage_preserves_identity_but_loses_fidelit
 def test_shifting_provider_interval_reduces_detection_recall(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def shifted(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -1361,7 +1361,7 @@ def test_shifting_provider_interval_reduces_detection_recall(monkeypatch) -> Non
         )
         return replace(result, plates=plates)
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", shifted)
+    monkeypatch.setattr(analysis, "_result_from_evidence", shifted)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 0.0
@@ -1373,7 +1373,7 @@ def test_shifting_provider_interval_reduces_detection_recall(monkeypatch) -> Non
 def test_shifting_provider_transverse_witness_reduces_detection_recall(monkeypatch, field) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def shifted(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -1382,7 +1382,7 @@ def test_shifting_provider_transverse_witness_reduces_detection_recall(monkeypat
         )
         return replace(result, plates=plates)
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", shifted)
+    monkeypatch.setattr(analysis, "_result_from_evidence", shifted)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 0.0

--- a/tests/test_issue_1374_chamfer_completeness_evidence.py
+++ b/tests/test_issue_1374_chamfer_completeness_evidence.py
@@ -283,7 +283,7 @@ def test_every_chamfer_boundary_is_observed_supported_on_the_real_public_path() 
 def test_chamfer_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis.build_recognition_evidence
     calls = 0
 
     def counted(*args, **kwargs):
@@ -291,7 +291,7 @@ def test_chamfer_observer_uses_one_build_owned_recognition_aggregate(monkeypatch
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted)
+    monkeypatch.setattr(analysis, "build_recognition_evidence", counted)
     assert _default_observers()["chamfers"](_lone())
     assert calls == 1
 
@@ -512,13 +512,13 @@ def test_severing_chamfer_measurement_provenance_loses_drawing_credit(monkeypatc
 def test_deleting_provider_chamfers_cannot_shrink_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def without_chamfers(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, chamfers=())
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_chamfers)
+    monkeypatch.setattr(analysis, "_result_from_evidence", without_chamfers)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -531,7 +531,7 @@ def test_deleting_provider_chamfers_cannot_shrink_independent_denominator(monkey
 def test_weakening_provider_chamfer_parameters_reduces_fidelity(monkeypatch, field) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def weakened(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -540,7 +540,7 @@ def test_weakening_provider_chamfer_parameters_reduces_fidelity(monkeypatch, fie
         )
         return replace(result, chamfers=values)
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened)
+    monkeypatch.setattr(analysis, "_result_from_evidence", weakened)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0

--- a/tests/test_issue_1374_fillet_completeness_evidence.py
+++ b/tests/test_issue_1374_fillet_completeness_evidence.py
@@ -256,7 +256,7 @@ def test_every_fillet_boundary_is_observed_supported_on_the_real_public_path() -
 def test_fillet_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis.build_recognition_evidence
     calls = 0
 
     def counted(*args, **kwargs):
@@ -264,7 +264,7 @@ def test_fillet_observer_uses_one_build_owned_recognition_aggregate(monkeypatch)
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted)
+    monkeypatch.setattr(analysis, "build_recognition_evidence", counted)
     assert _default_observers()["fillets"](_lone())
     assert calls == 1
 
@@ -483,13 +483,13 @@ def test_severing_fillet_measurement_provenance_loses_drawing_credit(monkeypatch
 def test_deleting_provider_fillets_cannot_shrink_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def without_fillets(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, fillets=())
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_fillets)
+    monkeypatch.setattr(analysis, "_result_from_evidence", without_fillets)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -501,14 +501,14 @@ def test_deleting_provider_fillets_cannot_shrink_independent_denominator(monkeyp
 def test_weakening_provider_fillet_radius_reduces_fidelity(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def weakened(*args, **kwargs):
         result = original(*args, **kwargs)
         values = tuple(replace(item, radius=item.radius + 0.5) for item in result.fillets)
         return replace(result, fillets=values)
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened)
+    monkeypatch.setattr(analysis, "_result_from_evidence", weakened)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0

--- a/tests/test_issue_1374_turned_step_completeness_evidence.py
+++ b/tests/test_issue_1374_turned_step_completeness_evidence.py
@@ -1088,7 +1088,7 @@ def test_generated_drawing_evaluator_requires_the_public_build_boundary(monkeypa
 def test_turned_step_observer_uses_one_build_owned_recognition_aggregate(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis.build_recognition_evidence
     calls = 0
 
     def counted(*args, **kwargs):
@@ -1096,7 +1096,7 @@ def test_turned_step_observer_uses_one_build_owned_recognition_aggregate(monkeyp
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", counted)
+    monkeypatch.setattr(analysis, "build_recognition_evidence", counted)
     assert _default_observers()["turned-steps"](_shaft())
     assert calls == 1
 
@@ -1434,13 +1434,13 @@ def test_severing_step_measurement_provenance_loses_drawing_credit(monkeypatch) 
 def test_deleting_provider_profiles_cannot_shrink_independent_denominator(monkeypatch) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def without_profiles(*args, **kwargs):
         result = original(*args, **kwargs)
         return replace(result, turned_steps=())
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", without_profiles)
+    monkeypatch.setattr(analysis, "_result_from_evidence", without_profiles)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.matched == 0
@@ -1453,7 +1453,7 @@ def test_deleting_provider_profiles_cannot_shrink_independent_denominator(monkey
 def test_weakening_provider_band_parameter_reduces_fidelity(monkeypatch, parameter: str) -> None:
     import draftwright.analysis as analysis
 
-    original = analysis.build_raw_recognition_result
+    original = analysis._result_from_evidence
 
     def weakened(*args, **kwargs):
         result = original(*args, **kwargs)
@@ -1483,7 +1483,7 @@ def test_weakening_provider_band_parameter_reduces_fidelity(monkeypatch, paramet
             )
         return replace(result, turned_steps=steps)
 
-    monkeypatch.setattr(analysis, "build_raw_recognition_result", weakened)
+    monkeypatch.setattr(analysis, "_result_from_evidence", weakened)
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0

--- a/tests/test_part_model.py
+++ b/tests/test_part_model.py
@@ -298,7 +298,8 @@ def test_feature_detection_runs_once_per_build(monkeypatch):
     """ADR 0008 Amendment 5 / #244 — one aggregate inventory per build.
 
     The recogniser package owns its internal family orchestration; Draftwright's contract is
-    the single public ``build_raw_recognition_result`` call whose result every consumer reuses.
+    the single public ``build_recognition_evidence`` acquisition whose result every consumer
+    reuses.
     """
     from build123d import Cylinder, Pos, Rotation
 
@@ -306,14 +307,14 @@ def test_feature_detection_runs_once_per_build(monkeypatch):
     from draftwright import build_drawing
 
     calls = 0
-    original = amod.build_raw_recognition_result
+    original = amod.build_recognition_evidence
 
     def wrap(*args, **kwargs):
         nonlocal calls
         calls += 1
         return original(*args, **kwargs)
 
-    monkeypatch.setattr(amod, "build_raw_recognition_result", wrap)
+    monkeypatch.setattr(amod, "build_recognition_evidence", wrap)
 
     # A turned X shaft exercises the detected path, including a repack when required.
     build_drawing(Rotation(0, 90, 0) * (Cylinder(15, 30) + Pos(0, 0, 30) * Cylinder(8, 30)))

--- a/tests/test_recognition_result.py
+++ b/tests/test_recognition_result.py
@@ -49,7 +49,7 @@ def test_built_drawing_exposes_its_recognition_result_without_private_state(monk
     def forbidden(*args, **kwargs):
         raise AssertionError("Drawing.recognition() re-ran recognition instead of handing back")
 
-    monkeypatch.setattr(analysis_module, "build_raw_recognition_result", forbidden)
+    monkeypatch.setattr(analysis_module, "build_recognition_evidence", forbidden)
     assert drawing.recognition() is result
 
 


### PR DESCRIPTION
## Summary

- acquire raw recognition through the released `b123d_recognisers.evidence` API and retain its exact result/evidence pair in the drawing-owned cache
- preserve that same run across declared lazy critique and scale/view retries; bare and framed results remain evidence-less without a backfill scan
- expose the paired evidence through experimental read-only `Drawing.recognition_evidence()` and ratchet the public provider boundary
- record the ownership decision in ADRs 0015, 0017, and 0020; rendering and generated outputs are unchanged in this foundation slice

This is the first independently mergeable slice of #1438. Framed accepted-occurrence evidence remains deferred to upstream pzfreo/b123d-recognisers#463 and does not block raw/report work.

## ADR review

Audited against ADRs 0010, 0011, 0013, 0014, 0015, 0017, and 0020. The evidence remains below the IR/compiler waist, declared builds remain recognition-free until physical critique, and no placement or persistent-topology contract changes.

## Verification

- `scripts/pr-check --full`: 6,410 passed, 5 skipped, 2 xfailed
- project coverage 95.63%; changed-line coverage 100%
- independent exact-head correctness, ADR, and quality reviews: clean, no nits
- review finding iteration completed: changelog/lifetime docs and adversarial evidence-namespace guard coverage added, then all three reviewers re-reviewed exact head clean

Refs #1438
