### PR TITLE
Track through-step occurrence ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- Accepted through-step occurrences now retain either their exact `ThroughStepFeature` or every
+  exact final `StepLevelFeature`, `PlateFeature`, and `EnvelopeFeature` that jointly carries the
+  established compatibility projection. Plate claims are body-local, replacement is atomic, and a
+  missing or ambiguous selected owner fails closed rather than granting partial credit. One
+  occurrence can name multiple run-local IR owners without a second scan, persistent ID, generated
+  artefact, or change to rendering machinery (#1438, ADR 0017 Amendment 18).
+
 - Accepted turned-step occurrences now retain the conversion decision that already gives an
   ordinary profile band its exact `StepFeature` or absorbs a groove-floor band into the exact
   same-run `GrooveFeature`. The takeover must be one-to-one in both directions, so an ambiguous

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -18,7 +18,8 @@
   records each accepted countersink as absorbed by its exact same-run hole owner. Amendment 16
   records the conditional direct-or-step-ladder owner of every accepted channel occurrence.
   Amendment 17 records each turned-profile step as directly represented or absorbed by its exact
-  groove owner.
+  groove owner. Amendment 18 records direct and multi-feature legacy ownership for accepted
+  through-step occurrences.
 - **Date:** 2026-08-03
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -464,6 +465,53 @@ and 0014 remain untouched; ADRs 0011 and 0015 retain the semantic Sheet/IR waist
 recognition-free declared build; ADR 0013 keeps provider recognition separate from consumer
 precedence; and ADR 0020's framed evidence boundary is unchanged.
 
+## Amendment 18 — Through steps retain direct or multi-feature legacy ownership
+
+Every accepted through-step occurrence now enters the supported-owner denominator. A record that
+crosses the aggregate adapter is `represented` by its exact `ThroughStepFeature`. When the existing
+Z-up compatibility grammar intentionally preempts an X/Y-running aggregate, the occurrence remains
+`represented` by the complete set of final IR features that jointly define both transverse legs:
+the exact `PlateFeature` where a plate interval is direct, the `StepLevelFeature` for a retained
+level or shoulder, and the `EnvelopeFeature` where the complementary maximum-side interval needs
+the overall extent. One occurrence therefore has one disposition but may have multiple semantic
+feature bindings.
+
+The owner set is captured from the same fixed-point classification that decides whether the
+aggregate lowers. The released evidence ledger limits plate candidates to exact same-run records
+that share a defining face with the accepted through-step occurrence; the existing interval grammar,
+not face overlap alone, still decides whether that candidate defines a leg. Equal spans in
+disconnected bodies therefore cannot cross-own one another, while asymmetric plates remain valid.
+Multiple scoped plate records matching one leg are ambiguous and force direct aggregate lowering.
+Plate lineage then uses exact record identity; step-level and envelope claims resolve only to the
+corresponding feature objects created by that build. The multi-feature owner set is conjunctive and
+replacement validation is atomic: if any selected owner does not reach the final IR, no partial
+binding is recorded and the accepted occurrence becomes `unexpectedly_missing`. Equal-valued
+occurrences remain distinct, and the implementation does not reconstruct correspondence from
+feature order, labels, rendered dimensions, topology indices, or object addresses.
+
+The evidence-bearing aggregate is a classification input independent of whether an ownership
+collector observes the build. The standalone detected-model entry obtains that same product in its
+existing single aggregate run, while the ordinary build handoff carries it beside the projected
+`RecognitionResult`; automatic and standalone model assembly therefore make the same decision
+without a second recognition scan.
+
+Supported paths that deliberately lack same-run evidence — framed recognition and a caller-supplied
+aggregate — retain the established unscoped compatibility classification. They do not pretend to
+know occurrence correspondence, reject a projection merely because the observation boundary hid
+that evidence, or acquire another recognition run. Evidence-specific ownership remains unavailable
+there; the model itself does not change solely because evidence cannot cross that boundary. ADR
+0020's independently selected provider frame may still change coordinate-dependent classification,
+as it did before this amendment; this ownership slice does not redefine framed recognition.
+
+This consumes only the released public `ThroughStep`, `Plate`, aggregate, level, and riser records.
+It adds no provider API, recognition scan, persistent/report identity, manufacturing inference,
+compiled-plan dependency, annotation placement, or generated artefact. It does not alter rendering
+machinery or established unambiguous projections; a newly proven ambiguous projection may instead
+take the truthful direct aggregate path. ADRs 0010 and 0014 remain untouched; ADRs 0011 and 0015
+retain the semantic Sheet/IR waist and recognition-free declared build; ADR 0013 keeps provider
+recognition separate from consumer classification; and ADR 0020's framed evidence boundary is
+unchanged.
+
 ## Accepted Contract
 
 ### 1. One orchestration owns the recognition universe
@@ -511,11 +559,11 @@ This originally answered **result-to-build provenance only**. Amendment 12 recor
 occurrence→IR ownership for unconditional 1:1 adapters, and Amendment 13 adds explicit singleton,
 grouped, and pattern-member ownership for holes, slots, and pockets. Amendment 15 adds exact nested
 countersink→hole ownership, Amendment 16 adds conditional direct-or-step-ladder channel ownership,
-and Amendment 17 adds direct-or-groove turned-step ownership. Remaining supported conditional
-families, and the general
-feature→requirement→annotation correspondence, remain subjects of the evidence gates below. Settled
-unsupported, evidence-only, and deferred policy is explicit per accepted occurrence under Amendment
-14.
+Amendment 17 adds direct-or-groove turned-step ownership, and Amendment 18 adds direct or
+multi-feature legacy through-step ownership. Remaining supported conditional families, and the
+general feature→requirement→annotation correspondence, remain subjects of the evidence gates below.
+Settled unsupported, evidence-only, and deferred policy is explicit per accepted occurrence under
+Amendment 14.
 
 `lint_prismatic_coverage(recognition=...)` is a known channel outside the structural ownership
 path (#1032). The preferred correction is to remove or narrow the channel when that boundary

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -212,7 +212,8 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   aggregate membership. Ownerless outcomes are projected from the existing consumer capability
   declaration, not a second policy table. It exposes no persistent topology/order/address ID.
   Unconditional 1:1 adapters, singleton/grouped/pattern hole/slot/pocket members, nested
-  countersinks, conditional channel and turned-step owners, and settled
+  countersinks, conditional channel/turned-step owners, direct or multi-feature through-step
+  owners, and settled
   unsupported/deferred/evidence-only occurrences are classified; remaining conditional
   cross-family records stay unclassified.
 - **`recogniser_policy.py`** — the rank-0 Draftwright-owned source for reviewed unsupported,
@@ -571,11 +572,12 @@ policy) live in `CLAUDE.md`. This is the per-ADR status trail; each ADR's
   compiler grammar and placement solve, and a side-normal footprint is filtered from the legacy
   Z-level projection only when exact support correspondence proves that ownership. No renderer
   consumes the provider record or places an annotation at a caller-supplied page coordinate.
-  Amendments 12–17 give unconditional 1:1 adapters, hole/slot/pocket singleton/grouped/pattern
-  members, nested countersinks, and conditional channel/turned-step decisions exact run-local
-  occurrence→final-IR ownership in `BuildState`, while settled unsupported, evidence-only, and
-  deferred occurrences have explicit ownerless outcomes. Remaining conditional families, plus general
-  IR-feature→requirement correspondence, are not yet provided. The original
+  Amendments 12–18 give unconditional 1:1 adapters, hole/slot/pocket singleton/grouped/pattern
+  members, nested countersinks, conditional channel/turned-step decisions, and direct or
+  multi-feature through-step decisions exact run-local occurrence→final-IR ownership in
+  `BuildState`, while settled unsupported, evidence-only, and deferred occurrences have explicit
+  ownerless outcomes. Remaining conditional families, plus general IR-feature→requirement
+  correspondence, are not yet provided. The original
   four-type identity taxonomy, shared requirements module, general outcome ledger,
   reconciliation stage, and diagnostics model are candidate extensions rather than an
   approved phase sequence. #1018 now requires two end-to-end slices before any of them is

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -1025,6 +1025,7 @@ def _analyse(
         else _build_part_model_from_recognition(
             part,
             cast(RecognitionResult, recognition),
+            evidence=recognition_evidence,
             ownership=ownership_builder,
             holes=holes,
             double_d_bores=double_d_bores,

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -361,6 +361,7 @@ def build_model(a: Analysis):
     return _build_part_model_from_recognition(
         a.part,
         a.recognition,
+        evidence=a.recognition_evidence,
         holes=a.holes,
         double_d_bores=a.recognition.double_d_bores,
         patterns=a.patterns,

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -20,7 +20,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass, replace
 from math import isfinite, ulp
 from numbers import Real
-from typing import Any
+from typing import Any, Literal
 
 from b123d_recognisers import (
     AngledStep,
@@ -66,7 +66,6 @@ from b123d_recognisers import (
     ThroughStep,
     TurnedStep,
     analyse_cylinders,
-    build_raw_recognition_result,
     has_multi_axis_plates,
     project_step_shoulders,
     recognise_bosses,
@@ -91,6 +90,7 @@ from b123d_recognisers import (
     recognise_through_steps,
     step_level_records,
 )
+from b123d_recognisers.evidence import RecognitionEvidence, build_recognition_evidence
 
 from draftwright._geometry import (
     _axis_letter,
@@ -259,6 +259,7 @@ class _RecognitionHandoff:
 
     part: object
     result: RecognitionResult
+    evidence: RecognitionEvidence | None = None
     ownership: RecognitionOwnershipBuilder | None = None
 
 
@@ -271,6 +272,7 @@ def _build_part_model_from_recognition(
     part,
     recognition_result: RecognitionResult,
     *,
+    evidence: RecognitionEvidence | None = None,
     ownership: RecognitionOwnershipBuilder | None = None,
     **kwargs,
 ) -> PartModel:
@@ -279,7 +281,13 @@ def _build_part_model_from_recognition(
         raise TypeError("recognition_result must be an exact RecognitionResult")
     if ownership is not None and ownership.result is not recognition_result:
         raise ValueError("recognition ownership and result must come from the same run")
-    token = _RECOGNITION_HANDOFF.set(_RecognitionHandoff(part, recognition_result, ownership))
+    if evidence is None and ownership is not None:
+        evidence = ownership.evidence
+    if evidence is not None and evidence.result is not recognition_result:
+        raise ValueError("recognition evidence and result must come from the same run")
+    token = _RECOGNITION_HANDOFF.set(
+        _RecognitionHandoff(part, recognition_result, evidence, ownership)
+    )
     try:
         return build_part_model(part, **kwargs)
     finally:
@@ -1209,8 +1217,132 @@ def _through_step_shoulder_sites(steps, bbox) -> tuple[tuple[str, float], ...]:
     return tuple(sites)
 
 
+@dataclass(frozen=True)
+class _ThroughStepLegacyOwner:
+    """One exact semantic input selected to own a through-step leg projection."""
+
+    kind: Literal["envelope", "plate", "step_level"]
+    record: Plate | None = None
+
+
+def _through_step_plate_owner_record_ids(
+    evidence: RecognitionEvidence,
+    step: ThroughStep,
+    plates: tuple[Plate, ...],
+) -> frozenset[int] | None:
+    """Same-run plate scope, or ``None`` when *step* is not from that evidence run."""
+
+    step_occurrences = tuple(
+        occurrence
+        for occurrence in evidence.features
+        if evidence.family(occurrence) == "through_steps" and evidence.record(occurrence) is step
+    )
+    if len(step_occurrences) != 1:
+        return None
+    defining_faces = evidence.defining_faces(step_occurrences[0])
+    candidate_by_id = {id(plate): plate for plate in plates}
+    owners: set[int] = set()
+    for occurrence in evidence.features:
+        if evidence.family(occurrence) != "plates":
+            continue
+        record = evidence.record(occurrence)
+        candidate = candidate_by_id.get(id(record))
+        if candidate is record and defining_faces & evidence.defining_faces(occurrence):
+            owners.add(id(record))
+    return frozenset(owners)
+
+
+def _through_step_legacy_owners(
+    step,
+    bbox,
+    step_zs,
+    shoulders,
+    plates,
+    *,
+    envelope_emittable: bool,
+    plate_owner_record_ids: frozenset[int] | None = None,
+) -> tuple[_ThroughStepLegacyOwner, ...] | None:
+    """Return the exact legacy projection inputs that jointly define both section legs."""
+
+    bounds = {
+        "x": (float(bbox.min.X), float(bbox.max.X)),
+        "y": (float(bbox.min.Y), float(bbox.max.Y)),
+        "z": (float(bbox.min.Z), float(bbox.max.Z)),
+    }
+    step_level_owner = _ThroughStepLegacyOwner("step_level")
+    envelope_owner = _ThroughStepLegacyOwner("envelope")
+    intervals: list[tuple[str, float, float, tuple[_ThroughStepLegacyOwner, ...]]] = []
+    for z in step_zs or ():
+        intervals.append(("z", *sorted((bounds["z"][0], z)), (step_level_owner,)))
+        if envelope_emittable:
+            intervals.append(
+                (
+                    "z",
+                    *sorted((z, bounds["z"][1])),
+                    (step_level_owner, envelope_owner),
+                )
+            )
+    for shoulder in shoulders:
+        lo, hi = bounds[shoulder.axis]
+        intervals.append((shoulder.axis, *sorted((lo, shoulder.position)), (step_level_owner,)))
+        if envelope_emittable:
+            intervals.append(
+                (
+                    shoulder.axis,
+                    *sorted((shoulder.position, hi)),
+                    (step_level_owner, envelope_owner),
+                )
+            )
+    for plate in plates or ():
+        if plate_owner_record_ids is not None and id(plate) not in plate_owner_record_ids:
+            continue
+        axis = plate.axis
+        plate_lo, plate_hi = sorted((plate.lo, plate.hi))
+        plate_owner = _ThroughStepLegacyOwner("plate", plate)
+        intervals.append((axis, plate_lo, plate_hi, (plate_owner,)))
+        if envelope_emittable:
+            bound_lo, bound_hi = bounds[axis]
+            if abs(plate_lo - bound_lo) < 0.5:
+                intervals.append((axis, plate_hi, bound_hi, (plate_owner, envelope_owner)))
+            if abs(plate_hi - bound_hi) < 0.5:
+                intervals.append((axis, bound_lo, plate_lo, (plate_owner, envelope_owner)))
+
+    selected: list[_ThroughStepLegacyOwner] = []
+    selected_keys: set[tuple[str, int | None]] = set()
+    for axis, lo, hi in _through_step_leg_spans((step,)):
+        matches = tuple(
+            owners
+            for owner_axis, owner_lo, owner_hi, owners in intervals
+            if owner_axis == axis and abs(owner_lo - lo) < 0.5 and abs(owner_hi - hi) < 0.5
+        )
+        if not matches:
+            return None
+        matching_plate_ids = {
+            id(owner.record) for owners in matches for owner in owners if owner.kind == "plate"
+        }
+        if plate_owner_record_ids is not None and len(matching_plate_ids) > 1:
+            # Equal spans in distinct body-local plates are not enough evidence to choose a
+            # physical owner when the same-run evidence scope is authoritative. Evidence-less
+            # framed/injected paths retain the established unscoped compatibility decision.
+            return None
+        for owners in matches:
+            for owner in owners:
+                key = (owner.kind, id(owner.record) if owner.record is not None else None)
+                if key not in selected_keys:
+                    selected_keys.add(key)
+                    selected.append(owner)
+    return tuple(selected)
+
+
 def _through_step_legacy_complete(
-    step, bbox, step_zs, shoulders, plates, *, envelope_emittable: bool
+    step,
+    bbox,
+    step_zs,
+    shoulders,
+    plates,
+    *,
+    envelope_emittable: bool,
+    plate_owner_record_ids: frozenset[int] | None = None,
 ) -> bool:
     """Whether the established Z-up grammar directly defines both open-section legs.
 
@@ -1221,39 +1353,18 @@ def _through_step_legacy_complete(
     family preference: if either physical leg has no owner the aggregate record must lower
     instead of disappearing from completeness (#1382).
     """
-    bounds = {
-        "x": (float(bbox.min.X), float(bbox.max.X)),
-        "y": (float(bbox.min.Y), float(bbox.max.Y)),
-        "z": (float(bbox.min.Z), float(bbox.max.Z)),
-    }
-    intervals: list[tuple[str, float, float]] = []
-    for z in step_zs or ():
-        intervals.append(("z", *sorted((bounds["z"][0], z))))
-        if envelope_emittable:
-            intervals.append(("z", *sorted((z, bounds["z"][1]))))
-    for shoulder in shoulders:
-        lo, hi = bounds[shoulder.axis]
-        intervals.append((shoulder.axis, *sorted((lo, shoulder.position))))
-        if envelope_emittable:
-            intervals.append((shoulder.axis, *sorted((shoulder.position, hi))))
-    for plate in plates or ():
-        axis = plate.axis
-        plate_lo, plate_hi = sorted((plate.lo, plate.hi))
-        intervals.append((axis, plate_lo, plate_hi))
-        if envelope_emittable:
-            bound_lo, bound_hi = bounds[axis]
-            if abs(plate_lo - bound_lo) < 0.5:
-                intervals.append((axis, plate_hi, bound_hi))
-            if abs(plate_hi - bound_hi) < 0.5:
-                intervals.append((axis, bound_lo, plate_lo))
-
-    def _owned(axis: str, lo: float, hi: float) -> bool:
-        return any(
-            owner_axis == axis and abs(owner_lo - lo) < 0.5 and abs(owner_hi - hi) < 0.5
-            for owner_axis, owner_lo, owner_hi in intervals
+    return (
+        _through_step_legacy_owners(
+            step,
+            bbox,
+            step_zs,
+            shoulders,
+            plates,
+            envelope_emittable=envelope_emittable,
+            plate_owner_record_ids=plate_owner_record_ids,
         )
-
-    return all(_owned(axis, lo, hi) for axis, lo, hi in _through_step_leg_spans((step,)))
+        is not None
+    )
 
 
 def build_part_model(
@@ -1320,7 +1431,9 @@ def build_part_model(
     if blends_supplied:
         blends = tuple(blends)
     handoff = _RECOGNITION_HANDOFF.get()
-    recognition_result = handoff.result if handoff is not None and handoff.part is part else None
+    handoff_matches = handoff is not None and handoff.part is part
+    recognition_result = handoff.result if handoff_matches and handoff is not None else None
+    recognition_evidence = handoff.evidence if handoff_matches and handoff is not None else None
     ownership = (
         handoff.ownership if recognition_result is not None and handoff is not None else None
     )
@@ -1378,6 +1491,9 @@ def build_part_model(
             raise ValueError("fillets and blends must preserve aggregate ownership exactly")
     bbox = part.bounding_box()
     features: list[Feature] = []
+    envelope_feature: Feature | None = None
+    plate_features_by_record_id: dict[int, Feature] = {}
+    step_level_feature: Feature | None = None
 
     def append_direct(record: object) -> None:
         """Convert and bind while the exact occurrence-to-IR decision is in hand."""
@@ -1406,7 +1522,7 @@ def build_part_model(
                 sizes=(bbox.size.X, bbox.size.Y, bbox.size.Z),
                 centre=(centre.X, centre.Y, centre.Z),
             )
-            recognition = build_raw_recognition_result(
+            recognition_evidence = build_recognition_evidence(
                 part,
                 cylinders=cyls,
                 rotational=(
@@ -1416,6 +1532,7 @@ def build_part_model(
                     or cylinder_class.is_rotational
                 ),
             )
+            recognition = recognition_evidence.result
         else:
             cyls = recognition.cylinders
         # Fillet and Blend are two projections of the same rounded-chain geometry. The
@@ -1711,6 +1828,18 @@ def build_part_model(
         else ()
     )
     shoulders = project_step_shoulders(risers, levels=list(ownership_step_zs))
+    through_step_plate_owner_ids = (
+        {
+            id(step): _through_step_plate_owner_record_ids(
+                recognition_evidence,
+                step,
+                ownership_plates,
+            )
+            for step in through_steps
+        }
+        if recognition_evidence is not None
+        else {}
+    )
     # Z-run records are the native through-step projection. X/Y-run records remain with the
     # established Z-up grammar only when that grammar proves BOTH exact physical legs; a
     # partial legacy projection is replaced by the complete aggregate owner.
@@ -1725,6 +1854,7 @@ def build_part_model(
             shoulders,
             ownership_plates,
             envelope_emittable=envelope_emittable,
+            plate_owner_record_ids=through_step_plate_owner_ids.get(id(step)),
         )
     )
     # Ownership is a fixed point, not a per-record vote over the unfiltered inventory. One
@@ -1760,7 +1890,7 @@ def build_part_model(
         promoted = tuple(
             step
             for step in through_steps
-            if step not in lowered_through_steps
+            if all(step is not lowered for lowered in lowered_through_steps)
             and not _through_step_legacy_complete(
                 step,
                 bbox,
@@ -1768,11 +1898,26 @@ def build_part_model(
                 remaining_shoulders,
                 remaining_plates,
                 envelope_emittable=envelope_emittable,
+                plate_owner_record_ids=through_step_plate_owner_ids.get(id(step)),
             )
         )
         if not promoted:
             break
         lowered_through_steps += promoted
+    lowered_through_step_ids = {id(step) for step in lowered_through_steps}
+    legacy_through_step_owners = {
+        id(step): _through_step_legacy_owners(
+            step,
+            bbox,
+            remaining_levels,
+            remaining_shoulders,
+            remaining_plates,
+            envelope_emittable=envelope_emittable,
+            plate_owner_record_ids=through_step_plate_owner_ids.get(id(step)),
+        )
+        for step in through_steps
+        if id(step) not in lowered_through_step_ids
+    }
     through_leg_spans = _through_step_leg_spans(lowered_through_steps)
     through_level_zs = _through_step_level_zs(lowered_through_steps)
     through_shoulder_sites = _through_step_shoulder_sites(lowered_through_steps, bbox)
@@ -2061,7 +2206,8 @@ def build_part_model(
             # rather than one the code held. Now there is one spelling.
             from draftwright.model.declare import _envelope_from_bbox
 
-            features.append(_envelope_from_bbox(bbox))
+            envelope_feature = _envelope_from_bbox(bbox)
+            features.append(envelope_feature)
 
     # Plate/wall thicknesses on a multi-plate prismatic (#559) — the thin extent of a
     # slab that no other prismatic dim recovers (a wall along X/Y, or a Z base plate too
@@ -2084,7 +2230,9 @@ def build_part_model(
                     # The aggregate open section is the higher-level owner of this exact
                     # thickness interval. Keeping the plate too prints one physical leg twice.
                     continue
-                features.append(convert(pl, ctx))
+                plate_feature = convert(pl, ctx)
+                features.append(plate_feature)
+                plate_features_by_record_id[id(pl)] = plate_feature
 
     # Prismatic step-height ladder — horizontal face levels on a NON-turned part
     # (a turned part's steps are StepFeatures, dimensioned by the IR length chain).
@@ -2201,7 +2349,42 @@ def build_part_model(
     # exact matching transition/thickness is removed from those legacy projections so the local
     # two-leg grammar reaches the sheet once, on every principal run axis.
     for through in lowered_through_steps:
-        features.append(convert(through, ctx))
+        through_feature = convert(through, ctx)
+        features.append(through_feature)
+        if ownership is not None:
+            ownership.bind(
+                through,
+                through_feature,
+                reason_code="through_step_adapter",
+            )
+    if ownership is not None:
+        for through in through_steps:
+            if id(through) in lowered_through_step_ids:
+                continue
+            claims = legacy_through_step_owners.get(id(through))
+            if claims is None:
+                continue
+            owner_features: list[Feature] = []
+            unresolved = False
+            for claim in claims:
+                owner_feature = (
+                    envelope_feature
+                    if claim.kind == "envelope"
+                    else step_level_feature
+                    if claim.kind == "step_level"
+                    else plate_features_by_record_id.get(id(claim.record))
+                )
+                if owner_feature is None:
+                    unresolved = True
+                    break
+                if not any(existing is owner_feature for existing in owner_features):
+                    owner_features.append(owner_feature)
+            if not unresolved:
+                ownership.bind_many(
+                    through,
+                    tuple(owner_features),
+                    reason_code="through_step_legacy_projection",
+                )
 
     # Machined flats on round stock (#148b) — a planar face truncating a cylinder,
     # called out by its across-flats size. Detected UNCONDITIONALLY (not gated by the

--- a/src/draftwright/recognition_ownership.py
+++ b/src/draftwright/recognition_ownership.py
@@ -53,7 +53,7 @@ NESTED_FAMILIES = frozenset({"countersinks"})
 # These accepted occurrences have a supported consumer path, but the final owner depends on
 # Draftwright's cross-family classification.  The conversion site must record either the direct
 # adapter or the exact aggregate feature that intentionally absorbs the occurrence.
-CONDITIONAL_FAMILIES = frozenset({"channels", "turned_steps"})
+CONDITIONAL_FAMILIES = frozenset({"channels", "through_steps", "turned_steps"})
 
 OwnershipDisposition = Literal["represented", "absorbed"]
 PolicyDisposition = OwnerlessDisposition
@@ -75,9 +75,11 @@ _REPRESENTED_REASON_CODES = frozenset(
         "pmi_split_member",
         "pocket_adapter",
         "slot_adapter",
+        "through_step_adapter",
         "turned_step_adapter",
     }
 )
+_MULTI_FEATURE_REASON_CODES = frozenset({"through_step_legacy_projection"})
 _ABSORBED_REASON_CODES = frozenset(
     {
         "grouped_hole_member",
@@ -101,6 +103,8 @@ _REASON_FAMILY = {
     "pocket_pattern_member": "pockets",
     "slot_adapter": "slots",
     "slot_pattern_member": "slots",
+    "through_step_adapter": "through_steps",
+    "through_step_legacy_projection": "through_steps",
     "turned_step_adapter": "turned_steps",
     "turned_step_groove_owner": "turned_steps",
 }
@@ -117,7 +121,7 @@ _FEATURE_ABSORPTION_EXISTING_OWNER = {
 
 @dataclass(frozen=True)
 class OccurrenceBinding:
-    """One exact accepted occurrence consumed by one exact final IR feature object."""
+    """One exact accepted occurrence consumed by one or more exact final IR features."""
 
     occurrence: FeatureRef
     feature: object
@@ -126,6 +130,24 @@ class OccurrenceBinding:
     # Run-local position within a grouped IR feature.  This is explicit lineage used to follow
     # later IR splits; it is not a topology index or a persistent report identifier.
     member_index: int | None = None
+    # Some established projections need more than one semantic owner to define the accepted
+    # occurrence. Keep ``feature`` as the primary compatibility spelling while exposing the
+    # complete, explicitly recorded owner set through ``features``.
+    additional_features: tuple[object, ...] = ()
+
+    @property
+    def features(self) -> tuple[object, ...]:
+        """Exact final owners in conversion-decision order."""
+
+        return (self.feature, *self.additional_features)
+
+    def __post_init__(self) -> None:
+        if type(self.additional_features) is not tuple:
+            raise TypeError("additional_features must be an exact tuple")
+        if any(owner is self.feature for owner in self.additional_features) or len(
+            {id(owner) for owner in self.additional_features}
+        ) != len(self.additional_features):
+            raise ValueError("occurrence binding repeats an IR owner")
 
 
 @dataclass(frozen=True)
@@ -349,6 +371,49 @@ class RecognitionOwnershipBuilder:
             )
         )
 
+    def bind_many(
+        self,
+        record: object,
+        features: tuple[object, ...],
+        *,
+        reason_code: str,
+    ) -> None:
+        """Bind one occurrence to an explicitly selected set of final IR owners."""
+
+        occurrence = self._occurrence_for(record)
+        if type(reason_code) is not str or reason_code not in _MULTI_FEATURE_REASON_CODES:
+            raise ValueError("unknown multi-feature ownership reason_code")
+        if self.evidence.family(occurrence) != _REASON_FAMILY[reason_code]:
+            raise ValueError(
+                "multi-feature ownership reason_code does not match occurrence family"
+            )
+        if id(occurrence) in self._bound_occurrence_ids:
+            raise ValueError("recognition occurrence already has an IR owner")
+        if type(features) is not tuple:
+            raise TypeError("multi-feature owners must be an exact tuple")
+        if not features:
+            raise ValueError("multi-feature ownership requires at least one IR owner")
+        if len({id(feature) for feature in features}) != len(features):
+            raise ValueError("multi-feature ownership repeats an IR owner")
+        if any(
+            getattr(feature, "kind", None) not in {"envelope", "plate", "step_level"}
+            for feature in features
+        ):
+            raise ValueError(
+                "through-step legacy ownership requires envelope, plate, or step-level IR"
+            )
+
+        self._bound_occurrence_ids.add(id(occurrence))
+        self._owned_feature_ids.update(id(feature) for feature in features)
+        self._bindings.append(
+            OccurrenceBinding(
+                occurrence,
+                features[0],
+                reason_code=reason_code,
+                additional_features=features[1:],
+            )
+        )
+
     def absorb(self, records: tuple[object, ...], feature: object, *, reason_code: str) -> None:
         """Record an explicit N:1 aggregate decision for exact member records."""
 
@@ -431,7 +496,9 @@ class RecognitionOwnershipBuilder:
         if id(occurrence) in self._bound_occurrence_ids:
             raise ValueError("recognition occurrence already has an IR owner")
         existing_bindings = tuple(
-            binding for binding in self._bindings if binding.feature is feature
+            binding
+            for binding in self._bindings
+            if any(owner is feature for owner in binding.features)
         )
         existing_owner = _FEATURE_ABSORPTION_EXISTING_OWNER.get(reason_code)
         if existing_owner is not None and not any(
@@ -479,7 +546,9 @@ class RecognitionOwnershipBuilder:
         """Follow one explicit IR-lowering lineage without reconstructing correspondence."""
 
         matches = [
-            index for index, binding in enumerate(self._bindings) if binding.feature is source
+            index
+            for index, binding in enumerate(self._bindings)
+            if any(feature is source for feature in binding.features)
         ]
         if not matches:
             return
@@ -490,7 +559,10 @@ class RecognitionOwnershipBuilder:
         ):
             raise ValueError("IR replacement groups must use distinct replacement objects")
         externally_owned_ids = {
-            id(binding.feature) for binding in self._bindings if binding.feature is not source
+            id(feature)
+            for binding in self._bindings
+            if not any(owner is source for owner in binding.features)
+            for feature in binding.features
         }
         if any(id(replacement) in externally_owned_ids for replacement in replacements):
             raise ValueError("lowered IR feature already owns a recognition occurrence")
@@ -498,20 +570,40 @@ class RecognitionOwnershipBuilder:
         if source_member_groups is None:
             if len(replacements) == 1:
                 replacement = replacements[0]
-                for index in matches:
-                    binding = self._bindings[index]
-                    self._bindings[index] = OccurrenceBinding(
-                        binding.occurrence,
-                        replacement,
-                        binding.disposition,
-                        binding.reason_code,
-                        binding.member_index,
+                rewritten_bindings: list[OccurrenceBinding] = []
+                for binding in self._bindings:
+                    owners = tuple(
+                        replacement if owner is source else owner for owner in binding.features
                     )
+                    if len({id(owner) for owner in owners}) != len(owners):
+                        raise ValueError("IR replacement duplicates an existing owner")
+                    rewritten_bindings.append(
+                        OccurrenceBinding(
+                            binding.occurrence,
+                            owners[0],
+                            binding.disposition,
+                            binding.reason_code,
+                            binding.member_index,
+                            owners[1:],
+                        )
+                    )
+                self._bindings = rewritten_bindings
             else:
+                # A multi-feature owner set is conjunctive: every selected feature jointly
+                # carries the occurrence. If any required owner disappears without an explicit
+                # replacement, partial credit would contradict the recorded conversion decision.
                 self._bindings = [
-                    binding for binding in self._bindings if binding.feature is not source
+                    binding
+                    for binding in self._bindings
+                    if not any(owner is source for owner in binding.features)
                 ]
         else:
+            if any(
+                self._bindings[index].feature is not source
+                or self._bindings[index].additional_features
+                for index in matches
+            ):
+                raise ValueError("grouped IR lineage requires a sole source owner")
             member_lineage: dict[int, tuple[object, int, int]] = {}
             for replacement, group in zip(replacements, source_member_groups, strict=True):
                 for replacement_index, source_index in enumerate(group):
@@ -561,7 +653,9 @@ class RecognitionOwnershipBuilder:
             self._bindings = rewritten
 
         self._bound_occurrence_ids = {id(binding.occurrence) for binding in self._bindings}
-        self._owned_feature_ids = {id(binding.feature) for binding in self._bindings}
+        self._owned_feature_ids = {
+            id(feature) for binding in self._bindings for feature in binding.features
+        }
 
     def snapshot(self) -> RecognitionOwnership:
         """Copy the current ledger without manufacturing owners for missing occurrences."""

--- a/tests/test_issue_1382_circular_blind_step_semantics.py
+++ b/tests/test_issue_1382_circular_blind_step_semantics.py
@@ -289,13 +289,13 @@ def test_standalone_model_runs_one_aggregate_and_one_cylinder_scan(monkeypatch) 
     import draftwright.model.detect as detect
 
     rotational_flags = []
-    real_build = detect.build_raw_recognition_result
+    real_build = detect.build_recognition_evidence
 
     def recording_build(*args, **kwargs):
         rotational_flags.append(kwargs["rotational"])
         return real_build(*args, **kwargs)
 
-    monkeypatch.setattr(detect, "build_raw_recognition_result", recording_build)
+    monkeypatch.setattr(detect, "build_recognition_evidence", recording_build)
     with counting_calls(
         {"turned_steps": recognise_turned_steps, "cylinders": analyse_cylinders}
     ) as counts:

--- a/tests/test_issue_1382_through_step_semantics.py
+++ b/tests/test_issue_1382_through_step_semantics.py
@@ -320,7 +320,7 @@ def test_fixed_point_reprojects_shoulders_after_an_owned_level_disappears() -> N
     riser = replace(recognition.risers[0], positions=(-5,))
     model = build_part_model(
         part,
-        through_steps=(aggregate_owned, initially_legacy_owned),
+        through_steps=(initially_legacy_owned, aggregate_owned),
         step_zs=(0, 5),
         face_levels=(),
         risers=(riser,),
@@ -333,7 +333,11 @@ def test_fixed_point_reprojects_shoulders_after_an_owned_level_disappears() -> N
     # The first aggregate removes level 0. The remaining level 5 no longer supports the
     # riser's foot at 0, so the second aggregate must be promoted rather than trusting a
     # shoulder that will disappear from the emitted StepLevelFeature.
-    assert [feature.kind for feature in model.features].count("through_step") == 2
+    through_features = [feature for feature in model.features if feature.kind == "through_step"]
+    assert [feature.frame.origin for feature in through_features] == [
+        aggregate_owned.at,
+        initially_legacy_owned.at,
+    ]
     assert not [feature for feature in model.features if feature.kind == "step_level"]
 
 

--- a/tests/test_issue_1438_channel_ownership.py
+++ b/tests/test_issue_1438_channel_ownership.py
@@ -46,7 +46,7 @@ def _channel_occurrence(ownership):
 
 
 def test_conditional_family_roster_is_explicit() -> None:
-    assert CONDITIONAL_FAMILIES == {"channels", "turned_steps"}
+    assert CONDITIONAL_FAMILIES == {"channels", "through_steps", "turned_steps"}
 
 
 def test_multi_plate_channel_is_represented_by_its_exact_channel_feature() -> None:

--- a/tests/test_issue_1438_through_step_ownership.py
+++ b/tests/test_issue_1438_through_step_ownership.py
@@ -1,0 +1,462 @@
+"""#1438 — through steps retain direct or exact multi-feature legacy ownership."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+from b123d_recognisers import Plate as RecognisedPlate
+from b123d_recognisers.evidence import build_recognition_evidence
+from build123d import Box, Compound, Pos, Rot
+
+from draftwright import build_drawing
+from draftwright.analysis import _analyse
+from draftwright.annotations.orchestrator import build_model as build_analysis_model
+from draftwright.model import detect
+from draftwright.recognition_ownership import (
+    OccurrenceBinding,
+    RecognitionOwnershipBuilder,
+)
+
+
+def _through_step_part():
+    return Box(40, 30, 20) - Pos(15, 10, 0) * Box(20, 20, 30)
+
+
+def _monolithic_rebate():
+    return Box(80, 60, 30) - Pos(0, 0, 7.5) * Box(80, 20, 15)
+
+
+def _equal_span_compound():
+    base = Box(80, 40, 8) + Pos(-36, 0, 24) * Box(8, 40, 40)
+    return Compound(children=[Pos(0, -100, 0) * base, Pos(0, 100, 0) * base])
+
+
+def _occurrences(ownership):
+    return tuple(
+        occurrence
+        for occurrence in ownership.evidence.features
+        if ownership.evidence.family(occurrence) == "through_steps"
+    )
+
+
+def test_native_through_step_is_represented_by_its_exact_aggregate_feature() -> None:
+    drawing = build_drawing(_through_step_part())
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    (occurrence,) = _occurrences(ownership)
+    binding = ownership.binding_for(occurrence)
+
+    assert binding is not None
+    assert binding.disposition == "represented"
+    assert binding.reason_code == "through_step_adapter"
+    assert binding.features == (binding.feature,)
+    assert getattr(binding.feature, "kind", None) == "through_step"
+    assert any(binding.feature is feature for feature in drawing.model().features)
+    assert ownership.unexpectedly_missing == ()
+
+
+def test_legacy_projection_records_every_exact_feature_needed_for_both_legs() -> None:
+    drawing = build_drawing(Rot(90, 0, 0) * _through_step_part())
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    (occurrence,) = _occurrences(ownership)
+    binding = ownership.binding_for(occurrence)
+
+    assert binding is not None
+    assert binding.disposition == "represented"
+    assert binding.reason_code == "through_step_legacy_projection"
+    assert [getattr(feature, "kind", None) for feature in binding.features] == [
+        "step_level",
+        "envelope",
+    ]
+    assert all(
+        any(owner is feature for feature in drawing.model().features) for owner in binding.features
+    )
+    assert ownership.unexpectedly_missing == ()
+
+
+def test_equal_valued_occurrences_keep_distinct_direct_owners() -> None:
+    base = _through_step_part()
+    drawing = build_drawing(Compound(children=[Pos(-60, 0, 0) * base, Pos(60, 0, 0) * base]))
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    occurrences = _occurrences(ownership)
+    bindings = tuple(ownership.binding_for(occurrence) for occurrence in occurrences)
+
+    assert len(occurrences) == 2
+    assert all(binding is not None for binding in bindings)
+    assert len({id(binding.feature) for binding in bindings if binding is not None}) == 2
+    assert all(
+        binding is not None
+        and binding.reason_code == "through_step_adapter"
+        and getattr(binding.feature, "kind", None) == "through_step"
+        for binding in bindings
+    )
+    assert ownership.unexpectedly_missing == ()
+
+
+def test_equal_span_plate_owners_are_body_local_and_follow_removal(monkeypatch) -> None:
+    part = _equal_span_compound()
+    evidence = build_recognition_evidence(part)
+    builder = RecognitionOwnershipBuilder(evidence)
+    original_convert = detect.convert
+    converted_plates: dict[int, object] = {}
+
+    def record_plate_conversion(record, ctx):
+        feature = original_convert(record, ctx)
+        if type(record) is RecognisedPlate:
+            converted_plates[id(record)] = feature
+        return feature
+
+    monkeypatch.setattr(detect, "convert", record_plate_conversion)
+    model = detect._build_part_model_from_recognition(
+        part,
+        evidence.result,
+        ownership=builder,
+    )
+    ownership = builder.snapshot()
+    occurrences = _occurrences(ownership)
+    bindings = tuple(ownership.binding_for(occurrence) for occurrence in occurrences)
+
+    assert len(occurrences) == 2
+    assert all(binding is not None for binding in bindings)
+    assert all(
+        binding is not None
+        and binding.reason_code == "through_step_legacy_projection"
+        and [feature.kind for feature in binding.features] == ["plate", "envelope", "plate"]
+        for binding in bindings
+    )
+    assert all(
+        any(owner is feature for feature in model.features)
+        for binding in bindings
+        if binding is not None
+        for owner in binding.features
+    )
+    plate_owner_ids = tuple(
+        {id(feature) for feature in binding.features if feature.kind == "plate"}
+        for binding in bindings
+        if binding is not None
+    )
+    assert len(plate_owner_ids) == 2
+    assert all(len(owner_ids) == 2 for owner_ids in plate_owner_ids)
+    assert plate_owner_ids[0].isdisjoint(plate_owner_ids[1])
+    plate_occurrences = tuple(
+        occurrence for occurrence in evidence.features if evidence.family(occurrence) == "plates"
+    )
+    for occurrence, binding in zip(occurrences, bindings, strict=True):
+        assert binding is not None
+        defining_faces = evidence.defining_faces(occurrence)
+        expected_records = tuple(
+            evidence.record(plate_occurrence)
+            for plate_occurrence in plate_occurrences
+            if defining_faces & evidence.defining_faces(plate_occurrence)
+        )
+        assert {id(converted_plates[id(record)]) for record in expected_records} == {
+            id(feature) for feature in binding.features if feature.kind == "plate"
+        }
+    assert ownership.unexpectedly_missing == ()
+
+    first_binding = bindings[0]
+    assert first_binding is not None
+    first_plate = next(feature for feature in first_binding.features if feature.kind == "plate")
+    builder.remap_feature(first_plate, ())
+    after_removal = builder.snapshot()
+    assert after_removal.binding_for(occurrences[0]) is None
+    assert after_removal.status(occurrences[0]) == "unexpectedly_missing"
+    assert after_removal.binding_for(occurrences[1]) is not None
+
+
+def test_equal_span_compound_has_automatic_and_standalone_model_parity() -> None:
+    part = _equal_span_compound()
+
+    automatic = build_drawing(part).model()
+    standalone = detect.build_part_model(part)
+
+    assert standalone.features == automatic.features
+    assert standalone.datums == automatic.datums
+    assert standalone.orientation == automatic.orientation
+    assert not [feature for feature in standalone.features if feature.kind == "through_step"]
+
+
+def test_equal_span_compound_secondary_model_keeps_exact_evidence_parity() -> None:
+    part = _equal_span_compound()
+
+    analysis = _analyse(part, "", "", "ISO 2768-m", "", "drawing")
+    secondary = build_analysis_model(analysis)
+
+    assert secondary.features == analysis.model.features
+    assert not [feature for feature in secondary.features if feature.kind == "through_step"]
+
+
+def test_ambiguous_scoped_plate_leg_fails_closed() -> None:
+    part = _equal_span_compound()
+    evidence = build_recognition_evidence(part)
+    result = evidence.result
+    step = result.through_steps[0]
+    step_occurrence = next(
+        occurrence
+        for occurrence in evidence.features
+        if evidence.family(occurrence) == "through_steps" and evidence.record(occurrence) is step
+    )
+    local_plate = next(
+        evidence.record(occurrence)
+        for occurrence in evidence.features
+        if evidence.family(occurrence) == "plates"
+        and evidence.defining_faces(step_occurrence) & evidence.defining_faces(occurrence)
+    )
+    duplicate = RecognisedPlate(
+        axis=local_plate.axis,
+        lo=local_plate.lo,
+        hi=local_plate.hi,
+        u=local_plate.u,
+        v=local_plate.v,
+    )
+
+    exact_owner_ids = detect._through_step_plate_owner_record_ids(
+        evidence,
+        step,
+        tuple(result.plates),
+    )
+    assert id(local_plate) in exact_owner_ids
+    assert (
+        detect._through_step_plate_owner_record_ids(
+            evidence,
+            replace(step),
+            tuple(result.plates),
+        )
+        is None
+    )
+    assert (
+        detect._through_step_legacy_owners(
+            step,
+            part.bounding_box(),
+            (),
+            (),
+            (*result.plates, duplicate),
+            envelope_emittable=True,
+        )
+        is not None
+    )
+    assert (
+        detect._through_step_legacy_owners(
+            step,
+            part.bounding_box(),
+            (),
+            (),
+            (*result.plates, duplicate),
+            envelope_emittable=True,
+            plate_owner_record_ids=exact_owner_ids | {id(duplicate)},
+        )
+        is None
+    )
+
+
+def test_asymmetric_plate_centroid_keeps_exact_evidence_owner() -> None:
+    base = Box(80, 40, 8) + Pos(-36, 0, 24) * Box(8, 40, 40)
+    part = base - Pos(-36, 15, 30) * Box(12, 6, 10)
+    drawing = build_drawing(part)
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    (occurrence,) = _occurrences(ownership)
+    binding = ownership.binding_for(occurrence)
+    assert binding is not None
+    assert binding.reason_code == "through_step_legacy_projection"
+    assert [feature.kind for feature in binding.features] == ["plate", "envelope", "plate"]
+    assert not [feature for feature in drawing.model().features if feature.kind == "through_step"]
+    assert ownership.unexpectedly_missing == ()
+
+
+def test_unrecorded_through_step_fails_closed_as_unexpectedly_missing() -> None:
+    evidence = build_recognition_evidence(_through_step_part())
+    ownership = RecognitionOwnershipBuilder(evidence).snapshot()
+    occurrences = _occurrences(ownership)
+
+    assert ownership.expected_conditional == occurrences
+    assert all(
+        ownership.status(occurrence) == "unexpectedly_missing" for occurrence in occurrences
+    )
+    assert ownership.unexpectedly_missing == occurrences
+
+
+def test_recognition_handoff_rejects_evidence_from_another_run() -> None:
+    part = _through_step_part()
+    first = build_recognition_evidence(part)
+    second = build_recognition_evidence(part)
+
+    with pytest.raises(ValueError, match="evidence and result must come from the same run"):
+        detect._build_part_model_from_recognition(
+            part,
+            first.result,
+            evidence=second,
+        )
+
+
+def test_multi_feature_binding_is_closed_and_follows_explicit_owner_remaps() -> None:
+    evidence = build_recognition_evidence(Rot(90, 0, 0) * _through_step_part())
+    builder = RecognitionOwnershipBuilder(evidence)
+    (occurrence,) = _occurrences(builder.snapshot())
+    record = evidence.record(occurrence)
+
+    class Owner:
+        def __init__(self, kind: str) -> None:
+            self.kind = kind
+
+    plate = Owner("plate")
+    envelope = Owner("envelope")
+    with pytest.raises(ValueError, match="unknown multi-feature"):
+        builder.bind_many(record, (plate,), reason_code="direct_adapter")
+    with pytest.raises(TypeError, match="exact tuple"):
+        builder.bind_many(
+            record,
+            [plate],  # type: ignore[arg-type]
+            reason_code="through_step_legacy_projection",
+        )
+    with pytest.raises(ValueError, match="at least one"):
+        builder.bind_many(record, (), reason_code="through_step_legacy_projection")
+    with pytest.raises(ValueError, match="repeats"):
+        builder.bind_many(
+            record,
+            (plate, plate),
+            reason_code="through_step_legacy_projection",
+        )
+    with pytest.raises(ValueError, match="requires envelope, plate, or step-level"):
+        builder.bind_many(
+            record,
+            (Owner("through_step"),),
+            reason_code="through_step_legacy_projection",
+        )
+
+    builder.bind_many(
+        record,
+        (plate, envelope),
+        reason_code="through_step_legacy_projection",
+    )
+    with pytest.raises(ValueError, match="occurrence already"):
+        builder.bind_many(
+            record,
+            (Owner("step_level"),),
+            reason_code="through_step_legacy_projection",
+        )
+    with pytest.raises(ValueError, match="sole source owner"):
+        builder.remap_feature(plate, (Owner("plate"),), ((0,),))
+    with pytest.raises(ValueError, match="duplicates an existing owner"):
+        builder.remap_feature(plate, (envelope,))
+
+    replacement = Owner("plate")
+    builder.remap_feature(plate, (replacement,))
+    binding = builder.snapshot().binding_for(occurrence)
+    assert binding is not None
+    assert binding.features == (replacement, envelope)
+
+    builder.remap_feature(replacement, ())
+    missing = builder.snapshot()
+    assert missing.binding_for(occurrence) is None
+    assert missing.status(occurrence) == "unexpectedly_missing"
+
+
+def test_failed_shared_owner_remap_is_atomic_and_retryable() -> None:
+    base = _through_step_part()
+    part = Compound(children=[Pos(-60, 0, 0) * base, Pos(60, 0, 0) * base])
+    evidence = build_recognition_evidence(part)
+    builder = RecognitionOwnershipBuilder(evidence)
+    occurrences = _occurrences(builder.snapshot())
+
+    class Owner:
+        def __init__(self, kind: str) -> None:
+            self.kind = kind
+
+    shared = Owner("plate")
+    first_tail = Owner("envelope")
+    second_tail = Owner("step_level")
+    builder.bind_many(
+        evidence.record(occurrences[0]),
+        (shared, first_tail),
+        reason_code="through_step_legacy_projection",
+    )
+    builder.bind_many(
+        evidence.record(occurrences[1]),
+        (shared, second_tail),
+        reason_code="through_step_legacy_projection",
+    )
+    before = builder.snapshot().bindings
+
+    with pytest.raises(ValueError, match="duplicates an existing owner"):
+        builder.remap_feature(shared, (second_tail,))
+    assert builder.snapshot().bindings == before
+
+    replacement = Owner("plate")
+    builder.remap_feature(shared, (replacement,))
+    assert all(binding.features[0] is replacement for binding in builder.snapshot().bindings)
+
+
+def test_occurrence_binding_rejects_mutable_or_repeated_additional_owners() -> None:
+    evidence = build_recognition_evidence(_through_step_part())
+    (occurrence,) = _occurrences(RecognitionOwnershipBuilder(evidence).snapshot())
+    owner = object()
+
+    with pytest.raises(TypeError, match="exact tuple"):
+        OccurrenceBinding(
+            occurrence,
+            owner,
+            additional_features=[object()],  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValueError, match="repeats an IR owner"):
+        OccurrenceBinding(occurrence, owner, additional_features=(owner,))
+
+
+def test_multi_feature_reason_cannot_bind_another_conditional_family() -> None:
+    part = Compound(
+        children=[
+            Pos(-80, 0, 0) * _through_step_part(),
+            Pos(80, 0, 0) * _monolithic_rebate(),
+        ]
+    )
+    evidence = build_recognition_evidence(part)
+    builder = RecognitionOwnershipBuilder(evidence)
+    channel = next(
+        occurrence for occurrence in evidence.features if evidence.family(occurrence) == "channels"
+    )
+
+    class StepLevel:
+        kind = "step_level"
+
+    with pytest.raises(ValueError, match="does not match occurrence family"):
+        builder.bind_many(
+            evidence.record(channel),
+            (StepLevel(),),
+            reason_code="through_step_legacy_projection",
+        )
+
+
+@pytest.mark.parametrize("corruption", ["missing", "unemitted"])
+def test_corrupted_final_legacy_owner_selection_fails_closed(monkeypatch, corruption) -> None:
+    original = detect._through_step_legacy_owners
+    complete_calls = 0
+
+    def corrupt_final_selection(*args, **kwargs):
+        nonlocal complete_calls
+        result = original(*args, **kwargs)
+        if result is None:
+            return None
+        complete_calls += 1
+        if complete_calls != 3:
+            return result
+        if corruption == "missing":
+            return None
+        absent_plate = RecognisedPlate(axis="x", lo=5, hi=20, u=0, v=0)
+        return (detect._ThroughStepLegacyOwner("plate", absent_plate),)
+
+    monkeypatch.setattr(detect, "_through_step_legacy_owners", corrupt_final_selection)
+    drawing = build_drawing(Rot(90, 0, 0) * _through_step_part())
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    (occurrence,) = _occurrences(ownership)
+    assert ownership.binding_for(occurrence) is None
+    assert ownership.status(occurrence) == "unexpectedly_missing"
+    assert ownership.unexpectedly_missing == (occurrence,)


### PR DESCRIPTION
## Symptom and evidence

- User-visible problem: accepted through-step occurrences were outside the occurrence ownership denominator, including compatibility projections represented jointly by several final IR features.
- Fixture/reproducer: native, rotated legacy, equal-valued multi-body, disconnected equal-span plate, asymmetric-plate, removal/remap, and corrupted-final-owner cases in `tests/test_issue_1438_through_step_ownership.py`.
- Before/after result: every accepted through step now has an exact direct owner or a conjunctive exact legacy-owner set; unresolved or corrupted ownership becomes `unexpectedly_missing`.
- Mutation that makes the guard fail: removal or substitution of a selected final legacy owner invalidates the whole binding; mismatched evidence/result authority is rejected.

## Contract and scope

- Smallest contract this change tests: direct through steps bind to their exact `ThroughStepFeature`; an established legacy projection binds to every exact final plate/step-level/envelope feature needed for both legs.
- Relevant ADRs: 0010, 0011, 0013, 0014, 0015, 0017 Amendment 18, and 0020 reviewed. Only ADR 0017 is narrowly amended.
- Explicitly deferred: public JSON/report schema, generated-Python snapshot, other remaining conditional families, and the pre-existing coordinate-dependent framed/raw classification difference. No renderer or generated artefact changes.
- Uses only released public `b123d-recognisers` evidence APIs; no upstream contract change is required.

Progresses #1438
Parent epic: #1256

## Validation

- [x] `scripts/pr-check --quick` (covered by the stronger full preflight)
- [x] `scripts/pr-check --full`: 6,508 passed, 5 skipped, 2 expected xfails; 95.69% project coverage; 99% changed-line coverage
- [x] The named removal/substitution mutations fail closed
- [x] Automatic, standalone, supplied-aggregate, secondary-construction, and relevant declared boundaries were checked
- [x] Recognition/evidence identity and one-run reuse were checked
- [x] Three independent exact-head Google-style reviews completed; ADR and contract clean, quality only one optional test-maintainability nit

## Stop check

- [x] No two consecutive review rounds invalidated the core association strategy
- [x] No new prerequisite was discovered

## Contributor License Agreement

- [x] I have read the CLA and agree to it.