### PR TITLE
Classify step projection evidence outcomes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- Accepted `FaceLevel` and `RiserEvidence` occurrences now receive explicit `evidence_only`
+  outcomes. The released records remain shared substrate for the supported correlated height
+  ladder and shoulder projection, not independent inferred features or drawing requirements; no
+  IR, Sheet DSL, renderer, or recogniser API change is introduced (#1438, ADR 0017 Amendment 20).
+
 - Accepted round-boss occurrences now retain the exact existing consumer outcome: a singleton
   `BossFeature`, one diameter-consolidated representative with transient member lineage, the exact
   turned-step owner, or the exact groove owner reached through that step or the profile-gate

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -20,7 +20,8 @@
   Amendment 17 records each turned-profile step as directly represented or absorbed by its exact
   groove owner. Amendment 18 records direct and multi-feature legacy ownership for accepted
   through-step occurrences. Amendment 19 records the direct, consolidated, turned-step, or groove
-  owner selected for every accepted round-boss occurrence.
+  owner selected for every accepted round-boss occurrence. Amendment 20 gives every accepted
+  face-level and riser evidence occurrence an explicit evidence-only outcome.
 - **Date:** 2026-08-03
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -551,6 +552,31 @@ inference, compiled-plan dependency, annotation placement, generated artefact, o
 ADRs 0010 and 0014 remain untouched; ADRs 0011 and 0015 retain the semantic Sheet/IR waist and
 recognition-free declared build; ADR 0013 keeps geometry recognition separate from consumer
 classification; and ADR 0020's framed evidence boundary is unchanged.
+
+## Amendment 20 — Face levels and risers are explicit projection evidence
+
+Every accepted raw `FaceLevel` and `RiserEvidence` occurrence now receives an `evidence_only`
+consumer outcome with a closed, family-specific reason code. This follows the released provider
+manifest rather than inferring a new ownership relation: both record types have role `evidence`,
+are deliberately absent from the provider feature census, and are not independent drafting
+requirements. `FaceLevel` records are body-local support for the correlated height ladder;
+`RiserEvidence` is the shared scan product from which consumers project `StepShoulder` values.
+
+The face-level and riser capability families remain supported. Their evidence contributes to the
+existing `StepLevelFeature`, sizing, and physical critique paths, but an individual evidence record
+is not itself a feature that should demand a one-to-one IR owner. Reporting it as
+`unexpectedly_missing` would manufacture a requirement the provider explicitly excludes;
+reporting it as `absorbed` would falsely promise exact per-record correspondence through consumer
+filters that intentionally operate on correlated level sets. The evidence-only outcome states the
+narrow truth without downgrading the aggregate feature grammar.
+
+The outcome is projected from the same run-owned evidence authority as every other occurrence.
+Equal-valued body-local records remain distinct, while record equality, scalar coordinates,
+feature order, face indices, and object addresses never become persistent identity. It introduces
+no IR adapter, Sheet DSL word, recognition scan, provider API, annotation, requirement,
+compiled-plan dependency, generated artefact, or visual change. ADRs 0010 and 0014 are untouched;
+ADRs 0011 and 0015 retain the declared/compiler waist; ADR 0013 retains the released provider
+boundary; and ADR 0020's evidence-less framed path remains unchanged.
 
 ## Accepted Contract
 

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -598,6 +598,13 @@ the profile-gate fallback. The occurrence's own geometry remains available even 
 uses a consolidated owner. Ambiguous selection fails closed as `unexpectedly_missing`; it cannot be
 certified by equal values, ordering, rendered labels, or topology identity.
 
+`FaceLevel` and `RiserEvidence` occurrences now receive explicit `evidence_only` outcomes. This
+follows the released provider manifest: both are role=`evidence`, deliberately absent from the
+feature census, and consumed as shared substrate for Draftwright's correlated `StepLevelFeature`
+height/shoulder projection. The aggregate face-level and riser families remain supported; the
+outcome says only that each raw evidence record is not itself an independent inferred feature or
+completeness requirement. It adds no Sheet word, IR adapter, drawing ink, or provider API.
+
 ## Recognisers 0.4.9 prepared frame boundary
 
 Draftwright's 0.4.9 boundary accepted `RiserEvidence` v2,

--- a/src/draftwright/recogniser_policy.py
+++ b/src/draftwright/recogniser_policy.py
@@ -15,6 +15,16 @@ GEOMETRY_ONLY_RATIONALE = (
     "alone must not create inferred gear intent."
 )
 
+# These aggregate records are released as physical recognition evidence, not feature-census
+# entries. Draftwright consumes them as substrate for its correlated StepLevelFeature projection;
+# an individual evidence record is not itself a drafting feature or completeness requirement.
+EVIDENCE_ONLY_FAMILIES: Mapping[str, str] = MappingProxyType(
+    {
+        "step-levels": "step_level_projection_evidence",
+        "risers": "riser_projection_evidence",
+    }
+)
+
 # Families the installed package proves but Draftwright does not fully support. This is the
 # single consumer-policy source used by both the capability declaration and occurrence ledger.
 # It is not a parking bay: an undecided family needs a live decision issue, while a settled
@@ -92,6 +102,13 @@ def ownerless_occurrence_policy(family: str) -> OwnerlessOccurrencePolicy | None
     if type(family) is not str:
         raise TypeError("recognition evidence family must be an exact str")
     family_id = family.replace("_", "-")
+    evidence_only = EVIDENCE_ONLY_FAMILIES.get(family_id)
+    if evidence_only is not None:
+        return OwnerlessOccurrencePolicy(
+            disposition="evidence_only",
+            reason_code=evidence_only,
+            tracking=None,
+        )
     if family_id == GEOMETRY_ONLY_FAMILY_ID:
         return OwnerlessOccurrencePolicy(
             disposition="evidence_only",

--- a/tests/test_issue_1438_policy_dispositions.py
+++ b/tests/test_issue_1438_policy_dispositions.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 from pathlib import Path
 
 import pytest
+from b123d_recognisers import capability_manifest
 from b123d_recognisers.evidence import build_recognition_evidence
 from build123d import (
     Align,
     Box,
     BuildPart,
     BuildSketch,
+    Compound,
     Cylinder,
     Plane,
     Pos,
@@ -23,7 +25,11 @@ from build123d import (
 from draftwright import build_drawing
 from draftwright import recognition_ownership as ownership_module
 from draftwright.recogniser_contract import consumer_capability_declaration
-from draftwright.recogniser_policy import UNSUPPORTED_FAMILIES, ownerless_occurrence_policy
+from draftwright.recogniser_policy import (
+    EVIDENCE_ONLY_FAMILIES,
+    UNSUPPORTED_FAMILIES,
+    ownerless_occurrence_policy,
+)
 from draftwright.recognition_ownership import (
     OccurrencePolicyOutcome,
     RecognitionOwnershipBuilder,
@@ -58,6 +64,11 @@ def _oriented_slot_part():
 
 def _repeating_profile_part():
     return import_step(str(_FIXTURES / "issue_1058_wheel_rh.step"))
+
+
+def _step_projection_evidence_part():
+    aligned = (Align.MIN, Align.MIN, Align.MIN)
+    return Box(60, 40, 20, align=aligned) - Pos(30, 0, 10) * Box(30, 40, 10, align=aligned)
 
 
 @pytest.mark.parametrize(
@@ -103,8 +114,32 @@ def _repeating_profile_part():
             "geometry_only_critique",
             None,
         ),
+        (
+            _step_projection_evidence_part,
+            "step_levels",
+            1,
+            "evidence_only",
+            "step_level_projection_evidence",
+            None,
+        ),
+        (
+            _step_projection_evidence_part,
+            "risers",
+            1,
+            "evidence_only",
+            "riser_projection_evidence",
+            None,
+        ),
     ),
-    ids=("angled-step", "passage", "prismatic-pocket", "oriented-slots", "radial-profile"),
+    ids=(
+        "angled-step",
+        "passage",
+        "prismatic-pocket",
+        "oriented-slots",
+        "radial-profile",
+        "face-level-evidence",
+        "riser-evidence",
+    ),
 )
 def test_settled_policy_classifies_each_exact_accepted_occurrence(
     part_factory,
@@ -160,6 +195,72 @@ def test_supported_unknown_and_malformed_families_cannot_gain_ownerless_policy()
 def test_shared_ownerless_policy_table_is_immutable() -> None:
     with pytest.raises(TypeError, match="does not support item assignment"):
         UNSUPPORTED_FAMILIES["passages"] = UNSUPPORTED_FAMILIES["angled-steps"]  # type: ignore[index]
+    with pytest.raises(TypeError, match="does not support item assignment"):
+        EVIDENCE_ONLY_FAMILIES["risers"] = EVIDENCE_ONLY_FAMILIES["step-levels"]  # type: ignore[index]
+
+
+def test_evidence_occurrence_policy_does_not_downgrade_supported_aggregate_families() -> None:
+    declarations = {
+        family["id"]: family for family in consumer_capability_declaration()["families"]
+    }
+
+    assert declarations["face-levels"]["disposition"] == "supported"
+    assert declarations["risers"]["disposition"] == "supported"
+    step_policy = ownerless_occurrence_policy("step_levels")
+    riser_policy = ownerless_occurrence_policy("risers")
+    assert step_policy is not None and step_policy.disposition == "evidence_only"
+    assert riser_policy is not None and riser_policy.disposition == "evidence_only"
+
+
+def test_equal_body_local_projection_evidence_keeps_distinct_outcomes() -> None:
+    def stepped_block():
+        return Box(40, 30, 10) + Pos(0, 0, 10) * Box(20, 30, 10)
+
+    part = Compound(children=[Pos(-60, 0, 0) * stepped_block(), Pos(60, 0, 0) * stepped_block()])
+    evidence = build_recognition_evidence(part)
+    ownership = RecognitionOwnershipBuilder(evidence).snapshot()
+
+    for family, expected_count in (("step_levels", 2), ("risers", 4)):
+        occurrences = tuple(
+            occurrence for occurrence in evidence.features if evidence.family(occurrence) == family
+        )
+        outcomes = tuple(ownership.policy_for(occurrence) for occurrence in occurrences)
+
+        assert len(occurrences) == expected_count
+        assert len({id(occurrence) for occurrence in occurrences}) == expected_count
+        assert all(outcome is not None for outcome in outcomes)
+        assert len({id(outcome) for outcome in outcomes}) == expected_count
+        assert all(outcome.disposition == "evidence_only" for outcome in outcomes if outcome)
+
+
+def test_projection_evidence_policy_matches_the_released_provider_roles() -> None:
+    manifest = {family["id"]: family for family in capability_manifest()["families"]}
+
+    assert manifest["face-levels"]["census_output"] is None
+    assert manifest["risers"]["census_output"] is None
+    assert {record["role"] for record in manifest["face-levels"]["records"]} == {"evidence"}
+    assert {record["name"]: record["role"] for record in manifest["risers"]["records"]} == {
+        "RiserEvidence": "evidence",
+        "StepShoulder": "projection",
+    }
+
+
+def test_raw_step_ladder_keeps_supported_ir_beside_evidence_only_inputs() -> None:
+    drawing = build_drawing(_step_projection_evidence_part())
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    assert any(feature.kind == "step_level" for feature in drawing.model().features)
+    for family in ("step_levels", "risers"):
+        occurrences = tuple(
+            occurrence
+            for occurrence in ownership.evidence.features
+            if ownership.evidence.family(occurrence) == family
+        )
+        assert occurrences
+        assert all(ownership.status(occurrence) == "evidence_only" for occurrence in occurrences)
+        assert all(ownership.binding_for(occurrence) is None for occurrence in occurrences)
+        assert all(occurrence not in ownership.unexpectedly_missing for occurrence in occurrences)
 
 
 def test_an_occurrence_cannot_have_both_owner_and_ownerless_policy(monkeypatch) -> None:


### PR DESCRIPTION
Part of #1438 and #1256.

## Outcome

Give every accepted raw FaceLevel and RiserEvidence occurrence an explicit evidence_only consumer outcome while preserving the supported aggregate face-level/riser capability and existing StepLevelFeature projection.

This is the honest released-provider boundary: the records are role=evidence and deliberately absent from the feature census. Treating them as represented or absorbed would claim one-to-one ownership that the correlated projection does not preserve; treating them as unexpectedly missing would invent independent drafting requirements.

## Scope

- add immutable closed policy entries for step_levels and risers
- retain distinct outcomes for equal-valued body-local occurrences
- guard the released 0.4.12 manifest roles and census contract
- prove a real raw step ladder still emits its supported StepLevelFeature
- document the boundary and ADR 0017 Amendment 20
- no IR, Sheet DSL, renderer, generated artefact, visual output, scoring, or recognition scan changes
- no provider API change required

## Validation

- 6,534 passed, 5 skipped, 2 expected xfails
- project coverage 95.70%
- changed-line coverage 100% (93% required)
- Ruff, formatting, mypy, static checks, documentation build, and diff check green
- clean worktree at exact head 20357e6492a69f33547aa91a1d28852d9a38fb0b

## Independent review

Three fresh Google Code Review-style reviews inspected exact head 20357e6492a69f33547aa91a1d28852d9a38fb0b and tree 5a4d979b252b4caaa09e2d1b80485956533977aa against main 5fa83de8b6e17b2573cb8d40cf1d17b2196c0e83:

- ADR review: CLEAN, no findings or nits
- provider/ownership contract review: CLEAN, no findings or nits
- code quality/test review: CLEAN, no findings or nits

## ADR audit

ADRs 0010, 0011, 0013, 0014, 0015, 0017, and 0020 were checked. Only ADR 0017 is narrowly amended. Recognition-free declared builds, plan-independent completeness, provider/public API separation, solver-owned placement, and the evidence-less framed boundary are unchanged.