### PR TITLE
Classify ownerless recognition occurrences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- Accepted angled-step, passage, prismatic-pocket, oriented-slot, and repeating-radial-profile
+  occurrences now receive exact run-local ownerless outcomes from Draftwright's existing consumer
+  capability declaration: `unsupported`, `deferred`, or report-facing `evidence_only`, with closed
+  reason codes and existing tracking issues. Equal-valued occurrences stay distinct; policy does
+  not invent IR owners, requirements, topology IDs, recognition scans, generated artefacts, or
+  visual output (#1438, ADR 0017 Amendment 14).
+
 - Accepted physical hole, slot, and pocket occurrences now retain explicit run-local ownership
   when conversion represents a singleton or absorbs members into one same-spec hole group or
   derived pattern feature. Family-specific reason codes and transient member lineage follow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,8 +38,9 @@ Compact map, bottom to top:
   `_geometry.py` (page-plane maths + the ADR 0014 Amdt 3 material field; the DAG's
   bottom leaf), `fonts.py` (pinned IBM Plex, ADR 0006), `fits.py` (ISO 286),
   `intents.py` (deferred-edit low IR), `recognition_cache.py` (ADR 0017 one-result
-  lifecycle), `recognition_ownership.py` (run-local accepted-occurrence→final-IR bindings,
-  including explicit group/pattern absorption),
+  lifecycle), `recognition_ownership.py` (run-local accepted-occurrence outcomes, including
+  final-IR binding, group/pattern absorption, and settled ownerless consumer policy),
+  `recogniser_policy.py` (single Draftwright-owned unsupported/deferred/evidence-only policy),
   `recognition_frame.py` (ADR 0020 prepared local-frame boundary and fail-closed
   body-local occurrence joins), `blend_contract.py` (strict released-Blend schema and
   occurrence identity),

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -13,7 +13,8 @@
   Amendment 11 (2026-09-02) retains the provider's raw accepted-occurrence evidence in the same
   consumer-owned cache without adding a second recognition run. Amendment 12 (2026-09-03)
   records the first conversion-time, run-local occurrence→IR ownership bindings. Amendment 13
-  (2026-09-03) records explicit member ownership for hole, slot, and pocket groupings.
+  (2026-09-03) records explicit member ownership for hole, slot, and pocket groupings. Amendment
+  14 records settled ownerless consumer-policy outcomes per accepted occurrence.
 - **Date:** 2026-08-03
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -352,6 +353,31 @@ ADR 0013 remains the provider boundary; ADR 0020's framed path remains evidence-
 released upstream contract. Declared builds therefore remain recognition-free until physical
 critique/report/export, and these ownership outcomes alone do not claim drawing completeness.
 
+## Amendment 14 — Settled ownerless policy is explicit per occurrence
+
+Five accepted physical families intentionally have no Draftwright IR owner. Each raw automatic
+build now projects the already-reviewed top-level disposition in the consumer capability
+declaration onto every exact same-run `FeatureRef`: angled steps, passages, and prismatic pockets
+are `unsupported`; oriented slots are `deferred`; and repeating radial profiles are
+`evidence_only` because they may critique separately authored gear intent but cannot create it.
+Each outcome carries a closed reason code and, for unsupported/deferred policy, the declaration's
+existing tracking issue. This is a pure Draftwright policy projection; the geometry provider does
+not decide drafting support.
+
+Occurrence identity remains the provider-issued opaque reference. Equal-valued oriented slots
+therefore retain distinct outcomes, while records, faces, registry order, coordinates, and
+topology are never used to reconstruct identity. These occurrences are not expected to produce an
+IR feature and cannot become `unexpectedly_missing`; conversely, an ownerless policy outcome cannot
+certify a drawing requirement as complete. Remaining supported nested/classification-only families
+stay `unclassified` until their exact ownership rules are separately demonstrated.
+
+This adds no provider API, recognition scan, persistent/report identifier, IR feature,
+manufacturing inference, annotation, requirement, compiled-plan dependency, generated artefact, or
+visual change. The policy is derived from the existing fail-closed consumer capability declaration
+rather than copied into a second registry. ADRs 0010 and 0014 are untouched; ADRs 0011 and 0015
+retain the declared/compiler boundaries; ADR 0013 retains provider geometry versus consumer policy;
+and ADR 0020's framed path remains honestly evidence-less until a released provider contract exists.
+
 ## Accepted Contract
 
 ### 1. One orchestration owns the recognition universe
@@ -398,8 +424,9 @@ not accept an arbitrary aggregate and then attempt to prove it came from the sam
 This originally answered **result-to-build provenance only**. Amendment 12 records exact
 occurrence→IR ownership for unconditional 1:1 adapters, and Amendment 13 adds explicit singleton,
 grouped, and pattern-member ownership for holes, slots, and pockets. Nested, classification-only,
-unsupported, evidence-only and deferred families, and the general
-feature→requirement→annotation correspondence, remain subjects of the evidence gates below.
+supported nested and classification-only families, and the general feature→requirement→annotation
+correspondence, remain subjects of the evidence gates below. Settled unsupported, evidence-only,
+and deferred policy is explicit per accepted occurrence under Amendment 14.
 
 `lint_prismatic_coverage(recognition=...)` is a known channel outside the structural ownership
 path (#1032). The preferred correction is to remove or narrow the channel when that boundary

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ keep that table, this document, and `CLAUDE.md`'s compact map in step. The
 The dependency graph is a DAG (the #138 / ADR 0005 split is complete). Bottom to
 top: leaf modules (`layout.py`, `registry.py`, `fonts.py`, `_geometry.py`,
 `fits.py`, `intents.py`, `recognition_cache.py`, `recognition_ownership.py`,
-`recognition_frame.py`, and the
+`recogniser_policy.py`, `recognition_frame.py`, and the
 strict `blend_contract.py` provider-record boundary, and the `linting/` subpackage) →
 `_core.py` → stage modules (`export.py`,
 `repair.py`, `projection.py`, `compose.py`, `analysis.py`, `drawing.py`, the
@@ -209,9 +209,15 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
 - **`recognition_ownership.py`** — the run-local consumer ledger below/beside the ADR 0015 IR
   waist. During record→IR conversion it binds opaque provider occurrences to the exact IR
   feature objects that represent or absorb them, by same-run record identity and explicit
-  aggregate membership. It exposes no persistent topology/order/address ID. Unconditional 1:1
-  adapters plus singleton/grouped/pattern hole, slot, and pocket members are classified; nested,
-  classification-only, unsupported, evidence-only, and deferred families remain unclassified.
+  aggregate membership. Ownerless outcomes are projected from the existing consumer capability
+  declaration, not a second policy table. It exposes no persistent topology/order/address ID.
+  Unconditional 1:1 adapters, singleton/grouped/pattern hole/slot/pocket members, and settled
+  unsupported/deferred/evidence-only occurrences are classified; remaining nested and
+  classification-only families stay unclassified.
+- **`recogniser_policy.py`** — the rank-0 Draftwright-owned source for reviewed unsupported,
+  deferred, and geometry-only family policy. Both the cross-repository capability declaration and
+  the run-local occurrence ledger project this same immutable data; recognition remains
+  geometry-only and no engine leaf imports the rank-7 contract validator.
 - **`recognition_frame.py`** — the ADR 0020 prepared local-frame boundary. It calls the public
   provider preparation seam, classifies the exact normalized solid from its already-scanned
   cylinders, runs one paired aggregate, propagates typed refusal without fallback, and exposes
@@ -221,7 +227,8 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   It rejects widened, mutable, non-finite, non-canonical, and unreleased values and owns the
   exact occurrence key shared by conversion and completeness lint.
 - **`recogniser_contract.py`** — the fail-closed cross-repository capability join. It consumes
-  only the installed `b123d-recognisers` public manifest, then validates Draftwright-owned IR,
+  only the installed `b123d-recognisers` public manifest and rank-0 consumer policy, then validates
+  Draftwright-owned IR,
   `Sheet`, generated-code, drawing, completeness, and documentation declarations. It is rank 7
   because validation dynamically resolves implementation references across every lower layer;
   package geometry policy never imports or owns this consumer overlay.

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -991,9 +991,10 @@ class Drawing:
 
         This experimental, read-only ledger is available only when raw automatic recognition
         supplied :meth:`recognition_evidence`. It currently classifies unconditional one-to-one
-        adapters; all grouped, absorbed, classification-only and deferred families remain
-        explicitly unclassified. It carries opaque provider references and therefore cannot be
-        serialized or used as persistent feature identity.
+        adapters; singleton/grouped/pattern holes, slots, and pockets; and settled ownerless
+        unsupported, deferred, and evidence-only policy. Remaining nested and classification-only
+        families stay explicitly unclassified. It carries opaque provider references and therefore
+        cannot be serialized or used as persistent feature identity.
         """
 
         return self._build.recognition_ownership

--- a/src/draftwright/recogniser_contract.py
+++ b/src/draftwright/recogniser_contract.py
@@ -17,6 +17,17 @@ from typing import Any
 
 from b123d_recognisers import capability_manifest
 
+from draftwright.recogniser_policy import (
+    DEFERRED_FAMILIES as _DEFERRED_FAMILIES,
+)
+from draftwright.recogniser_policy import (
+    GEOMETRY_ONLY_FAMILY_ID,
+    GEOMETRY_ONLY_RATIONALE,
+)
+from draftwright.recogniser_policy import (
+    UNSUPPORTED_FAMILIES as _UNSUPPORTED,
+)
+
 CONSUMER_CAPABILITY_FORMAT = "draftwright-recogniser-capabilities"
 CONSUMER_CAPABILITY_FORMAT_VERSION = 1
 _RECOGNISER_DISTRIBUTION = "b123d-recognisers"
@@ -346,16 +357,13 @@ def _family_declaration(family_id: str, spec: _FamilySpec) -> dict[str, Any]:
 
 
 def _geometry_only_declaration() -> dict[str, Any]:
-    rationale = (
-        "Independent repeating-profile evidence critiques a separately authored gear; geometry "
-        "alone must not create inferred gear intent."
-    )
+    rationale = GEOMETRY_ONLY_RATIONALE
     no_inferred = {
         "state": "not-applicable",
         "rationale": "No inferred drafting feature exists for geometry-only critique evidence.",
     }
     return {
-        "id": "repeating-radial-profiles",
+        "id": GEOMETRY_ONLY_FAMILY_ID,
         "record_schemas": _record_schema_versions(
             "repeating-radial-profiles", ("RepeatingRadialProfile",)
         ),
@@ -378,67 +386,6 @@ def _geometry_only_declaration() -> dict[str, Any]:
             ],
         },
     }
-
-
-#: Families the installed package proves but Draftwright does not fully support, each with the
-#: issue recording its consumer disposition. Not a parking bay: an undecided family must still
-#: have a live decision issue, while a settled unsupported boundary must carry an explicit
-#: outcome such as Passage completeness below. ``pending_family_declarations`` reports anything
-#: absent from BOTH this map and ``_FAMILIES``, so the next new family fails closed exactly as
-#: the first three did (#1244), and the 0.4.6 step families do now (#1382).
-_UNSUPPORTED: dict[str, tuple[tuple[str, ...], str, str]] = {
-    "oriented-slot-patterns": (
-        ("OrientedSlotArray", "OrientedSlotGrid"),
-        "https://github.com/pzfreo/draftwright/issues/1430",
-        "The derived records group free-axis oriented slots, but the principal-axis "
-        "SlotPatternFeature cannot preserve their vector plane, member passage authority, and "
-        "pattern identity. A dedicated consumer contract is being reviewed before any grouping "
-        "or dimensions are emitted.",
-    ),
-    "oriented-slots": (
-        ("OrientedSlot",),
-        "https://github.com/pzfreo/draftwright/issues/1430",
-        "The record carries free-axis directions and an authoritative SectionPassage source. "
-        "Coercing it into the legacy axis-letter SlotFeature would discard that correspondence, "
-        "so its dedicated IR, Sheet vocabulary, drawing grammar, and completeness denominator "
-        "remain under review.",
-    ),
-    "passages": (
-        (
-            "Passage",
-            "PassageEnds",
-            "PassageFrame",
-            "PassageSection",
-            "PassageSectionVertex",
-            "SectionPassage",
-        ),
-        "https://github.com/pzfreo/draftwright/issues/1245",
-        "A prismatic through-opening — the internal counterpart to polygonal stock. The rich "
-        "record permits arbitrary line/arc sections, so treating its regular-polygon subset as "
-        "a supported IR feature or HEX callout would overstate the drawing contract. Draftwright "
-        "therefore reports every occurrence as an unsupported completeness requirement.",
-    ),
-    "prismatic-pockets": (
-        ("PrismaticPocket",),
-        "https://github.com/pzfreo/draftwright/issues/1246",
-        "The aggregate removes candidates also owned by the supported `pockets` family, so each "
-        "remaining PrismaticPocket is a distinct recess not superseded by Pocket. Its section may "
-        "be any planar polygon: width/length is false for triangles and a regular-polygon A/F "
-        "callout is incomplete in the general case. Draftwright therefore reports every "
-        "surviving occurrence as an unsupported completeness requirement.",
-    ),
-    "angled-steps": (
-        ("AngledStep",),
-        "https://github.com/pzfreo/draftwright/issues/1247",
-        "Introduced by 0.2.5 to stop `recognise_chamfers` reporting step slants as chamfers "
-        "(precision 44% -> 78%). The aggregate reconciles the shared slanted face in favour of "
-        "AngledStep, but its angle, legs and run length do not themselves decide which drawing "
-        "requirements or section/detail view are required. Draftwright therefore reports every "
-        "occurrence as an unsupported completeness requirement.",
-    ),
-}
-
-_DEFERRED_FAMILIES: frozenset[str] = frozenset({"oriented-slot-patterns", "oriented-slots"})
 
 
 def _unsupported_declaration(family_id: str) -> dict[str, Any]:

--- a/src/draftwright/recogniser_policy.py
+++ b/src/draftwright/recogniser_policy.py
@@ -1,0 +1,115 @@
+"""Leaf consumer policy for accepted recogniser occurrence families."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from types import MappingProxyType
+from typing import Literal
+
+OwnerlessDisposition = Literal["unsupported", "deferred", "evidence_only"]
+
+GEOMETRY_ONLY_FAMILY_ID = "repeating-radial-profiles"
+GEOMETRY_ONLY_RATIONALE = (
+    "Independent repeating-profile evidence critiques a separately authored gear; geometry "
+    "alone must not create inferred gear intent."
+)
+
+# Families the installed package proves but Draftwright does not fully support. This is the
+# single consumer-policy source used by both the capability declaration and occurrence ledger.
+# It is not a parking bay: an undecided family needs a live decision issue, while a settled
+# unsupported boundary needs an explicit outcome. The rank-7 contract's exhaustive manifest join
+# ensures a new provider family cannot hide by being absent from this table and the supported map.
+UNSUPPORTED_FAMILIES: Mapping[str, tuple[tuple[str, ...], str, str]] = MappingProxyType(
+    {
+        "oriented-slot-patterns": (
+            ("OrientedSlotArray", "OrientedSlotGrid"),
+            "https://github.com/pzfreo/draftwright/issues/1430",
+            "The derived records group free-axis oriented slots, but the principal-axis "
+            "SlotPatternFeature cannot preserve their vector plane, member passage authority, and "
+            "pattern identity. A dedicated consumer contract is being reviewed before any grouping "
+            "or dimensions are emitted.",
+        ),
+        "oriented-slots": (
+            ("OrientedSlot",),
+            "https://github.com/pzfreo/draftwright/issues/1430",
+            "The record carries free-axis directions and an authoritative SectionPassage source. "
+            "Coercing it into the legacy axis-letter SlotFeature would discard that correspondence, "
+            "so its dedicated IR, Sheet vocabulary, drawing grammar, and completeness denominator "
+            "remain under review.",
+        ),
+        "passages": (
+            (
+                "Passage",
+                "PassageEnds",
+                "PassageFrame",
+                "PassageSection",
+                "PassageSectionVertex",
+                "SectionPassage",
+            ),
+            "https://github.com/pzfreo/draftwright/issues/1245",
+            "A prismatic through-opening — the internal counterpart to polygonal stock. The rich "
+            "record permits arbitrary line/arc sections, so treating its regular-polygon subset as "
+            "a supported IR feature or HEX callout would overstate the drawing contract. Draftwright "
+            "therefore reports every occurrence as an unsupported completeness requirement.",
+        ),
+        "prismatic-pockets": (
+            ("PrismaticPocket",),
+            "https://github.com/pzfreo/draftwright/issues/1246",
+            "The aggregate removes candidates also owned by the supported `pockets` family, so each "
+            "remaining PrismaticPocket is a distinct recess not superseded by Pocket. Its section may "
+            "be any planar polygon: width/length is false for triangles and a regular-polygon A/F "
+            "callout is incomplete in the general case. Draftwright therefore reports every "
+            "surviving occurrence as an unsupported completeness requirement.",
+        ),
+        "angled-steps": (
+            ("AngledStep",),
+            "https://github.com/pzfreo/draftwright/issues/1247",
+            "Introduced by 0.2.5 to stop `recognise_chamfers` reporting step slants as chamfers "
+            "(precision 44% -> 78%). The aggregate reconciles the shared slanted face in favour of "
+            "AngledStep, but its angle, legs and run length do not themselves decide which drawing "
+            "requirements or section/detail view are required. Draftwright therefore reports every "
+            "occurrence as an unsupported completeness requirement.",
+        ),
+    }
+)
+
+DEFERRED_FAMILIES: frozenset[str] = frozenset({"oriented-slot-patterns", "oriented-slots"})
+
+
+@dataclass(frozen=True)
+class OwnerlessOccurrencePolicy:
+    """Settled consumer meaning for a physical occurrence with no IR owner."""
+
+    disposition: OwnerlessDisposition
+    reason_code: str
+    tracking: str | None
+
+
+def ownerless_occurrence_policy(family: str) -> OwnerlessOccurrencePolicy | None:
+    """Return policy for one public ``RecognitionEvidence.family`` identifier."""
+
+    if type(family) is not str:
+        raise TypeError("recognition evidence family must be an exact str")
+    family_id = family.replace("_", "-")
+    if family_id == GEOMETRY_ONLY_FAMILY_ID:
+        return OwnerlessOccurrencePolicy(
+            disposition="evidence_only",
+            reason_code="geometry_only_critique",
+            tracking=None,
+        )
+    spec = UNSUPPORTED_FAMILIES.get(family_id)
+    if spec is None:
+        return None
+    disposition: OwnerlessDisposition = (
+        "deferred" if family_id in DEFERRED_FAMILIES else "unsupported"
+    )
+    return OwnerlessOccurrencePolicy(
+        disposition=disposition,
+        reason_code=(
+            "consumer_semantics_deferred"
+            if disposition == "deferred"
+            else "consumer_semantics_unsupported"
+        ),
+        tracking=spec[1],
+    )

--- a/src/draftwright/recognition_ownership.py
+++ b/src/draftwright/recognition_ownership.py
@@ -1,6 +1,6 @@
-"""Run-local ownership between provider occurrences and Draftwright IR features.
+"""Run-local consumer outcomes for provider occurrences and Draftwright IR features.
 
-This is consumer-owned correspondence state below and beside the ADR-0015 IR waist.  It keeps
+This is consumer-owned correspondence state below and beside the ADR-0015 IR waist. It keeps
 the provider's opaque :class:`FeatureRef` only for the lifetime of one recognition run and never
 turns object addresses, feature order, record values, or topology indices into persistent IDs.
 """
@@ -12,9 +12,15 @@ from typing import Literal
 
 from b123d_recognisers.evidence import FeatureRef, RecognitionEvidence
 
+from draftwright.recogniser_policy import (
+    OwnerlessDisposition,
+    ownerless_occurrence_policy,
+)
+
 # These aggregate families have an unconditional one-record -> one-feature adapter in
-# model.detect.  Nested, classification-only, and intentionally deferred families stay
-# unclassified until a later slice can state their ownership honestly.
+# model.detect.  Nested and classification-only families stay unclassified until a later slice
+# can state their ownership honestly. Consumer-policy-only occurrences are classified separately
+# below because they deliberately have no IR owner.
 DIRECT_FAMILIES = frozenset(
     {
         "blends",
@@ -40,6 +46,16 @@ DIRECT_FAMILIES = frozenset(
 GROUPABLE_FAMILIES = frozenset({"holes", "pockets", "slots"})
 
 OwnershipDisposition = Literal["represented", "absorbed"]
+PolicyDisposition = OwnerlessDisposition
+OccurrenceStatus = Literal[
+    "represented",
+    "absorbed",
+    "unsupported",
+    "deferred",
+    "evidence_only",
+    "unexpectedly_missing",
+    "unclassified",
+]
 
 _REPRESENTED_REASON_CODES = frozenset(
     {
@@ -84,6 +100,35 @@ class OccurrenceBinding:
 
 
 @dataclass(frozen=True)
+class OccurrencePolicyOutcome:
+    """One exact accepted occurrence with an explicit ownerless consumer policy."""
+
+    occurrence: FeatureRef
+    disposition: PolicyDisposition
+    reason_code: str
+    tracking: str | None
+
+
+def _policy_outcomes(evidence: RecognitionEvidence) -> tuple[OccurrencePolicyOutcome, ...]:
+    """Project the existing consumer capability declaration onto exact occurrences."""
+
+    outcomes: list[OccurrencePolicyOutcome] = []
+    for occurrence in evidence.features:
+        policy = ownerless_occurrence_policy(evidence.family(occurrence))
+        if policy is None:
+            continue
+        outcomes.append(
+            OccurrencePolicyOutcome(
+                occurrence=occurrence,
+                disposition=policy.disposition,
+                reason_code=policy.reason_code,
+                tracking=policy.tracking,
+            )
+        )
+    return tuple(outcomes)
+
+
+@dataclass(frozen=True)
 class RecognitionOwnership:
     """Immutable run-local ownership ledger paired with one evidence authority."""
 
@@ -91,12 +136,21 @@ class RecognitionOwnership:
     expected_direct: tuple[FeatureRef, ...]
     expected_groupable: tuple[FeatureRef, ...]
     bindings: tuple[OccurrenceBinding, ...]
+    policy_outcomes: tuple[OccurrencePolicyOutcome, ...]
+
+    @property
+    def owner_expected_occurrences(self) -> tuple[FeatureRef, ...]:
+        """Supported occurrences whose adapters must record an IR owner."""
+
+        return self.expected_direct + self.expected_groupable
 
     @property
     def expected_occurrences(self) -> tuple[FeatureRef, ...]:
         """Occurrences whose implemented consumer paths must produce an explicit outcome."""
 
-        return self.expected_direct + self.expected_groupable
+        return self.owner_expected_occurrences + tuple(
+            outcome.occurrence for outcome in self.policy_outcomes
+        )
 
     def binding_for(self, occurrence: FeatureRef) -> OccurrenceBinding | None:
         """Return the ownership binding for an occurrence, validating its authority first."""
@@ -106,19 +160,34 @@ class RecognitionOwnership:
             (binding for binding in self.bindings if binding.occurrence is occurrence), None
         )
 
-    def status(
+    def policy_for(self, occurrence: FeatureRef) -> OccurrencePolicyOutcome | None:
+        """Return an ownerless policy outcome, validating its evidence authority first."""
+
+        self.evidence.family(occurrence)
+        return next(
+            (outcome for outcome in self.policy_outcomes if outcome.occurrence is occurrence),
+            None,
+        )
+
+    def outcome_for(
         self, occurrence: FeatureRef
-    ) -> Literal["represented", "absorbed", "unexpectedly_missing", "unclassified"]:
+    ) -> OccurrenceBinding | OccurrencePolicyOutcome | None:
+        """Return the implemented outcome for one exact accepted occurrence."""
+
+        binding = self.binding_for(occurrence)
+        return binding if binding is not None else self.policy_for(occurrence)
+
+    def status(self, occurrence: FeatureRef) -> OccurrenceStatus:
         """Classify only the ownership contracts implemented so far.
 
         ``unclassified`` is deliberately not a report disposition.  It is the migration state
-        for nested/deferred families whose ownership rules are not implemented yet.
+        for nested and classification-only families whose ownership rules are not implemented.
         """
 
-        binding = self.binding_for(occurrence)
-        if binding is not None:
-            return binding.disposition
-        if any(expected is occurrence for expected in self.expected_occurrences):
+        outcome = self.outcome_for(occurrence)
+        if outcome is not None:
+            return outcome.disposition
+        if any(expected is occurrence for expected in self.owner_expected_occurrences):
             return "unexpectedly_missing"
         return "unclassified"
 
@@ -128,7 +197,7 @@ class RecognitionOwnership:
 
         return tuple(
             occurrence
-            for occurrence in self.expected_occurrences
+            for occurrence in self.owner_expected_occurrences
             if self.binding_for(occurrence) is None
         )
 
@@ -155,6 +224,12 @@ class RecognitionOwnershipBuilder:
             record = evidence.record(occurrence)
             self._by_record_identity.setdefault(id(record), []).append((occurrence, record))
         self._bindings: list[OccurrenceBinding] = []
+        self._policy_outcomes = _policy_outcomes(evidence)
+        expected_ids = {
+            id(occurrence) for occurrence in self._expected_direct + self._expected_groupable
+        }
+        if any(id(outcome.occurrence) in expected_ids for outcome in self._policy_outcomes):
+            raise RuntimeError("recognition occurrence has conflicting owner and policy contracts")
         self._bound_occurrence_ids: set[int] = set()
         self._owned_feature_ids: set[int] = set()
 
@@ -349,4 +424,5 @@ class RecognitionOwnershipBuilder:
             expected_direct=self._expected_direct,
             expected_groupable=self._expected_groupable,
             bindings=tuple(self._bindings),
+            policy_outcomes=self._policy_outcomes,
         )

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -82,6 +82,7 @@ _LAYERS: dict[str, int] = {
     "recognition": 0,
     "recognition_cache": 0,
     "recognition_ownership": 0,
+    "recogniser_policy": 0,
     "recognition_frame": 0,
     # Strict shared validator for the released provider Blend record and its occurrence key.
     "blend_contract": 0,

--- a/tests/test_issue_1438_policy_dispositions.py
+++ b/tests/test_issue_1438_policy_dispositions.py
@@ -1,0 +1,215 @@
+"""#1438: settled ownerless consumer policy is explicit per accepted occurrence."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from b123d_recognisers.evidence import build_recognition_evidence
+from build123d import (
+    Align,
+    Box,
+    BuildPart,
+    BuildSketch,
+    Cylinder,
+    Plane,
+    Pos,
+    RegularPolygon,
+    Rot,
+    extrude,
+    import_step,
+)
+
+from draftwright import build_drawing
+from draftwright import recognition_ownership as ownership_module
+from draftwright.recogniser_contract import consumer_capability_declaration
+from draftwright.recogniser_policy import UNSUPPORTED_FAMILIES, ownerless_occurrence_policy
+from draftwright.recognition_ownership import (
+    OccurrencePolicyOutcome,
+    RecognitionOwnershipBuilder,
+)
+
+_FIXTURES = Path(__file__).parent / "fixtures"
+_CENTER = (Align.CENTER, Align.CENTER, Align.CENTER)
+
+
+def _angled_step_part():
+    return import_step(str(_FIXTURES / "issue_1247_angled_blind_step.step"))
+
+
+def _passage_part():
+    return Box(40, 40, 10) - extrude(RegularPolygon(6, 6), amount=12, both=True)
+
+
+def _prismatic_pocket_part():
+    with BuildPart() as tool:
+        with BuildSketch(Plane.XY.offset(4)):
+            RegularPolygon(12, 6)
+        extrude(amount=20)
+    return Box(120, 80, 20) - tool.part
+
+
+def _oriented_slot_part():
+    part = Box(120, 90, 10)
+    for x in (-30, 0, 30):
+        part -= Pos(x, 0, 0) * Rot(0, 0, 30) * Box(24, 6, 20, align=_CENTER)
+    return part
+
+
+def _repeating_profile_part():
+    return import_step(str(_FIXTURES / "issue_1058_wheel_rh.step"))
+
+
+@pytest.mark.parametrize(
+    ("part_factory", "family", "count", "disposition", "reason_code", "tracking"),
+    (
+        (
+            _angled_step_part,
+            "angled_steps",
+            1,
+            "unsupported",
+            "consumer_semantics_unsupported",
+            "https://github.com/pzfreo/draftwright/issues/1247",
+        ),
+        (
+            _passage_part,
+            "passages",
+            1,
+            "unsupported",
+            "consumer_semantics_unsupported",
+            "https://github.com/pzfreo/draftwright/issues/1245",
+        ),
+        (
+            _prismatic_pocket_part,
+            "prismatic_pockets",
+            1,
+            "unsupported",
+            "consumer_semantics_unsupported",
+            "https://github.com/pzfreo/draftwright/issues/1246",
+        ),
+        (
+            _oriented_slot_part,
+            "oriented_slots",
+            3,
+            "deferred",
+            "consumer_semantics_deferred",
+            "https://github.com/pzfreo/draftwright/issues/1430",
+        ),
+        (
+            _repeating_profile_part,
+            "repeating_radial_profiles",
+            1,
+            "evidence_only",
+            "geometry_only_critique",
+            None,
+        ),
+    ),
+    ids=("angled-step", "passage", "prismatic-pocket", "oriented-slots", "radial-profile"),
+)
+def test_settled_policy_classifies_each_exact_accepted_occurrence(
+    part_factory,
+    family: str,
+    count: int,
+    disposition: str,
+    reason_code: str,
+    tracking: str | None,
+) -> None:
+    evidence = build_recognition_evidence(part_factory())
+    ownership = RecognitionOwnershipBuilder(evidence).snapshot()
+    occurrences = tuple(
+        occurrence for occurrence in evidence.features if evidence.family(occurrence) == family
+    )
+
+    assert len(occurrences) == count
+    assert len({id(occurrence) for occurrence in occurrences}) == count
+    for occurrence in occurrences:
+        outcome = ownership.outcome_for(occurrence)
+        assert type(outcome) is OccurrencePolicyOutcome
+        assert outcome.occurrence is occurrence
+        assert outcome.disposition == disposition
+        assert outcome.reason_code == reason_code
+        assert outcome.tracking == tracking
+        assert ownership.policy_for(occurrence) is outcome
+        assert ownership.binding_for(occurrence) is None
+        assert ownership.status(occurrence) == disposition
+        assert occurrence in ownership.expected_occurrences
+        assert occurrence not in ownership.owner_expected_occurrences
+        assert occurrence not in ownership.unexpectedly_missing
+
+
+def test_policy_outcomes_follow_evidence_order_without_collapsing_equal_members() -> None:
+    evidence = build_recognition_evidence(_oriented_slot_part())
+    ownership = RecognitionOwnershipBuilder(evidence).snapshot()
+    occurrences = tuple(
+        occurrence
+        for occurrence in evidence.features
+        if evidence.family(occurrence) == "oriented_slots"
+    )
+
+    assert tuple(outcome.occurrence for outcome in ownership.policy_outcomes) == occurrences
+    assert len({id(outcome) for outcome in ownership.policy_outcomes}) == 3
+
+
+def test_supported_unknown_and_malformed_families_cannot_gain_ownerless_policy() -> None:
+    assert ownerless_occurrence_policy("holes") is None
+    assert ownerless_occurrence_policy("future_family") is None
+    with pytest.raises(TypeError, match="exact str"):
+        ownerless_occurrence_policy(123)  # type: ignore[arg-type]
+
+
+def test_shared_ownerless_policy_table_is_immutable() -> None:
+    with pytest.raises(TypeError, match="does not support item assignment"):
+        UNSUPPORTED_FAMILIES["passages"] = UNSUPPORTED_FAMILIES["angled-steps"]  # type: ignore[index]
+
+
+def test_an_occurrence_cannot_have_both_owner_and_ownerless_policy(monkeypatch) -> None:
+    evidence = build_recognition_evidence(
+        Box(30, 30, 10, align=_CENTER) - Cylinder(3, 10, align=_CENTER)
+    )
+    occurrence = next(
+        occurrence for occurrence in evidence.features if evidence.family(occurrence) == "holes"
+    )
+    conflict = OccurrencePolicyOutcome(
+        occurrence=occurrence,
+        disposition="unsupported",
+        reason_code="consumer_semantics_unsupported",
+        tracking="https://github.com/pzfreo/draftwright/issues/1438",
+    )
+    monkeypatch.setattr(ownership_module, "_policy_outcomes", lambda _evidence: (conflict,))
+
+    with pytest.raises(RuntimeError, match="conflicting owner and policy"):
+        RecognitionOwnershipBuilder(evidence)
+
+
+def test_policy_outcome_uses_the_existing_capability_declaration() -> None:
+    declarations = {
+        family["id"]: family for family in consumer_capability_declaration()["families"]
+    }
+    evidence = build_recognition_evidence(_passage_part())
+    ownership = RecognitionOwnershipBuilder(evidence).snapshot()
+    occurrence = next(
+        occurrence for occurrence in evidence.features if evidence.family(occurrence) == "passages"
+    )
+    outcome = ownership.policy_for(occurrence)
+
+    assert outcome is not None
+    assert outcome.disposition == declarations["passages"]["disposition"]
+    assert outcome.tracking == declarations["passages"]["tracking"]
+
+
+def test_raw_automatic_build_attaches_policy_to_its_exact_evidence_authority() -> None:
+    drawing = build_drawing(_passage_part())
+    evidence = drawing.recognition_evidence()
+    ownership = drawing.recognition_ownership()
+
+    assert evidence is not None
+    assert ownership is not None
+    assert ownership.evidence is evidence
+    occurrence = next(
+        occurrence for occurrence in evidence.features if evidence.family(occurrence) == "passages"
+    )
+    assert ownership.status(occurrence) == "unsupported"
+    outcome = ownership.policy_for(occurrence)
+    assert outcome is not None
+    assert outcome.tracking is not None
+    assert outcome.tracking.endswith("/1245")


### PR DESCRIPTION
## Summary

- project the released public `RecognitionEvidence` authority onto exact ownerless occurrences
- classify accepted angled steps, passages, and prismatic pockets as `unsupported`; oriented slots as `deferred`; and repeating radial profiles as `evidence_only`
- share one immutable rank-0 consumer-policy source between the capability declaration and occurrence ledger
- expose a complete implemented-outcome roster while keeping `unexpectedly_missing` restricted to supported occurrences that require an IR owner
- retain exact run-local `FeatureRef` identity, including equal-valued occurrences, without provider-private imports, topology IDs, duplicate scans, or report serialization

This is the policy-disposition foundation for the versioned JSON report. It intentionally does not yet change generated Python, PDF/SVG/DXF/PNG output, annotation placement, or declared-build recognition behavior.

Advances #1438 and #1256.

## Verification

- `BASE_REF=origin/main scripts/pr-check --full`
- 6,456 passed, 5 skipped, 2 expected xfailed
- total coverage 95.66%; diff coverage 100% (67/67 changed executable lines)
- fresh exact-head independent reviews: contract CLEAN/no nits; quality CLEAN/no nits; ADR CLEAN with one optional docstring wording nit

## ADR audit

Checked ADRs 0010, 0011, 0013, 0014, 0015, 0017, and 0020. ADR 0017 receives only the narrowly evidenced ownerless-disposition amendment. The change preserves annotation provenance, semantic Sheet code, the released public recogniser boundary, shared placement, compiler/completeness independence, one recognition authority per run, and the raw/framed geometry boundary.
