### PR TITLE
Track conditional channel occurrence ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- Accepted channel occurrences now receive an exact conditional consumer outcome. A genuine
+  multi-axis plate channel is `represented` by its `ChannelFeature`; a monolithic Z-depth rebate is
+  `absorbed` only when one retained body-local support carries its floor and both shoulders into the
+  final step ladder. Cross-axis, disconnected, or filtered channels fail closed as
+  `unexpectedly_missing` instead of inheriting an unrelated ladder, without a second scan,
+  persistent ID, generated artefact, or visual change (#1438, ADR 0017 Amendment 16).
+
 - Accepted countersink occurrences now receive an exact run-local outcome. A seat carried by a
   `HoleRecord` is `absorbed` by that hole's final feature and transient member lineage; an unattached,
   unowned, or duplicate nested occurrence fails closed without dimension matching, topology IDs, a

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -15,7 +15,8 @@
   records the first conversion-time, run-local occurrence→IR ownership bindings. Amendment 13
   (2026-09-03) records explicit member ownership for hole, slot, and pocket groupings. Amendment
   14 records settled ownerless consumer-policy outcomes per accepted occurrence. Amendment 15
-  records each accepted countersink as absorbed by its exact same-run hole owner.
+  records each accepted countersink as absorbed by its exact same-run hole owner. Amendment 16
+  records the conditional direct-or-step-ladder owner of every accepted channel occurrence.
 - **Date:** 2026-08-03
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -400,6 +401,40 @@ annotation placement, generated artefact, report ID, topology ID, or visual chan
 the semantic Sheet/IR waist; ADR 0013 remains the released provider boundary; and ADR 0020's framed
 path remains evidence-less pending the upstream correspondence contract.
 
+## Amendment 16 — Channels retain the consumer's conditional owner
+
+Every accepted raw channel occurrence now enters the supported-owner denominator. In a genuine
+multi-axis plate assembly, the existing channel adapter produces a `ChannelFeature` and records that
+exact object as `represented`. A monolithic Z-depth rebate continues to use the established
+prismatic `StepLevelFeature`; the channel is `absorbed` only when that final ladder contains its
+floor and both width-axis shoulders, coupled through one retained body-local face support and that
+exact support occurrence's riser provenance over the channel's depth span. This records the
+existing consumer classification where it is made rather than reconstructing ownership from a
+finished model.
+
+Direct cross-record coordinate comparisons allow half of the `Channel` record's two-decimal
+publication cell. A shoulder reconstructed from independently published centre and width allows
+the composed 0.0075 loss against raw support bounds, plus half of the shoulder projection's 0.001
+publication cell against its three-decimal output (0.008 total). Comparisons add one scale-aware
+float ULP only at the boundary; provider occurrence identity and final-support retention remain
+exact. Thus ordinary
+or large translations cannot erase honest ownership, while the tolerances cannot bridge a
+different published channel coordinate.
+
+The support/floor/shoulder check is deliberately fail closed. A cross-axis channel or disconnected
+body cannot inherit an unrelated Z ladder merely because matching scalar facts exist, and a
+filtered or absent defining support, level, or shoulder leaves the accepted occurrence
+`unexpectedly_missing`. Multiple exact channel records may share one aggregate ladder when their
+body-local provenance reaches it, but value-equal support occurrences, feature ordering, rendered
+dimensions, labels, topology indices, or page coordinates never establish that relationship.
+
+The implementation consumes the released same-run public `Channel` record and existing aggregate;
+it adds no provider API, recognition scan, persistent/report identity, manufacturing inference,
+compiled-plan dependency, annotation placement, generated artefact, or visual change. ADRs 0010 and
+0014 remain untouched; ADRs 0011 and 0015 retain the semantic Sheet/IR waist and recognition-free
+declared build; ADR 0013 keeps geometry recognition separate from consumer classification; and ADR
+0020's framed evidence boundary is unchanged.
+
 ## Accepted Contract
 
 ### 1. One orchestration owns the recognition universe
@@ -446,10 +481,11 @@ not accept an arbitrary aggregate and then attempt to prove it came from the sam
 This originally answered **result-to-build provenance only**. Amendment 12 records exact
 occurrence→IR ownership for unconditional 1:1 adapters, and Amendment 13 adds explicit singleton,
 grouped, and pattern-member ownership for holes, slots, and pockets. Amendment 15 adds exact nested
-countersink→hole ownership. Remaining supported nested and classification-only families, and the
-general feature→requirement→annotation correspondence, remain subjects of the evidence gates below.
-Settled unsupported, evidence-only, and deferred policy is explicit per accepted occurrence under
-Amendment 14.
+countersink→hole ownership, and Amendment 16 adds conditional direct-or-step-ladder channel
+ownership. Remaining supported conditional families, and the general
+feature→requirement→annotation correspondence, remain subjects of the evidence gates below. Settled
+unsupported, evidence-only, and deferred policy is explicit per accepted occurrence under Amendment
+14.
 
 `lint_prismatic_coverage(recognition=...)` is a known channel outside the structural ownership
 path (#1032). The preferred correction is to remove or narrow the channel when that boundary

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -212,8 +212,8 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   aggregate membership. Ownerless outcomes are projected from the existing consumer capability
   declaration, not a second policy table. It exposes no persistent topology/order/address ID.
   Unconditional 1:1 adapters, singleton/grouped/pattern hole/slot/pocket members, nested
-  countersinks, and settled unsupported/deferred/evidence-only occurrences are classified;
-  remaining nested and classification-only families stay unclassified.
+  countersinks, conditional channel owners, and settled unsupported/deferred/evidence-only
+  occurrences are classified; remaining conditional cross-family records stay unclassified.
 - **`recogniser_policy.py`** — the rank-0 Draftwright-owned source for reviewed unsupported,
   deferred, and geometry-only family policy. Both the cross-repository capability declaration and
   the run-local occurrence ledger project this same immutable data; recognition remains
@@ -570,10 +570,10 @@ policy) live in `CLAUDE.md`. This is the per-ADR status trail; each ADR's
   compiler grammar and placement solve, and a side-normal footprint is filtered from the legacy
   Z-level projection only when exact support correspondence proves that ownership. No renderer
   consumes the provider record or places an annotation at a caller-supplied page coordinate.
-  Amendments 12–15 give unconditional 1:1 adapters, hole/slot/pocket singleton/grouped/pattern
-  members, and nested countersinks exact run-local occurrence→final-IR ownership in `BuildState`,
-  while settled unsupported, evidence-only, and deferred occurrences have explicit ownerless
-  outcomes. Remaining nested and classification-only families, plus general
+  Amendments 12–16 give unconditional 1:1 adapters, hole/slot/pocket singleton/grouped/pattern
+  members, nested countersinks, and conditional channel decisions exact run-local
+  occurrence→final-IR ownership in `BuildState`, while settled unsupported, evidence-only, and
+  deferred occurrences have explicit ownerless outcomes. Remaining conditional families, plus general
   IR-feature→requirement correspondence, are not yet provided. The original
   four-type identity taxonomy, shared requirements module, general outcome ledger,
   reconciliation stage, and diagnostics model are candidate extensions rather than an

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -440,9 +440,9 @@ class BuildState:
     - ``part_model`` — the detected/declared ADR-0008 PartModel (read surface for
       semantic edits, #397).
     - ``recognition`` — the ADR 0017 aggregate reused by model detection and critique.
-    - ``recognition_ownership`` — same-run represented, grouped/pattern, nested, and ownerless
-      occurrence outcomes captured while conversion makes the decision; provider references
-      never enter the IR waist.
+    - ``recognition_ownership`` — same-run represented, grouped/pattern, nested, conditional
+      aggregate, and ownerless occurrence outcomes captured while conversion makes the decision;
+      provider references never enter the IR waist.
     - ``view_edge_cache`` — lint's per-view edge bboxes, keyed on id(view shape)
       (helpers #143/#164).
     - ``ann_box_cache`` — lint's annotation bounding boxes (#602): identity- AND

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -18,7 +18,7 @@ from collections import Counter
 from collections.abc import Callable
 from contextvars import ContextVar
 from dataclasses import dataclass, replace
-from math import isfinite
+from math import isfinite, ulp
 from numbers import Real
 from typing import Any
 
@@ -626,6 +626,136 @@ def _convert_channel(channel: Channel, ctx: ConvContext) -> ChannelFeature:
         d_hi=channel.d_hi,
         open_sign=channel.open_sign,
     )
+
+
+_CHANNEL_PUBLICATION_HALF_CELL = 0.005
+_CHANNEL_DERIVED_SHOULDER_RAW_TOL = 0.0075
+_CHANNEL_DERIVED_SHOULDER_PROJECTED_TOL = 0.008
+
+
+def _channel_coordinate_matches(
+    published: float,
+    raw: float,
+    *,
+    tolerance: float = _CHANNEL_PUBLICATION_HALF_CELL,
+) -> bool:
+    """Match published and raw evidence within a semantic cell plus one float ULP."""
+
+    return abs(published - raw) <= tolerance + max(ulp(published), ulp(raw))
+
+
+def _channel_coordinate_in_span(
+    published: float,
+    raw_span: tuple[float, float],
+    *,
+    tolerance: float,
+) -> bool:
+    """Whether a published coordinate lies within a raw span modulo publication loss."""
+
+    return (
+        published >= raw_span[0]
+        or _channel_coordinate_matches(published, raw_span[0], tolerance=tolerance)
+    ) and (
+        published <= raw_span[1]
+        or _channel_coordinate_matches(published, raw_span[1], tolerance=tolerance)
+    )
+
+
+def _step_level_owns_channel(
+    channel: Channel,
+    feature: StepLevelFeature,
+    *,
+    face_levels: tuple[FaceLevel, ...],
+    risers: tuple[RiserEvidence, ...],
+) -> bool:
+    """Whether one body-local support carries the channel into the final Z ladder."""
+
+    if channel.depth_axis != feature.frame.axis:
+        return False
+    floor = channel.d_lo if channel.open_sign > 0 else channel.d_hi
+    shoulder_positions = (
+        channel.w_center - channel.width / 2,
+        channel.w_center + channel.width / 2,
+    )
+    if not any(_channel_coordinate_matches(floor, level) for level in feature.levels):
+        return False
+
+    # Scalar floor/shoulder values are not sufficient ownership evidence: a disconnected
+    # body may happen to establish the same values.  Couple the facts through one retained
+    # FaceLevel support and the risers whose public body_levels provenance names it.
+    long_span = (channel.lo, channel.hi)
+    for support in face_levels:
+        if (
+            support.x_span is None
+            or support.y_span is None
+            or not _channel_coordinate_matches(floor, support.z)
+        ):
+            continue
+        support_spans = {"x": support.x_span, "y": support.y_span}
+        if any(
+            not _channel_coordinate_matches(expected, actual)
+            for actual, expected in zip(support_spans[channel.long_axis], long_span, strict=True)
+        ):
+            continue
+        width_span = support_spans[channel.width_axis]
+        if not all(
+            _channel_coordinate_in_span(
+                shoulder,
+                width_span,
+                tolerance=_CHANNEL_DERIVED_SHOULDER_RAW_TOL,
+            )
+            for shoulder in shoulder_positions
+        ):
+            continue
+        if not any(
+            abs(retained.level - support.z) <= 1e-6
+            and all(
+                abs(actual - expected) <= 1e-6
+                for actual, expected in zip(retained.x_span, support.x_span, strict=True)
+            )
+            and all(
+                abs(actual - expected) <= 1e-6
+                for actual, expected in zip(retained.y_span, support.y_span, strict=True)
+            )
+            for retained in feature.level_supports
+        ):
+            continue
+
+        body_risers = tuple(
+            riser
+            for riser in risers
+            if riser.body_levels is not None
+            and any(body_level is support for body_level in riser.body_levels)
+            and _channel_coordinate_matches(channel.d_lo, riser.z_lo)
+            and _channel_coordinate_matches(channel.d_hi, riser.z_hi)
+        )
+        body_shoulders = tuple(
+            (shoulder.axis, shoulder.position)
+            for shoulder in project_step_shoulders(body_risers, levels=list(feature.levels))
+        )
+        if all(
+            any(
+                axis == channel.width_axis
+                and _channel_coordinate_matches(
+                    shoulder,
+                    position,
+                    tolerance=_CHANNEL_DERIVED_SHOULDER_PROJECTED_TOL,
+                )
+                for axis, position in body_shoulders
+            )
+            and any(
+                axis == channel.width_axis
+                and _channel_coordinate_matches(
+                    shoulder,
+                    position,
+                    tolerance=_CHANNEL_DERIVED_SHOULDER_PROJECTED_TOL,
+                )
+                for axis, position in feature.shoulders
+            )
+            for shoulder in shoulder_positions
+        ):
+            return True
+    return False
 
 
 def _convert_pad(pad: RaisedPad, ctx: ConvContext) -> PadFeature:
@@ -1647,7 +1777,11 @@ def build_part_model(
     through_level_zs = _through_step_level_zs(lowered_through_steps)
     through_shoulder_sites = _through_step_shoulder_sites(lowered_through_steps, bbox)
     if not profiles and rotational is None and multi_plate:
-        features.extend(convert(channel, ctx) for channel in channels)
+        for channel in channels:
+            channel_feature = convert(channel, ctx)
+            features.append(channel_feature)
+            if ownership is not None:
+                ownership.bind(channel, channel_feature, reason_code="channel_adapter")
 
     # Holes and hole patterns. A recognised pattern becomes one PatternFeature
     # (count× member-diameter + pattern dims); its member holes are NOT also
@@ -1978,16 +2112,28 @@ def build_part_model(
                     for owner_axis, owner_position in through_shoulder_sites
                 )
             )
-            features.append(
-                StepLevelFeature(
-                    frame=Frame((c.X, c.Y, bbox.min.Z), "z"),
-                    base=bbox.min.Z,
-                    levels=_levels,
-                    shoulders=_shoulders,
-                    datum=(bbox.min.X, bbox.min.Y, bbox.min.Z),
-                    level_supports=_level_supports,
-                )
+            step_level_feature = StepLevelFeature(
+                frame=Frame((c.X, c.Y, bbox.min.Z), "z"),
+                base=bbox.min.Z,
+                levels=_levels,
+                shoulders=_shoulders,
+                datum=(bbox.min.X, bbox.min.Y, bbox.min.Z),
+                level_supports=_level_supports,
             )
+            features.append(step_level_feature)
+            if ownership is not None and not multi_plate:
+                for channel in channels:
+                    if _step_level_owns_channel(
+                        channel,
+                        step_level_feature,
+                        face_levels=face_levels,
+                        risers=risers,
+                    ):
+                        ownership.absorb_into(
+                            channel,
+                            step_level_feature,
+                            reason_code="channel_step_level_owner",
+                        )
 
     # Chamfers (#560/#1254) — called out C{leg} / {leg}×{angle}°. The package recognises
     # both oblique planar and conical turned forms; both lower through the same converter and

--- a/src/draftwright/recognition_ownership.py
+++ b/src/draftwright/recognition_ownership.py
@@ -50,6 +50,11 @@ GROUPABLE_FAMILIES = frozenset({"holes", "pockets", "slots"})
 # duplicate feature or requirement.
 NESTED_FAMILIES = frozenset({"countersinks"})
 
+# These accepted occurrences have a supported consumer path, but the final owner depends on
+# Draftwright's cross-family classification.  The conversion site must record either the direct
+# adapter or the exact aggregate feature that intentionally absorbs the occurrence.
+CONDITIONAL_FAMILIES = frozenset({"channels"})
+
 OwnershipDisposition = Literal["represented", "absorbed"]
 PolicyDisposition = OwnerlessDisposition
 OccurrenceStatus = Literal[
@@ -65,6 +70,7 @@ OccurrenceStatus = Literal[
 _REPRESENTED_REASON_CODES = frozenset(
     {
         "direct_adapter",
+        "channel_adapter",
         "hole_adapter",
         "pmi_split_member",
         "pocket_adapter",
@@ -79,7 +85,10 @@ _ABSORBED_REASON_CODES = frozenset(
         "slot_pattern_member",
     }
 )
+_FEATURE_ABSORPTION_REASON_CODES = frozenset({"channel_step_level_owner"})
 _REASON_FAMILY = {
+    "channel_adapter": "channels",
+    "channel_step_level_owner": "channels",
     "countersink_hole_owner": "countersinks",
     "grouped_hole_member": "holes",
     "hole_adapter": "holes",
@@ -92,6 +101,7 @@ _REASON_FAMILY = {
 }
 _NESTED_OWNER_FAMILY = {"countersink_hole_owner": "holes"}
 _NESTED_OWNER_FIELD = {"countersink_hole_owner": "csink"}
+_FEATURE_ABSORPTION_OWNER_KIND = {"channel_step_level_owner": "step_level"}
 
 
 @dataclass(frozen=True)
@@ -144,6 +154,7 @@ class RecognitionOwnership:
     expected_direct: tuple[FeatureRef, ...]
     expected_groupable: tuple[FeatureRef, ...]
     expected_nested: tuple[FeatureRef, ...]
+    expected_conditional: tuple[FeatureRef, ...]
     bindings: tuple[OccurrenceBinding, ...]
     policy_outcomes: tuple[OccurrencePolicyOutcome, ...]
 
@@ -151,7 +162,12 @@ class RecognitionOwnership:
     def owner_expected_occurrences(self) -> tuple[FeatureRef, ...]:
         """Supported occurrences whose adapters must record an IR owner."""
 
-        return self.expected_direct + self.expected_groupable + self.expected_nested
+        return (
+            self.expected_direct
+            + self.expected_groupable
+            + self.expected_nested
+            + self.expected_conditional
+        )
 
     @property
     def expected_occurrences(self) -> tuple[FeatureRef, ...]:
@@ -190,8 +206,7 @@ class RecognitionOwnership:
         """Classify only the ownership contracts implemented so far.
 
         ``unclassified`` is deliberately not a report disposition.  It is the migration state
-        for remaining nested and classification-only families whose ownership rules are not
-        implemented.
+        for remaining conditional cross-family records whose ownership rules are not implemented.
         """
 
         outcome = self.outcome_for(occurrence)
@@ -234,8 +249,18 @@ class RecognitionOwnershipBuilder:
             for occurrence in evidence.features
             if evidence.family(occurrence) in NESTED_FAMILIES
         )
+        self._expected_conditional = tuple(
+            occurrence
+            for occurrence in evidence.features
+            if evidence.family(occurrence) in CONDITIONAL_FAMILIES
+        )
         self._by_record_identity: dict[int, list[tuple[FeatureRef, object]]] = {}
-        for occurrence in self._expected_direct + self._expected_groupable + self._expected_nested:
+        for occurrence in (
+            self._expected_direct
+            + self._expected_groupable
+            + self._expected_nested
+            + self._expected_conditional
+        ):
             record = evidence.record(occurrence)
             self._by_record_identity.setdefault(id(record), []).append((occurrence, record))
         self._bindings: list[OccurrenceBinding] = []
@@ -243,7 +268,10 @@ class RecognitionOwnershipBuilder:
         expected_ids = {
             id(occurrence)
             for occurrence in (
-                self._expected_direct + self._expected_groupable + self._expected_nested
+                self._expected_direct
+                + self._expected_groupable
+                + self._expected_nested
+                + self._expected_conditional
             )
         }
         if any(id(outcome.occurrence) in expected_ids for outcome in self._policy_outcomes):
@@ -379,6 +407,35 @@ class RecognitionOwnershipBuilder:
             )
         )
 
+    def absorb_into(self, record: object, feature: object, *, reason_code: str) -> None:
+        """Bind an exact occurrence to a consumer-selected aggregate IR owner."""
+
+        if type(reason_code) is not str or reason_code not in _FEATURE_ABSORPTION_REASON_CODES:
+            raise ValueError("unknown feature-absorption ownership reason_code")
+        occurrence = self._occurrence_for(record)
+        if self.evidence.family(occurrence) != _REASON_FAMILY[reason_code]:
+            raise ValueError("feature-absorption reason_code does not match occurrence family")
+        if getattr(feature, "kind", None) != _FEATURE_ABSORPTION_OWNER_KIND[reason_code]:
+            raise ValueError("feature-absorption reason_code does not match IR owner kind")
+        if id(occurrence) in self._bound_occurrence_ids:
+            raise ValueError("recognition occurrence already has an IR owner")
+        if id(feature) in self._owned_feature_ids and any(
+            binding.feature is feature
+            and (binding.disposition != "absorbed" or binding.reason_code != reason_code)
+            for binding in self._bindings
+        ):
+            raise ValueError("IR feature already has an incompatible recognition owner")
+        self._bound_occurrence_ids.add(id(occurrence))
+        self._owned_feature_ids.add(id(feature))
+        self._bindings.append(
+            OccurrenceBinding(
+                occurrence,
+                feature,
+                disposition="absorbed",
+                reason_code=reason_code,
+            )
+        )
+
     def remap_feature(
         self,
         source: object,
@@ -480,6 +537,7 @@ class RecognitionOwnershipBuilder:
             expected_direct=self._expected_direct,
             expected_groupable=self._expected_groupable,
             expected_nested=self._expected_nested,
+            expected_conditional=self._expected_conditional,
             bindings=tuple(self._bindings),
             policy_outcomes=self._policy_outcomes,
         )

--- a/tests/test_issue_1438_channel_ownership.py
+++ b/tests/test_issue_1438_channel_ownership.py
@@ -1,0 +1,358 @@
+"""#1438 — accepted channels retain their exact conditional IR ownership."""
+
+from __future__ import annotations
+
+import pytest
+from b123d_recognisers import Channel, FaceLevel
+from b123d_recognisers.evidence import build_recognition_evidence
+from build123d import Box, Compound, Cylinder, Pos, Rot
+
+from draftwright import build_drawing
+from draftwright.model.detect import _channel_coordinate_matches, _step_level_owns_channel
+from draftwright.model.ir import Frame, StepLevelFeature
+from draftwright.recognition_ownership import CONDITIONAL_FAMILIES, RecognitionOwnershipBuilder
+
+
+def _u_channel():
+    width = 50.0
+    wall = 12.5
+    part = (
+        Box(50, width, 12)
+        + Pos(0, -width / 2 + wall / 2, 15) * Box(50, wall, 18)
+        + Pos(0, width / 2 - wall / 2, 15) * Box(50, wall, 18)
+    )
+    return part
+
+
+def _monolithic_rebate():
+    return Box(80, 60, 30) - Pos(0, 0, 7.5) * Box(80, 20, 15)
+
+
+def _two_monolithic_rebates():
+    return (
+        Box(120, 100, 30)
+        - Pos(0, -25, 7.5) * Box(120, 15, 15)
+        - Pos(0, 25, 7.5) * Box(120, 15, 15)
+    )
+
+
+def _channel_occurrence(ownership):
+    (occurrence,) = tuple(
+        occurrence
+        for occurrence in ownership.evidence.features
+        if ownership.evidence.family(occurrence) == "channels"
+    )
+    return occurrence
+
+
+def test_conditional_family_roster_is_explicit() -> None:
+    assert CONDITIONAL_FAMILIES == {"channels"}
+
+
+def test_multi_plate_channel_is_represented_by_its_exact_channel_feature() -> None:
+    drawing = build_drawing(_u_channel())
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    occurrence = _channel_occurrence(ownership)
+    binding = ownership.binding_for(occurrence)
+
+    assert binding is not None
+    assert binding.disposition == "represented"
+    assert binding.reason_code == "channel_adapter"
+    assert binding.feature.kind == "channel"
+    assert any(binding.feature is feature for feature in drawing.model().features)
+    assert ownership.status(occurrence) == "represented"
+    assert ownership.unexpectedly_missing == ()
+
+
+def test_monolithic_rebate_channel_is_absorbed_by_the_exact_step_ladder() -> None:
+    drawing = build_drawing(_monolithic_rebate())
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    occurrence = _channel_occurrence(ownership)
+    binding = ownership.binding_for(occurrence)
+
+    assert binding is not None
+    assert binding.disposition == "absorbed"
+    assert binding.reason_code == "channel_step_level_owner"
+    assert binding.feature.kind == "step_level"
+    assert any(binding.feature is feature for feature in drawing.model().features)
+    assert ownership.status(occurrence) == "absorbed"
+    assert ownership.unexpectedly_missing == ()
+
+
+def test_cross_axis_rebate_does_not_inherit_an_unrelated_z_step_ladder() -> None:
+    drawing = build_drawing(Rot(90, 0, 0) * _monolithic_rebate())
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    occurrence = _channel_occurrence(ownership)
+    record = ownership.evidence.record(occurrence)
+
+    assert record.depth_axis == "y"
+    assert any(feature.kind == "step_level" for feature in drawing.model().features)
+    assert ownership.binding_for(occurrence) is None
+    assert ownership.status(occurrence) == "unexpectedly_missing"
+    assert ownership.unexpectedly_missing == (occurrence,)
+
+
+def test_disconnected_body_cannot_donate_a_channel_step_ladder_owner() -> None:
+    downward_rebate = Box(80, 60, 30) - Pos(0, 0, -7.5) * Box(80, 20, 15)
+    part = Compound(
+        children=[
+            Pos(-50, 0, 0) * downward_rebate,
+            Pos(50, 0.4, 0) * _monolithic_rebate(),
+        ]
+    )
+    drawing = build_drawing(part)
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    occurrences = tuple(
+        occurrence
+        for occurrence in ownership.evidence.features
+        if ownership.evidence.family(occurrence) == "channels"
+    )
+    downward = next(
+        occurrence
+        for occurrence in occurrences
+        if ownership.evidence.record(occurrence).open_sign < 0
+    )
+    upward = next(
+        occurrence
+        for occurrence in occurrences
+        if ownership.evidence.record(occurrence).open_sign > 0
+    )
+    ladder = next(feature for feature in drawing.model().features if feature.kind == "step_level")
+
+    assert ladder.level_supports[0].x_span == pytest.approx((10.0, 90.0))
+    assert ownership.binding_for(downward) is None
+    assert ownership.status(downward) == "unexpectedly_missing"
+    assert ownership.status(upward) == "absorbed"
+
+
+def test_equal_face_level_values_do_not_erase_body_local_channel_ownership() -> None:
+    downward_rebate = Box(80, 60, 30) - Pos(0, 0, -7.5) * Box(80, 20, 15)
+    drawing = build_drawing(Compound(children=[downward_rebate, _monolithic_rebate()]))
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    level_occurrences = tuple(
+        occurrence
+        for occurrence in ownership.evidence.features
+        if ownership.evidence.family(occurrence) == "step_levels"
+    )
+    assert len(level_occurrences) == 2
+    assert ownership.evidence.record(level_occurrences[0]) == ownership.evidence.record(
+        level_occurrences[1]
+    )
+    assert ownership.evidence.record(level_occurrences[0]) is not ownership.evidence.record(
+        level_occurrences[1]
+    )
+
+    channel_occurrences = tuple(
+        occurrence
+        for occurrence in ownership.evidence.features
+        if ownership.evidence.family(occurrence) == "channels"
+    )
+    downward = next(
+        occurrence
+        for occurrence in channel_occurrences
+        if ownership.evidence.record(occurrence).open_sign < 0
+    )
+    upward = next(
+        occurrence
+        for occurrence in channel_occurrences
+        if ownership.evidence.record(occurrence).open_sign > 0
+    )
+
+    assert ownership.binding_for(downward) is None
+    assert ownership.status(downward) == "unexpectedly_missing"
+    assert ownership.status(upward) == "absorbed"
+
+
+@pytest.mark.parametrize(
+    "translation",
+    [
+        (0.123, 0.0, 0.0),
+        (0.0, 0.123, 0.0),
+        (0.0, 0.0, 0.123),
+        (0.0, 1_000_000.123, 0.0),
+        (0.0, 2_150_000_000.005, 0.0),
+    ],
+)
+def test_channel_publication_rounding_keeps_the_exact_body_owner(translation) -> None:
+    drawing = build_drawing(Pos(*translation) * _monolithic_rebate())
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    occurrence = _channel_occurrence(ownership)
+    binding = ownership.binding_for(occurrence)
+
+    assert binding is not None
+    assert binding.disposition == "absorbed"
+    assert binding.reason_code == "channel_step_level_owner"
+
+
+def test_channel_publication_half_cell_boundary_is_explicit() -> None:
+    assert _channel_coordinate_matches(10.0, 10.005)
+    assert _channel_coordinate_matches(1_000_000.0, 1_000_000.005)
+    assert _channel_coordinate_matches(2_150_000_000.01, 2_150_000_000.005)
+    assert not _channel_coordinate_matches(10.0, 10.0051)
+    assert not _channel_coordinate_matches(2_150_000_000.01, 2_150_000_000.004)
+
+
+@pytest.mark.parametrize("offset", [0.0049, 0.0051])
+def test_independently_published_center_and_width_keep_their_owner(offset) -> None:
+    part = Box(80, 60, 30) - Pos(0, offset, 7.5) * Box(80, 20.0049, 15)
+    drawing = build_drawing(part)
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    occurrence = _channel_occurrence(ownership)
+    binding = ownership.binding_for(occurrence)
+
+    assert binding is not None
+    assert binding.disposition == "absorbed"
+    assert binding.reason_code == "channel_step_level_owner"
+
+
+def test_derived_shoulder_publication_boundary_is_explicit() -> None:
+    assert _channel_coordinate_matches(10.0, 10.0075, tolerance=0.0075)
+    assert _channel_coordinate_matches(10.0, 10.008, tolerance=0.008)
+    assert not _channel_coordinate_matches(10.0, 10.0076, tolerance=0.0075)
+    assert not _channel_coordinate_matches(10.0, 10.0081, tolerance=0.008)
+
+
+def test_channel_is_not_absorbed_when_an_exact_shoulder_left_the_final_ladder() -> None:
+    through_step = Box(40, 40, 20) - Pos(15, 10, 0) * Box(20, 20, 30)
+    part = Compound(children=[_monolithic_rebate(), Pos(0, 10, 100) * through_step])
+    drawing = build_drawing(part)
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    occurrence = _channel_occurrence(ownership)
+    channel = ownership.evidence.record(occurrence)
+    ladder = next(feature for feature in drawing.model().features if feature.kind == "step_level")
+
+    assert channel.w_center == pytest.approx(0.0)
+    assert channel.width == pytest.approx(20.0)
+    assert ladder.levels == pytest.approx((0.0,))
+    assert ladder.shoulders == (("y", -10.0),)
+    assert ownership.binding_for(occurrence) is None
+    assert ownership.status(occurrence) == "unexpectedly_missing"
+
+
+def test_channel_owner_predicate_fails_closed_without_complete_floor_support() -> None:
+    channel = Channel(
+        width_axis="y",
+        long_axis="x",
+        width=20.0,
+        w_center=0.0,
+        lo=-40.0,
+        hi=40.0,
+        d_lo=0.0,
+        d_hi=15.0,
+        open_sign=1,
+    )
+    missing_floor = StepLevelFeature(
+        frame=Frame((0.0, 0.0, -15.0), "z"),
+        base=-15.0,
+        levels=(5.0,),
+    )
+    floor_only = StepLevelFeature(
+        frame=Frame((0.0, 0.0, -15.0), "z"),
+        base=-15.0,
+        levels=(0.0,),
+    )
+
+    assert not _step_level_owns_channel(channel, missing_floor, face_levels=(), risers=())
+    assert not _step_level_owns_channel(
+        channel,
+        floor_only,
+        face_levels=(FaceLevel(0.0, None, (-10.0, 10.0)),),
+        risers=(),
+    )
+    assert not _step_level_owns_channel(
+        channel,
+        floor_only,
+        face_levels=(FaceLevel(0.0, (-40.0, 40.0), (-5.0, 5.0)),),
+        risers=(),
+    )
+
+
+def test_multiple_exact_channels_may_share_their_final_step_ladder() -> None:
+    drawing = build_drawing(_two_monolithic_rebates())
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    occurrences = tuple(
+        occurrence
+        for occurrence in ownership.evidence.features
+        if ownership.evidence.family(occurrence) == "channels"
+    )
+    bindings = tuple(ownership.binding_for(occurrence) for occurrence in occurrences)
+
+    assert len(occurrences) == 2
+    assert all(binding is not None for binding in bindings)
+    owners = {id(binding.feature) for binding in bindings if binding is not None}
+    assert len(owners) == 1
+    assert all(
+        binding is not None
+        and binding.disposition == "absorbed"
+        and binding.reason_code == "channel_step_level_owner"
+        for binding in bindings
+    )
+    assert ownership.unexpectedly_missing == ()
+
+
+def test_unbound_channel_fails_closed_as_unexpectedly_missing() -> None:
+    evidence = build_recognition_evidence(_u_channel())
+    ownership = RecognitionOwnershipBuilder(evidence).snapshot()
+    occurrence = _channel_occurrence(ownership)
+
+    assert ownership.expected_conditional == (occurrence,)
+    assert occurrence in ownership.owner_expected_occurrences
+    assert ownership.status(occurrence) == "unexpectedly_missing"
+    assert ownership.unexpectedly_missing == (occurrence,)
+
+
+def test_feature_absorption_rejects_unknown_wrong_family_wrong_owner_and_duplicates() -> None:
+    part = _monolithic_rebate() - Pos(0, 20, 0) * Cylinder(2, 30)
+    evidence = build_recognition_evidence(part)
+    builder = RecognitionOwnershipBuilder(evidence)
+    channel_occurrence = next(
+        occurrence for occurrence in evidence.features if evidence.family(occurrence) == "channels"
+    )
+    channel = evidence.record(channel_occurrence)
+    hole = next(
+        evidence.record(occurrence)
+        for occurrence in evidence.features
+        if evidence.family(occurrence) == "holes"
+    )
+
+    class StepOwner:
+        kind = "step_level"
+
+    with pytest.raises(ValueError, match="unknown feature-absorption ownership reason_code"):
+        builder.absorb_into(channel, StepOwner(), reason_code="future_contract")
+    with pytest.raises(ValueError, match="does not match occurrence family"):
+        builder.absorb_into(hole, StepOwner(), reason_code="channel_step_level_owner")
+    with pytest.raises(ValueError, match="does not match IR owner kind"):
+        builder.absorb_into(channel, object(), reason_code="channel_step_level_owner")
+
+    occupied_owner = StepOwner()
+    builder.bind(hole, occupied_owner, reason_code="hole_adapter")
+    with pytest.raises(ValueError, match="already has an incompatible recognition owner"):
+        builder.absorb_into(channel, occupied_owner, reason_code="channel_step_level_owner")
+
+    owner = StepOwner()
+    builder.absorb_into(channel, owner, reason_code="channel_step_level_owner")
+    with pytest.raises(ValueError, match="already has an IR owner"):
+        builder.absorb_into(channel, owner, reason_code="channel_step_level_owner")
+
+    binding = builder.snapshot().binding_for(channel_occurrence)
+    assert binding is not None
+    assert binding.feature is owner


### PR DESCRIPTION
Part of #1438.

## Summary

- classify every accepted raw channel occurrence as directly represented, honestly absorbed by its final step ladder, or unexpectedly missing
- bind multi-axis U-channels to their exact `ChannelFeature` and monolithic Z-depth rebates only to a body-local, retained `StepLevelFeature` owner
- couple rebate ownership through exact provider `FaceLevel` identity, matching depth-span risers, retained floor support, and both final shoulders
- account for the provider's two-decimal Channel publication and three-decimal projected shoulders with bounded half-cell/composed tolerances plus one scale-aware float ULP
- add no recognition rescan, private provider API, persistent topology/report ID, generated artefact, or visual/model/render change

## Evidence

- direct U-channel, monolithic rebate, two-channel shared aggregate, cross-axis, missing-shoulder, displaced-body, equal-valued-body, fractional centre/width, X/Y/Z translation, billion-scale translation, and just-outside-boundary cases are covered
- full exact-head gate: 6,485 passed, 5 skipped, 2 expected xfailed
- total coverage 95.67%; changed executable lines 100%
- Ruff, formatting, mypy, codespell, strict docs, and diff checks passed

## Independent review

Three fresh independent reviews inspected exact head `2b1815155164c0b7a9fe55a9da2e07b135e959e5` / tree `4a86939a2897ad3bc257b103ad1de1814c3b49fc` after all findings were fixed:

- ADR review: CLEAN, no nits
- recognition-ownership contract review: CLEAN, no nits
- Google-style code-quality review: CLEAN, no nits

## ADR review

Reviewed against ADRs 0010, 0011, 0013, 0014, 0015, 0017 Amendment 16, and 0020. Recognition stays in the raw conversion boundary; declared and successful framed builds remain recognition/ownership-free; the IR/compiler/placement waist and shared annotation solve are unchanged.