### PR TITLE
Track grouped recognition occurrence ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,18 @@
 
 ### Added
 
+- Accepted physical hole, slot, and pocket occurrences now retain explicit run-local ownership
+  when conversion represents a singleton or absorbs members into one same-spec hole group or
+  derived pattern feature. Family-specific reason codes and transient member lineage follow
+  member-specific AP242 splits to the exact final IR objects; missing lineage fails closed rather
+  than retaining a stale owner. Provider-derived patterns do not become invented occurrences, and
+  no report ID, extra recognition scan, generated artefact, or visual output is introduced (#1438,
+  ADR 0017 Amendment 13).
+
 - Raw automatic builds now capture run-local, conversion-time ownership from accepted provider
   occurrences to their exact Draftwright IR features for unconditional one-to-one adapters. Equal
   record values, order, coordinates and topology indices cannot create a binding; an omitted direct
-  binding fails closed as unexpectedly missing, while grouped/absorbed/deferred families remain
+  binding fails closed as unexpectedly missing, while ownership rules not yet implemented remain
   explicitly unclassified. The experimental read-only `Drawing.recognition_ownership()` exposes
   the non-serializable ledger; it stays outside the IR/compiler and changes no generated or visual
   artefact (#1438, ADR 0017 Amendment 12).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,8 @@ Compact map, bottom to top:
   `_geometry.py` (page-plane maths + the ADR 0014 Amdt 3 material field; the DAG's
   bottom leaf), `fonts.py` (pinned IBM Plex, ADR 0006), `fits.py` (ISO 286),
   `intents.py` (deferred-edit low IR), `recognition_cache.py` (ADR 0017 one-result
-  lifecycle), `recognition_ownership.py` (run-local accepted-occurrence→IR bindings),
+  lifecycle), `recognition_ownership.py` (run-local accepted-occurrence→final-IR bindings,
+  including explicit group/pattern absorption),
   `recognition_frame.py` (ADR 0020 prepared local-frame boundary and fail-closed
   body-local occurrence joins), `blend_contract.py` (strict released-Blend schema and
   occurrence identity),

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -12,7 +12,8 @@
   additive inventories fail closed while retaining the existing paired-ramp consumer meaning.
   Amendment 11 (2026-09-02) retains the provider's raw accepted-occurrence evidence in the same
   consumer-owned cache without adding a second recognition run. Amendment 12 (2026-09-03)
-  records the first conversion-time, run-local occurrence→IR ownership bindings.
+  records the first conversion-time, run-local occurrence→IR ownership bindings. Amendment 13
+  (2026-09-03) records explicit member ownership for hole, slot, and pocket groupings.
 - **Date:** 2026-08-03
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -325,6 +326,32 @@ not invent ownership. `Drawing.recognition_ownership()` exposes the non-serializ
 experimental read-only view so consumers need not reach into private build state. This remains
 reporting foundation: no public report schema or completeness claim is introduced by this amendment.
 
+## Amendment 13 — Group and pattern members have explicit final owners
+
+The provider evidence ledger exposes accepted physical holes, slots, and pockets as opaque
+`FeatureRef` occurrences. Its derived hole/slot/pocket pattern records are not occurrences and
+Draftwright does not manufacture occurrence identity for them. At the existing conversion decision
+sites, a lone unpatterned member is now recorded as `represented`; every member folded into one
+same-spec hole group or one derived pattern feature is recorded as `absorbed`, with a closed,
+family-specific reason code and the exact shared final IR owner. Pattern membership supplied by the
+same aggregate establishes this N:1 decision. Record equality, feature order, coordinates, face
+overlap, and topology traversal do not.
+
+A member's integer position within that run-local owner is retained only as transient lowering
+lineage. When member-specific AP242 PMI splits a grouped `HoleFeature`, the lowering seam returns the
+exact source-member partition alongside its replacement objects. Each occurrence is rebound to its
+exact final owner; a resulting singleton becomes `represented`, a remaining multi-member owner stays
+`absorbed`, and absent or ambiguous lineage fails closed rather than retaining a stale pre-lowering
+object. This position is neither serialized nor presented as a persistent topology/report ID.
+
+The amendment uses only the released public `RecognitionEvidence` surface and the existing
+consumer-owned aggregate. It adds no recognition scan, manufacturing inference, compiled-plan
+dependency, annotation placement, generated-script/report schema, or visual change. ADR 0010's
+annotation provenance and ADR 0014's solve are untouched; ADRs 0011/0015 retain the IR/compiler waist;
+ADR 0013 remains the provider boundary; ADR 0020's framed path remains evidence-less pending the
+released upstream contract. Declared builds therefore remain recognition-free until physical
+critique/report/export, and these ownership outcomes alone do not claim drawing completeness.
+
 ## Accepted Contract
 
 ### 1. One orchestration owns the recognition universe
@@ -368,10 +395,11 @@ The result is stored in typed `BuildState`, whose builder/lazy-critique path is 
 writer. This makes the result's relationship to its drawing structural: engine consumers do
 not accept an arbitrary aggregate and then attempt to prove it came from the same part.
 
-This originally answered **result-to-build provenance only**. Amendment 12 now records exact
-occurrence→IR ownership for unconditional 1:1 adapters. Grouped, nested, absorbed and deferred
-families, and the general feature→requirement→annotation correspondence, remain subjects of the
-evidence gates below.
+This originally answered **result-to-build provenance only**. Amendment 12 records exact
+occurrence→IR ownership for unconditional 1:1 adapters, and Amendment 13 adds explicit singleton,
+grouped, and pattern-member ownership for holes, slots, and pockets. Nested, classification-only,
+unsupported, evidence-only and deferred families, and the general
+feature→requirement→annotation correspondence, remain subjects of the evidence gates below.
 
 `lint_prismatic_coverage(recognition=...)` is a known channel outside the structural ownership
 path (#1032). The preferred correction is to remove or narrow the channel when that boundary

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -208,9 +208,10 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   remains valid without evidence; the cache never rescans to backfill it.
 - **`recognition_ownership.py`** — the run-local consumer ledger below/beside the ADR 0015 IR
   waist. During record→IR conversion it binds opaque provider occurrences to the exact IR
-  feature objects that represent them, by same-run record identity. It exposes no persistent
-  topology/order/address ID. The first ownership slice classifies only unconditional 1:1 adapters;
-  grouped, nested, absorbed, classification-only and deferred families remain unclassified.
+  feature objects that represent or absorb them, by same-run record identity and explicit
+  aggregate membership. It exposes no persistent topology/order/address ID. Unconditional 1:1
+  adapters plus singleton/grouped/pattern hole, slot, and pocket members are classified; nested,
+  classification-only, unsupported, evidence-only, and deferred families remain unclassified.
 - **`recognition_frame.py`** — the ADR 0020 prepared local-frame boundary. It calls the public
   provider preparation seam, classifies the exact normalized solid from its already-scanned
   cylinders, runs one paired aggregate, propagates typed refusal without fallback, and exposes
@@ -562,9 +563,10 @@ policy) live in `CLAUDE.md`. This is the per-ADR status trail; each ADR's
   compiler grammar and placement solve, and a side-normal footprint is filtered from the legacy
   Z-level projection only when exact support correspondence proves that ownership. No renderer
   consumes the provider record or places an annotation at a caller-supplied page coordinate.
-  Amendment 12 additionally gives unconditional 1:1 adapters exact run-local
-  occurrence→IR-feature ownership in `BuildState`. Grouped, nested, absorbed and deferred
-  families, plus general IR-feature→requirement correspondence, are not yet provided. The original
+  Amendments 12–13 give unconditional 1:1 adapters and hole/slot/pocket singleton, grouped, and
+  pattern-member paths exact run-local occurrence→final-IR ownership in `BuildState`. Nested,
+  classification-only, unsupported, evidence-only, and deferred families, plus general
+  IR-feature→requirement correspondence, are not yet provided. The original
   four-type identity taxonomy, shared requirements module, general outcome ledger,
   reconciliation stage, and diagnostics model are candidate extensions rather than an
   approved phase sequence. #1018 now requires two end-to-end slices before any of them is

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -1674,7 +1674,14 @@ def build_part_model(
             # ADR 0015 waist; that option stays recorded on #971.
             continue
         patterned.update(id(h) for h in members)
-        features.append(_pattern_feature(pat, members))
+        hole_pattern_feature = _pattern_feature(pat, members)
+        features.append(hole_pattern_feature)
+        if ownership is not None:
+            ownership.absorb(
+                tuple(members),
+                hole_pattern_feature,
+                reason_code="hole_pattern_member",
+            )
     # Un-patterned holes: group by machining spec so identical holes share one
     # count× callout (the engine's grouped-callout rule); HoleSpec keys on the
     # snapped axis and the countersink too, so opposite-face drillings and csk-vs-plain
@@ -1688,7 +1695,22 @@ def build_part_model(
         rep = grp[0]
         frame = Frame(origin=_xyz(rep.location), axis=_axis_letter(rep))
         mem_locs = tuple(_xyz(h.location) for h in grp)
-        features.append(_member_hole(rep, frame, members=mem_locs, count=len(grp)))
+        hole_feature = _member_hole(rep, frame, members=mem_locs, count=len(grp))
+        features.append(hole_feature)
+        if ownership is not None:
+            if len(grp) == 1:
+                ownership.bind(
+                    rep,
+                    hole_feature,
+                    reason_code="hole_adapter",
+                    member_index=0,
+                )
+            else:
+                ownership.absorb(
+                    tuple(grp),
+                    hole_feature,
+                    reason_code="grouped_hole_member",
+                )
 
     # Profiled bores are their own recognition family because full-cylinder recognition
     # cannot see their partial cylindrical faces. They still lower to HoleFeature so the
@@ -1709,11 +1731,21 @@ def build_part_model(
     patterned_sl: set = set()
     for pat in slot_patterns:
         patterned_sl.update(pat.slots)
-        features.append(_slot_pattern_feature(pat, list(pat.slots)))
+        slot_pattern_feature = _slot_pattern_feature(pat, list(pat.slots))
+        features.append(slot_pattern_feature)
+        if ownership is not None:
+            ownership.absorb(
+                tuple(pat.slots),
+                slot_pattern_feature,
+                reason_code="slot_pattern_member",
+            )
     for sl in slots:
         if sl in patterned_sl:
             continue
-        features.append(convert(sl, ctx))
+        slot_feature = convert(sl, ctx)
+        features.append(slot_feature)
+        if ownership is not None:
+            ownership.bind(sl, slot_feature, reason_code="slot_adapter")
 
     # Capped, edge-open rectangular U-section slots (#1421). The aggregate has already
     # reconciled their topology against ordinary through slots, pockets, channels and passage
@@ -1742,11 +1774,21 @@ def build_part_model(
     patterned_pk: set = set()
     for pat in pocket_patterns:
         patterned_pk.update(pat.pockets)
-        features.append(_pocket_pattern_feature(pat, list(pat.pockets)))
+        pocket_pattern_feature = _pocket_pattern_feature(pat, list(pat.pockets))
+        features.append(pocket_pattern_feature)
+        if ownership is not None:
+            ownership.absorb(
+                tuple(pat.pockets),
+                pocket_pattern_feature,
+                reason_code="pocket_pattern_member",
+            )
     for pk in pockets:
         if pk in patterned_pk:
             continue
-        features.append(convert(pk, ctx))
+        pocket_feature = convert(pk, ctx)
+        features.append(pocket_feature)
+        if ownership is not None:
+            ownership.bind(pk, pocket_feature, reason_code="pocket_adapter")
 
     # Bounded rectangular raised pads: footprint sizing, attachment-axis height, and
     # two in-plane locations. A Z attachment level may also enter the general profile

--- a/src/draftwright/model/pmi_lowering.py
+++ b/src/draftwright/model/pmi_lowering.py
@@ -33,7 +33,7 @@ from draftwright.model.ir import (
 )
 
 ToleranceValue = float | tuple[float, float]
-FeatureRemap = Callable[[Feature, tuple[Feature, ...]], None]
+FeatureRemap = Callable[[Feature, tuple[Feature, ...], tuple[tuple[int, ...], ...] | None], None]
 
 
 def _members(feature: HoleFeature | PatternFeature):
@@ -261,6 +261,7 @@ def lower_ap242_hole_tolerances(
             groups.setdefault(value, []).append(member_index)
             group_sources.setdefault(value, []).extend(dim_indices)
         replacements: list[Feature] = []
+        replacement_member_groups: list[tuple[int, ...]] = []
         for value, group_member_indices in groups.items():
             members = tuple(points[index] for index in group_member_indices)
             split = replace(
@@ -271,6 +272,7 @@ def lower_ap242_hole_tolerances(
             )
             rebuilt.append(split)
             replacements.append(split)
+            replacement_member_groups.append(tuple(group_member_indices))
             for tail, inherited_value in inherited:
                 decorations[(split, *tail)] = inherited_value
             if value is not None:
@@ -285,7 +287,11 @@ def lower_ap242_hole_tolerances(
                     value=value, source="ap242_pmi", source_ids=ids
                 )
         if feature_remap is not None:
-            feature_remap(feature, tuple(replacements))
+            feature_remap(
+                feature,
+                tuple(replacements),
+                tuple(replacement_member_groups),
+            )
 
     return replace(model, features=rebuilt, decorations=decorations)
 
@@ -837,7 +843,7 @@ def lower_ap242_manufacturing_requirements(
     lowered = _remap_model_features(model, replacements)
     if feature_remap is not None:
         for source, replacement in replacement_pairs:
-            feature_remap(source, (replacement,))
+            feature_remap(source, (replacement,), None)
     rebuilt: list[Feature] = []
     for index, lowered_feature in enumerate(lowered.features):
         if index in consumed:

--- a/src/draftwright/recognition_ownership.py
+++ b/src/draftwright/recognition_ownership.py
@@ -13,8 +13,8 @@ from typing import Literal
 from b123d_recognisers.evidence import FeatureRef, RecognitionEvidence
 
 # These aggregate families have an unconditional one-record -> one-feature adapter in
-# model.detect.  Grouped, nested, absorbed, classification-only, and intentionally deferred
-# families stay unclassified until a later slice can state their N:1 / 1:0 ownership honestly.
+# model.detect.  Nested, classification-only, and intentionally deferred families stay
+# unclassified until a later slice can state their ownership honestly.
 DIRECT_FAMILIES = frozenset(
     {
         "blends",
@@ -33,25 +33,73 @@ DIRECT_FAMILIES = frozenset(
     }
 )
 
+# The aggregate exposes these as authoritative physical member occurrences.  Draftwright may
+# lower one member to one feature or absorb several members into one grouped/pattern feature.
+# The derived pattern records are deliberately not FeatureRefs and must not be promoted into
+# invented persistent occurrences.
+GROUPABLE_FAMILIES = frozenset({"holes", "pockets", "slots"})
+
+OwnershipDisposition = Literal["represented", "absorbed"]
+
+_REPRESENTED_REASON_CODES = frozenset(
+    {
+        "direct_adapter",
+        "hole_adapter",
+        "pmi_split_member",
+        "pocket_adapter",
+        "slot_adapter",
+    }
+)
+_ABSORBED_REASON_CODES = frozenset(
+    {
+        "grouped_hole_member",
+        "hole_pattern_member",
+        "pocket_pattern_member",
+        "slot_pattern_member",
+    }
+)
+_REASON_FAMILY = {
+    "grouped_hole_member": "holes",
+    "hole_adapter": "holes",
+    "hole_pattern_member": "holes",
+    "pmi_split_member": "holes",
+    "pocket_adapter": "pockets",
+    "pocket_pattern_member": "pockets",
+    "slot_adapter": "slots",
+    "slot_pattern_member": "slots",
+}
+
 
 @dataclass(frozen=True)
 class OccurrenceBinding:
-    """One exact accepted occurrence represented by one exact IR feature object."""
+    """One exact accepted occurrence consumed by one exact final IR feature object."""
 
     occurrence: FeatureRef
     feature: object
+    disposition: OwnershipDisposition = "represented"
+    reason_code: str = "direct_adapter"
+    # Run-local position within a grouped IR feature.  This is explicit lineage used to follow
+    # later IR splits; it is not a topology index or a persistent report identifier.
+    member_index: int | None = None
 
 
 @dataclass(frozen=True)
 class RecognitionOwnership:
-    """Immutable run-local direct-ownership ledger paired with one evidence authority."""
+    """Immutable run-local ownership ledger paired with one evidence authority."""
 
     evidence: RecognitionEvidence
     expected_direct: tuple[FeatureRef, ...]
+    expected_groupable: tuple[FeatureRef, ...]
     bindings: tuple[OccurrenceBinding, ...]
 
+    @property
+    def expected_occurrences(self) -> tuple[FeatureRef, ...]:
+        """Occurrences whose implemented consumer paths must produce an explicit outcome."""
+
+        return self.expected_direct + self.expected_groupable
+
     def binding_for(self, occurrence: FeatureRef) -> OccurrenceBinding | None:
-        """Return the direct binding for an occurrence, validating its authority first."""
+        """Return the ownership binding for an occurrence, validating its authority first."""
 
         self.evidence.family(occurrence)
         return next(
@@ -60,32 +108,33 @@ class RecognitionOwnership:
 
     def status(
         self, occurrence: FeatureRef
-    ) -> Literal["represented", "unexpectedly_missing", "unclassified"]:
-        """Classify only the direct contract this slice can prove.
+    ) -> Literal["represented", "absorbed", "unexpectedly_missing", "unclassified"]:
+        """Classify only the ownership contracts implemented so far.
 
         ``unclassified`` is deliberately not a report disposition.  It is the migration state
-        for grouped/absorbed/deferred families whose ownership rules are not implemented yet.
+        for nested/deferred families whose ownership rules are not implemented yet.
         """
 
-        if self.binding_for(occurrence) is not None:
-            return "represented"
-        if any(expected is occurrence for expected in self.expected_direct):
+        binding = self.binding_for(occurrence)
+        if binding is not None:
+            return binding.disposition
+        if any(expected is occurrence for expected in self.expected_occurrences):
             return "unexpectedly_missing"
         return "unclassified"
 
     @property
     def unexpectedly_missing(self) -> tuple[FeatureRef, ...]:
-        """Direct occurrences for which the adapter failed to record an IR owner."""
+        """Supported occurrences for which conversion failed to record an IR owner."""
 
         return tuple(
             occurrence
-            for occurrence in self.expected_direct
+            for occurrence in self.expected_occurrences
             if self.binding_for(occurrence) is None
         )
 
 
 class RecognitionOwnershipBuilder:
-    """Mutable conversion-time collector; freeze before attaching it to a drawing."""
+    """Mutable conversion-time collector; snapshot before attaching it to a drawing."""
 
     def __init__(self, evidence: RecognitionEvidence) -> None:
         if type(evidence) is not RecognitionEvidence:
@@ -96,8 +145,13 @@ class RecognitionOwnershipBuilder:
             for occurrence in evidence.features
             if evidence.family(occurrence) in DIRECT_FAMILIES
         )
+        self._expected_groupable = tuple(
+            occurrence
+            for occurrence in evidence.features
+            if evidence.family(occurrence) in GROUPABLE_FAMILIES
+        )
         self._by_record_identity: dict[int, list[tuple[FeatureRef, object]]] = {}
-        for occurrence in self._expected_direct:
+        for occurrence in self._expected_direct + self._expected_groupable:
             record = evidence.record(occurrence)
             self._by_record_identity.setdefault(id(record), []).append((occurrence, record))
         self._bindings: list[OccurrenceBinding] = []
@@ -110,8 +164,8 @@ class RecognitionOwnershipBuilder:
 
         return self.evidence.result
 
-    def bind(self, record: object, feature: object) -> None:
-        """Bind at the adapter decision site using exact run-local record identity."""
+    def _occurrence_for(self, record: object) -> FeatureRef:
+        """Resolve only exact records issued by this evidence authority."""
 
         matches = [
             occurrence
@@ -120,21 +174,86 @@ class RecognitionOwnershipBuilder:
         ]
         if len(matches) != 1:
             reason = (
-                "does not belong to a direct evidence occurrence"
+                "does not belong to a supported evidence occurrence"
                 if not matches
                 else "is ambiguous"
             )
             raise ValueError(f"recognition record {reason}")
-        occurrence = matches[0]
+        return matches[0]
+
+    def bind(
+        self,
+        record: object,
+        feature: object,
+        *,
+        reason_code: str = "direct_adapter",
+        member_index: int | None = None,
+    ) -> None:
+        """Bind at the adapter decision site using exact run-local record identity."""
+
+        occurrence = self._occurrence_for(record)
+        if type(reason_code) is not str or reason_code not in _REPRESENTED_REASON_CODES:
+            raise ValueError("unknown represented ownership reason_code")
+        expected_family = _REASON_FAMILY.get(reason_code)
+        actual_family = self.evidence.family(occurrence)
+        if reason_code == "direct_adapter" and actual_family not in DIRECT_FAMILIES:
+            raise ValueError("direct ownership reason_code requires a direct occurrence family")
+        if expected_family is not None and actual_family != expected_family:
+            raise ValueError("represented ownership reason_code does not match occurrence family")
         if id(occurrence) in self._bound_occurrence_ids:
             raise ValueError("recognition occurrence already has an IR owner")
         if id(feature) in self._owned_feature_ids:
             raise ValueError("IR feature already owns a recognition occurrence")
+        if member_index is not None and member_index < 0:
+            raise ValueError("member_index must be non-negative")
         self._bound_occurrence_ids.add(id(occurrence))
         self._owned_feature_ids.add(id(feature))
-        self._bindings.append(OccurrenceBinding(occurrence, feature))
+        self._bindings.append(
+            OccurrenceBinding(
+                occurrence,
+                feature,
+                reason_code=reason_code,
+                member_index=member_index,
+            )
+        )
 
-    def remap_feature(self, source: object, replacements: tuple[object, ...]) -> None:
+    def absorb(self, records: tuple[object, ...], feature: object, *, reason_code: str) -> None:
+        """Record an explicit N:1 aggregate decision for exact member records."""
+
+        if not records:
+            raise ValueError("an absorbed aggregate needs at least one member record")
+        if type(reason_code) is not str or reason_code not in _ABSORBED_REASON_CODES:
+            raise ValueError("unknown absorbed ownership reason_code")
+        reason = reason_code
+        occurrences = tuple(self._occurrence_for(record) for record in records)
+        expected_family = _REASON_FAMILY[reason]
+        if any(self.evidence.family(occurrence) != expected_family for occurrence in occurrences):
+            raise ValueError("absorbed ownership reason_code does not match occurrence family")
+        if len({id(occurrence) for occurrence in occurrences}) != len(occurrences):
+            raise ValueError("an absorbed aggregate repeats a recognition occurrence")
+        if any(id(occurrence) in self._bound_occurrence_ids for occurrence in occurrences):
+            raise ValueError("recognition occurrence already has an IR owner")
+        if id(feature) in self._owned_feature_ids:
+            raise ValueError("IR feature already owns a recognition occurrence")
+        self._owned_feature_ids.add(id(feature))
+        for member_index, occurrence in enumerate(occurrences):
+            self._bound_occurrence_ids.add(id(occurrence))
+            self._bindings.append(
+                OccurrenceBinding(
+                    occurrence,
+                    feature,
+                    disposition="absorbed",
+                    reason_code=reason,
+                    member_index=member_index,
+                )
+            )
+
+    def remap_feature(
+        self,
+        source: object,
+        replacements: tuple[object, ...],
+        source_member_groups: tuple[tuple[int, ...], ...] | None = None,
+    ) -> None:
         """Follow one explicit IR-lowering lineage without reconstructing correspondence."""
 
         matches = [
@@ -142,21 +261,85 @@ class RecognitionOwnershipBuilder:
         ]
         if not matches:
             return
-        if len(matches) != 1:
-            raise ValueError("IR feature has multiple recognition occurrence owners")
-        index = matches[0]
-        self._owned_feature_ids.discard(id(source))
-        if len(replacements) != 1:
-            # A split can no longer satisfy this slice's exact 1:1 contract. Removing the stale
-            # pre-lowering binding makes the expected occurrence unexpectedly_missing rather
-            # than pointing at an object absent from the finished model.
-            del self._bindings[index]
-            return
-        replacement = replacements[0]
-        if id(replacement) in self._owned_feature_ids:
+        if source_member_groups is not None and len(source_member_groups) != len(replacements):
+            raise ValueError("IR replacement groups must align with replacements")
+        if source_member_groups is not None and len({id(item) for item in replacements}) != len(
+            replacements
+        ):
+            raise ValueError("IR replacement groups must use distinct replacement objects")
+        externally_owned_ids = {
+            id(binding.feature) for binding in self._bindings if binding.feature is not source
+        }
+        if any(id(replacement) in externally_owned_ids for replacement in replacements):
             raise ValueError("lowered IR feature already owns a recognition occurrence")
-        self._owned_feature_ids.add(id(replacement))
-        self._bindings[index] = OccurrenceBinding(self._bindings[index].occurrence, replacement)
+
+        if source_member_groups is None:
+            if len(replacements) == 1:
+                replacement = replacements[0]
+                for index in matches:
+                    binding = self._bindings[index]
+                    self._bindings[index] = OccurrenceBinding(
+                        binding.occurrence,
+                        replacement,
+                        binding.disposition,
+                        binding.reason_code,
+                        binding.member_index,
+                    )
+            else:
+                self._bindings = [
+                    binding for binding in self._bindings if binding.feature is not source
+                ]
+        else:
+            member_lineage: dict[int, tuple[object, int, int]] = {}
+            for replacement, group in zip(replacements, source_member_groups, strict=True):
+                for replacement_index, source_index in enumerate(group):
+                    if source_index in member_lineage:
+                        raise ValueError("IR replacement groups repeat a source member")
+                    member_lineage[source_index] = (
+                        replacement,
+                        replacement_index,
+                        len(group),
+                    )
+            rewritten: list[OccurrenceBinding] = []
+            source_bindings = [self._bindings[index] for index in matches]
+            singleton_source_index = (
+                next(iter(member_lineage))
+                if len(source_bindings) == 1 and len(member_lineage) == 1
+                else None
+            )
+            for binding in self._bindings:
+                if binding.feature is not source:
+                    rewritten.append(binding)
+                    continue
+                binding_source_index = binding.member_index
+                if binding_source_index is None:
+                    binding_source_index = singleton_source_index
+                lineage = (
+                    member_lineage.get(binding_source_index)
+                    if binding_source_index is not None
+                    else None
+                )
+                if lineage is None:
+                    continue
+                replacement, replacement_index, replacement_group_size = lineage
+                disposition = binding.disposition
+                reason_code = binding.reason_code
+                if binding.reason_code == "grouped_hole_member" and replacement_group_size == 1:
+                    disposition = "represented"
+                    reason_code = "pmi_split_member"
+                rewritten.append(
+                    OccurrenceBinding(
+                        binding.occurrence,
+                        replacement,
+                        disposition,
+                        reason_code,
+                        replacement_index,
+                    )
+                )
+            self._bindings = rewritten
+
+        self._bound_occurrence_ids = {id(binding.occurrence) for binding in self._bindings}
+        self._owned_feature_ids = {id(binding.feature) for binding in self._bindings}
 
     def snapshot(self) -> RecognitionOwnership:
         """Copy the current ledger without manufacturing owners for missing occurrences."""
@@ -164,5 +347,6 @@ class RecognitionOwnershipBuilder:
         return RecognitionOwnership(
             evidence=self.evidence,
             expected_direct=self._expected_direct,
+            expected_groupable=self._expected_groupable,
             bindings=tuple(self._bindings),
         )

--- a/tests/test_issue_1438_occurrence_ownership.py
+++ b/tests/test_issue_1438_occurrence_ownership.py
@@ -165,7 +165,7 @@ def test_automatic_build_binds_each_direct_occurrence_to_its_exact_ir_feature() 
     } == {id(record) for record in drawing.recognition().fillets}
 
 
-def test_grouped_family_stays_unclassified_instead_of_becoming_a_false_missing() -> None:
+def test_singleton_hole_is_represented_by_its_exact_finished_ir_feature() -> None:
     part = Box(40, 30, 10, align=(Align.CENTER, Align.CENTER, Align.CENTER)) - Cylinder(3, 20)
     drawing = build_drawing(part)
     ownership = drawing.recognition_ownership()
@@ -176,8 +176,13 @@ def test_grouped_family_stays_unclassified_instead_of_becoming_a_false_missing()
         for occurrence in ownership.evidence.features
         if ownership.evidence.family(occurrence) == "holes"
     )
-    assert ownership.status(hole) == "unclassified"
-    assert ownership.binding_for(hole) is None
+    binding = ownership.binding_for(hole)
+
+    assert ownership.status(hole) == "represented"
+    assert binding is not None
+    assert binding.reason_code == "hole_adapter"
+    assert binding.member_index == 0
+    assert any(binding.feature is feature for feature in drawing.model().features)
     assert ownership.unexpectedly_missing == ()
 
 

--- a/tests/test_issue_1438_pattern_ownership.py
+++ b/tests/test_issue_1438_pattern_ownership.py
@@ -1,0 +1,346 @@
+"""#1438 — grouped and patterned members retain exact final IR ownership."""
+
+from __future__ import annotations
+
+import pytest
+from b123d_recognisers.evidence import build_recognition_evidence
+from build123d import Align, Box, Cylinder, Pos
+
+from draftwright import build_drawing
+from draftwright.model.detect import _build_part_model_from_recognition
+from draftwright.pmi import PmiRecord
+from draftwright.recognition_ownership import GROUPABLE_FAMILIES, RecognitionOwnershipBuilder
+
+_XYZ_MIN = (Align.CENTER, Align.CENTER, Align.MIN)
+
+
+def _single_hole():
+    return Box(80, 50, 10, align=_XYZ_MIN) - Pos(12, 7, 0) * Cylinder(2, 10, align=_XYZ_MIN)
+
+
+def _scattered_holes():
+    part = Box(80, 60, 10, align=_XYZ_MIN)
+    for x, y in ((-20, -10), (15, 12)):
+        part -= Pos(x, y, 0) * Cylinder(2, 10, align=_XYZ_MIN)
+    return part
+
+
+def _three_scattered_holes():
+    part = Box(100, 80, 10, align=_XYZ_MIN)
+    for x, y in ((-25, -12), (5, 16), (27, -17)):
+        part -= Pos(x, y, 0) * Cylinder(2, 10, align=_XYZ_MIN)
+    return part
+
+
+def _hole_row():
+    part = Box(120, 40, 10, align=_XYZ_MIN)
+    for x in (-30, -10, 10, 30):
+        part -= Pos(x, 0, 0) * Cylinder(3, 10, align=_XYZ_MIN)
+    return part
+
+
+def _single_slot():
+    return Box(60, 40, 20) - Box(30, 8, 20)
+
+
+def _slot_row():
+    part = Box(60, 180, 20)
+    for y in (-45, -15, 15, 45):
+        part -= Pos(0, y, 0) * Box(30, 8, 20)
+    return part
+
+
+def _single_pocket():
+    return Box(60, 40, 20) - Pos(0, 0, 7) * Box(30, 18, 6)
+
+
+def _pocket_row():
+    part = Box(30, 150, 20)
+    for y in (-45, -15, 15, 45):
+        part -= Pos(0, y, 7) * Box(10, 12, 6)
+    return part
+
+
+def _occurrences(ownership, family):
+    return tuple(
+        occurrence
+        for occurrence in ownership.evidence.features
+        if ownership.evidence.family(occurrence) == family
+    )
+
+
+def test_groupable_family_roster_is_explicit() -> None:
+    assert GROUPABLE_FAMILIES == {"holes", "pockets", "slots"}
+
+
+def test_each_unpatterned_groupable_family_has_a_direct_final_owner() -> None:
+    cases = (
+        (_single_hole(), "holes", "hole", "hole_adapter"),
+        (_single_slot(), "slots", "slot", "slot_adapter"),
+        (_single_pocket(), "pockets", "pocket", "pocket_adapter"),
+    )
+
+    for part, family, feature_kind, reason_code in cases:
+        drawing = build_drawing(part)
+        ownership = drawing.recognition_ownership()
+        assert ownership is not None
+        (occurrence,) = _occurrences(ownership, family)
+        binding = ownership.binding_for(occurrence)
+
+        assert binding is not None
+        assert ownership.status(occurrence) == "represented"
+        assert binding.reason_code == reason_code
+        assert binding.feature.kind == feature_kind
+        assert any(binding.feature is feature for feature in drawing.model().features)
+        assert ownership.unexpectedly_missing == ()
+
+
+def test_same_spec_scattered_holes_are_explicitly_absorbed_by_one_group() -> None:
+    drawing = build_drawing(_scattered_holes())
+    ownership = drawing.recognition_ownership()
+    assert ownership is not None
+    occurrences = _occurrences(ownership, "holes")
+    assert len(occurrences) == 2
+    bindings = tuple(ownership.binding_for(occurrence) for occurrence in occurrences)
+
+    assert all(binding is not None for binding in bindings)
+    assert all(ownership.status(occurrence) == "absorbed" for occurrence in occurrences)
+    assert {binding.reason_code for binding in bindings if binding is not None} == {
+        "grouped_hole_member"
+    }
+    assert {binding.member_index for binding in bindings if binding is not None} == {0, 1}
+    assert len({id(binding.feature) for binding in bindings if binding is not None}) == 1
+    owner = next(binding.feature for binding in bindings if binding is not None)
+    assert owner.kind == "hole"
+    assert owner.count == 2
+    assert any(owner is feature for feature in drawing.model().features)
+    assert ownership.unexpectedly_missing == ()
+
+
+def test_pattern_members_are_absorbed_by_the_exact_shared_pattern_owner() -> None:
+    cases = (
+        (_hole_row(), "holes", "pattern", "hole_pattern_member", 4),
+        (_slot_row(), "slots", "slot_pattern", "slot_pattern_member", 4),
+        (_pocket_row(), "pockets", "pocket_pattern", "pocket_pattern_member", 4),
+    )
+
+    for part, family, feature_kind, reason_code, count in cases:
+        drawing = build_drawing(part)
+        ownership = drawing.recognition_ownership()
+        assert ownership is not None
+        occurrences = _occurrences(ownership, family)
+        assert len(occurrences) == count
+        bindings = tuple(ownership.binding_for(occurrence) for occurrence in occurrences)
+
+        assert all(binding is not None for binding in bindings)
+        assert all(ownership.status(occurrence) == "absorbed" for occurrence in occurrences)
+        assert {binding.reason_code for binding in bindings if binding is not None} == {
+            reason_code
+        }
+        assert {binding.member_index for binding in bindings if binding is not None} == set(
+            range(count)
+        )
+        assert len({id(binding.feature) for binding in bindings if binding is not None}) == 1
+        owner = next(binding.feature for binding in bindings if binding is not None)
+        assert owner.kind == feature_kind
+        assert owner.count == count
+        assert any(owner is feature for feature in drawing.model().features)
+        assert ownership.unexpectedly_missing == ()
+
+
+def test_member_specific_pmi_split_rebinds_each_occurrence_to_its_final_owner() -> None:
+    part = _three_scattered_holes()
+    evidence = build_recognition_evidence(part)
+    builder = RecognitionOwnershipBuilder(evidence)
+    occurrences = tuple(
+        occurrence for occurrence in evidence.features if evidence.family(occurrence) == "holes"
+    )
+    assert len(occurrences) == 3
+    selected = evidence.record(occurrences[1])
+    x, y, z = selected.location
+    radius = selected.diameter / 2
+    pmi = PmiRecord(
+        kind="diameter",
+        type_code=15,
+        value=selected.diameter,
+        upper_tol=0.2,
+        lower_tol=0.1,
+        ref_pts=((x - radius, y, z), (x + radius, y, z)),
+        ref_bbox=(
+            x - radius - 0.1,
+            y - radius - 0.1,
+            -0.1,
+            x + radius + 0.1,
+            y + radius + 0.1,
+            z + 0.1,
+        ),
+        dominant_axis="Z",
+        label=f"ø{selected.diameter:g} +0.2/-0.1",
+        source_id="dimension:one-member",
+        source_category="dimension",
+    )
+
+    model = _build_part_model_from_recognition(
+        part,
+        evidence.result,
+        ownership=builder,
+        pmi=(pmi,),
+    )
+    ownership = builder.snapshot()
+    bindings = tuple(ownership.binding_for(occurrence) for occurrence in occurrences)
+
+    assert all(binding is not None for binding in bindings)
+    assert [ownership.status(occurrence) for occurrence in occurrences].count("represented") == 1
+    assert [ownership.status(occurrence) for occurrence in occurrences].count("absorbed") == 2
+    assert {binding.reason_code for binding in bindings if binding is not None} == {
+        "grouped_hole_member",
+        "pmi_split_member",
+    }
+    assert len({id(binding.feature) for binding in bindings if binding is not None}) == 2
+    assert sorted({binding.feature.count for binding in bindings if binding is not None}) == [1, 2]
+    assert all(
+        any(binding.feature is feature for feature in model.features)
+        for binding in bindings
+        if binding is not None
+    )
+    assert (
+        sum(
+            requirement.source_ids == ("dimension:one-member",)
+            for requirement in model.decorations.values()
+        )
+        == 1
+    )
+    assert ownership.unexpectedly_missing == ()
+
+
+def test_unbound_groupable_occurrence_fails_closed_as_unexpectedly_missing() -> None:
+    evidence = build_recognition_evidence(_single_hole())
+    ownership = RecognitionOwnershipBuilder(evidence).snapshot()
+    (occurrence,) = ownership.expected_groupable
+
+    assert ownership.status(occurrence) == "unexpectedly_missing"
+    assert ownership.unexpectedly_missing == (occurrence,)
+
+
+def test_absorption_rejects_unknown_reasons_repeats_and_foreign_records() -> None:
+    evidence = build_recognition_evidence(_scattered_holes())
+    occurrences = RecognitionOwnershipBuilder(evidence).snapshot().expected_groupable
+    records = tuple(evidence.record(occurrence) for occurrence in occurrences)
+
+    with pytest.raises(ValueError, match="unknown absorbed"):
+        RecognitionOwnershipBuilder(evidence).absorb(records, object(), reason_code="invented")
+    with pytest.raises(ValueError, match="unknown absorbed"):
+        RecognitionOwnershipBuilder(evidence).absorb(
+            records, object(), reason_code=" grouped_hole_member "
+        )
+    with pytest.raises(ValueError, match="repeats"):
+        RecognitionOwnershipBuilder(evidence).absorb(
+            (records[0], records[0]), object(), reason_code="grouped_hole_member"
+        )
+    foreign = build_recognition_evidence(_scattered_holes())
+    with pytest.raises(ValueError, match="does not belong"):
+        RecognitionOwnershipBuilder(evidence).absorb(
+            (foreign.record(foreign.features[0]),),
+            object(),
+            reason_code="grouped_hole_member",
+        )
+
+    with pytest.raises(ValueError, match="does not match occurrence family"):
+        RecognitionOwnershipBuilder(evidence).absorb(
+            records,
+            object(),
+            reason_code="slot_pattern_member",
+        )
+    with pytest.raises(ValueError, match="does not match occurrence family"):
+        RecognitionOwnershipBuilder(evidence).bind(
+            records[0],
+            object(),
+            reason_code="slot_adapter",
+        )
+    with pytest.raises(ValueError, match="requires a direct occurrence family"):
+        RecognitionOwnershipBuilder(evidence).bind(records[0], object())
+
+
+def test_builder_guards_invalid_group_and_lowering_lineage() -> None:
+    evidence = build_recognition_evidence(_scattered_holes())
+    occurrences = RecognitionOwnershipBuilder(evidence).snapshot().expected_groupable
+    records = tuple(evidence.record(occurrence) for occurrence in occurrences)
+
+    with pytest.raises(ValueError, match="unknown represented"):
+        RecognitionOwnershipBuilder(evidence).bind(records[0], object(), reason_code="invented")
+    with pytest.raises(ValueError, match="unknown represented"):
+        RecognitionOwnershipBuilder(evidence).bind(
+            records[0], object(), reason_code=" hole_adapter "
+        )
+    with pytest.raises(ValueError, match="non-negative"):
+        RecognitionOwnershipBuilder(evidence).bind(
+            records[0], object(), reason_code="hole_adapter", member_index=-1
+        )
+    with pytest.raises(ValueError, match="at least one"):
+        RecognitionOwnershipBuilder(evidence).absorb(
+            (), object(), reason_code="grouped_hole_member"
+        )
+
+    duplicate_occurrence = RecognitionOwnershipBuilder(evidence)
+    duplicate_occurrence.bind(records[0], object(), reason_code="hole_adapter")
+    with pytest.raises(ValueError, match="occurrence already"):
+        duplicate_occurrence.absorb(records, object(), reason_code="grouped_hole_member")
+
+    duplicate_owner = RecognitionOwnershipBuilder(evidence)
+    owner = object()
+    duplicate_owner.bind(records[0], owner, reason_code="hole_adapter")
+    with pytest.raises(ValueError, match="IR feature already"):
+        duplicate_owner.absorb((records[1],), owner, reason_code="grouped_hole_member")
+
+    misaligned = RecognitionOwnershipBuilder(evidence)
+    source = object()
+    misaligned.absorb(records, source, reason_code="grouped_hole_member")
+    with pytest.raises(ValueError, match="must align"):
+        misaligned.remap_feature(source, (object(), object()), ((0,),))
+    with pytest.raises(ValueError, match="repeat a source member"):
+        misaligned.remap_feature(source, (object(), object()), ((0,), (0,)))
+
+    incomplete = RecognitionOwnershipBuilder(evidence)
+    source = object()
+    incomplete.absorb(records, source, reason_code="grouped_hole_member")
+    replacement = object()
+    incomplete.remap_feature(source, (replacement,), ((0,),))
+    ownership = incomplete.snapshot()
+
+    assert ownership.binding_for(occurrences[0]).feature is replacement
+    assert ownership.status(occurrences[1]) == "unexpectedly_missing"
+
+
+def test_remap_rejects_an_owner_collision_without_mutating_the_ledger() -> None:
+    evidence = build_recognition_evidence(_scattered_holes())
+    occurrences = RecognitionOwnershipBuilder(evidence).snapshot().expected_groupable
+    records = tuple(evidence.record(occurrence) for occurrence in occurrences)
+
+    for member_groups in (None, ((0,),)):
+        builder = RecognitionOwnershipBuilder(evidence)
+        source = object()
+        occupied = object()
+        builder.bind(records[0], source, reason_code="hole_adapter", member_index=0)
+        builder.bind(records[1], occupied, reason_code="hole_adapter", member_index=0)
+
+        with pytest.raises(ValueError, match="already owns"):
+            builder.remap_feature(source, (occupied,), member_groups)
+
+        ownership = builder.snapshot()
+        assert ownership.binding_for(occurrences[0]).feature is source
+        assert ownership.binding_for(occurrences[1]).feature is occupied
+
+
+def test_member_remap_requires_distinct_replacement_objects() -> None:
+    evidence = build_recognition_evidence(_scattered_holes())
+    builder = RecognitionOwnershipBuilder(evidence)
+    occurrences = builder.snapshot().expected_groupable
+    records = tuple(evidence.record(occurrence) for occurrence in occurrences)
+    source = object()
+    builder.absorb(records, source, reason_code="grouped_hole_member")
+    repeated = object()
+
+    with pytest.raises(ValueError, match="distinct replacement"):
+        builder.remap_feature(source, (repeated, repeated), ((0,), (1,)))
+
+    assert all(builder.snapshot().binding_for(item).feature is source for item in occurrences)


### PR DESCRIPTION
## Summary

- bind each accepted physical hole, slot, and pocket occurrence to its exact final Draftwright IR owner at conversion time
- classify unpatterned singletons as `represented` and same-spec hole groups plus hole/slot/pocket pattern members as `absorbed` with closed family-specific reason codes
- keep provider-derived pattern records out of the occurrence inventory and retain only transient run-local member lineage
- follow member-specific AP242 hole splits to exact replacement objects; reject owner collisions and incomplete lineage without retaining stale ownership

## Safety properties

- same-run exact record identity only; no value, coordinate, face-overlap, ordering, or topology reconstruction
- released public `RecognitionEvidence` API only; no recogniser change or extra scan
- no persistent occurrence/topology ID and no serialization in this slice
- declared builds remain recognition-free until physical critique/report/export; evidence-less framed builds remain honest
- no manufacturing inference, compiled-plan dependency, annotation placement, generated-code change, or visual artefact change

## Validation

- `scripts/pr-check --full`: 6,445 passed, 5 skipped, 2 xfailed
- total coverage 95.66%; changed-line coverage 100%
- Ruff, formatting, mypy, codespell, strict documentation build, and diff checks pass
- real singleton, grouped-hole, and hole/slot/pocket pattern builds verify exact final owners
- real member-specific AP242 splitting verifies one retained group plus one represented singleton
- mutation guards cover missing lineage, duplicate occurrence/owner claims, scalar and member-remap owner collisions, repeated replacements, foreign/value-copy records, and invalid reason/family combinations

## Independent review

Exact reviewed head: `8ecd96f5b6671e7c1d4c8f0d125f9ce80f53761a`. Three fresh independent Google-style reviews are CLEAN with no required findings or optional nits after one fix/re-review iteration.

## ADR review before merge

- ADR 0010: annotation provenance remains in the registry seam; this ledger does not certify ink
- ADR 0011: no change to declared IR or generated semantic code
- ADR 0013: only the released public provider evidence and aggregate membership are consumed
- ADR 0014: no annotation or raw page-coordinate placement path is introduced
- ADR 0015: ownership stays beside/below the IR waist and completeness remains independent of compilation
- ADR 0017: Amendment 13 narrowly records explicit singleton/N:1 ownership and AP242 member lineage while preserving one recognition run
- ADR 0020: raw evidence is not conflated with framed provenance; framed evidence remains unavailable pending the released upstream seam

Part of #1438 and #1256.