### PR TITLE
Capture direct recognition occurrence ownership (#1438)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Added
 
+- Raw automatic builds now capture run-local, conversion-time ownership from accepted provider
+  occurrences to their exact Draftwright IR features for unconditional one-to-one adapters. Equal
+  record values, order, coordinates and topology indices cannot create a binding; an omitted direct
+  binding fails closed as unexpectedly missing, while grouped/absorbed/deferred families remain
+  explicitly unclassified. The experimental read-only `Drawing.recognition_ownership()` exposes
+  the non-serializable ledger; it stays outside the IR/compiler and changes no generated or visual
+  artefact (#1438, ADR 0017 Amendment 12).
+
 - Raw automatic recognition now retains the provider's run-scoped `RecognitionEvidence` beside
   its exact `RecognitionResult`, exposed through the experimental read-only
   `Drawing.recognition_evidence()`. Declared drawings acquire the pair lazily on first physical

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,8 @@ Compact map, bottom to top:
   `_geometry.py` (page-plane maths + the ADR 0014 Amdt 3 material field; the DAG's
   bottom leaf), `fonts.py` (pinned IBM Plex, ADR 0006), `fits.py` (ISO 286),
   `intents.py` (deferred-edit low IR), `recognition_cache.py` (ADR 0017 one-result
-  lifecycle), `recognition_frame.py` (ADR 0020 prepared local-frame boundary and fail-closed
+  lifecycle), `recognition_ownership.py` (run-local accepted-occurrence→IR bindings),
+  `recognition_frame.py` (ADR 0020 prepared local-frame boundary and fail-closed
   body-local occurrence joins), `blend_contract.py` (strict released-Blend schema and
   occurrence identity),
   `_warnings.py`, `_pmi_part21.py`, and the `linting/` subpackage

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -11,7 +11,8 @@
   the same independently for the round-bottom family. Amendment 9 (2026-09-02) adopts the 0.4.12
   additive inventories fail closed while retaining the existing paired-ramp consumer meaning.
   Amendment 11 (2026-09-02) retains the provider's raw accepted-occurrence evidence in the same
-  consumer-owned cache without adding a second recognition run.
+  consumer-owned cache without adding a second recognition run. Amendment 12 (2026-09-03)
+  records the first conversion-time, run-local occurrence→IR ownership bindings.
 - **Date:** 2026-08-03
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -302,6 +303,27 @@ This amendment extends the accepted ownership unit, not the completeness denomin
 persistent topology identifier, report schema, record-to-IR inference, manufacturing intent,
 compiled-plan dependency, placement path, or visual output. Later #1438 slices must demonstrate the
 consumer disposition rules independently before this evidence can support an authoritative report.
+
+## Amendment 12 — Direct occurrence ownership is captured at conversion time
+
+Draftwright now retains a sibling `RecognitionOwnership` ledger for raw automatic builds. For each
+aggregate family whose adapter unconditionally converts one accepted record into one IR feature,
+`model.detect` binds the provider's opaque `FeatureRef` to that exact newly-created feature at the
+conversion site. Resolution uses exact same-run record identity: equal-valued copies, feature
+ordering, labels, coordinates, face overlap, object addresses and topology indices cannot establish
+ownership. The immutable ledger is paired with the same `RecognitionEvidence`, survives scale/view
+retries with the stored sizing model, and is attached beside the model in `BuildState`; provider
+references do not enter `PartModel`, compilation, placement, generated programs, or visual output.
+
+This first vertical slice covers only unconditional 1:1 adapters: blends, chamfers, circular blind
+steps, double-D bores, fillets, flats, grooves, pads, paired ramp steps, polygonal bosses/stock, and
+rectangular/round-bottom blind slots. An expected direct occurrence without a recorded owner is
+retained as `unexpectedly_missing`. Every grouped, nested, absorbed, classification-only, or
+deferred family remains explicitly `unclassified` until its N:1 or 1:0 consumer rule is implemented;
+it is not falsely reported as missing. Declared builds and evidence-less framed/bare aggregates do
+not invent ownership. `Drawing.recognition_ownership()` exposes the non-serializable ledger as an
+experimental read-only view so consumers need not reach into private build state. This remains
+reporting foundation: no public report schema or completeness claim is introduced by this amendment.
 
 ## Accepted Contract
 

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -368,9 +368,10 @@ The result is stored in typed `BuildState`, whose builder/lazy-critique path is 
 writer. This makes the result's relationship to its drawing structural: engine consumers do
 not accept an arbitrary aggregate and then attempt to prove it came from the same part.
 
-This answers **result-to-build provenance only**. It does not answer which recognition record
-became which IR feature, requirement, or annotation. That record-to-feature correspondence is
-the subject of the evidence gates below.
+This originally answered **result-to-build provenance only**. Amendment 12 now records exact
+occurrence→IR ownership for unconditional 1:1 adapters. Grouped, nested, absorbed and deferred
+families, and the general feature→requirement→annotation correspondence, remain subjects of the
+evidence gates below.
 
 `lint_prismatic_coverage(recognition=...)` is a known channel outside the structural ownership
 path (#1032). The preferred correction is to remove or narrow the channel when that boundary

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,8 @@ keep that table, this document, and `CLAUDE.md`'s compact map in step. The
 
 The dependency graph is a DAG (the #138 / ADR 0005 split is complete). Bottom to
 top: leaf modules (`layout.py`, `registry.py`, `fonts.py`, `_geometry.py`,
-`fits.py`, `intents.py`, `recognition_cache.py`, `recognition_frame.py`, and the
+`fits.py`, `intents.py`, `recognition_cache.py`, `recognition_ownership.py`,
+`recognition_frame.py`, and the
 strict `blend_contract.py` provider-record boundary, and the `linting/` subpackage) →
 `_core.py` → stage modules (`export.py`,
 `repair.py`, `projection.py`, `compose.py`, `analysis.py`, `drawing.py`, the
@@ -200,10 +201,15 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   `_QUOTED_RE` (a lint-message label regex shared with the
   repair loop) lives in `_core`.
 - **`recognition_cache.py`** — Draftwright's ADR 0017 one-result lifecycle owner. It calls
-  external `build_raw_recognition_result(part)` at most once for a build/lazy-critique run.
-  The explicit name records that the default IR consumes caller/world coordinates; the package
-  owns recognition, while Draftwright owns when the result is computed and reused. Explicit
-  framed builds bypass this raw cache with their already-paired aggregate.
+  external `build_recognition_evidence(part)` at most once for a raw build/lazy-critique run,
+  retaining its exact `RecognitionResult` projection and evidence authority together. The
+  package owns recognition, while Draftwright owns when the pair is computed and reused. A bare
+  or explicit framed result remains valid without evidence; the cache never rescans to backfill it.
+- **`recognition_ownership.py`** — the run-local consumer ledger below/beside the ADR 0015 IR
+  waist. During record→IR conversion it binds opaque provider occurrences to the exact IR
+  feature objects that represent them, by same-run record identity. It exposes no persistent
+  topology/order/address ID. The first ownership slice classifies only unconditional 1:1 adapters;
+  grouped, nested, absorbed, classification-only and deferred families remain unclassified.
 - **`recognition_frame.py`** — the ADR 0020 prepared local-frame boundary. It calls the public
   provider preparation seam, classifies the exact normalized solid from its already-scanned
   cylinders, runs one paired aggregate, propagates typed refusal without fallback, and exposes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -200,11 +200,12 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   `b123d_recognisers` (typed hole records in `coverage.py`) + build123d_drafting.
   `_QUOTED_RE` (a lint-message label regex shared with the
   repair loop) lives in `_core`.
-- **`recognition_cache.py`** — Draftwright's ADR 0017 one-result lifecycle owner. It calls
-  external `build_recognition_evidence(part)` at most once for a raw build/lazy-critique run,
-  retaining its exact `RecognitionResult` projection and evidence authority together. The
-  package owns recognition, while Draftwright owns when the pair is computed and reused. A bare
-  or explicit framed result remains valid without evidence; the cache never rescans to backfill it.
+- **`recognition_cache.py`** — Draftwright's ADR 0017 one-result lifecycle owner. Raw automatic
+  analysis seeds it with one external `build_recognition_evidence(part)` acquisition; on a lazy
+  declared critique the empty cache makes that call itself. It retains the exact
+  `RecognitionResult` projection and evidence authority together. The package owns recognition,
+  while Draftwright owns when the pair is computed and reused. A bare or explicit framed result
+  remains valid without evidence; the cache never rescans to backfill it.
 - **`recognition_ownership.py`** — the run-local consumer ledger below/beside the ADR 0015 IR
   waist. During record→IR conversion it binds opaque provider occurrences to the exact IR
   feature objects that represent them, by same-run record identity. It exposes no persistent
@@ -561,8 +562,9 @@ policy) live in `CLAUDE.md`. This is the per-ADR status trail; each ADR's
   compiler grammar and placement solve, and a side-normal footprint is filtered from the legacy
   Z-level projection only when exact support correspondence proves that ownership. No renderer
   consumes the provider record or places an annotation at a caller-supplied page coordinate.
-  The accepted contract stops there. `BuildState` proves result-to-build provenance; it does
-  **not** yet provide recognition-record→IR-feature→requirement correspondence. The original
+  Amendment 12 additionally gives unconditional 1:1 adapters exact run-local
+  occurrence→IR-feature ownership in `BuildState`. Grouped, nested, absorbed and deferred
+  families, plus general IR-feature→requirement correspondence, are not yet provided. The original
   four-type identity taxonomy, shared requirements module, general outcome ledger,
   reconciliation stage, and diagnostics model are candidate extensions rather than an
   approved phase sequence. #1018 now requires two end-to-end slices before any of them is

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from b123d_recognisers.evidence import RecognitionEvidence
 
     from draftwright.compose import StripDepths
+    from draftwright.recognition_ownership import RecognitionOwnership
 
 from build123d import (
     Align,
@@ -1225,6 +1226,10 @@ class Analysis:
     #: provider exposes framed evidence, and for a deliberately injected bare aggregate.  It is
     #: never reconstructed from ``recognition`` because that would create a second run universe.
     recognition_evidence: RecognitionEvidence | None = None
+    #: Conversion-time, run-local accepted-occurrence -> IR ownership.  This stays beside the
+    #: model rather than entering the ADR-0015 compiler waist.  Only direct 1:1 adapters are
+    #: classified initially; grouped/absorbed families remain explicitly unclassified.
+    recognition_ownership: RecognitionOwnership | None = None
     #: The relational arrangement the sheet was composed under — ADR 0018 §5's fourth
     #: dimension, decided once by `compose.choose_scale` and carried here so that placement
     #: and the repack loop compose under the arrangement whose feasibility was actually

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -70,6 +70,7 @@ from draftwright.recognition_frame import (
     prepare_framed_detection,
     require_unambiguous_groove_owner,
 )
+from draftwright.recognition_ownership import RecognitionOwnershipBuilder
 from draftwright.view_plan import ViewConstraints, arrangement_of
 
 _log = logging.getLogger(__name__)
@@ -1011,6 +1012,11 @@ def _analyse(
         if is_rotational and od_axis == "z"
         else ()
     )
+    ownership_builder = (
+        RecognitionOwnershipBuilder(recognition_evidence)
+        if layout_model is None and _reuse is None and recognition_evidence is not None
+        else None
+    )
     sizing_model = (
         layout_model
         if layout_model is not None
@@ -1019,6 +1025,7 @@ def _analyse(
         else _build_part_model_from_recognition(
             part,
             cast(RecognitionResult, recognition),
+            ownership=ownership_builder,
             holes=holes,
             double_d_bores=double_d_bores,
             patterns=patterns,
@@ -1058,6 +1065,15 @@ def _analyse(
             lower_pmi=pmi_mode == "annotate",
             cyls=shared_cyls,
         )
+    )
+    recognition_ownership = (
+        None
+        if layout_model is not None
+        else _reuse.recognition_ownership
+        if _reuse is not None
+        else ownership_builder.freeze()
+        if ownership_builder is not None
+        else None
     )
     # Authored omission affects annotation FOOTPRINT sizing, but the analysis model retains
     # its historical automatic requirement inventory for view-feasibility preflight.  The
@@ -1261,6 +1277,7 @@ def _analyse(
         ),
         recognition=recognition,
         recognition_evidence=recognition_evidence,
+        recognition_ownership=recognition_ownership,
         bb=bb,
         x_size=x_size,
         y_size=y_size,

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -1071,7 +1071,7 @@ def _analyse(
         if layout_model is not None
         else _reuse.recognition_ownership
         if _reuse is not None
-        else ownership_builder.freeze()
+        else ownership_builder.snapshot()
         if ownership_builder is not None
         else None
     )

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -635,6 +635,7 @@ def _assemble(
         a.recognition,
         evidence=a.recognition_evidence,
         cache=critique_recognition_cache if a.recognition is None else None,
+        ownership=a.recognition_ownership,
     )
     dwg._build.part_model = pm
     # Persist the caller's detail-view setting: on the auto_dims=False path the flag

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -24,6 +24,8 @@ if TYPE_CHECKING:
     from b123d_recognisers import RecognitionResult
     from b123d_recognisers.evidence import RecognitionEvidence
 
+    from draftwright.recognition_ownership import RecognitionOwnership
+
 # PEP 702 @deprecated. A `sys.version_info` guard (not try/except) so the type checker,
 # which targets the 3.10 floor, resolves the backport branch instead of `warnings.deprecated`
 # (only in 3.13+ typeshed).
@@ -438,6 +440,8 @@ class BuildState:
     - ``part_model`` — the detected/declared ADR-0008 PartModel (read surface for
       semantic edits, #397).
     - ``recognition`` — the ADR 0017 aggregate reused by model detection and critique.
+    - ``recognition_ownership`` — same-run direct occurrence→IR bindings captured while
+      conversion makes the decision; provider references never enter the IR waist.
     - ``view_edge_cache`` — lint's per-view edge bboxes, keyed on id(view shape)
       (helpers #143/#164).
     - ``ann_box_cache`` — lint's annotation bounding boxes (#602): identity- AND
@@ -459,6 +463,7 @@ class BuildState:
 
     analysis: Analysis | None = None
     recognition_cache: RecognitionCache = dataclasses_field(default_factory=RecognitionCache)
+    recognition_ownership: RecognitionOwnership | None = None
     part_model: object | None = None
     view_edge_cache: dict = dataclasses_field(default_factory=dict)
     ann_box_cache: dict = dataclasses_field(default_factory=dict)
@@ -498,6 +503,7 @@ class BuildState:
     @recognition.setter
     def recognition(self, value: RecognitionResult | None) -> None:
         self.recognition_cache.seed(value)
+        self.recognition_ownership = None
 
     def attach_recognition(
         self,
@@ -505,6 +511,7 @@ class BuildState:
         *,
         evidence: RecognitionEvidence | None = None,
         cache: RecognitionCache | None = None,
+        ownership: RecognitionOwnership | None = None,
     ) -> None:
         """Attach one coherent acquisition at the builder's single fill site.
 
@@ -514,11 +521,15 @@ class BuildState:
         """
 
         if cache is not None:
-            if result is not None or evidence is not None:
+            if result is not None or evidence is not None or ownership is not None:
                 raise ValueError("cannot attach both a recognition cache and a new acquisition")
             self.recognition_cache = cache
+            self.recognition_ownership = None
             return
+        if ownership is not None and ownership.evidence is not evidence:
+            raise ValueError("recognition ownership and evidence must come from the same run")
         self.recognition_cache.seed(result, evidence=evidence)
+        self.recognition_ownership = ownership
 
     @property
     def recognition_evidence(self) -> RecognitionEvidence | None:
@@ -974,6 +985,18 @@ class Drawing:
         """
 
         return self._build.recognition_evidence
+
+    def recognition_ownership(self) -> RecognitionOwnership | None:
+        """Run-local accepted-occurrence ownership captured during detected conversion.
+
+        This experimental, read-only ledger is available only when raw automatic recognition
+        supplied :meth:`recognition_evidence`. It currently classifies unconditional one-to-one
+        adapters; all grouped, absorbed, classification-only and deferred families remain
+        explicitly unclassified. It carries opaque provider references and therefore cannot be
+        serialized or used as persistent feature identity.
+        """
+
+        return self._build.recognition_ownership
 
     # --- build-context compat properties (#639): one BuildState, thin views.
     # _part_model and the two caches are GETTER-ONLY by design (#691 review):

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -141,6 +141,7 @@ from draftwright.recognition_frame import (
     groove_owns_turned_step_band,
     require_unambiguous_groove_owner,
 )
+from draftwright.recognition_ownership import RecognitionOwnershipBuilder
 
 
 def _member_hole(h, frame: Frame, members: tuple = (), count: int = 1) -> HoleFeature:
@@ -258,6 +259,7 @@ class _RecognitionHandoff:
 
     part: object
     result: RecognitionResult
+    ownership: RecognitionOwnershipBuilder | None = None
 
 
 _RECOGNITION_HANDOFF: ContextVar[_RecognitionHandoff | None] = ContextVar(
@@ -266,12 +268,18 @@ _RECOGNITION_HANDOFF: ContextVar[_RecognitionHandoff | None] = ContextVar(
 
 
 def _build_part_model_from_recognition(
-    part, recognition_result: RecognitionResult, **kwargs
+    part,
+    recognition_result: RecognitionResult,
+    *,
+    ownership: RecognitionOwnershipBuilder | None = None,
+    **kwargs,
 ) -> PartModel:
     """Internal detected-path entry that binds aggregate provenance to its source part."""
     if type(recognition_result) is not RecognitionResult:
         raise TypeError("recognition_result must be an exact RecognitionResult")
-    token = _RECOGNITION_HANDOFF.set(_RecognitionHandoff(part, recognition_result))
+    if ownership is not None and ownership.result is not recognition_result:
+        raise ValueError("recognition ownership and result must come from the same run")
+    token = _RECOGNITION_HANDOFF.set(_RecognitionHandoff(part, recognition_result, ownership))
     try:
         return build_part_model(part, **kwargs)
     finally:
@@ -1183,6 +1191,9 @@ def build_part_model(
         blends = tuple(blends)
     handoff = _RECOGNITION_HANDOFF.get()
     recognition_result = handoff.result if handoff is not None and handoff.part is part else None
+    ownership = (
+        handoff.ownership if recognition_result is not None and handoff is not None else None
+    )
     circular_blind_steps_supplied = circular_blind_steps is not None
     if circular_blind_steps_supplied:
         circular_blind_steps = tuple(circular_blind_steps)
@@ -1237,6 +1248,14 @@ def build_part_model(
             raise ValueError("fillets and blends must preserve aggregate ownership exactly")
     bbox = part.bounding_box()
     features: list[Feature] = []
+
+    def append_direct(record: object) -> None:
+        """Convert and bind while the exact occurrence-to-IR decision is in hand."""
+
+        feature = convert(record, ctx)
+        features.append(feature)
+        if ownership is not None:
+            ownership.bind(record, feature)
 
     # Turned-profile classification up front so the shared convert-context carries the
     # part's turning axis (the StepFeature span axis). Pure detection — no feature is
@@ -1676,7 +1695,8 @@ def build_part_model(
     # established hole location, GD&T, placement and edit paths remain one implementation.
     if double_d_bores is None:
         double_d_bores = recognise_double_d_bores(part)
-    features.extend(convert(bore, ctx) for bore in double_d_bores)
+    for bore in double_d_bores:
+        append_direct(bore)
 
     # Milled slots / reduced across-flats sections (detected for any part). A recognised array
     # of identical slots becomes ONE SlotPatternFeature (count× SLOT W×L + pitch, #841); its
@@ -1700,13 +1720,13 @@ def build_part_model(
     # evidence. Consume that exact inventory as a dedicated semantic feature; do not rescan or
     # coerce it into any of those grammars.
     for blind_slot in rectangular_blind_slots:
-        features.append(convert(blind_slot, ctx))
+        append_direct(blind_slot)
 
     # Capped, edge-open U-section slots with a straight floor joined by equal round sides.
     # This released aggregate inventory owns the physical family; ordinary and rectangular
     # slots, pockets, channels and passages must not regain ownership downstream.
     for blind_slot in round_bottom_blind_slots:
-        features.append(convert(blind_slot, ctx))
+        append_direct(blind_slot)
 
     # Blind rectangular recesses — floored slots/pockets (#148a). A recognised array of
     # identical pockets becomes ONE PocketPatternFeature (count× W×L×D + pitch, #841); its
@@ -1731,18 +1751,21 @@ def build_part_model(
     # Bounded rectangular raised pads: footprint sizing, attachment-axis height, and
     # two in-plane locations. A Z attachment level may also enter the general profile
     # ladder, but that datum-to-level fact does not replace the pad's local rise.
-    features.extend(convert(pad, ctx) for pad in pads)
+    for pad in pads:
+        append_direct(pad)
 
     # Bounded regular polygonal bosses own an across-flats callout and their direct axial
     # height. They are distinct from circular bosses (diameter semantics) and rectangular
     # pads (two orthogonal footprint sizes).
     if polygonal_bosses is None:
         polygonal_bosses = recognise_polygonal_bosses(part)
-    features.extend(convert(boss, ctx) for boss in polygonal_bosses)
+    for boss in polygonal_bosses:
+        append_direct(boss)
 
     # A whole regular polygonal prism is stock, not a boss: it owns the form/A-F
     # definition and its axial stock length independently of attachment evidence.
-    features.extend(convert(stock, ctx) for stock in polygonal_stock)
+    for stock in polygonal_stock:
+        append_direct(stock)
 
     # Turned / circlip grooves (#148c) — recognised up front so the turned-step chain can
     # exclude any band a groove already dimensions: a groove floor is an annular band, and
@@ -1920,25 +1943,25 @@ def build_part_model(
     # both oblique planar and conical turned forms; both lower through the same converter and
     # IR. An injected aggregate inventory is consumed directly, without a sibling rescan.
     for ch in chamfers:
-        features.append(convert(ch, ctx))
+        append_direct(ch)
 
     # Fillets (#561/#1281) — called out R{radius} (grouped n× at render). The package
     # recognises both cylindrical prismatic blends and toroidal turned rounds; both lower
     # through the same converter and IR. An injected aggregate inventory is consumed directly,
     # without a sibling rescan.
     for fl in fillets:
-        features.append(convert(fl, ctx))
+        append_direct(fl)
 
     # Accepted Blend records are the aggregate remainder after exact Fillet precedence.
     # Preserve their free-axis contract in dedicated IR; never rerun or locally rematch Fillets.
     for blend_record in blends:
-        features.append(convert(blend_record, ctx))
+        append_direct(blend_record)
 
     # Quarter-cylindrical corner cuts with one blind terminal (#1382). The aggregate
     # supplies the oriented centreline and transverse quarter arc, so radius and depth
     # lower without topology access or a sibling scan.
     for circular_step in circular_blind_steps:
-        features.append(convert(circular_step, ctx))
+        append_direct(circular_step)
 
     # Mirror-symmetric paired-ramp steps (#1382) — the aggregate proves two equal acute
     # cross-section angles and one open-to-terminal run.  Consume the supplied aggregate
@@ -1948,7 +1971,7 @@ def build_part_model(
         # inventory already embodies that one orchestration decision and is never re-filtered.
         paired_ramp_steps = recognise_paired_ramp_steps(part) if orientation is None else ()
     for ramp in paired_ramp_steps:
-        features.append(convert(ramp, ctx))
+        append_direct(ramp)
 
     # Rectangular open-profile through steps (#1382).  The aggregate record owns the exact
     # run/anchor/section correspondence; Draftwright lowers its two transverse section legs
@@ -1966,7 +1989,7 @@ def build_part_model(
     # yet its flat still needs a callout. The recogniser self-gates on OD adjacency, so a
     # part with no round stock yields none.
     for flat in recognise_flats(part, cyls=cyls) if flats is None else flats:
-        features.append(convert(flat, ctx))
+        append_direct(flat)
 
     # Turned / circlip grooves on round stock (#148c) — an annular channel (a strict
     # local-minimum OD band) dimensioned by width + floor diameter, recognised above so the
@@ -1974,7 +1997,7 @@ def build_part_model(
     # is round stock and classifies rotational, yet the groove still needs its own callout.
     # The recogniser self-gates on external OD bands, so a prismatic part yields none.
     for groove in grooves:
-        features.append(convert(groove, ctx))
+        append_direct(groove)
 
     # Rotational furniture — OD + centrelines + concentric bore leaders (#237). Its
     # presence marks the part rotational; emitted from the classification (od, bores).

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -2022,7 +2022,14 @@ def build_part_model(
     # instead of the emitter inventing a second ownership decision (#1116).
     from draftwright.model.pmi_lowering import lower_ap242_dimensions
 
-    return lower_ap242_dimensions(model) if lower_pmi else model
+    return (
+        lower_ap242_dimensions(
+            model,
+            feature_remap=ownership.remap_feature if ownership is not None else None,
+        )
+        if lower_pmi
+        else model
+    )
 
 
 def _is_round(bbox, bosses, tol: float = 0.5) -> bool:

--- a/src/draftwright/model/pmi_lowering.py
+++ b/src/draftwright/model/pmi_lowering.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import re
 from collections import defaultdict
+from collections.abc import Callable
 from dataclasses import replace
 from decimal import Decimal
 from typing import Literal, cast
@@ -32,6 +33,7 @@ from draftwright.model.ir import (
 )
 
 ToleranceValue = float | tuple[float, float]
+FeatureRemap = Callable[[Feature, tuple[Feature, ...]], None]
 
 
 def _members(feature: HoleFeature | PatternFeature):
@@ -76,7 +78,9 @@ def _source_ids(dim: AuthoredDimension) -> tuple[str, ...]:
     return (dim.source_id,) if dim.source_id else ()
 
 
-def lower_ap242_hole_tolerances(model: PartModel) -> PartModel:
+def lower_ap242_hole_tolerances(
+    model: PartModel, *, feature_remap: FeatureRemap | None = None
+) -> PartModel:
     """Consume confidently correlated AP242 hole-tolerance dimensions exactly once.
 
     A count-group is split only where member requirements differ.  A real pattern stays a
@@ -256,6 +260,7 @@ def lower_ap242_hole_tolerances(model: PartModel) -> PartModel:
             value = proposals[dim_indices[0]][2] if dim_indices else None
             groups.setdefault(value, []).append(member_index)
             group_sources.setdefault(value, []).extend(dim_indices)
+        replacements: list[Feature] = []
         for value, group_member_indices in groups.items():
             members = tuple(points[index] for index in group_member_indices)
             split = replace(
@@ -265,6 +270,7 @@ def lower_ap242_hole_tolerances(model: PartModel) -> PartModel:
                 members=members,
             )
             rebuilt.append(split)
+            replacements.append(split)
             for tail, inherited_value in inherited:
                 decorations[(split, *tail)] = inherited_value
             if value is not None:
@@ -278,6 +284,8 @@ def lower_ap242_hole_tolerances(model: PartModel) -> PartModel:
                 decorations[(split, "diameter")] = ToleranceDecoration(
                     value=value, source="ap242_pmi", source_ids=ids
                 )
+        if feature_remap is not None:
+            feature_remap(feature, tuple(replacements))
 
     return replace(model, features=rebuilt, decorations=decorations)
 
@@ -713,7 +721,9 @@ def _remap_model_features(model: PartModel, replacements: dict[int, Feature]) ->
     )
 
 
-def lower_ap242_manufacturing_requirements(model: PartModel) -> PartModel:
+def lower_ap242_manufacturing_requirements(
+    model: PartModel, *, feature_remap: FeatureRemap | None = None
+) -> PartModel:
     """Lower supported semantic requirements through exact source topology."""
     raw = {
         index: feature
@@ -731,6 +741,7 @@ def lower_ap242_manufacturing_requirements(model: PartModel) -> PartModel:
         if isinstance(feature, (StepFeature, BossFeature, HoleFeature, PatternFeature))
     ]
     replacements: dict[int, Feature] = {}
+    replacement_pairs: list[tuple[Feature, Feature]] = []
     consumed: set[int] = set()
     blocked: dict[int, str] = {}
     claimed: set[int] = set()
@@ -819,10 +830,14 @@ def lower_ap242_manufacturing_requirements(model: PartModel) -> PartModel:
                 continue
             updated = replace(current, thread=requirement)
         replacements[id(owner)] = updated
+        replacement_pairs.append((owner, updated))
         claimed.add(id(owner))
         consumed.add(index)
 
     lowered = _remap_model_features(model, replacements)
+    if feature_remap is not None:
+        for source, replacement in replacement_pairs:
+            feature_remap(source, (replacement,))
     rebuilt: list[Feature] = []
     for index, lowered_feature in enumerate(lowered.features):
         if index in consumed:
@@ -833,7 +848,11 @@ def lower_ap242_manufacturing_requirements(model: PartModel) -> PartModel:
     return replace(lowered, features=rebuilt)
 
 
-def lower_ap242_dimensions(model: PartModel) -> PartModel:
+def lower_ap242_dimensions(
+    model: PartModel, *, feature_remap: FeatureRemap | None = None
+) -> PartModel:
     """Run every geometry-correlated AP242 lowering at the IR waist."""
-    dimensions = lower_ap242_nominal_diameters(lower_ap242_hole_tolerances(model))
-    return lower_ap242_manufacturing_requirements(dimensions)
+    dimensions = lower_ap242_nominal_diameters(
+        lower_ap242_hole_tolerances(model, feature_remap=feature_remap)
+    )
+    return lower_ap242_manufacturing_requirements(dimensions, feature_remap=feature_remap)

--- a/src/draftwright/recognition_ownership.py
+++ b/src/draftwright/recognition_ownership.py
@@ -134,8 +134,32 @@ class RecognitionOwnershipBuilder:
         self._owned_feature_ids.add(id(feature))
         self._bindings.append(OccurrenceBinding(occurrence, feature))
 
-    def freeze(self) -> RecognitionOwnership:
-        """Seal the current ledger without manufacturing owners for missing occurrences."""
+    def remap_feature(self, source: object, replacements: tuple[object, ...]) -> None:
+        """Follow one explicit IR-lowering lineage without reconstructing correspondence."""
+
+        matches = [
+            index for index, binding in enumerate(self._bindings) if binding.feature is source
+        ]
+        if not matches:
+            return
+        if len(matches) != 1:
+            raise ValueError("IR feature has multiple recognition occurrence owners")
+        index = matches[0]
+        self._owned_feature_ids.discard(id(source))
+        if len(replacements) != 1:
+            # A split can no longer satisfy this slice's exact 1:1 contract. Removing the stale
+            # pre-lowering binding makes the expected occurrence unexpectedly_missing rather
+            # than pointing at an object absent from the finished model.
+            del self._bindings[index]
+            return
+        replacement = replacements[0]
+        if id(replacement) in self._owned_feature_ids:
+            raise ValueError("lowered IR feature already owns a recognition occurrence")
+        self._owned_feature_ids.add(id(replacement))
+        self._bindings[index] = OccurrenceBinding(self._bindings[index].occurrence, replacement)
+
+    def snapshot(self) -> RecognitionOwnership:
+        """Copy the current ledger without manufacturing owners for missing occurrences."""
 
         return RecognitionOwnership(
             evidence=self.evidence,

--- a/src/draftwright/recognition_ownership.py
+++ b/src/draftwright/recognition_ownership.py
@@ -1,0 +1,144 @@
+"""Run-local ownership between provider occurrences and Draftwright IR features.
+
+This is consumer-owned correspondence state below and beside the ADR-0015 IR waist.  It keeps
+the provider's opaque :class:`FeatureRef` only for the lifetime of one recognition run and never
+turns object addresses, feature order, record values, or topology indices into persistent IDs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from b123d_recognisers.evidence import FeatureRef, RecognitionEvidence
+
+# These aggregate families have an unconditional one-record -> one-feature adapter in
+# model.detect.  Grouped, nested, absorbed, classification-only, and intentionally deferred
+# families stay unclassified until a later slice can state their N:1 / 1:0 ownership honestly.
+DIRECT_FAMILIES = frozenset(
+    {
+        "blends",
+        "chamfers",
+        "circular_blind_steps",
+        "double_d_bores",
+        "fillets",
+        "flats",
+        "grooves",
+        "pads",
+        "paired_ramp_steps",
+        "polygonal_bosses",
+        "polygonal_stock",
+        "rectangular_blind_slots",
+        "round_bottom_blind_slots",
+    }
+)
+
+
+@dataclass(frozen=True)
+class OccurrenceBinding:
+    """One exact accepted occurrence represented by one exact IR feature object."""
+
+    occurrence: FeatureRef
+    feature: object
+
+
+@dataclass(frozen=True)
+class RecognitionOwnership:
+    """Immutable run-local direct-ownership ledger paired with one evidence authority."""
+
+    evidence: RecognitionEvidence
+    expected_direct: tuple[FeatureRef, ...]
+    bindings: tuple[OccurrenceBinding, ...]
+
+    def binding_for(self, occurrence: FeatureRef) -> OccurrenceBinding | None:
+        """Return the direct binding for an occurrence, validating its authority first."""
+
+        self.evidence.family(occurrence)
+        return next(
+            (binding for binding in self.bindings if binding.occurrence is occurrence), None
+        )
+
+    def status(
+        self, occurrence: FeatureRef
+    ) -> Literal["represented", "unexpectedly_missing", "unclassified"]:
+        """Classify only the direct contract this slice can prove.
+
+        ``unclassified`` is deliberately not a report disposition.  It is the migration state
+        for grouped/absorbed/deferred families whose ownership rules are not implemented yet.
+        """
+
+        if self.binding_for(occurrence) is not None:
+            return "represented"
+        if any(expected is occurrence for expected in self.expected_direct):
+            return "unexpectedly_missing"
+        return "unclassified"
+
+    @property
+    def unexpectedly_missing(self) -> tuple[FeatureRef, ...]:
+        """Direct occurrences for which the adapter failed to record an IR owner."""
+
+        return tuple(
+            occurrence
+            for occurrence in self.expected_direct
+            if self.binding_for(occurrence) is None
+        )
+
+
+class RecognitionOwnershipBuilder:
+    """Mutable conversion-time collector; freeze before attaching it to a drawing."""
+
+    def __init__(self, evidence: RecognitionEvidence) -> None:
+        if type(evidence) is not RecognitionEvidence:
+            raise TypeError("evidence must be an exact RecognitionEvidence")
+        self.evidence = evidence
+        self._expected_direct = tuple(
+            occurrence
+            for occurrence in evidence.features
+            if evidence.family(occurrence) in DIRECT_FAMILIES
+        )
+        self._by_record_identity: dict[int, list[tuple[FeatureRef, object]]] = {}
+        for occurrence in self._expected_direct:
+            record = evidence.record(occurrence)
+            self._by_record_identity.setdefault(id(record), []).append((occurrence, record))
+        self._bindings: list[OccurrenceBinding] = []
+        self._bound_occurrence_ids: set[int] = set()
+        self._owned_feature_ids: set[int] = set()
+
+    @property
+    def result(self):
+        """The exact aggregate paired with this builder's evidence authority."""
+
+        return self.evidence.result
+
+    def bind(self, record: object, feature: object) -> None:
+        """Bind at the adapter decision site using exact run-local record identity."""
+
+        matches = [
+            occurrence
+            for occurrence, candidate in self._by_record_identity.get(id(record), ())
+            if candidate is record
+        ]
+        if len(matches) != 1:
+            reason = (
+                "does not belong to a direct evidence occurrence"
+                if not matches
+                else "is ambiguous"
+            )
+            raise ValueError(f"recognition record {reason}")
+        occurrence = matches[0]
+        if id(occurrence) in self._bound_occurrence_ids:
+            raise ValueError("recognition occurrence already has an IR owner")
+        if id(feature) in self._owned_feature_ids:
+            raise ValueError("IR feature already owns a recognition occurrence")
+        self._bound_occurrence_ids.add(id(occurrence))
+        self._owned_feature_ids.add(id(feature))
+        self._bindings.append(OccurrenceBinding(occurrence, feature))
+
+    def freeze(self) -> RecognitionOwnership:
+        """Seal the current ledger without manufacturing owners for missing occurrences."""
+
+        return RecognitionOwnership(
+            evidence=self.evidence,
+            expected_direct=self._expected_direct,
+            bindings=tuple(self._bindings),
+        )

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -81,6 +81,7 @@ _LAYERS: dict[str, int] = {
     "intents": 0,
     "recognition": 0,
     "recognition_cache": 0,
+    "recognition_ownership": 0,
     "recognition_frame": 0,
     # Strict shared validator for the released provider Blend record and its occurrence key.
     "blend_contract": 0,
@@ -452,6 +453,9 @@ _MODEL_MAY_IMPORT = {
     "model",
     "recognition",
     "recognition_frame",
+    # ADR 0017 Amendment 12: detect records exact run-local occurrence→IR ownership at the
+    # conversion site. The leaf ledger depends on neither the model nor any upper stage.
+    "recognition_ownership",
     # ADR 0018: the dimension planner resolves requirement ownership against the selected
     # semantic view set.  `view_plan` is a rank-0, drawing-independent leaf.
     "view_plan",

--- a/tests/test_issue_1438_occurrence_ownership.py
+++ b/tests/test_issue_1438_occurrence_ownership.py
@@ -8,12 +8,32 @@ from pathlib import Path
 
 import pytest
 from b123d_recognisers.evidence import build_recognition_evidence
-from build123d import Align, Axis, Box, Cylinder, fillet, import_step
+from build123d import (
+    Align,
+    Axis,
+    Box,
+    BuildLine,
+    BuildSketch,
+    Cylinder,
+    Line,
+    Plane,
+    Polygon,
+    Pos,
+    RadiusArc,
+    Rot,
+    Vector,
+    extrude,
+    fillet,
+    import_step,
+    make_face,
+)
 
 from draftwright import build_drawing
 from draftwright.analysis import _analyse
 from draftwright.drawing import BuildState
-from draftwright.recognition_ownership import RecognitionOwnershipBuilder
+from draftwright.model.detect import _build_part_model_from_recognition
+from draftwright.pmi import PmiRecord
+from draftwright.recognition_ownership import DIRECT_FAMILIES, RecognitionOwnershipBuilder
 
 FIXTURES = Path(__file__).parent / "fixtures" / "evaluation"
 
@@ -21,6 +41,98 @@ FIXTURES = Path(__file__).parent / "fixtures" / "evaluation"
 def _single_fillet():
     stock = Box(60, 40, 30)
     return fillet(stock.edges().filter_by(Axis.Z)[0], 4)
+
+
+def _small_blends():
+    stock = Box(40, 30, 20)
+    return fillet(list(stock.edges().filter_by(Axis.Z)), 0.2)
+
+
+def _circular_blind_step():
+    return Box(40, 30, 20) - Pos(7.5, 15, 10) * Rot(0, 90, 0) * Cylinder(4, 25)
+
+
+def _paired_ramp_step():
+    profile = Polygon((0, -8), (0, 8), (-10, 0))
+    cutter = Pos(20, 20, 0) * extrude(Plane.XZ * profile, 25)
+    return Box(40, 40, 30) - cutter
+
+
+def _rectangular_blind_slot():
+    stock = Box(30, 20, 40, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    tool = Pos(0, 5, 0) * Box(10, 5, 20, align=(Align.CENTER, Align.MIN, Align.MIN))
+    return stock - tool
+
+
+def _round_bottom_blind_slot():
+    with BuildLine() as boundary:
+        Line((-5, 0), (5, 0))
+        RadiusArc((5, 0), (2, -3), 3)
+        Line((2, -3), (-2, -3))
+        RadiusArc((-2, -3), (-5, 0), 3)
+    with BuildSketch() as sketch:
+        make_face(boundary.line)
+    stock = Pos(0, -5, 0) * Box(30, 10, 40)
+    tool = extrude(sketch.sketch, amount=20, dir=Vector(0, 0, 1))
+    return stock - tool
+
+
+DIRECT_CASES = (
+    ("blends", _small_blends),
+    ("chamfers", lambda: import_step(FIXTURES / "chamfer-planar-z.step")),
+    ("circular_blind_steps", _circular_blind_step),
+    ("double_d_bores", lambda: import_step(FIXTURES / "double-d-single-z.step")),
+    ("fillets", _single_fillet),
+    ("flats", lambda: import_step(FIXTURES / "flat-lone-d.step")),
+    ("grooves", lambda: import_step(FIXTURES / "groove-lone-z.step")),
+    ("pads", lambda: import_step(FIXTURES / "pad-x-positive.step")),
+    ("paired_ramp_steps", _paired_ramp_step),
+    ("polygonal_bosses", lambda: import_step(FIXTURES / "polygonal-boss-x.step")),
+    ("polygonal_stock", lambda: import_step(FIXTURES / "polygonal-stock-x.step")),
+    ("rectangular_blind_slots", _rectangular_blind_slot),
+    ("round_bottom_blind_slots", _round_bottom_blind_slot),
+)
+
+
+def test_direct_case_roster_is_independent_and_complete() -> None:
+    assert tuple(family for family, _factory in DIRECT_CASES) == (
+        "blends",
+        "chamfers",
+        "circular_blind_steps",
+        "double_d_bores",
+        "fillets",
+        "flats",
+        "grooves",
+        "pads",
+        "paired_ramp_steps",
+        "polygonal_bosses",
+        "polygonal_stock",
+        "rectangular_blind_slots",
+        "round_bottom_blind_slots",
+    )
+    assert set(family for family, _factory in DIRECT_CASES) == DIRECT_FAMILIES
+
+
+@pytest.mark.parametrize(
+    ("family", "part_factory"), DIRECT_CASES, ids=[family for family, _factory in DIRECT_CASES]
+)
+def test_every_advertised_direct_family_binds_to_finished_model(family, part_factory) -> None:
+    drawing = build_drawing(part_factory())
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    occurrences = tuple(
+        occurrence
+        for occurrence in ownership.evidence.features
+        if ownership.evidence.family(occurrence) == family
+    )
+    assert occurrences
+    assert ownership.unexpectedly_missing == ()
+    for occurrence in occurrences:
+        binding = ownership.binding_for(occurrence)
+        assert binding is not None
+        assert ownership.status(occurrence) == "represented"
+        assert any(binding.feature is feature for feature in drawing.model().features)
 
 
 def test_automatic_build_binds_each_direct_occurrence_to_its_exact_ir_feature() -> None:
@@ -71,17 +183,67 @@ def test_grouped_family_stays_unclassified_instead_of_becoming_a_false_missing()
 
 def test_an_unbound_direct_occurrence_fails_closed_as_unexpectedly_missing() -> None:
     evidence = build_recognition_evidence(_single_fillet())
-    ownership = RecognitionOwnershipBuilder(evidence).freeze()
+    ownership = RecognitionOwnershipBuilder(evidence).snapshot()
     (occurrence,) = ownership.expected_direct
 
     assert ownership.status(occurrence) == "unexpectedly_missing"
     assert ownership.unexpectedly_missing == (occurrence,)
 
 
+def test_explicit_pmi_lowering_lineage_rebinds_double_d_to_the_final_ir_object() -> None:
+    part = import_step(FIXTURES / "double-d-single-z.step")
+    evidence = build_recognition_evidence(part)
+    builder = RecognitionOwnershipBuilder(evidence)
+    pmi = PmiRecord(
+        kind="diameter",
+        type_code=15,
+        value=10.0,
+        upper_tol=0.1,
+        lower_tol=0.1,
+        ref_pts=((-5.0, 0.0, 5.0), (5.0, 0.0, 5.0)),
+        ref_bbox=(-5.1, -5.1, -0.1, 5.1, 5.1, 10.1),
+        dominant_axis="Z",
+        label="ø10 ±0.1",
+        source_id="dimension:double-d",
+        source_category="dimension",
+    )
+
+    model = _build_part_model_from_recognition(
+        part,
+        evidence.result,
+        ownership=builder,
+        pmi=(pmi,),
+    )
+    ownership = builder.snapshot()
+    (occurrence,) = tuple(
+        item for item in evidence.features if evidence.family(item) == "double_d_bores"
+    )
+    binding = ownership.binding_for(occurrence)
+
+    assert binding is not None
+    assert ownership.status(occurrence) == "represented"
+    assert any(binding.feature is feature for feature in model.features)
+    assert model.decorations[(binding.feature, "diameter")].source_ids == ("dimension:double-d",)
+
+
+def test_a_bound_feature_split_fails_closed_instead_of_retaining_stale_identity() -> None:
+    evidence = build_recognition_evidence(_single_fillet())
+    builder = RecognitionOwnershipBuilder(evidence)
+    occurrence = builder.snapshot().expected_direct[0]
+    source = object()
+    builder.bind(evidence.record(occurrence), source)
+
+    builder.remap_feature(source, (object(), object()))
+    ownership = builder.snapshot()
+
+    assert ownership.status(occurrence) == "unexpectedly_missing"
+    assert ownership.binding_for(occurrence) is None
+
+
 def test_value_equal_record_cannot_impersonate_the_provider_occurrence() -> None:
     evidence = build_recognition_evidence(_single_fillet())
     builder = RecognitionOwnershipBuilder(evidence)
-    record = evidence.record(builder.freeze().expected_direct[0])
+    record = evidence.record(builder.snapshot().expected_direct[0])
     copied_record = replace(record)
 
     assert copied_record == record
@@ -96,7 +258,7 @@ def test_builder_rejects_invalid_evidence_and_duplicate_ownership() -> None:
 
     evidence = build_recognition_evidence(_single_fillet())
     builder = RecognitionOwnershipBuilder(evidence)
-    occurrence = builder.freeze().expected_direct[0]
+    occurrence = builder.snapshot().expected_direct[0]
     feature = object()
     builder.bind(evidence.record(occurrence), feature)
     with pytest.raises(ValueError, match="occurrence already"):
@@ -104,7 +266,7 @@ def test_builder_rejects_invalid_evidence_and_duplicate_ownership() -> None:
 
     repeated = build_recognition_evidence(import_step(FIXTURES / "fillet-repeated.step"))
     repeated_builder = RecognitionOwnershipBuilder(repeated)
-    first, second, *_ = repeated_builder.freeze().expected_direct
+    first, second, *_ = repeated_builder.snapshot().expected_direct
     shared_feature = object()
     repeated_builder.bind(repeated.record(first), shared_feature)
     with pytest.raises(ValueError, match="IR feature already"):
@@ -144,7 +306,7 @@ def test_build_state_rejects_ownership_from_another_evidence_authority() -> None
     part = _single_fillet()
     first = build_recognition_evidence(part)
     second = build_recognition_evidence(part)
-    ownership = RecognitionOwnershipBuilder(first).freeze()
+    ownership = RecognitionOwnershipBuilder(first).snapshot()
 
     with pytest.raises(ValueError, match="same run"):
         BuildState().attach_recognition(second.result, evidence=second, ownership=ownership)
@@ -152,7 +314,7 @@ def test_build_state_rejects_ownership_from_another_evidence_authority() -> None
 
 def test_ownership_ledger_is_deliberately_not_serializable() -> None:
     evidence = build_recognition_evidence(_single_fillet())
-    ownership = RecognitionOwnershipBuilder(evidence).freeze()
+    ownership = RecognitionOwnershipBuilder(evidence).snapshot()
 
     with pytest.raises(TypeError, match="run-local"):
         pickle.dumps(ownership)

--- a/tests/test_issue_1438_occurrence_ownership.py
+++ b/tests/test_issue_1438_occurrence_ownership.py
@@ -1,0 +1,158 @@
+"""#1438 — accepted occurrences retain exact run-local IR ownership."""
+
+from __future__ import annotations
+
+import pickle
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+from b123d_recognisers.evidence import build_recognition_evidence
+from build123d import Align, Axis, Box, Cylinder, fillet, import_step
+
+from draftwright import build_drawing
+from draftwright.analysis import _analyse
+from draftwright.drawing import BuildState
+from draftwright.recognition_ownership import RecognitionOwnershipBuilder
+
+FIXTURES = Path(__file__).parent / "fixtures" / "evaluation"
+
+
+def _single_fillet():
+    stock = Box(60, 40, 30)
+    return fillet(stock.edges().filter_by(Axis.Z)[0], 4)
+
+
+def test_automatic_build_binds_each_direct_occurrence_to_its_exact_ir_feature() -> None:
+    drawing = build_drawing(import_step(FIXTURES / "fillet-repeated.step"))
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    assert ownership.evidence is drawing.recognition_evidence()
+    fillets = tuple(
+        occurrence
+        for occurrence in ownership.evidence.features
+        if ownership.evidence.family(occurrence) == "fillets"
+    )
+    assert len(fillets) == 4
+    assert ownership.unexpectedly_missing == ()
+    assert all(ownership.status(occurrence) == "represented" for occurrence in fillets)
+
+    bindings = tuple(ownership.binding_for(occurrence) for occurrence in fillets)
+    assert all(binding is not None for binding in bindings)
+    assert len({id(binding.feature) for binding in bindings if binding is not None}) == 4
+    assert all(
+        any(binding.feature is feature for feature in drawing.model().features)
+        for binding in bindings
+        if binding is not None
+    )
+    assert {
+        id(ownership.evidence.record(binding.occurrence))
+        for binding in bindings
+        if binding is not None
+    } == {id(record) for record in drawing.recognition().fillets}
+
+
+def test_grouped_family_stays_unclassified_instead_of_becoming_a_false_missing() -> None:
+    part = Box(40, 30, 10, align=(Align.CENTER, Align.CENTER, Align.CENTER)) - Cylinder(3, 20)
+    drawing = build_drawing(part)
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    (hole,) = tuple(
+        occurrence
+        for occurrence in ownership.evidence.features
+        if ownership.evidence.family(occurrence) == "holes"
+    )
+    assert ownership.status(hole) == "unclassified"
+    assert ownership.binding_for(hole) is None
+    assert ownership.unexpectedly_missing == ()
+
+
+def test_an_unbound_direct_occurrence_fails_closed_as_unexpectedly_missing() -> None:
+    evidence = build_recognition_evidence(_single_fillet())
+    ownership = RecognitionOwnershipBuilder(evidence).freeze()
+    (occurrence,) = ownership.expected_direct
+
+    assert ownership.status(occurrence) == "unexpectedly_missing"
+    assert ownership.unexpectedly_missing == (occurrence,)
+
+
+def test_value_equal_record_cannot_impersonate_the_provider_occurrence() -> None:
+    evidence = build_recognition_evidence(_single_fillet())
+    builder = RecognitionOwnershipBuilder(evidence)
+    record = evidence.record(builder.freeze().expected_direct[0])
+    copied_record = replace(record)
+
+    assert copied_record == record
+    assert copied_record is not record
+    with pytest.raises(ValueError, match="does not belong"):
+        builder.bind(copied_record, object())
+
+
+def test_builder_rejects_invalid_evidence_and_duplicate_ownership() -> None:
+    with pytest.raises(TypeError, match="exact RecognitionEvidence"):
+        RecognitionOwnershipBuilder(object())  # type: ignore[arg-type]
+
+    evidence = build_recognition_evidence(_single_fillet())
+    builder = RecognitionOwnershipBuilder(evidence)
+    occurrence = builder.freeze().expected_direct[0]
+    feature = object()
+    builder.bind(evidence.record(occurrence), feature)
+    with pytest.raises(ValueError, match="occurrence already"):
+        builder.bind(evidence.record(occurrence), object())
+
+    repeated = build_recognition_evidence(import_step(FIXTURES / "fillet-repeated.step"))
+    repeated_builder = RecognitionOwnershipBuilder(repeated)
+    first, second, *_ = repeated_builder.freeze().expected_direct
+    shared_feature = object()
+    repeated_builder.bind(repeated.record(first), shared_feature)
+    with pytest.raises(ValueError, match="IR feature already"):
+        repeated_builder.bind(repeated.record(second), shared_feature)
+
+
+def test_declared_and_framed_builds_do_not_invent_occurrence_ownership() -> None:
+    part = _single_fillet()
+    declared = build_drawing(part, model=[])
+    framed = build_drawing(part, framed_recognition=True)
+
+    assert declared.recognition_ownership() is None
+    assert framed.recognition_evidence() is None
+    assert framed.recognition_ownership() is None
+
+
+def test_scale_retry_reuses_the_exact_model_evidence_and_ownership_authority() -> None:
+    first = _analyse(_single_fillet(), "", "", "ISO 2768-m", "", "drawing")
+    second = _analyse(
+        _single_fillet(),
+        "",
+        "",
+        "ISO 2768-m",
+        "",
+        "drawing",
+        scale=first.SCALE,
+        _reuse=first,
+    )
+
+    assert second.model is first.model
+    assert second.recognition is first.recognition
+    assert second.recognition_evidence is first.recognition_evidence
+    assert second.recognition_ownership is first.recognition_ownership
+
+
+def test_build_state_rejects_ownership_from_another_evidence_authority() -> None:
+    part = _single_fillet()
+    first = build_recognition_evidence(part)
+    second = build_recognition_evidence(part)
+    ownership = RecognitionOwnershipBuilder(first).freeze()
+
+    with pytest.raises(ValueError, match="same run"):
+        BuildState().attach_recognition(second.result, evidence=second, ownership=ownership)
+
+
+def test_ownership_ledger_is_deliberately_not_serializable() -> None:
+    evidence = build_recognition_evidence(_single_fillet())
+    ownership = RecognitionOwnershipBuilder(evidence).freeze()
+
+    with pytest.raises(TypeError, match="run-local"):
+        pickle.dumps(ownership)


### PR DESCRIPTION
## Outcome

Captures run-local ownership from every accepted occurrence in the 13 unconditional 1:1 recogniser families to the exact final Draftwright IR feature.

This is the second vertical slice of #1438, following the build-owned recognition evidence/cache foundation in #1439. Grouped, nested, absorbed, unsupported, deferred, and report serialization remain for later slices.

## Contract

- records ownership at the model-assembly decision site; no post-hoc geometry/value/order matching
- keeps FeatureRef identity run-local and non-serializable
- follows explicit 1:1 AP242 IR replacement lineage
- fails closed as unexpectedly_missing when lowering splits one owner into multiple features
- preserves one recognition run across automatic build retries
- leaves declared and framed builds without raw ownership
- does not alter generated Python or visual exports

## ADR review

Audited against ADRs 0010, 0011, 0013, 0014, 0015, 0017, and 0020. ADR 0017 receives a narrowly scoped amendment for this demonstrated direct-ownership contract.

## Validation

- 3 independent exact-head reviews: CLEAN (ADR, contract, quality); one optional wording nit only
- uv run ruff check .
- uv run mypy src
- full suite on 18 workers: 6435 passed, 5 skipped, 2 xfailed
- total coverage: 95.63%
- real raw-build regression for all 13 direct families
- AP242 Double-D replacement/split regressions

Part of #1438
Parent epic: #1256