### PR TITLE
Track round boss occurrence ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Added
 
+- Accepted round-boss occurrences now retain the exact existing consumer outcome: a singleton
+  `BossFeature`, one diameter-consolidated representative with transient member lineage, the exact
+  turned-step owner, or the exact groove owner reached through that step or the profile-gate
+  fallback. Ambiguous or missing correspondence fails closed without another scan, persistent ID,
+  generated artefact, or visual change (#1438, ADR 0017 Amendment 19).
+
 - Accepted through-step occurrences now retain either their exact `ThroughStepFeature` or every
   exact final `StepLevelFeature`, `PlateFeature`, and `EnvelopeFeature` that jointly carries the
   established compatibility projection. Plate claims are body-local, replacement is atomic, and a

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -19,7 +19,8 @@
   records the conditional direct-or-step-ladder owner of every accepted channel occurrence.
   Amendment 17 records each turned-profile step as directly represented or absorbed by its exact
   groove owner. Amendment 18 records direct and multi-feature legacy ownership for accepted
-  through-step occurrences.
+  through-step occurrences. Amendment 19 records the direct, consolidated, turned-step, or groove
+  owner selected for every accepted round-boss occurrence.
 - **Date:** 2026-08-03
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -512,6 +513,45 @@ retain the semantic Sheet/IR waist and recognition-free declared build; ADR 0013
 recognition separate from consumer classification; and ADR 0020's framed evidence boundary is
 unchanged.
 
+## Amendment 19 — Round bosses retain their exact consumer-selected owner
+
+Every accepted round-boss occurrence now enters the supported-owner denominator. A singleton that
+crosses the prismatic adapter is `represented` by its exact `BossFeature`. Where the established
+prismatic projection intentionally keeps one representative per diameter, every same-diameter
+occurrence is `absorbed` by that one feature with explicit transient member lineage. When a boss
+occurrence matches an existing turned-profile step, it is absorbed through that exact same-run
+`TurnedStep` occurrence to the step's final owner: ordinarily a `StepFeature`, or the
+`GrooveFeature` that already absorbs a groove-floor step. When the profile gate is absent but the
+existing groove-floor predicate still suppresses a boss, the occurrence is absorbed directly
+through the exact same-run groove record.
+
+These are records of the existing consumer decisions, not a new grouping or rendering policy. The
+diameter representative still follows the established insertion-stable tolerance grouping, and no
+extra boss feature, count prefix, annotation, requirement, or generated declaration is introduced.
+The accepted occurrence retains its own provider geometry beside the final IR owner, so a later
+report can distinguish two equal-diameter physical bosses even though the current drawing projects
+one representative. Turned correspondence is captured from the exact step record selected by the
+existing axis-line, diameter, and span decision; final ownership is followed through the step's
+already-recorded binding rather than reconstructed from the resulting feature's coordinates.
+
+The conditional paths fail closed. A boss that matches zero or multiple candidate steps, two boss
+occurrences competing for one step, a groove-floor group that lacks a unique same-run groove, or a
+missing intermediate owner remains `unexpectedly_missing`; equal values, feature order, labels,
+rendered dimensions, topology indices, page coordinates, and object addresses cannot manufacture a
+binding. Chained correspondence retains its exact intermediate lineage through IR remapping, and
+at most one boss may depend on either an intermediate occurrence or its final IR owner. Where a
+turned-step route and the direct groove fallback compete for one final groove, the more specific
+turned-step route wins and the other occurrence remains missing. Declared builds and evidence-less
+framed or bare-result paths retain their existing recognition behavior without inventing
+occurrence ownership.
+
+This consumes only released public `BossRecord`, `TurnedStep`, `Groove`, aggregate, and evidence
+contracts. It adds no provider API, recognition scan, persistent/report identity, manufacturing
+inference, compiled-plan dependency, annotation placement, generated artefact, or visual change.
+ADRs 0010 and 0014 remain untouched; ADRs 0011 and 0015 retain the semantic Sheet/IR waist and
+recognition-free declared build; ADR 0013 keeps geometry recognition separate from consumer
+classification; and ADR 0020's framed evidence boundary is unchanged.
+
 ## Accepted Contract
 
 ### 1. One orchestration owns the recognition universe
@@ -560,7 +600,8 @@ occurrence→IR ownership for unconditional 1:1 adapters, and Amendment 13 adds 
 grouped, and pattern-member ownership for holes, slots, and pockets. Amendment 15 adds exact nested
 countersink→hole ownership, Amendment 16 adds conditional direct-or-step-ladder channel ownership,
 Amendment 17 adds direct-or-groove turned-step ownership, and Amendment 18 adds direct or
-multi-feature legacy through-step ownership. Remaining supported conditional families, and the
+multi-feature legacy through-step ownership. Amendment 19 adds direct, diameter-consolidated,
+turned-step, or groove ownership for round bosses. Remaining supported conditional families, and the
 general feature→requirement→annotation correspondence, remain subjects of the evidence gates below.
 Settled unsupported, evidence-only, and deferred policy is explicit per accepted occurrence under
 Amendment 14.

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -591,6 +591,13 @@ backfill evidence. The framed route remains evidence-less pending upstream
 [`b123d-recognisers#463`](https://github.com/pzfreo/b123d-recognisers/issues/463). This foundation
 does not yet claim a report disposition or change any rendered artefact.
 
+Round-boss ownership is now explicit at that same run-local boundary. Each accepted `BossRecord`
+retains the exact consumer-selected final owner: its singleton `BossFeature`, the one existing
+same-diameter representative, its body-local turned step, or the groove that absorbs that step or
+the profile-gate fallback. The occurrence's own geometry remains available even when the drawing
+uses a consolidated owner. Ambiguous selection fails closed as `unexpectedly_missing`; it cannot be
+certified by equal values, ordering, rendered labels, or topology identity.
+
 ## Recognisers 0.4.9 prepared frame boundary
 
 Draftwright's 0.4.9 boundary accepted `RiserEvidence` v2,

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -222,12 +222,12 @@ def _pattern_feature(pat, members) -> PatternFeature:
     return PatternFeature(frame, "other", n, _member_hole(members[0], frame), members=locs)
 
 
-def _distinct_by_diameter(bosses, tol: float = 0.15):
-    """One representative boss per distinct external diameter."""
-    out: dict[float, object] = {}
+def _groups_by_diameter(bosses, tol: float = 0.15):
+    """Group bosses exactly as the existing diameter representative projection does."""
+    out: dict[float, list[object]] = {}
     for b in bosses:
         key = next((k for k in out if abs(k - b.diameter) <= tol), b.diameter)
-        out.setdefault(key, b)
+        out.setdefault(key, []).append(b)
     return list(out.values())
 
 
@@ -235,17 +235,23 @@ def _boss_is_groove_floor(b, grooves) -> bool:
     """A recognised boss coinciding with a groove floor — same turning axis and (floor) ø — is
     that floor. The groove callout already dimensions it, so it must not also get a boss ø
     (#148c review; applies whether or not the part read as a turned profile)."""
+    return bool(_boss_groove_floor_candidates(b, grooves))
+
+
+def _boss_groove_floor_candidates(b, grooves):
+    """Exact groove records satisfying the established boss-floor consumer predicate."""
     ax = _axis_letter(b)
     axis_index = "xyz".index(ax)
-    return any(
-        abs(b.diameter - g.diameter) <= _DIA_TOL
+    return tuple(
+        g
+        for g in grooves
+        if abs(b.diameter - g.diameter) <= _DIA_TOL
         and g.axis == ax
         and all(
             abs(float(b.location[index]) - float(g.at[index])) <= 0.5
             for index in range(3)
             if index != axis_index
         )
-        for g in grooves
     )
 
 
@@ -1727,7 +1733,9 @@ def build_part_model(
     # before aggregate ownership is decided; the bbox alone is private geometry, not ink.
     if bosses is None:
         bosses = recognise_bosses(part, cyls=cyls)
-    bosses_d = _distinct_by_diameter(bosses)
+    boss_groups = _groups_by_diameter(bosses)
+    bosses_d = [group[0] for group in boss_groups]
+    pending_boss_owners: list[tuple[object, object, str]] = []
     if polygonal_stock is None:
         polygonal_stock = recognise_polygonal_stock(part)
     envelope_emittable = bool(
@@ -2158,6 +2166,8 @@ def build_part_model(
         # with the feature_diameters inventory the coverage lint checks against. A groove
         # floor is likewise a narrow reduced band, but the groove callout already carries its
         # ø, so it is suppressed here (_boss_is_groove_floor) to avoid a duplicate boss ø.
+        boss_step_candidates: list[tuple[object, tuple[object, ...]]] = []
+        boss_groove_candidates: list[tuple[object, tuple[object, ...]]] = []
         for b in bosses:
             axis = _axis_letter(b)
             axis_index = "xyz".index(axis)
@@ -2167,8 +2177,10 @@ def build_part_model(
                     float(b.location[axis_index] - b.axis[axis_index] * b.height),
                 )
             )
-            owned = any(
-                profile.axis == axis
+            candidate_steps = tuple(
+                step
+                for profile in profiles
+                if profile.axis == axis
                 and (
                     profile.profile is None
                     or all(
@@ -2177,25 +2189,87 @@ def build_part_model(
                         if index != axis_index
                     )
                 )
-                and any(
+                for step in profile.steps
+                if (
                     abs(b.diameter - step.diameter) <= _DIA_TOL
                     and abs(b_lo - step.lo) <= 0.5
                     and abs(b_hi - step.hi) <= 0.5
-                    for step in profile.steps
                 )
-                for profile in profiles
             )
-            if not owned and not _boss_is_groove_floor(b, grooves):
-                features.append(convert(b, ctx))
+            boss_step_candidates.append((b, candidate_steps))
+            owned = bool(candidate_steps)
+            if not owned:
+                candidate_grooves = _boss_groove_floor_candidates(b, grooves)
+                boss_groove_candidates.append((b, candidate_grooves))
+                if not candidate_grooves:
+                    boss_feature = convert(b, ctx)
+                    features.append(boss_feature)
+                    if ownership is not None:
+                        ownership.bind(b, boss_feature, reason_code="boss_adapter")
+        if ownership is not None:
+            step_claim_counts = Counter(
+                id(candidate) for _, candidates in boss_step_candidates for candidate in candidates
+            )
+            pending_boss_owners.extend(
+                (boss, candidates[0], "boss_turned_step_owner")
+                for boss, candidates in boss_step_candidates
+                if len(candidates) == 1 and step_claim_counts[id(candidates[0])] == 1
+            )
+            groove_claim_counts = Counter(
+                id(candidate)
+                for _, candidates in boss_groove_candidates
+                for candidate in candidates
+            )
+            pending_boss_owners.extend(
+                (boss, candidates[0], "boss_groove_owner")
+                for boss, candidates in boss_groove_candidates
+                if len(candidates) == 1 and groove_claim_counts[id(candidates[0])] == 1
+            )
     else:
-        for b in bosses_d:
+        boss_groove_candidates = [
+            (boss, _boss_groove_floor_candidates(boss, grooves)) for boss in bosses
+        ]
+        groove_claim_counts = Counter(
+            id(candidate) for _, candidates in boss_groove_candidates for candidate in candidates
+        )
+        groove_candidates_by_boss_id = {
+            id(boss): candidates for boss, candidates in boss_groove_candidates
+        }
+        for group in boss_groups:
+            b = group[0]
             # A grooved round body can still fail the turned-step squareness gate (e.g. a
             # shaft with a rectangular flange) and land here with prof=None. Suppress the
             # groove-floor boss so its ø is not dimensioned twice — boss ø + groove callout
             # (#148c 3rd-pass review).
             if _boss_is_groove_floor(b, grooves):
+                if ownership is not None:
+                    pending_boss_owners.extend(
+                        (member, candidates[0], "boss_groove_owner")
+                        for member in group
+                        if len(candidates := groove_candidates_by_boss_id[id(member)]) == 1
+                        and groove_claim_counts[id(candidates[0])] == 1
+                    )
                 continue
-            features.append(convert(b, ctx))
+            boss_feature = convert(b, ctx)
+            features.append(boss_feature)
+            if ownership is not None:
+                represented = tuple(
+                    member for member in group if not groove_candidates_by_boss_id[id(member)]
+                )
+                if len(represented) == 1:
+                    ownership.bind(represented[0], boss_feature, reason_code="boss_adapter")
+                else:
+                    ownership.absorb(
+                        represented,
+                        boss_feature,
+                        reason_code="boss_diameter_group_member",
+                    )
+                pending_boss_owners.extend(
+                    (member, candidates[0], "boss_groove_owner")
+                    for member in group
+                    if len(candidates := groove_candidates_by_boss_id[id(member)]) == 1
+                    and groove_claim_counts[id(candidates[0])] == 1
+                )
         # Overall envelope dims for a *prismatic* part — not a round single-OD body
         # (a boss whose diameter fills the footprint is the body, dimensioned by its
         # OD, not a box).
@@ -2411,6 +2485,20 @@ def build_part_model(
                         groove_feature,
                         reason_code="turned_step_groove_owner",
                     )
+
+    if ownership is not None:
+        # A turned step is the more specific correspondence. Resolve it before the direct
+        # groove-floor fallback so the builder's final-owner cardinality guard leaves a
+        # disconnected same-diameter boss honestly missing rather than crediting both.
+        ordered_boss_owners = sorted(
+            pending_boss_owners,
+            key=lambda pending: pending[2] != "boss_turned_step_owner",
+        )
+        for boss_record, owner_record, reason_code in ordered_boss_owners:
+            if ownership.has_owner(owner_record) and not ownership.has_chained_dependent(
+                owner_record
+            ):
+                ownership.absorb_via(boss_record, owner_record, reason_code=reason_code)
 
     # Rotational furniture — OD + centrelines + concentric bore leaders (#237). Its
     # presence marks the part rotational; emitted from the classification (od, bores).

--- a/src/draftwright/recognition_ownership.py
+++ b/src/draftwright/recognition_ownership.py
@@ -53,7 +53,7 @@ NESTED_FAMILIES = frozenset({"countersinks"})
 # These accepted occurrences have a supported consumer path, but the final owner depends on
 # Draftwright's cross-family classification.  The conversion site must record either the direct
 # adapter or the exact aggregate feature that intentionally absorbs the occurrence.
-CONDITIONAL_FAMILIES = frozenset({"channels", "through_steps", "turned_steps"})
+CONDITIONAL_FAMILIES = frozenset({"bosses", "channels", "through_steps", "turned_steps"})
 
 OwnershipDisposition = Literal["represented", "absorbed"]
 PolicyDisposition = OwnerlessDisposition
@@ -69,6 +69,7 @@ OccurrenceStatus = Literal[
 
 _REPRESENTED_REASON_CODES = frozenset(
     {
+        "boss_adapter",
         "direct_adapter",
         "channel_adapter",
         "hole_adapter",
@@ -82,6 +83,7 @@ _REPRESENTED_REASON_CODES = frozenset(
 _MULTI_FEATURE_REASON_CODES = frozenset({"through_step_legacy_projection"})
 _ABSORBED_REASON_CODES = frozenset(
     {
+        "boss_diameter_group_member",
         "grouped_hole_member",
         "hole_pattern_member",
         "pocket_pattern_member",
@@ -92,6 +94,10 @@ _FEATURE_ABSORPTION_REASON_CODES = frozenset(
     {"channel_step_level_owner", "turned_step_groove_owner"}
 )
 _REASON_FAMILY = {
+    "boss_adapter": "bosses",
+    "boss_diameter_group_member": "bosses",
+    "boss_groove_owner": "bosses",
+    "boss_turned_step_owner": "bosses",
     "channel_adapter": "channels",
     "channel_step_level_owner": "channels",
     "countersink_hole_owner": "countersinks",
@@ -117,6 +123,10 @@ _FEATURE_ABSORPTION_OWNER_KIND = {
 _FEATURE_ABSORPTION_EXISTING_OWNER = {
     "turned_step_groove_owner": ("grooves", "direct_adapter"),
 }
+_CHAINED_OWNER_FAMILY = {
+    "boss_groove_owner": "grooves",
+    "boss_turned_step_owner": "turned_steps",
+}
 
 
 @dataclass(frozen=True)
@@ -134,6 +144,9 @@ class OccurrenceBinding:
     # occurrence. Keep ``feature`` as the primary compatibility spelling while exposing the
     # complete, explicitly recorded owner set through ``features``.
     additional_features: tuple[object, ...] = ()
+    # Exact run-local intermediate occurrence selected by a chained ownership decision. This
+    # makes reverse cardinality derivable after IR remapping; it is not a persistent identifier.
+    via_occurrence: FeatureRef | None = None
 
     @property
     def features(self) -> tuple[object, ...]:
@@ -148,6 +161,8 @@ class OccurrenceBinding:
             {id(owner) for owner in self.additional_features}
         ) != len(self.additional_features):
             raise ValueError("occurrence binding repeats an IR owner")
+        if (self.reason_code in _CHAINED_OWNER_FAMILY) != (self.via_occurrence is not None):
+            raise ValueError("chained ownership bindings require exact intermediate lineage")
 
 
 @dataclass(frozen=True)
@@ -483,6 +498,66 @@ class RecognitionOwnershipBuilder:
             )
         )
 
+    def absorb_via(self, record: object, owner_record: object, *, reason_code: str) -> None:
+        """Bind one occurrence to another occurrence's already-selected final IR owner."""
+
+        if type(reason_code) is not str or reason_code not in _CHAINED_OWNER_FAMILY:
+            raise ValueError("unknown chained ownership reason_code")
+        occurrence = self._occurrence_for(record)
+        owner_occurrence = self._occurrence_for(owner_record)
+        if self.evidence.family(occurrence) != _REASON_FAMILY[reason_code]:
+            raise ValueError("chained ownership reason_code does not match occurrence family")
+        if self.evidence.family(owner_occurrence) != _CHAINED_OWNER_FAMILY[reason_code]:
+            raise ValueError("chained ownership reason_code does not match owner family")
+        if id(occurrence) in self._bound_occurrence_ids:
+            raise ValueError("recognition occurrence already has an IR owner")
+        owner_binding = next(
+            (binding for binding in self._bindings if binding.occurrence is owner_occurrence),
+            None,
+        )
+        if owner_binding is None:
+            raise ValueError("chained recognition ownership requires an existing exact owner")
+        if any(binding.via_occurrence is owner_occurrence for binding in self._bindings):
+            raise ValueError("chained recognition owner occurrence already has a dependent")
+        if any(
+            binding.via_occurrence is not None and binding.feature is owner_binding.feature
+            for binding in self._bindings
+        ):
+            raise ValueError("chained final IR owner already has a dependent")
+        self._bound_occurrence_ids.add(id(occurrence))
+        self._owned_feature_ids.add(id(owner_binding.feature))
+        self._bindings.append(
+            OccurrenceBinding(
+                occurrence,
+                owner_binding.feature,
+                disposition="absorbed",
+                reason_code=reason_code,
+                via_occurrence=owner_occurrence,
+            )
+        )
+
+    def has_owner(self, record: object) -> bool:
+        """Return whether an exact same-run record already has a final IR owner."""
+
+        occurrence = self._occurrence_for(record)
+        return any(binding.occurrence is occurrence for binding in self._bindings)
+
+    def has_chained_dependent(self, record: object) -> bool:
+        """Return whether this occurrence or its final owner already carries a chain."""
+
+        owner_occurrence = self._occurrence_for(record)
+        owner_binding = next(
+            (binding for binding in self._bindings if binding.occurrence is owner_occurrence),
+            None,
+        )
+        if owner_binding is None:
+            return False
+        return any(
+            binding.via_occurrence is owner_occurrence
+            or (binding.via_occurrence is not None and binding.feature is owner_binding.feature)
+            for binding in self._bindings
+        )
+
     def absorb_into(self, record: object, feature: object, *, reason_code: str) -> None:
         """Bind an exact occurrence to a consumer-selected aggregate IR owner."""
 
@@ -585,6 +660,7 @@ class RecognitionOwnershipBuilder:
                             binding.reason_code,
                             binding.member_index,
                             owners[1:],
+                            binding.via_occurrence,
                         )
                     )
                 self._bindings = rewritten_bindings
@@ -648,6 +724,7 @@ class RecognitionOwnershipBuilder:
                         disposition,
                         reason_code,
                         replacement_index,
+                        via_occurrence=binding.via_occurrence,
                     )
                 )
             self._bindings = rewritten

--- a/tests/test_issue_1438_boss_ownership.py
+++ b/tests/test_issue_1438_boss_ownership.py
@@ -1,0 +1,464 @@
+"""#1438 — accepted round bosses retain their exact consumer outcome."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from b123d_recognisers.evidence import build_recognition_evidence
+from build123d import Box, Compound, Cylinder, Pos, import_step
+
+from draftwright import build_drawing
+from draftwright.recognition_ownership import OccurrenceBinding, RecognitionOwnershipBuilder
+
+FIXTURES = Path(__file__).parent / "fixtures" / "evaluation"
+
+
+def _occurrences(ownership, family: str):
+    return tuple(
+        occurrence
+        for occurrence in ownership.evidence.features
+        if ownership.evidence.family(occurrence) == family
+    )
+
+
+def _two_equal_bosses():
+    return Box(100, 60, 10) + Pos(-25, 0, 9) * Cylinder(8, 8) + Pos(25, 0, 9) * Cylinder(8, 8)
+
+
+def _stepped_shaft():
+    return Cylinder(20, 60) + Pos(0, 0, 45) * Cylinder(30, 30)
+
+
+def _boss_key(record) -> tuple[float, float, float]:
+    axis_index = max(range(3), key=lambda index: abs(record.axis[index]))
+    lo, hi = sorted(
+        (
+            float(record.location[axis_index]),
+            float(record.location[axis_index] - record.axis[axis_index] * record.height),
+        )
+    )
+    return record.diameter, lo, hi
+
+
+def test_a_plain_prismatic_boss_is_represented_by_its_exact_feature() -> None:
+    drawing = build_drawing(Box(60, 60, 10) + Pos(0, 0, 9) * Cylinder(12, 8))
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    (occurrence,) = _occurrences(ownership, "bosses")
+    binding = ownership.binding_for(occurrence)
+
+    assert binding is not None
+    assert binding.disposition == "represented"
+    assert binding.reason_code == "boss_adapter"
+    assert binding.feature.kind == "boss"
+    assert any(binding.feature is feature for feature in drawing.model().features)
+    assert ownership.unexpectedly_missing == ()
+
+
+def test_equal_diameter_bosses_retain_occurrence_membership_in_one_existing_owner() -> None:
+    drawing = build_drawing(_two_equal_bosses())
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    occurrences = _occurrences(ownership, "bosses")
+    bindings = tuple(ownership.binding_for(occurrence) for occurrence in occurrences)
+
+    assert len(occurrences) == 2
+    assert all(binding is not None for binding in bindings)
+    assert all(
+        binding is not None
+        and binding.disposition == "absorbed"
+        and binding.reason_code == "boss_diameter_group_member"
+        for binding in bindings
+    )
+    assert bindings[0].feature is bindings[1].feature
+    assert tuple(binding.member_index for binding in bindings if binding is not None) == (0, 1)
+    assert sum(feature.kind == "boss" for feature in drawing.model().features) == 1
+    assert ownership.unexpectedly_missing == ()
+
+
+def test_turned_bosses_follow_their_exact_step_owners() -> None:
+    drawing = build_drawing(_stepped_shaft())
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    boss_occurrences = _occurrences(ownership, "bosses")
+    step_occurrences = _occurrences(ownership, "turned_steps")
+    boss_bindings = tuple(ownership.binding_for(occurrence) for occurrence in boss_occurrences)
+    step_bindings = tuple(ownership.binding_for(occurrence) for occurrence in step_occurrences)
+
+    assert len(boss_bindings) == len(step_bindings) == 2
+    assert all(
+        binding is not None
+        and binding.disposition == "absorbed"
+        and binding.reason_code == "boss_turned_step_owner"
+        and binding.feature.kind == "step"
+        for binding in boss_bindings
+    )
+    step_owners = {
+        (record.diameter, record.lo, record.hi): binding.feature
+        for occurrence, binding in zip(step_occurrences, step_bindings, strict=True)
+        if binding is not None
+        for record in (ownership.evidence.record(occurrence),)
+    }
+    assert all(
+        binding is not None
+        and binding.feature is step_owners[_boss_key(ownership.evidence.record(occurrence))]
+        for occurrence, binding in zip(boss_occurrences, boss_bindings, strict=True)
+    )
+    assert ownership.unexpectedly_missing == ()
+
+
+def test_groove_floor_boss_follows_the_absorbed_step_to_the_exact_groove() -> None:
+    drawing = build_drawing(import_step(FIXTURES / "groove-narrow.step"))
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    boss_bindings = tuple(
+        ownership.binding_for(occurrence) for occurrence in _occurrences(ownership, "bosses")
+    )
+    groove_binding = ownership.binding_for(_occurrences(ownership, "grooves")[0])
+
+    assert groove_binding is not None
+    assert len(boss_bindings) == 3
+    assert all(
+        binding is not None
+        and binding.disposition == "absorbed"
+        and binding.reason_code == "boss_turned_step_owner"
+        for binding in boss_bindings
+    )
+    floor_occurrence = next(
+        occurrence
+        for occurrence in _occurrences(ownership, "bosses")
+        if ownership.evidence.record(occurrence).diameter == pytest.approx(18.0)
+    )
+    floor_binding = ownership.binding_for(floor_occurrence)
+    assert floor_binding is not None
+    assert floor_binding.feature is groove_binding.feature
+    assert floor_binding.reason_code == "boss_turned_step_owner"
+    assert all(
+        binding is not None and binding.feature.kind == "step"
+        for occurrence, binding in zip(
+            _occurrences(ownership, "bosses"), boss_bindings, strict=True
+        )
+        if occurrence is not floor_occurrence
+    )
+    assert ownership.unexpectedly_missing == ()
+
+
+def test_profile_gate_fallback_binds_the_floor_boss_directly_to_its_groove() -> None:
+    part = Cylinder(10, 40) - Pos(0, 0, 5) * (Cylinder(10, 2) - Cylinder(8, 2))
+    part += Box(40, 12, 4)
+    drawing = build_drawing(part)
+    recognition = drawing.recognition()
+    ownership = drawing.recognition_ownership()
+
+    assert recognition is not None
+    assert recognition.turned_profiles == ()
+    assert ownership is not None
+    floor_occurrence = next(
+        occurrence
+        for occurrence in _occurrences(ownership, "bosses")
+        if ownership.evidence.record(occurrence).diameter == pytest.approx(16.0)
+    )
+    floor_binding = ownership.binding_for(floor_occurrence)
+    groove_binding = ownership.binding_for(_occurrences(ownership, "grooves")[0])
+
+    assert floor_binding is not None
+    assert groove_binding is not None
+    assert floor_binding.disposition == "absorbed"
+    assert floor_binding.reason_code == "boss_groove_owner"
+    assert floor_binding.feature is groove_binding.feature
+    assert floor_binding.feature.kind == "groove"
+    assert ownership.unexpectedly_missing == ()
+
+
+def test_a_groove_representative_cannot_claim_a_distinct_equal_diameter_boss() -> None:
+    part = Cylinder(10, 40) - Pos(0, 0, 5) * (Cylinder(10, 2) - Cylinder(8, 2))
+    part += Box(40, 12, 4)
+    part += Pos(24, 0, 0) * Cylinder(8, 8, rotation=(0, 90, 0))
+    drawing = build_drawing(part)
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    equal_diameter = tuple(
+        occurrence
+        for occurrence in _occurrences(ownership, "bosses")
+        if ownership.evidence.record(occurrence).diameter == pytest.approx(16.0)
+    )
+    floor = next(
+        occurrence
+        for occurrence in equal_diameter
+        if ownership.evidence.record(occurrence).axis == pytest.approx((0.0, 0.0, 1.0))
+    )
+    cross_axis = next(occurrence for occurrence in equal_diameter if occurrence is not floor)
+    floor_binding = ownership.binding_for(floor)
+
+    assert floor_binding is not None
+    assert floor_binding.reason_code == "boss_groove_owner"
+    assert floor_binding.feature.kind == "groove"
+    assert ownership.binding_for(cross_axis) is None
+    assert ownership.status(cross_axis) == "unexpectedly_missing"
+    assert cross_axis in ownership.unexpectedly_missing
+
+
+def test_two_coaxial_bosses_competing_for_one_step_both_fail_closed() -> None:
+    part = Compound(children=[_stepped_shaft(), Cylinder(20, 60)])
+    ownership = build_drawing(part).recognition_ownership()
+
+    assert ownership is not None
+    competing = tuple(
+        occurrence
+        for occurrence in _occurrences(ownership, "bosses")
+        if ownership.evidence.record(occurrence).diameter == pytest.approx(40.0)
+    )
+
+    assert len(competing) == 2
+    assert all(ownership.status(occurrence) == "unexpectedly_missing" for occurrence in competing)
+
+
+def test_one_boss_matching_two_nearby_profile_steps_fails_closed() -> None:
+    part = Compound(children=[_stepped_shaft(), Pos(0.25, 0, 0) * _stepped_shaft()])
+    ownership = build_drawing(part).recognition_ownership()
+
+    assert ownership is not None
+    bosses = _occurrences(ownership, "bosses")
+
+    assert len(bosses) == 4
+    assert all(ownership.status(occurrence) == "unexpectedly_missing" for occurrence in bosses)
+
+
+def test_two_coaxial_bosses_competing_for_one_groove_both_fail_closed() -> None:
+    base = Cylinder(10, 40) - Pos(0, 0, 5) * (Cylinder(10, 2) - Cylinder(8, 2))
+    base += Box(40, 12, 4)
+    part = Compound(children=[base, Pos(0, 0, 60) * Cylinder(8, 8)])
+    ownership = build_drawing(part).recognition_ownership()
+
+    assert ownership is not None
+    competing = tuple(
+        occurrence
+        for occurrence in _occurrences(ownership, "bosses")
+        if ownership.evidence.record(occurrence).diameter == pytest.approx(16.0)
+    )
+
+    assert len(competing) == 2
+    assert all(ownership.status(occurrence) == "unexpectedly_missing" for occurrence in competing)
+
+
+def test_step_route_precedes_a_disconnected_direct_route_to_the_same_groove() -> None:
+    main = import_step(FIXTURES / "groove-narrow.step")
+    remote = Pos(0, 0, 40) * (Cylinder(9, 8) + Box(30, 8, 3))
+    ownership = build_drawing(Compound(children=[main, remote])).recognition_ownership()
+
+    assert ownership is not None
+    diameter_18 = tuple(
+        occurrence
+        for occurrence in _occurrences(ownership, "bosses")
+        if ownership.evidence.record(occurrence).diameter == pytest.approx(18.0)
+    )
+    floor = next(
+        occurrence
+        for occurrence in diameter_18
+        if ownership.evidence.record(occurrence).height == pytest.approx(1.0)
+    )
+    remote_boss = next(occurrence for occurrence in diameter_18 if occurrence is not floor)
+    floor_binding = ownership.binding_for(floor)
+    groove_binding = ownership.binding_for(_occurrences(ownership, "grooves")[0])
+
+    assert floor_binding is not None
+    assert groove_binding is not None
+    assert floor_binding.reason_code == "boss_turned_step_owner"
+    assert floor_binding.feature is groove_binding.feature
+    assert ownership.binding_for(remote_boss) is None
+    assert ownership.status(remote_boss) == "unexpectedly_missing"
+
+
+def test_unbound_boss_fails_closed_as_unexpectedly_missing() -> None:
+    evidence = build_recognition_evidence(_two_equal_bosses())
+    ownership = RecognitionOwnershipBuilder(evidence).snapshot()
+    occurrences = _occurrences(ownership, "bosses")
+
+    assert ownership.expected_conditional == occurrences
+    assert all(
+        ownership.status(occurrence) == "unexpectedly_missing" for occurrence in occurrences
+    )
+    assert ownership.unexpectedly_missing == occurrences
+
+
+def test_chained_boss_ownership_requires_an_exact_owned_same_run_occurrence() -> None:
+    evidence = build_recognition_evidence(_stepped_shaft())
+    builder = RecognitionOwnershipBuilder(evidence)
+    ownership = builder.snapshot()
+    boss = evidence.record(_occurrences(ownership, "bosses")[0])
+    step = evidence.record(_occurrences(ownership, "turned_steps")[0])
+
+    with pytest.raises(ValueError, match="requires an existing exact owner"):
+        builder.absorb_via(boss, step, reason_code="boss_turned_step_owner")
+
+    foreign = build_recognition_evidence(_stepped_shaft())
+    foreign_step = foreign.record(
+        _occurrences(RecognitionOwnershipBuilder(foreign).snapshot(), "turned_steps")[0]
+    )
+    with pytest.raises(ValueError, match="does not belong"):
+        builder.absorb_via(boss, foreign_step, reason_code="boss_turned_step_owner")
+
+
+def test_chained_boss_ownership_rejects_wrong_reason_families_and_duplicates() -> None:
+    evidence = build_recognition_evidence(_stepped_shaft())
+    builder = RecognitionOwnershipBuilder(evidence)
+    ownership = builder.snapshot()
+    boss = evidence.record(_occurrences(ownership, "bosses")[0])
+    step = evidence.record(_occurrences(ownership, "turned_steps")[0])
+
+    with pytest.raises(ValueError, match="unknown chained ownership reason_code"):
+        builder.absorb_via(boss, step, reason_code="not-a-reason")
+    with pytest.raises(ValueError, match="does not match occurrence family"):
+        builder.absorb_via(step, step, reason_code="boss_turned_step_owner")
+    with pytest.raises(ValueError, match="does not match owner family"):
+        builder.absorb_via(boss, boss, reason_code="boss_turned_step_owner")
+
+    builder.bind(step, object(), reason_code="turned_step_adapter")
+    builder.absorb_via(boss, step, reason_code="boss_turned_step_owner")
+    with pytest.raises(ValueError, match="already has an IR owner"):
+        builder.absorb_via(boss, step, reason_code="boss_turned_step_owner")
+
+
+def test_two_bosses_cannot_claim_the_same_intermediate_step_occurrence() -> None:
+    evidence = build_recognition_evidence(_stepped_shaft())
+    builder = RecognitionOwnershipBuilder(evidence)
+    ownership = builder.snapshot()
+    bosses = tuple(evidence.record(item) for item in _occurrences(ownership, "bosses"))
+    step = evidence.record(_occurrences(ownership, "turned_steps")[0])
+
+    builder.bind(step, object(), reason_code="turned_step_adapter")
+    builder.absorb_via(bosses[0], step, reason_code="boss_turned_step_owner")
+    with pytest.raises(ValueError, match="owner occurrence already has a dependent"):
+        builder.absorb_via(bosses[1], step, reason_code="boss_turned_step_owner")
+
+
+def test_two_bosses_cannot_claim_the_same_intermediate_groove_occurrence() -> None:
+    evidence = build_recognition_evidence(import_step(FIXTURES / "groove-narrow.step"))
+    builder = RecognitionOwnershipBuilder(evidence)
+    ownership = builder.snapshot()
+    bosses = tuple(evidence.record(item) for item in _occurrences(ownership, "bosses"))
+    groove = evidence.record(_occurrences(ownership, "grooves")[0])
+
+    builder.bind(groove, object())
+    builder.absorb_via(bosses[0], groove, reason_code="boss_groove_owner")
+    with pytest.raises(ValueError, match="owner occurrence already has a dependent"):
+        builder.absorb_via(bosses[1], groove, reason_code="boss_groove_owner")
+
+
+def test_two_chain_paths_cannot_claim_the_same_final_groove_owner() -> None:
+    evidence = build_recognition_evidence(import_step(FIXTURES / "groove-narrow.step"))
+    builder = RecognitionOwnershipBuilder(evidence)
+    ownership = builder.snapshot()
+    boss_occurrences = _occurrences(ownership, "bosses")
+    floor_boss = next(
+        evidence.record(occurrence)
+        for occurrence in boss_occurrences
+        if evidence.record(occurrence).diameter == pytest.approx(18.0)
+    )
+    other_boss = next(
+        evidence.record(occurrence)
+        for occurrence in boss_occurrences
+        if evidence.record(occurrence) is not floor_boss
+    )
+    floor_step = next(
+        evidence.record(occurrence)
+        for occurrence in _occurrences(ownership, "turned_steps")
+        if evidence.record(occurrence).diameter == pytest.approx(18.0)
+    )
+    groove = evidence.record(_occurrences(ownership, "grooves")[0])
+    final_owner = SimpleNamespace(kind="groove")
+
+    builder.bind(groove, final_owner)
+    builder.absorb_into(floor_step, final_owner, reason_code="turned_step_groove_owner")
+    builder.absorb_via(floor_boss, floor_step, reason_code="boss_turned_step_owner")
+    with pytest.raises(ValueError, match="final IR owner already has a dependent"):
+        builder.absorb_via(other_boss, groove, reason_code="boss_groove_owner")
+
+
+def test_removed_step_chain_releases_its_intermediate_occurrence() -> None:
+    evidence = build_recognition_evidence(_stepped_shaft())
+    builder = RecognitionOwnershipBuilder(evidence)
+    ownership = builder.snapshot()
+    boss_occurrence = _occurrences(ownership, "bosses")[0]
+    boss = evidence.record(boss_occurrence)
+    step = evidence.record(_occurrences(ownership, "turned_steps")[0])
+    first_owner = object()
+
+    builder.bind(step, first_owner, reason_code="turned_step_adapter")
+    builder.absorb_via(boss, step, reason_code="boss_turned_step_owner")
+    builder.remap_feature(first_owner, ())
+
+    replacement_owner = object()
+    builder.bind(step, replacement_owner, reason_code="turned_step_adapter")
+    builder.absorb_via(boss, step, reason_code="boss_turned_step_owner")
+    binding = builder.snapshot().binding_for(boss_occurrence)
+    assert binding is not None
+    assert binding.feature is replacement_owner
+
+
+def test_remapped_step_chain_retains_its_intermediate_reservation() -> None:
+    evidence = build_recognition_evidence(_stepped_shaft())
+    builder = RecognitionOwnershipBuilder(evidence)
+    ownership = builder.snapshot()
+    boss_occurrences = _occurrences(ownership, "bosses")
+    bosses = tuple(evidence.record(occurrence) for occurrence in boss_occurrences)
+    step_occurrence = _occurrences(ownership, "turned_steps")[0]
+    step = evidence.record(step_occurrence)
+    first_owner = object()
+
+    builder.bind(step, first_owner, reason_code="turned_step_adapter")
+    builder.absorb_via(bosses[0], step, reason_code="boss_turned_step_owner")
+    replacement_owner = object()
+    builder.remap_feature(first_owner, (replacement_owner,))
+
+    binding = builder.snapshot().binding_for(boss_occurrences[0])
+    assert binding is not None
+    assert binding.feature is replacement_owner
+    assert binding.via_occurrence is step_occurrence
+    with pytest.raises(ValueError, match="owner occurrence already has a dependent"):
+        builder.absorb_via(bosses[1], step, reason_code="boss_turned_step_owner")
+
+
+def test_removed_groove_chain_releases_its_intermediate_occurrence() -> None:
+    evidence = build_recognition_evidence(import_step(FIXTURES / "groove-narrow.step"))
+    builder = RecognitionOwnershipBuilder(evidence)
+    ownership = builder.snapshot()
+    boss_occurrence = _occurrences(ownership, "bosses")[0]
+    boss = evidence.record(boss_occurrence)
+    groove = evidence.record(_occurrences(ownership, "grooves")[0])
+    first_owner = object()
+
+    builder.bind(groove, first_owner)
+    builder.absorb_via(boss, groove, reason_code="boss_groove_owner")
+    builder.remap_feature(first_owner, ())
+
+    replacement_owner = object()
+    builder.bind(groove, replacement_owner)
+    builder.absorb_via(boss, groove, reason_code="boss_groove_owner")
+    binding = builder.snapshot().binding_for(boss_occurrence)
+    assert binding is not None
+    assert binding.feature is replacement_owner
+
+
+def test_chained_binding_requires_intermediate_lineage_in_both_directions() -> None:
+    evidence = build_recognition_evidence(_stepped_shaft())
+    ownership = RecognitionOwnershipBuilder(evidence).snapshot()
+    boss_occurrence = _occurrences(ownership, "bosses")[0]
+    step_occurrence = _occurrences(ownership, "turned_steps")[0]
+
+    with pytest.raises(ValueError, match="require exact intermediate lineage"):
+        OccurrenceBinding(
+            boss_occurrence,
+            object(),
+            disposition="absorbed",
+            reason_code="boss_turned_step_owner",
+        )
+    with pytest.raises(ValueError, match="require exact intermediate lineage"):
+        OccurrenceBinding(boss_occurrence, object(), via_occurrence=step_occurrence)

--- a/tests/test_issue_1438_channel_ownership.py
+++ b/tests/test_issue_1438_channel_ownership.py
@@ -46,7 +46,7 @@ def _channel_occurrence(ownership):
 
 
 def test_conditional_family_roster_is_explicit() -> None:
-    assert CONDITIONAL_FAMILIES == {"channels", "through_steps", "turned_steps"}
+    assert CONDITIONAL_FAMILIES == {"bosses", "channels", "through_steps", "turned_steps"}
 
 
 def test_multi_plate_channel_is_represented_by_its_exact_channel_feature() -> None:

--- a/tests/test_issue_1438_turned_step_ownership.py
+++ b/tests/test_issue_1438_turned_step_ownership.py
@@ -165,7 +165,14 @@ def test_one_groove_cannot_absorb_two_nearby_accepted_step_bands() -> None:
     )
     assert all(ownership.binding_for(occurrence) is None for occurrence in ambiguous)
     assert all(ownership.status(occurrence) == "unexpectedly_missing" for occurrence in ambiguous)
-    assert ownership.unexpectedly_missing == ambiguous
+    assert (
+        tuple(
+            occurrence
+            for occurrence in ownership.unexpectedly_missing
+            if ownership.evidence.family(occurrence) == "turned_steps"
+        )
+        == ambiguous
+    )
 
 
 def test_unbound_turned_step_fails_closed_as_unexpectedly_missing() -> None:
@@ -173,12 +180,26 @@ def test_unbound_turned_step_fails_closed_as_unexpectedly_missing() -> None:
     ownership = RecognitionOwnershipBuilder(evidence).snapshot()
     occurrences = _occurrences(ownership, "turned_steps")
 
-    assert ownership.expected_conditional == occurrences
+    assert (
+        tuple(
+            occurrence
+            for occurrence in ownership.expected_conditional
+            if ownership.evidence.family(occurrence) == "turned_steps"
+        )
+        == occurrences
+    )
     assert all(occurrence in ownership.owner_expected_occurrences for occurrence in occurrences)
     assert all(
         ownership.status(occurrence) == "unexpectedly_missing" for occurrence in occurrences
     )
-    assert ownership.unexpectedly_missing == occurrences
+    assert (
+        tuple(
+            occurrence
+            for occurrence in ownership.unexpectedly_missing
+            if ownership.evidence.family(occurrence) == "turned_steps"
+        )
+        == occurrences
+    )
 
 
 def test_groove_absorption_requires_an_exact_same_run_groove_owner() -> None:


### PR DESCRIPTION
## Symptom and evidence

- User-visible problem: accepted round-boss occurrences were outside the supported ownership denominator even when Draftwright directly emitted a boss, consolidated equal diameters, or intentionally suppressed a boss in favor of a turned step or groove.
- Reproducers: singleton and equal-diameter bosses, turned shafts, groove-floor fallback, cross-axis and disconnected equal-diameter bosses, forward/reverse step ambiguity, competing groove candidates, mixed step/direct routes, and IR remap/delete lifecycle cases in `tests/test_issue_1438_boss_ownership.py`.
- Before/after result: each supported boss now records its exact direct, grouped, turned-step, or groove owner; ambiguous and conflicting candidates remain `unexpectedly_missing`.
- Mutation guards: one intermediate occurrence or final IR owner cannot credit two bosses, and removal/remapping preserves or releases run-local lineage correctly.

## Contract and scope

- Smallest contract: the existing consumer-selected boss projection records exact run-local occurrence ownership without changing the emitted model or drawing.
- Relevant ADRs: 0010, 0011, 0013, 0014, 0015, 0017 Amendment 19, and 0020 reviewed. Only ADR 0017 is narrowly amended.
- Turned-step correspondence takes precedence over the direct groove fallback when both would claim one final groove; competing occurrences fail closed.
- Explicitly deferred: face-level/riser dispositions and the public versioned JSON report projection.
- Uses only released public `b123d-recognisers` records and evidence. No upstream API change is required.
- No renderer, placement, generated-Python, compiled-plan, recognition-scan, or persistent-topology-ID change.

Progresses #1438
Parent epic: #1256

## Validation

- [x] `scripts/pr-check --static`
- [x] Full 18-worker suite: 6,528 passed, 5 skipped, 2 expected xfails
- [x] 95.70% project coverage; 98% changed-line coverage (93% required)
- [x] Exact positive correspondence and natural forward/reverse/cross-path ambiguity regressions
- [x] IR remap replacement plus delete/retry lifecycle regressions
- [x] Three independent exact-head Google-style reviews: ADR, contract, and quality all clean with no nits
- [x] Branch rebased onto current `main` before review and PR

## Stop check

- [x] Review iterations tightened cardinality and lifecycle invariants without invalidating the occurrence-to-owner strategy
- [x] No new prerequisite or recogniser API need was discovered

## Contributor License Agreement

- [x] I have read the CLA and agree to it.