### PR TITLE
Track nested countersink occurrence ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- Accepted countersink occurrences now receive an exact run-local outcome. A seat carried by a
+  `HoleRecord` is `absorbed` by that hole's final feature and transient member lineage; an unattached,
+  unowned, or duplicate nested occurrence fails closed without dimension matching, topology IDs, a
+  second scan, duplicate IR requirements, or visual changes (#1438, ADR 0017 Amendment 15).
+
 - Accepted angled-step, passage, prismatic-pocket, oriented-slot, and repeating-radial-profile
   occurrences now receive exact run-local ownerless outcomes from Draftwright's existing consumer
   capability declaration: `unsupported`, `deferred`, or report-facing `evidence_only`, with closed

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -14,7 +14,8 @@
   consumer-owned cache without adding a second recognition run. Amendment 12 (2026-09-03)
   records the first conversion-time, run-local occurrence→IR ownership bindings. Amendment 13
   (2026-09-03) records explicit member ownership for hole, slot, and pocket groupings. Amendment
-  14 records settled ownerless consumer-policy outcomes per accepted occurrence.
+  14 records settled ownerless consumer-policy outcomes per accepted occurrence. Amendment 15
+  records each accepted countersink as absorbed by its exact same-run hole owner.
 - **Date:** 2026-08-03
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -378,6 +379,27 @@ rather than copied into a second registry. ADRs 0010 and 0014 are untouched; ADR
 retain the declared/compiler boundaries; ADR 0013 retains provider geometry versus consumer policy;
 and ADR 0020's framed path remains honestly evidence-less until a released provider contract exists.
 
+## Amendment 15 — Nested countersinks retain their exact hole owner
+
+Every accepted raw countersink occurrence now receives an explicit consumer result. When the public
+aggregate attaches that exact record to a `HoleRecord.csink`, it receives an `absorbed` outcome and
+shares that hole's final `HoleFeature` owner. The binding is made only after the parent hole has an
+owner and retains the parent's transient member lineage, so single holes, same-spec groups,
+patterns, and later PMI splits preserve one bore/countersink feature and one countersink requirement
+rather than duplicating either.
+
+The correspondence uses the released public evidence records and same-run object identity. It does
+not match dimensions, coordinates, faces, record equality, or traversal order. A countersink that
+is accepted but absent from its parent hole, whose parent is unowned, or whose binding is duplicated
+fails closed as `unexpectedly_missing` or a conversion invariant violation; it cannot silently look
+complete. No recogniser API change or second scan is required.
+
+This adds no standalone countersink IR feature, manufacturing inference, compiled-plan dependency,
+annotation placement, generated artefact, report ID, topology ID, or visual change. ADRs 0010 and
+0014 retain the established hole annotation provenance and shared solve; ADRs 0011 and 0015 retain
+the semantic Sheet/IR waist; ADR 0013 remains the released provider boundary; and ADR 0020's framed
+path remains evidence-less pending the upstream correspondence contract.
+
 ## Accepted Contract
 
 ### 1. One orchestration owns the recognition universe
@@ -423,10 +445,11 @@ not accept an arbitrary aggregate and then attempt to prove it came from the sam
 
 This originally answered **result-to-build provenance only**. Amendment 12 records exact
 occurrence→IR ownership for unconditional 1:1 adapters, and Amendment 13 adds explicit singleton,
-grouped, and pattern-member ownership for holes, slots, and pockets. Nested, classification-only,
-supported nested and classification-only families, and the general feature→requirement→annotation
-correspondence, remain subjects of the evidence gates below. Settled unsupported, evidence-only,
-and deferred policy is explicit per accepted occurrence under Amendment 14.
+grouped, and pattern-member ownership for holes, slots, and pockets. Amendment 15 adds exact nested
+countersink→hole ownership. Remaining supported nested and classification-only families, and the
+general feature→requirement→annotation correspondence, remain subjects of the evidence gates below.
+Settled unsupported, evidence-only, and deferred policy is explicit per accepted occurrence under
+Amendment 14.
 
 `lint_prismatic_coverage(recognition=...)` is a known channel outside the structural ownership
 path (#1032). The preferred correction is to remove or narrow the channel when that boundary

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -211,9 +211,9 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   feature objects that represent or absorb them, by same-run record identity and explicit
   aggregate membership. Ownerless outcomes are projected from the existing consumer capability
   declaration, not a second policy table. It exposes no persistent topology/order/address ID.
-  Unconditional 1:1 adapters, singleton/grouped/pattern hole/slot/pocket members, and settled
-  unsupported/deferred/evidence-only occurrences are classified; remaining nested and
-  classification-only families stay unclassified.
+  Unconditional 1:1 adapters, singleton/grouped/pattern hole/slot/pocket members, nested
+  countersinks, and settled unsupported/deferred/evidence-only occurrences are classified;
+  remaining nested and classification-only families stay unclassified.
 - **`recogniser_policy.py`** — the rank-0 Draftwright-owned source for reviewed unsupported,
   deferred, and geometry-only family policy. Both the cross-repository capability declaration and
   the run-local occurrence ledger project this same immutable data; recognition remains
@@ -570,9 +570,10 @@ policy) live in `CLAUDE.md`. This is the per-ADR status trail; each ADR's
   compiler grammar and placement solve, and a side-normal footprint is filtered from the legacy
   Z-level projection only when exact support correspondence proves that ownership. No renderer
   consumes the provider record or places an annotation at a caller-supplied page coordinate.
-  Amendments 12–13 give unconditional 1:1 adapters and hole/slot/pocket singleton, grouped, and
-  pattern-member paths exact run-local occurrence→final-IR ownership in `BuildState`. Nested,
-  classification-only, unsupported, evidence-only, and deferred families, plus general
+  Amendments 12–15 give unconditional 1:1 adapters, hole/slot/pocket singleton/grouped/pattern
+  members, and nested countersinks exact run-local occurrence→final-IR ownership in `BuildState`,
+  while settled unsupported, evidence-only, and deferred occurrences have explicit ownerless
+  outcomes. Remaining nested and classification-only families, plus general
   IR-feature→requirement correspondence, are not yet provided. The original
   four-type identity taxonomy, shared requirements module, general outcome ledger,
   reconciliation stage, and diagnostics model are candidate extensions rather than an

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -440,8 +440,9 @@ class BuildState:
     - ``part_model`` — the detected/declared ADR-0008 PartModel (read surface for
       semantic edits, #397).
     - ``recognition`` — the ADR 0017 aggregate reused by model detection and critique.
-    - ``recognition_ownership`` — same-run direct occurrence→IR bindings captured while
-      conversion makes the decision; provider references never enter the IR waist.
+    - ``recognition_ownership`` — same-run represented, grouped/pattern, nested, and ownerless
+      occurrence outcomes captured while conversion makes the decision; provider references
+      never enter the IR waist.
     - ``view_edge_cache`` — lint's per-view edge bboxes, keyed on id(view shape)
       (helpers #143/#164).
     - ``ann_box_cache`` — lint's annotation bounding boxes (#602): identity- AND
@@ -991,10 +992,10 @@ class Drawing:
 
         This experimental, read-only ledger is available only when raw automatic recognition
         supplied :meth:`recognition_evidence`. It currently classifies unconditional one-to-one
-        adapters; singleton/grouped/pattern holes, slots, and pockets; and settled ownerless
-        unsupported, deferred, and evidence-only policy. Remaining nested and classification-only
-        families stay explicitly unclassified. It carries opaque provider references and therefore
-        cannot be serialized or used as persistent feature identity.
+        adapters; singleton/grouped/pattern holes, slots, and pockets; nested countersinks; and
+        settled ownerless unsupported, deferred, and evidence-only policy. Remaining nested and
+        classification-only families stay explicitly unclassified. It carries opaque provider
+        references and therefore cannot be serialized or used as persistent feature identity.
         """
 
         return self._build.recognition_ownership

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -1711,6 +1711,14 @@ def build_part_model(
                     hole_feature,
                     reason_code="grouped_hole_member",
                 )
+    if ownership is not None:
+        for hole in holes:
+            if hole.csink is not None:
+                ownership.absorb_nested(
+                    hole.csink,
+                    hole,
+                    reason_code="countersink_hole_owner",
+                )
 
     # Profiled bores are their own recognition family because full-cylinder recognition
     # cannot see their partial cylindrical faces. They still lower to HoleFeature so the

--- a/src/draftwright/recognition_ownership.py
+++ b/src/draftwright/recognition_ownership.py
@@ -18,9 +18,9 @@ from draftwright.recogniser_policy import (
 )
 
 # These aggregate families have an unconditional one-record -> one-feature adapter in
-# model.detect.  Nested and classification-only families stay unclassified until a later slice
-# can state their ownership honestly. Consumer-policy-only occurrences are classified separately
-# below because they deliberately have no IR owner.
+# model.detect. Remaining nested and classification-only families stay unclassified until a later
+# slice can state their ownership honestly. Consumer-policy-only occurrences are classified
+# separately below because they deliberately have no IR owner.
 DIRECT_FAMILIES = frozenset(
     {
         "blends",
@@ -44,6 +44,11 @@ DIRECT_FAMILIES = frozenset(
 # The derived pattern records are deliberately not FeatureRefs and must not be promoted into
 # invented persistent occurrences.
 GROUPABLE_FAMILIES = frozenset({"holes", "pockets", "slots"})
+
+# These accepted occurrences are nested records carried by a supported parent occurrence. They
+# must retain their own outcome while sharing the parent's final IR owner rather than creating a
+# duplicate feature or requirement.
+NESTED_FAMILIES = frozenset({"countersinks"})
 
 OwnershipDisposition = Literal["represented", "absorbed"]
 PolicyDisposition = OwnerlessDisposition
@@ -75,6 +80,7 @@ _ABSORBED_REASON_CODES = frozenset(
     }
 )
 _REASON_FAMILY = {
+    "countersink_hole_owner": "countersinks",
     "grouped_hole_member": "holes",
     "hole_adapter": "holes",
     "hole_pattern_member": "holes",
@@ -84,6 +90,8 @@ _REASON_FAMILY = {
     "slot_adapter": "slots",
     "slot_pattern_member": "slots",
 }
+_NESTED_OWNER_FAMILY = {"countersink_hole_owner": "holes"}
+_NESTED_OWNER_FIELD = {"countersink_hole_owner": "csink"}
 
 
 @dataclass(frozen=True)
@@ -135,6 +143,7 @@ class RecognitionOwnership:
     evidence: RecognitionEvidence
     expected_direct: tuple[FeatureRef, ...]
     expected_groupable: tuple[FeatureRef, ...]
+    expected_nested: tuple[FeatureRef, ...]
     bindings: tuple[OccurrenceBinding, ...]
     policy_outcomes: tuple[OccurrencePolicyOutcome, ...]
 
@@ -142,7 +151,7 @@ class RecognitionOwnership:
     def owner_expected_occurrences(self) -> tuple[FeatureRef, ...]:
         """Supported occurrences whose adapters must record an IR owner."""
 
-        return self.expected_direct + self.expected_groupable
+        return self.expected_direct + self.expected_groupable + self.expected_nested
 
     @property
     def expected_occurrences(self) -> tuple[FeatureRef, ...]:
@@ -181,7 +190,8 @@ class RecognitionOwnership:
         """Classify only the ownership contracts implemented so far.
 
         ``unclassified`` is deliberately not a report disposition.  It is the migration state
-        for nested and classification-only families whose ownership rules are not implemented.
+        for remaining nested and classification-only families whose ownership rules are not
+        implemented.
         """
 
         outcome = self.outcome_for(occurrence)
@@ -219,14 +229,22 @@ class RecognitionOwnershipBuilder:
             for occurrence in evidence.features
             if evidence.family(occurrence) in GROUPABLE_FAMILIES
         )
+        self._expected_nested = tuple(
+            occurrence
+            for occurrence in evidence.features
+            if evidence.family(occurrence) in NESTED_FAMILIES
+        )
         self._by_record_identity: dict[int, list[tuple[FeatureRef, object]]] = {}
-        for occurrence in self._expected_direct + self._expected_groupable:
+        for occurrence in self._expected_direct + self._expected_groupable + self._expected_nested:
             record = evidence.record(occurrence)
             self._by_record_identity.setdefault(id(record), []).append((occurrence, record))
         self._bindings: list[OccurrenceBinding] = []
         self._policy_outcomes = _policy_outcomes(evidence)
         expected_ids = {
-            id(occurrence) for occurrence in self._expected_direct + self._expected_groupable
+            id(occurrence)
+            for occurrence in (
+                self._expected_direct + self._expected_groupable + self._expected_nested
+            )
         }
         if any(id(outcome.occurrence) in expected_ids for outcome in self._policy_outcomes):
             raise RuntimeError("recognition occurrence has conflicting owner and policy contracts")
@@ -322,6 +340,44 @@ class RecognitionOwnershipBuilder:
                     member_index=member_index,
                 )
             )
+
+    def absorb_nested(
+        self,
+        record: object,
+        owner_record: object,
+        *,
+        reason_code: str,
+    ) -> None:
+        """Bind one exact nested occurrence to its exact parent's existing IR owner."""
+
+        if type(reason_code) is not str or reason_code not in _NESTED_OWNER_FAMILY:
+            raise ValueError("unknown nested ownership reason_code")
+        occurrence = self._occurrence_for(record)
+        owner_occurrence = self._occurrence_for(owner_record)
+        if self.evidence.family(occurrence) != _REASON_FAMILY[reason_code]:
+            raise ValueError("nested ownership reason_code does not match occurrence family")
+        if self.evidence.family(owner_occurrence) != _NESTED_OWNER_FAMILY[reason_code]:
+            raise ValueError("nested ownership reason_code does not match owner family")
+        if getattr(owner_record, _NESTED_OWNER_FIELD[reason_code]) is not record:
+            raise ValueError("nested recognition occurrence does not belong to its exact parent")
+        if id(occurrence) in self._bound_occurrence_ids:
+            raise ValueError("recognition occurrence already has an IR owner")
+        owner_binding = next(
+            (binding for binding in self._bindings if binding.occurrence is owner_occurrence),
+            None,
+        )
+        if owner_binding is None:
+            raise ValueError("nested recognition occurrence requires an existing parent owner")
+        self._bound_occurrence_ids.add(id(occurrence))
+        self._bindings.append(
+            OccurrenceBinding(
+                occurrence,
+                owner_binding.feature,
+                disposition="absorbed",
+                reason_code=reason_code,
+                member_index=owner_binding.member_index,
+            )
+        )
 
     def remap_feature(
         self,
@@ -423,6 +479,7 @@ class RecognitionOwnershipBuilder:
             evidence=self.evidence,
             expected_direct=self._expected_direct,
             expected_groupable=self._expected_groupable,
+            expected_nested=self._expected_nested,
             bindings=tuple(self._bindings),
             policy_outcomes=self._policy_outcomes,
         )

--- a/tests/test_issue_1438_nested_ownership.py
+++ b/tests/test_issue_1438_nested_ownership.py
@@ -1,0 +1,290 @@
+"""#1438 — nested accepted occurrences retain their exact parent ownership."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from b123d_recognisers.evidence import build_recognition_evidence
+from build123d import Box, Cone, Cylinder, Pos, import_step
+
+from draftwright import build_drawing
+from draftwright.model.detect import _build_part_model_from_recognition
+from draftwright.pmi import PmiRecord
+from draftwright.recognition_ownership import NESTED_FAMILIES, RecognitionOwnershipBuilder
+
+FIXTURES = Path(__file__).parent / "fixtures" / "evaluation"
+
+
+def _mixed_countersinks():
+    return import_step(FIXTURES / "countersink-mixed-pair.step")
+
+
+def _same_spec_countersinks():
+    part = Box(60, 30, 12)
+    for x in (-15, 15):
+        part -= Pos(x, 0, 0) * Cylinder(3, 12)
+        part -= Pos(x, 0, 4) * Cone(3, 7, 4)
+    return part
+
+
+def _two_ended_countersink():
+    return (
+        Box(50, 50, 12)
+        - Cylinder(3, 12)
+        - Pos(0, 0, 4) * Cone(3, 7, 4)
+        - Pos(0, 0, -4) * Cone(7, 3, 4)
+    )
+
+
+def test_nested_family_roster_is_explicit() -> None:
+    assert NESTED_FAMILIES == {"countersinks"}
+
+
+def test_each_countersink_is_absorbed_by_its_exact_hole_owner() -> None:
+    drawing = build_drawing(_mixed_countersinks())
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    evidence = ownership.evidence
+    holes = tuple(
+        occurrence for occurrence in evidence.features if evidence.family(occurrence) == "holes"
+    )
+    countersinks = tuple(
+        occurrence
+        for occurrence in evidence.features
+        if evidence.family(occurrence) == "countersinks"
+    )
+
+    assert len(holes) == len(countersinks) == 2
+    assert len({id(occurrence) for occurrence in countersinks}) == 2
+    for countersink in countersinks:
+        seat = evidence.record(countersink)
+        hole = next(hole for hole in holes if evidence.record(hole).csink is seat)
+        countersink_outcome = ownership.binding_for(countersink)
+        hole_outcome = ownership.binding_for(hole)
+
+        assert countersink_outcome is not None
+        assert hole_outcome is not None
+        assert countersink_outcome.disposition == "absorbed"
+        assert countersink_outcome.reason_code == "countersink_hole_owner"
+        assert countersink_outcome.feature is hole_outcome.feature
+        assert countersink_outcome.member_index == hole_outcome.member_index
+        assert ownership.status(countersink) == "absorbed"
+        assert countersink in ownership.expected_occurrences
+        assert countersink in ownership.owner_expected_occurrences
+    assert ownership.unexpectedly_missing == ()
+
+
+def test_unbound_countersink_fails_closed_as_unexpectedly_missing() -> None:
+    evidence = build_recognition_evidence(_mixed_countersinks())
+    ownership = RecognitionOwnershipBuilder(evidence).snapshot()
+    countersinks = ownership.expected_nested
+
+    assert len(countersinks) == 2
+    assert all(
+        ownership.status(occurrence) == "unexpectedly_missing" for occurrence in countersinks
+    )
+    assert (
+        tuple(
+            occurrence
+            for occurrence in ownership.unexpectedly_missing
+            if evidence.family(occurrence) == "countersinks"
+        )
+        == countersinks
+    )
+
+
+def test_grouped_countersinks_share_the_hole_owner_and_member_lineage() -> None:
+    ownership = build_drawing(_same_spec_countersinks()).recognition_ownership()
+
+    assert ownership is not None
+    evidence = ownership.evidence
+    hole_bindings = tuple(
+        ownership.binding_for(occurrence)
+        for occurrence in evidence.features
+        if evidence.family(occurrence) == "holes"
+    )
+    countersink_bindings = tuple(
+        ownership.binding_for(occurrence)
+        for occurrence in evidence.features
+        if evidence.family(occurrence) == "countersinks"
+    )
+
+    assert all(binding is not None for binding in hole_bindings + countersink_bindings)
+    assert len({id(binding.feature) for binding in hole_bindings + countersink_bindings}) == 1
+    assert tuple(binding.member_index for binding in hole_bindings) == (0, 1)
+    assert tuple(binding.member_index for binding in countersink_bindings) == (0, 1)
+
+
+def test_countersinks_follow_their_exact_hole_through_a_member_specific_pmi_split() -> None:
+    part = _same_spec_countersinks()
+    evidence = build_recognition_evidence(part)
+    builder = RecognitionOwnershipBuilder(evidence)
+    holes = tuple(
+        occurrence for occurrence in evidence.features if evidence.family(occurrence) == "holes"
+    )
+    countersinks = tuple(
+        occurrence
+        for occurrence in evidence.features
+        if evidence.family(occurrence) == "countersinks"
+    )
+    assert len(holes) == len(countersinks) == 2
+    selected_hole = holes[1]
+    selected = evidence.record(selected_hole)
+    x, y, z = selected.location
+    radius = selected.diameter / 2
+    pmi = PmiRecord(
+        kind="diameter",
+        type_code=15,
+        value=selected.diameter,
+        upper_tol=0.2,
+        lower_tol=0.1,
+        ref_pts=((x - radius, y, z), (x + radius, y, z)),
+        ref_bbox=(
+            x - radius - 0.1,
+            y - radius - 0.1,
+            z - 0.1,
+            x + radius + 0.1,
+            y + radius + 0.1,
+            z + 0.1,
+        ),
+        dominant_axis="Z",
+        label=f"ø{selected.diameter:g} +0.2/-0.1",
+        source_id="dimension:one-countersunk-member",
+        source_category="dimension",
+    )
+
+    model = _build_part_model_from_recognition(
+        part,
+        evidence.result,
+        ownership=builder,
+        pmi=(pmi,),
+    )
+    ownership = builder.snapshot()
+    model_feature_ids = {id(feature) for feature in model.features}
+    hole_bindings = {
+        id(evidence.record(occurrence)): ownership.binding_for(occurrence) for occurrence in holes
+    }
+    countersink_bindings = {
+        id(evidence.record(occurrence)): ownership.binding_for(occurrence)
+        for occurrence in countersinks
+    }
+
+    assert all(binding is not None for binding in hole_bindings.values())
+    assert all(binding is not None for binding in countersink_bindings.values())
+    assert len({id(binding.feature) for binding in hole_bindings.values() if binding}) == 2
+    for hole in holes:
+        hole_record = evidence.record(hole)
+        hole_binding = hole_bindings[id(hole_record)]
+        countersink_binding = countersink_bindings[id(hole_record.csink)]
+
+        assert hole_binding is not None
+        assert countersink_binding is not None
+        assert countersink_binding.feature is hole_binding.feature
+        assert countersink_binding.member_index == hole_binding.member_index == 0
+        assert countersink_binding.disposition == "absorbed"
+        assert countersink_binding.reason_code == "countersink_hole_owner"
+        assert id(hole_binding.feature) in model_feature_ids
+    selected_binding = hole_bindings[id(selected)]
+    assert selected_binding is not None
+    assert selected_binding.disposition == "represented"
+    assert selected_binding.reason_code == "pmi_split_member"
+    assert (
+        sum(
+            requirement.source_ids == ("dimension:one-countersunk-member",)
+            for requirement in model.decorations.values()
+        )
+        == 1
+    )
+    assert ownership.unexpectedly_missing == ()
+
+
+def test_an_accepted_second_end_without_a_hole_owner_fails_closed() -> None:
+    ownership = build_drawing(_two_ended_countersink(), page="A3").recognition_ownership()
+
+    assert ownership is not None
+    evidence = ownership.evidence
+    countersinks = tuple(
+        occurrence
+        for occurrence in evidence.features
+        if evidence.family(occurrence) == "countersinks"
+    )
+    statuses = [ownership.status(occurrence) for occurrence in countersinks]
+
+    assert len(countersinks) == 2
+    assert statuses.count("absorbed") == 1
+    assert statuses.count("unexpectedly_missing") == 1
+
+
+def test_nested_binding_requires_its_exact_parent_to_be_bound_first() -> None:
+    evidence = build_recognition_evidence(_mixed_countersinks())
+    builder = RecognitionOwnershipBuilder(evidence)
+    hole = next(
+        occurrence for occurrence in evidence.features if evidence.family(occurrence) == "holes"
+    )
+    hole_record = evidence.record(hole)
+
+    with pytest.raises(ValueError, match="existing parent owner"):
+        builder.absorb_nested(
+            hole_record.csink,
+            hole_record,
+            reason_code="countersink_hole_owner",
+        )
+
+
+def test_nested_binding_rejects_a_different_same_family_parent() -> None:
+    evidence = build_recognition_evidence(_mixed_countersinks())
+    builder = RecognitionOwnershipBuilder(evidence)
+    holes = tuple(
+        occurrence for occurrence in evidence.features if evidence.family(occurrence) == "holes"
+    )
+    assert len(holes) == 2
+    first = evidence.record(holes[0])
+    second = evidence.record(holes[1])
+    builder.bind(first, object(), reason_code="hole_adapter", member_index=0)
+    builder.bind(second, object(), reason_code="hole_adapter", member_index=0)
+
+    with pytest.raises(ValueError, match="does not belong to its exact parent"):
+        builder.absorb_nested(
+            first.csink,
+            second,
+            reason_code="countersink_hole_owner",
+        )
+
+
+def test_nested_binding_rejects_wrong_family_and_duplicate_occurrence() -> None:
+    evidence = build_recognition_evidence(_mixed_countersinks())
+    builder = RecognitionOwnershipBuilder(evidence)
+    hole = next(
+        occurrence for occurrence in evidence.features if evidence.family(occurrence) == "holes"
+    )
+    hole_record = evidence.record(hole)
+    feature = object()
+
+    with pytest.raises(ValueError, match="unknown nested ownership reason_code"):
+        builder.absorb_nested(hole_record.csink, hole_record, reason_code="future_contract")
+
+    with pytest.raises(ValueError, match="does not match owner family"):
+        builder.absorb_nested(
+            hole_record.csink,
+            hole_record.csink,
+            reason_code="countersink_hole_owner",
+        )
+
+    builder.bind(hole_record, feature, reason_code="hole_adapter", member_index=0)
+
+    with pytest.raises(ValueError, match="does not match occurrence family"):
+        builder.absorb_nested(hole_record, hole_record, reason_code="countersink_hole_owner")
+
+    builder.absorb_nested(
+        hole_record.csink,
+        hole_record,
+        reason_code="countersink_hole_owner",
+    )
+    with pytest.raises(ValueError, match="already has an IR owner"):
+        builder.absorb_nested(
+            hole_record.csink,
+            hole_record,
+            reason_code="countersink_hole_owner",
+        )


### PR DESCRIPTION
## Summary

- bind each accepted `countersinks` occurrence to the exact public `HoleRecord.csink` parent and its already-established IR owner
- retain exact member lineage through grouped holes, patterns, and member-specific AP242 PMI splits
- leave unattached or second-ended accepted countersinks `unexpectedly_missing` rather than manufacturing an owner

## Safety properties

- both child and parent must be exact same-run public evidence records, and `owner_record.csink is record`
- a swapped same-family parent, unbound parent, duplicate child, wrong family, or unknown reason fails closed before granting ownership
- no record equality, geometry proximity, topology reconstruction, persistent topology ID, duplicate recognition scan, or private provider API
- declared-build recognition laziness, compiled-plan independence, generated artefacts, and PDF/SVG/DXF/PNG appearance are unchanged

## Verification

- `BASE_REF=origin/main scripts/pr-check --full`: 6,465 passed, 5 skipped, 2 expected xfailed
- total coverage 95.67%; changed executable lines 100%
- realistic mixed, grouped, patterned, two-ended, defensive, and one-member AP242 split regressions
- three fresh independent exact-head ADR, recogniser-contract, and quality reviews are CLEAN with no nits after required findings were fixed and re-reviewed

## ADR audit

Reviewed against ADRs 0010, 0011, 0013, 0014, 0015, 0017, and 0020. ADR 0017 receives a narrow amendment documenting run-local nested occurrence ownership. No exception is required.

Part of #1438
Part of #1256