### PR TITLE
Track turned-step occurrence ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- Accepted turned-step occurrences now retain the conversion decision that already gives an
+  ordinary profile band its exact `StepFeature` or absorbs a groove-floor band into the exact
+  same-run `GrooveFeature`. The takeover must be one-to-one in both directions, so an ambiguous
+  groove, an adjacent band inside its positional tolerance, or any missing final owner fails closed
+  as `unexpectedly_missing`, with no second scan, persistent ID, generated artefact, or visual
+  change (#1438, ADR 0017 Amendment 17).
+
 - Accepted channel occurrences now receive an exact conditional consumer outcome. A genuine
   multi-axis plate channel is `represented` by its `ChannelFeature`; a monolithic Z-depth rebate is
   `absorbed` only when one retained body-local support carries its floor and both shoulders into the

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -17,6 +17,8 @@
   14 records settled ownerless consumer-policy outcomes per accepted occurrence. Amendment 15
   records each accepted countersink as absorbed by its exact same-run hole owner. Amendment 16
   records the conditional direct-or-step-ladder owner of every accepted channel occurrence.
+  Amendment 17 records each turned-profile step as directly represented or absorbed by its exact
+  groove owner.
 - **Date:** 2026-08-03
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -435,6 +437,33 @@ compiled-plan dependency, annotation placement, generated artefact, or visual ch
 declared build; ADR 0013 keeps geometry recognition separate from consumer classification; and ADR
 0020's framed evidence boundary is unchanged.
 
+## Amendment 17 — Turned steps retain direct or groove ownership
+
+Every accepted turned-step occurrence now enters the supported-owner denominator. An ordinary
+profile band records the exact `StepFeature` created by its existing adapter as `represented`. When
+the established groove-precedence rule suppresses a narrow floor band, that step is `absorbed` by
+the exact `GrooveFeature` created from the same-run groove record. The groove retains its own
+represented occurrence outcome; sharing its final feature does not manufacture a duplicate
+requirement.
+
+The relationship is captured where the consumer already evaluates
+`groove_owns_turned_step_band()`. A band with no matching groove keeps its direct adapter. A
+groove-suppressed band is absorbed only when exactly one groove from its unambiguously assigned
+body-local profile owns it **and that groove owns exactly one accepted step band**. Ambiguity in
+either direction leaves every affected accepted step `unexpectedly_missing`; in particular, a
+sub-millimetre adjacent band inside the positional tolerance cannot silently share a groove whose
+width and floor diameter do not represent it. Both the conversion decision and the ownership
+ledger enforce the groove-to-step cardinality, so another builder caller cannot manufacture an
+invalid snapshot. Feature order, equal diameters, labels, topology indices, and object addresses
+are never used as persistent correspondence.
+
+This consumes only released public `TurnedStep`, `Groove`, profile-key, and aggregate records. It
+adds no provider API, recognition scan, persistent/report identity, manufacturing inference,
+compiled-plan dependency, annotation placement, generated artefact, or visual change. ADRs 0010
+and 0014 remain untouched; ADRs 0011 and 0015 retain the semantic Sheet/IR waist and
+recognition-free declared build; ADR 0013 keeps provider recognition separate from consumer
+precedence; and ADR 0020's framed evidence boundary is unchanged.
+
 ## Accepted Contract
 
 ### 1. One orchestration owns the recognition universe
@@ -481,8 +510,9 @@ not accept an arbitrary aggregate and then attempt to prove it came from the sam
 This originally answered **result-to-build provenance only**. Amendment 12 records exact
 occurrence→IR ownership for unconditional 1:1 adapters, and Amendment 13 adds explicit singleton,
 grouped, and pattern-member ownership for holes, slots, and pockets. Amendment 15 adds exact nested
-countersink→hole ownership, and Amendment 16 adds conditional direct-or-step-ladder channel
-ownership. Remaining supported conditional families, and the general
+countersink→hole ownership, Amendment 16 adds conditional direct-or-step-ladder channel ownership,
+and Amendment 17 adds direct-or-groove turned-step ownership. Remaining supported conditional
+families, and the general
 feature→requirement→annotation correspondence, remain subjects of the evidence gates below. Settled
 unsupported, evidence-only, and deferred policy is explicit per accepted occurrence under Amendment
 14.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -212,8 +212,9 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   aggregate membership. Ownerless outcomes are projected from the existing consumer capability
   declaration, not a second policy table. It exposes no persistent topology/order/address ID.
   Unconditional 1:1 adapters, singleton/grouped/pattern hole/slot/pocket members, nested
-  countersinks, conditional channel owners, and settled unsupported/deferred/evidence-only
-  occurrences are classified; remaining conditional cross-family records stay unclassified.
+  countersinks, conditional channel and turned-step owners, and settled
+  unsupported/deferred/evidence-only occurrences are classified; remaining conditional
+  cross-family records stay unclassified.
 - **`recogniser_policy.py`** — the rank-0 Draftwright-owned source for reviewed unsupported,
   deferred, and geometry-only family policy. Both the cross-repository capability declaration and
   the run-local occurrence ledger project this same immutable data; recognition remains
@@ -570,8 +571,8 @@ policy) live in `CLAUDE.md`. This is the per-ADR status trail; each ADR's
   compiler grammar and placement solve, and a side-normal footprint is filtered from the legacy
   Z-level projection only when exact support correspondence proves that ownership. No renderer
   consumes the provider record or places an annotation at a caller-supplied page coordinate.
-  Amendments 12–16 give unconditional 1:1 adapters, hole/slot/pocket singleton/grouped/pattern
-  members, nested countersinks, and conditional channel decisions exact run-local
+  Amendments 12–17 give unconditional 1:1 adapters, hole/slot/pocket singleton/grouped/pattern
+  members, nested countersinks, and conditional channel/turned-step decisions exact run-local
   occurrence→final-IR ownership in `BuildState`, while settled unsupported, evidence-only, and
   deferred occurrences have explicit ownerless outcomes. Remaining conditional families, plus general
   IR-feature→requirement correspondence, are not yet provided. The original

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -1962,6 +1962,7 @@ def build_part_model(
     # Body-local turned profiles → step segments; else external bosses → diameters. Profile
     # identity owns the axis line, so parallel shafts never inherit the part bbox centre or
     # each other's groove bands (#1357).
+    groove_owned_steps: list[tuple[TurnedStep, Groove]] = []
     if profiles:
         grooves_by_profile: dict[int, list[Groove]] = {id(profile): [] for profile in profiles}
         for groove in grooves:
@@ -1969,19 +1970,42 @@ def build_part_model(
             if owners:
                 grooves_by_profile[id(owners[0])].append(groove)
         for profile in profiles:
-            for s in profile.steps:
+            step_groove_candidates = tuple(
+                (
+                    step,
+                    tuple(
+                        groove
+                        for groove in grooves_by_profile[id(profile)]
+                        if groove_owns_turned_step_band(groove, step)
+                    ),
+                )
+                for step in profile.steps
+            )
+            groove_candidate_counts = Counter(
+                id(groove)
+                for _step, candidate_grooves in step_groove_candidates
+                for groove in candidate_grooves
+            )
+            for s, step_groove_owners in step_groove_candidates:
                 # Skip the band a groove owns (its callout dimensions width + floor ø). Match
                 # on axial POSITION, not diameter: a narrow groove's step is reported at the
                 # WALL OD (local_od's pad engulfs both walls when the groove is < ~1.4 mm), so
                 # a floor-ø match would silently miss the common circlip case. The groove centre
                 # lies within its own step span; the short-length guard keeps a merged shaft run
-                # from matching.
-                if any(
-                    groove_owns_turned_step_band(groove, s)
-                    for groove in grooves_by_profile[id(profile)]
-                ):
+                # from matching. Require a one-to-one relation in both directions: a sub-mm
+                # neighbour can fall within the position tolerance of the same groove, whose
+                # width/floor diameter cannot represent both accepted physical bands.
+                if step_groove_owners:
+                    if (
+                        len(step_groove_owners) == 1
+                        and groove_candidate_counts[id(step_groove_owners[0])] == 1
+                    ):
+                        groove_owned_steps.append((s, step_groove_owners[0]))
                     continue
-                features.append(convert(s, ctx))
+                step_feature = convert(s, ctx)
+                features.append(step_feature)
+                if ownership is not None:
+                    ownership.bind(s, step_feature, reason_code="turned_step_adapter")
         # A narrow external band nested under / beside a larger OD reads as that OD in
         # local_od's max(), so it never becomes a step diameter and goes silently
         # undimensioned (#298). Emit each band the silhouette steps miss as a boss, so
@@ -2193,7 +2217,17 @@ def build_part_model(
     # is round stock and classifies rotational, yet the groove still needs its own callout.
     # The recogniser self-gates on external OD bands, so a prismatic part yields none.
     for groove in grooves:
-        append_direct(groove)
+        groove_feature = convert(groove, ctx)
+        features.append(groove_feature)
+        if ownership is not None:
+            ownership.bind(groove, groove_feature)
+            for step, owner_groove in groove_owned_steps:
+                if owner_groove is groove:
+                    ownership.absorb_into(
+                        step,
+                        groove_feature,
+                        reason_code="turned_step_groove_owner",
+                    )
 
     # Rotational furniture — OD + centrelines + concentric bore leaders (#237). Its
     # presence marks the part rotational; emitted from the classification (od, bores).

--- a/src/draftwright/recognition_ownership.py
+++ b/src/draftwright/recognition_ownership.py
@@ -53,7 +53,7 @@ NESTED_FAMILIES = frozenset({"countersinks"})
 # These accepted occurrences have a supported consumer path, but the final owner depends on
 # Draftwright's cross-family classification.  The conversion site must record either the direct
 # adapter or the exact aggregate feature that intentionally absorbs the occurrence.
-CONDITIONAL_FAMILIES = frozenset({"channels"})
+CONDITIONAL_FAMILIES = frozenset({"channels", "turned_steps"})
 
 OwnershipDisposition = Literal["represented", "absorbed"]
 PolicyDisposition = OwnerlessDisposition
@@ -75,6 +75,7 @@ _REPRESENTED_REASON_CODES = frozenset(
         "pmi_split_member",
         "pocket_adapter",
         "slot_adapter",
+        "turned_step_adapter",
     }
 )
 _ABSORBED_REASON_CODES = frozenset(
@@ -85,7 +86,9 @@ _ABSORBED_REASON_CODES = frozenset(
         "slot_pattern_member",
     }
 )
-_FEATURE_ABSORPTION_REASON_CODES = frozenset({"channel_step_level_owner"})
+_FEATURE_ABSORPTION_REASON_CODES = frozenset(
+    {"channel_step_level_owner", "turned_step_groove_owner"}
+)
 _REASON_FAMILY = {
     "channel_adapter": "channels",
     "channel_step_level_owner": "channels",
@@ -98,10 +101,18 @@ _REASON_FAMILY = {
     "pocket_pattern_member": "pockets",
     "slot_adapter": "slots",
     "slot_pattern_member": "slots",
+    "turned_step_adapter": "turned_steps",
+    "turned_step_groove_owner": "turned_steps",
 }
 _NESTED_OWNER_FAMILY = {"countersink_hole_owner": "holes"}
 _NESTED_OWNER_FIELD = {"countersink_hole_owner": "csink"}
-_FEATURE_ABSORPTION_OWNER_KIND = {"channel_step_level_owner": "step_level"}
+_FEATURE_ABSORPTION_OWNER_KIND = {
+    "channel_step_level_owner": "step_level",
+    "turned_step_groove_owner": "groove",
+}
+_FEATURE_ABSORPTION_EXISTING_OWNER = {
+    "turned_step_groove_owner": ("grooves", "direct_adapter"),
+}
 
 
 @dataclass(frozen=True)
@@ -419,10 +430,33 @@ class RecognitionOwnershipBuilder:
             raise ValueError("feature-absorption reason_code does not match IR owner kind")
         if id(occurrence) in self._bound_occurrence_ids:
             raise ValueError("recognition occurrence already has an IR owner")
-        if id(feature) in self._owned_feature_ids and any(
-            binding.feature is feature
-            and (binding.disposition != "absorbed" or binding.reason_code != reason_code)
-            for binding in self._bindings
+        existing_bindings = tuple(
+            binding for binding in self._bindings if binding.feature is feature
+        )
+        existing_owner = _FEATURE_ABSORPTION_EXISTING_OWNER.get(reason_code)
+        if existing_owner is not None and not any(
+            binding.disposition == "represented"
+            and self.evidence.family(binding.occurrence) == existing_owner[0]
+            and binding.reason_code == existing_owner[1]
+            for binding in existing_bindings
+        ):
+            raise ValueError("feature absorption requires an existing exact recognition owner")
+        if reason_code == "turned_step_groove_owner" and any(
+            binding.disposition == "absorbed" and binding.reason_code == "turned_step_groove_owner"
+            for binding in existing_bindings
+        ):
+            raise ValueError("groove feature already absorbs a turned-step occurrence")
+        if any(
+            not (
+                (binding.disposition == "absorbed" and binding.reason_code == reason_code)
+                or (
+                    existing_owner is not None
+                    and binding.disposition == "represented"
+                    and self.evidence.family(binding.occurrence) == existing_owner[0]
+                    and binding.reason_code == existing_owner[1]
+                )
+            )
+            for binding in existing_bindings
         ):
             raise ValueError("IR feature already has an incompatible recognition owner")
         self._bound_occurrence_ids.add(id(occurrence))

--- a/tests/test_issue_1438_channel_ownership.py
+++ b/tests/test_issue_1438_channel_ownership.py
@@ -46,7 +46,7 @@ def _channel_occurrence(ownership):
 
 
 def test_conditional_family_roster_is_explicit() -> None:
-    assert CONDITIONAL_FAMILIES == {"channels"}
+    assert CONDITIONAL_FAMILIES == {"channels", "turned_steps"}
 
 
 def test_multi_plate_channel_is_represented_by_its_exact_channel_feature() -> None:

--- a/tests/test_issue_1438_turned_step_ownership.py
+++ b/tests/test_issue_1438_turned_step_ownership.py
@@ -1,0 +1,228 @@
+"""#1438 — accepted turned steps retain direct or groove ownership."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from b123d_recognisers.evidence import build_recognition_evidence
+from build123d import Align, Cylinder, Pos, import_step
+
+from draftwright import build_drawing
+from draftwright.model import detect
+from draftwright.recognition_ownership import (
+    RecognitionOwnershipBuilder,
+)
+
+FIXTURES = Path(__file__).parent / "fixtures" / "evaluation"
+
+
+def _stepped_shaft():
+    return Cylinder(20, 60) + Pos(0, 0, 45) * Cylinder(30, 30)
+
+
+def _occurrences(ownership, family: str):
+    return tuple(
+        occurrence
+        for occurrence in ownership.evidence.features
+        if ownership.evidence.family(occurrence) == family
+    )
+
+
+def test_each_plain_turned_step_is_represented_by_its_exact_step_feature() -> None:
+    drawing = build_drawing(_stepped_shaft())
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    occurrences = _occurrences(ownership, "turned_steps")
+    bindings = tuple(ownership.binding_for(occurrence) for occurrence in occurrences)
+
+    assert len(occurrences) == 2
+    assert all(binding is not None for binding in bindings)
+    assert all(
+        binding is not None
+        and binding.disposition == "represented"
+        and binding.reason_code == "turned_step_adapter"
+        and binding.feature.kind == "step"
+        and any(binding.feature is feature for feature in drawing.model().features)
+        for binding in bindings
+    )
+    assert ownership.unexpectedly_missing == ()
+
+
+def test_groove_floor_step_is_absorbed_by_the_exact_groove_feature() -> None:
+    drawing = build_drawing(import_step(FIXTURES / "groove-narrow.step"))
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    step_occurrences = _occurrences(ownership, "turned_steps")
+    groove_occurrence = _occurrences(ownership, "grooves")[0]
+    groove_binding = ownership.binding_for(groove_occurrence)
+    step_bindings = tuple(ownership.binding_for(occurrence) for occurrence in step_occurrences)
+    absorbed = tuple(
+        binding
+        for binding in step_bindings
+        if binding is not None and binding.disposition == "absorbed"
+    )
+
+    assert len(step_occurrences) == 3
+    assert groove_binding is not None
+    assert groove_binding.disposition == "represented"
+    assert groove_binding.reason_code == "direct_adapter"
+    assert len(absorbed) == 1
+    assert absorbed[0].reason_code == "turned_step_groove_owner"
+    assert absorbed[0].feature is groove_binding.feature
+    assert absorbed[0].feature.kind == "groove"
+    assert (
+        sum(
+            binding is not None and binding.reason_code == "turned_step_adapter"
+            for binding in step_bindings
+        )
+        == 2
+    )
+    assert ownership.unexpectedly_missing == ()
+
+
+def test_ambiguous_groove_takeover_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    shaft = Cylinder(10, 60)
+    shaft -= Pos(0, 0, 15) * (Cylinder(10, 4) - Cylinder(8, 4))
+    shaft -= Pos(0, 0, -15) * (Cylinder(10, 4) - Cylinder(7, 4))
+    real_match = detect.groove_owns_turned_step_band
+
+    def two_grooves_claim_lower_band(groove, step) -> bool:
+        if step.lo == pytest.approx(-17.0) and step.hi == pytest.approx(-13.0):
+            return True
+        return real_match(groove, step)
+
+    monkeypatch.setattr(
+        detect,
+        "groove_owns_turned_step_band",
+        two_grooves_claim_lower_band,
+    )
+    drawing = build_drawing(shaft)
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    step_occurrences = _occurrences(ownership, "turned_steps")
+    ambiguous = next(
+        occurrence
+        for occurrence in step_occurrences
+        if ownership.evidence.record(occurrence).lo == pytest.approx(-17.0)
+    )
+    groove_bindings = tuple(
+        ownership.binding_for(occurrence) for occurrence in _occurrences(ownership, "grooves")
+    )
+
+    assert len(groove_bindings) == 2
+    assert all(
+        binding is not None
+        and binding.disposition == "represented"
+        and binding.reason_code == "direct_adapter"
+        and binding.feature.kind == "groove"
+        for binding in groove_bindings
+    )
+    assert ownership.binding_for(ambiguous) is None
+    assert ownership.status(ambiguous) == "unexpectedly_missing"
+    assert ambiguous in ownership.unexpectedly_missing
+
+
+def test_one_groove_cannot_absorb_two_nearby_accepted_step_bands() -> None:
+    def bottom_aligned_cylinder(radius: float, height: float):
+        return Cylinder(
+            radius,
+            height,
+            align=(Align.CENTER, Align.CENTER, Align.MIN),
+        )
+
+    width = 0.2
+    part = bottom_aligned_cylinder(10, 10)
+    part += Pos(0, 0, 10) * bottom_aligned_cylinder(9, width)
+    part += Pos(0, 0, 10 + width) * bottom_aligned_cylinder(10, width)
+    part += Pos(0, 0, 10 + 2 * width) * bottom_aligned_cylinder(12, 20 - 2 * width)
+    drawing = build_drawing(part)
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    groove_occurrences = _occurrences(ownership, "grooves")
+    step_occurrences = _occurrences(ownership, "turned_steps")
+    ambiguous = tuple(
+        occurrence
+        for occurrence in step_occurrences
+        if 10.0 <= ownership.evidence.record(occurrence).lo < 10.4
+    )
+
+    assert len(groove_occurrences) == 1
+    groove_binding = ownership.binding_for(groove_occurrences[0])
+    assert groove_binding is not None
+    assert groove_binding.disposition == "represented"
+    assert groove_binding.feature.kind == "groove"
+    assert len(step_occurrences) == 4
+    assert tuple(ownership.evidence.record(occurrence).diameter for occurrence in ambiguous) == (
+        18.0,
+        20.0,
+    )
+    assert all(ownership.binding_for(occurrence) is None for occurrence in ambiguous)
+    assert all(ownership.status(occurrence) == "unexpectedly_missing" for occurrence in ambiguous)
+    assert ownership.unexpectedly_missing == ambiguous
+
+
+def test_unbound_turned_step_fails_closed_as_unexpectedly_missing() -> None:
+    evidence = build_recognition_evidence(_stepped_shaft())
+    ownership = RecognitionOwnershipBuilder(evidence).snapshot()
+    occurrences = _occurrences(ownership, "turned_steps")
+
+    assert ownership.expected_conditional == occurrences
+    assert all(occurrence in ownership.owner_expected_occurrences for occurrence in occurrences)
+    assert all(
+        ownership.status(occurrence) == "unexpectedly_missing" for occurrence in occurrences
+    )
+    assert ownership.unexpectedly_missing == occurrences
+
+
+def test_groove_absorption_requires_an_exact_same_run_groove_owner() -> None:
+    evidence = build_recognition_evidence(_stepped_shaft())
+    builder = RecognitionOwnershipBuilder(evidence)
+    step = evidence.record(_occurrences(builder.snapshot(), "turned_steps")[0])
+
+    class UnownedGrooveFeature:
+        kind = "groove"
+
+    with pytest.raises(ValueError, match="requires an existing exact recognition owner"):
+        builder.absorb_into(
+            step,
+            UnownedGrooveFeature(),
+            reason_code="turned_step_groove_owner",
+        )
+
+
+def test_one_groove_feature_cannot_absorb_two_exact_same_run_steps() -> None:
+    evidence = build_recognition_evidence(import_step(FIXTURES / "groove-narrow.step"))
+    builder = RecognitionOwnershipBuilder(evidence)
+    initial = builder.snapshot()
+    groove = evidence.record(_occurrences(initial, "grooves")[0])
+    step_occurrences = _occurrences(initial, "turned_steps")
+    steps = tuple(evidence.record(occurrence) for occurrence in step_occurrences)
+    owned_step = next(step for step in steps if detect.groove_owns_turned_step_band(groove, step))
+    other_step = next(step for step in steps if step is not owned_step)
+    owned_occurrence = next(
+        occurrence for occurrence in step_occurrences if evidence.record(occurrence) is owned_step
+    )
+    other_occurrence = next(
+        occurrence for occurrence in step_occurrences if evidence.record(occurrence) is other_step
+    )
+
+    class GrooveFeature:
+        kind = "groove"
+
+    owner = GrooveFeature()
+    builder.bind(groove, owner)
+    builder.absorb_into(owned_step, owner, reason_code="turned_step_groove_owner")
+
+    with pytest.raises(ValueError, match="already absorbs a turned-step occurrence"):
+        builder.absorb_into(other_step, owner, reason_code="turned_step_groove_owner")
+
+    ownership = builder.snapshot()
+    assert ownership.binding_for(owned_occurrence) is not None
+    assert ownership.binding_for(other_occurrence) is None


### PR DESCRIPTION
## Summary

- add accepted turned-step occurrences to the conditional ownership denominator
- bind ordinary bands to their exact `StepFeature` and groove-suppressed bands to the exact same-run `GrooveFeature`
- require one-to-one groove/step ownership in both directions and fail closed as `unexpectedly_missing` on ambiguity or missing final ownership
- enforce the same cardinality in the ownership ledger, with physical and direct-builder regressions

Part of #1438 and #1256.

## Safety

- uses only released public `RecognitionEvidence`, `TurnedStep`, `Groove`, and profile records
- no recognition rescan, private provider API, persistent topology identity, compiled-plan dependency, or manufacturing-intent inference
- no declared-build recognition, annotation placement, generated-script, export, model, render, or visual-output change

## Verification

- rebased directly on current `origin/main` (`aecfb669`)
- `scripts/pr-check --full`: 6,492 passed, 5 skipped, 2 xfailed
- total coverage 95.67%; diff coverage 100%
- Ruff, formatting, mypy, codespell, strict docs, and diff checks clean
- three independent exact-head Google-style reviews at `b1819b9` are clean with no findings or nits

## ADR review

- ADR 0010: registry/provider seam unchanged
- ADR 0011: declared `Sheet` builds remain recognition-free
- ADR 0013: consumer precedence remains separate from provider recognition
- ADR 0014: no placement behavior or raw coordinates
- ADR 0015: correspondence is captured at conversion, independent of compiled plans
- ADR 0017 Amendment 17: exact direct/groove ownership and fail-closed bijection documented and enforced
- ADR 0020: raw/framed evidence boundary unchanged
