### PR TITLE
fix: reconcile same-face boss and blend ownership

### DIFF
--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -3718,6 +3718,12 @@ class Drawing:
                 assembly=self.assembly,
                 holes=holes,
                 bosses=bosses,
+                blends=recognition.blends,
+                recognition_evidence=self._build.recognition_evidence,
+                # The same profile set `detect` used, so the boss/blend absorption decision
+                # is one decision rather than two that can disagree. `prof_kw` is empty only
+                # where detect also falls back to the aggregate.
+                **({"turned_profiles": prof_kw["profiles"]} if "profiles" in prof_kw else {}),
                 registry=self._registry,
             )
             issues += lint_axial_coverage(

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -58,6 +58,11 @@ from draftwright.recognition_frame import (
     groove_owns_turned_step_band,
     profiles_owning_axial_band,
 )
+from draftwright.recognition_ownership import (
+    BOSS_BLEND_DIAMETER_TOL,
+    boss_blend_owner_pairs,
+    envelope_is_emittable,
+)
 from draftwright.view_plan import VIEW_AXES
 
 _UNSET = object()  # sentinel: distinguishes "not supplied" from a valid prof=None
@@ -269,6 +274,9 @@ def lint_feature_coverage(
     assembly=None,
     holes=None,
     bosses=None,
+    blends=None,
+    recognition_evidence=None,
+    turned_profiles=_UNSET,
     registry=None,
 ) -> list:
     """Coarse completeness check: report part diameters with no callout (#80).
@@ -303,6 +311,11 @@ def lint_feature_coverage(
     ``cyls`` accepts a precomputed ``analyse_cylinders(part)`` result so
     repeated lint runs need not re-scan the solid.
 
+    When same-run ``recognition_evidence`` proves that a recognised boss and blend share the
+    same defining face and circular value, the boss diameter is excluded from this coarse
+    physical inventory. The blend radius is the truthful callout for that face; counting its
+    equivalent diameter again would recreate the duplicate this lint is meant to detect.
+
     Counts are checked too (#92): the part's holes (via ``recognise_holes``) give
     a required count per diameter (each bore, counterbore, and spotface
     occurrence counts one), and structured callouts declare how many holes
@@ -318,6 +331,44 @@ def lint_feature_coverage(
     z_cyls, cross_cyls = cyls if cyls is not None else analyse_cylinders(part)
     if holes is None:
         holes = recognise_holes(part, cyls=(z_cyls, cross_cyls))
+    if bosses is None and recognition_evidence is not None:
+        bosses = recognition_evidence.result.bosses
+    if blends is None and recognition_evidence is not None:
+        blends = recognition_evidence.result.blends
+    # `bosses`/`blends` are inventories, so an empty one is not None. Testing `is not None`
+    # bought a `part.bounding_box()` on every lint of every part, including the great majority
+    # with no boss or blend to reconcile — a second solid measurement on the re-lint path that
+    # `test_relint_recomputes_no_annotation_boxes` budgets exactly one of. Truthiness skips it.
+    if bosses and blends and recognition_evidence is not None:
+        bbox = part.bounding_box()
+        # The BUILD's profile set, not the recognition result's. On a declared build they
+        # differ — `detect._analyse` uses the caller's `prof`/`profiles` — and detect decides
+        # absorption from its own. Re-deriving here let the IR drop a boss diameter that this
+        # lint still demanded a callout for. `_UNSET` means the caller had none to state, which
+        # is the same condition under which detect falls back to the aggregate.
+        profiles = (
+            recognition_evidence.result.turned_profiles
+            if turned_profiles is _UNSET
+            else turned_profiles
+        )
+        envelope_emittable = envelope_is_emittable(
+            bbox=bbox,
+            bosses=bosses,
+            turned_profiles=profiles,
+            polygonal_stock=recognition_evidence.result.polygonal_stock,
+        )
+        blend_owned_boss_ids = {
+            id(boss)
+            for boss, _blend in boss_blend_owner_pairs(
+                recognition_evidence,
+                tuple(bosses),
+                tuple(blends),
+                bbox=bbox,
+                envelope_emittable=envelope_emittable,
+                diameter_tolerance=BOSS_BLEND_DIAMETER_TOL,
+            )
+        }
+        bosses = tuple(boss for boss in bosses if id(boss) not in blend_owned_boss_ids)
     # Coverage inventory: the *recognised* dimensionable diameters (bores,
     # cbore/spotface steps, bosses) from feature_diameters — built via
     # recognise_holes/recognise_bosses, so slot ends and interrupted recesses (partial

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -142,7 +142,13 @@ from draftwright.recognition_frame import (
     groove_owns_turned_step_band,
     require_unambiguous_groove_owner,
 )
-from draftwright.recognition_ownership import RecognitionOwnershipBuilder
+from draftwright.recognition_ownership import (
+    BOSS_BLEND_DIAMETER_TOL,
+    RecognitionOwnershipBuilder,
+    boss_blend_owner_pairs,
+    boss_fills_footprint,
+    envelope_is_emittable,
+)
 
 
 def _member_hole(h, frame: Frame, members: tuple = (), count: int = 1) -> HoleFeature:
@@ -1828,8 +1834,26 @@ def build_part_model(
     pending_boss_owners: list[tuple[object, object, str]] = []
     if polygonal_stock is None:
         polygonal_stock = recognise_polygonal_stock(part)
-    envelope_emittable = bool(
-        not profiles and not _is_round(bbox, bosses_d) and not polygonal_stock
+    envelope_emittable = envelope_is_emittable(
+        bbox=bbox,
+        bosses=bosses_d,
+        turned_profiles=profiles,
+        polygonal_stock=polygonal_stock,
+    )
+    boss_blend_owner_by_id = (
+        {
+            id(boss): blend
+            for boss, blend in boss_blend_owner_pairs(
+                recognition_evidence,
+                tuple(bosses),
+                tuple(blends),
+                bbox=bbox,
+                envelope_emittable=envelope_emittable,
+                diameter_tolerance=BOSS_BLEND_DIAMETER_TOL,
+            )
+        }
+        if recognition_evidence is not None
+        else {}
     )
     if through_steps is None:
         # Match RecognitionResult applicability on the standalone path. A supplied aggregate
@@ -2260,6 +2284,9 @@ def build_part_model(
         boss_step_candidates: list[tuple[object, tuple[object, ...]]] = []
         boss_groove_candidates: list[tuple[object, tuple[object, ...]]] = []
         for b in bosses:
+            if owner_blend := boss_blend_owner_by_id.get(id(b)):
+                pending_boss_owners.append((b, owner_blend, "boss_blend_owner"))
+                continue
             axis = _axis_letter(b)
             axis_index = "xyz".index(axis)
             b_lo, b_hi = sorted(
@@ -2317,8 +2344,20 @@ def build_part_model(
                 if len(candidates) == 1 and groove_claim_counts[id(candidates[0])] == 1
             )
     else:
+        remaining_boss_groups = []
+        for group in boss_groups:
+            remaining = []
+            for boss in group:
+                if owner_blend := boss_blend_owner_by_id.get(id(boss)):
+                    pending_boss_owners.append((boss, owner_blend, "boss_blend_owner"))
+                else:
+                    remaining.append(boss)
+            if remaining:
+                remaining_boss_groups.append(remaining)
         boss_groove_candidates = [
-            (boss, _boss_groove_floor_candidates(boss, grooves)) for boss in bosses
+            (boss, _boss_groove_floor_candidates(boss, grooves))
+            for group in remaining_boss_groups
+            for boss in group
         ]
         groove_claim_counts = Counter(
             id(candidate) for _, candidates in boss_groove_candidates for candidate in candidates
@@ -2326,7 +2365,7 @@ def build_part_model(
         groove_candidates_by_boss_id = {
             id(boss): candidates for boss, candidates in boss_groove_candidates
         }
-        for group in boss_groups:
+        for group in remaining_boss_groups:
             b = group[0]
             # A grooved round body can still fail the turned-step squareness gate (e.g. a
             # shaft with a rectangular flange) and land here with prof=None. Suppress the
@@ -2611,12 +2650,18 @@ def build_part_model(
                     )
 
     if ownership is not None:
-        # A turned step is the more specific correspondence. Resolve it before the direct
-        # groove-floor fallback so the builder's final-owner cardinality guard leaves a
-        # disconnected same-diameter boss honestly missing rather than crediting both.
+        # Same-face blends and turned steps are more specific correspondences. Resolve them
+        # before the direct groove-floor fallback so the builder's final-owner cardinality
+        # guard leaves a disconnected same-diameter boss honestly missing rather than
+        # crediting both.
+        owner_precedence = {
+            "boss_blend_owner": 0,
+            "boss_turned_step_owner": 1,
+            "boss_groove_owner": 2,
+        }
         ordered_boss_owners = sorted(
             pending_boss_owners,
-            key=lambda pending: pending[2] != "boss_turned_step_owner",
+            key=lambda pending: owner_precedence[pending[2]],
         )
         for boss_record, owner_record, reason_code in ordered_boss_owners:
             if ownership.has_owner(owner_record) and not ownership.has_chained_dependent(
@@ -2659,8 +2704,9 @@ def build_part_model(
 
 def _is_round(bbox, bosses, tol: float = 0.5) -> bool:
     """True when a boss's OD fills the part footprint — a round body of revolution,
-    dimensioned by its OD rather than a width×depth box."""
-    return any(
-        abs(b.diameter - bbox.size.X) <= tol and abs(b.diameter - bbox.size.Y) <= tol
-        for b in bosses
-    )
+    dimensioned by its OD rather than a width×depth box.
+
+    Delegates so that `linting.coverage`, which cannot import `model`, shares this exact
+    predicate rather than keeping a second copy of its body and its tolerance.
+    """
+    return boss_fills_footprint(bbox, bosses, tol)

--- a/src/draftwright/recognition_ownership.py
+++ b/src/draftwright/recognition_ownership.py
@@ -7,15 +7,160 @@ turns object addresses, feature order, record values, or topology indices into p
 
 from __future__ import annotations
 
+from collections import Counter
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 from b123d_recognisers.evidence import FeatureRef, RecognitionEvidence
 
+from draftwright.blend_contract import blend_provider_key
 from draftwright.recogniser_policy import (
     OwnerlessDisposition,
     ownerless_occurrence_policy,
 )
+
+_BOSS_ENVELOPE_SPAN_TOL = 0.005
+
+#: Two circular values within this (mm) state the same circle. Detect and lint must use the
+#: SAME number when reconciling a boss against a blend: they were two independent `0.15`
+#: literals (`detect._DIA_TOL` and `lint_feature_coverage(tol=...)`) that happened to agree,
+#: and if they ever drifted the IR would absorb a boss the lint still demanded a callout for.
+BOSS_BLEND_DIAMETER_TOL = 0.15
+
+#: A boss OD within this (mm) of both footprint extents means the body is round, and its
+#: overall size is dimensioned by that OD rather than by a width x depth envelope.
+_ROUND_FOOTPRINT_TOL = 0.5
+
+
+def boss_fills_footprint(bbox, bosses, tol: float = _ROUND_FOOTPRINT_TOL) -> bool:
+    """Whether some boss's OD fills the part footprint — a round body of revolution."""
+
+    return any(
+        abs(boss.diameter - bbox.size.X) <= tol and abs(boss.diameter - bbox.size.Y) <= tol
+        for boss in bosses
+    )
+
+
+def envelope_is_emittable(*, bbox, bosses, turned_profiles, polygonal_stock) -> bool:
+    """Whether an ordinary envelope dimension will carry this part's overall size.
+
+    Absorbing a boss into a blend removes the boss's axial length, so the projection is only
+    safe when the envelope is itself emitted and can carry that length. Detect and lint both
+    have to answer this, and they have to answer it the *same way* — the IR drops a boss
+    diameter exactly when lint stops requiring one.
+
+    They did not share an answer. `detect` called `_is_round`; `linting.coverage` inlined that
+    function's body with its `0.5` copied in, and read `turned_profiles` off the recognition
+    result while detect used the *build's* profile set, which on a declared build is the
+    caller's (`detect._analyse`: `profiles = () if prof is None else (prof,)`). A build that
+    declared its profiles could therefore have detect absorb a boss whose diameter lint still
+    demanded — `feature_not_dimensioned` against a diameter the plan deliberately removed —
+    or the converse, hiding a real duplicate. One formula, one input, one answer.
+    """
+
+    return bool(
+        not turned_profiles and not boss_fills_footprint(bbox, bosses) and not polygonal_stock
+    )
+
+
+def boss_spans_envelope(boss: Any, bbox: Any) -> bool:
+    """Whether a boss's axial length is already carried by the part envelope.
+
+    `Any`, not `object`: both arguments are read by attribute — a provider record and a
+    build123d bounding box — which `object` cannot express, and the module's sibling
+    `recognition_frame` already types provider records this way. Annotated `object` these
+    seven accesses failed mypy, which the branch never ran.
+    """
+
+    axis_index = max(range(3), key=lambda index: abs(float(boss.axis[index])))
+    boss_lo, boss_hi = sorted(
+        (
+            float(boss.location[axis_index]),
+            float(boss.location[axis_index] - boss.axis[axis_index] * boss.height),
+        )
+    )
+    bbox_lo = float((bbox.min.X, bbox.min.Y, bbox.min.Z)[axis_index])
+    bbox_hi = float((bbox.max.X, bbox.max.Y, bbox.max.Z)[axis_index])
+    return (
+        abs(boss_lo - bbox_lo) <= _BOSS_ENVELOPE_SPAN_TOL
+        and abs(boss_hi - bbox_hi) <= _BOSS_ENVELOPE_SPAN_TOL
+    )
+
+
+def boss_blend_owner_pairs(
+    evidence: RecognitionEvidence,
+    bosses: tuple,
+    blends: tuple,
+    *,
+    bbox: object,
+    envelope_emittable: bool,
+    diameter_tolerance: float = 0.15,
+) -> tuple[tuple[object, object], ...]:
+    """Return unambiguous same-face boss/blend projections from one provider run.
+
+    Scalar equality is not ownership evidence: unrelated ``R4`` and ``ø8`` features are
+    common. A pair is accepted only when the provider's opaque evidence assigns both records
+    the same non-empty defining-face set, their axes agree, and their values state the same
+    circle. Absorbing the boss would also remove its length, so its axial span must already be
+    carried by an emitted envelope. The final one-to-one gate prevents one occurrence from
+    crediting several owners.
+    """
+
+    if not envelope_emittable:
+        return ()
+
+    def occurrence_for(family: str, record: object) -> FeatureRef | None:
+        matches = tuple(
+            occurrence
+            for occurrence in evidence.features
+            if evidence.family(occurrence) == family and evidence.record(occurrence) is record
+        )
+        return matches[0] if len(matches) == 1 else None
+
+    candidate_rows: list[tuple[object, tuple[object, ...]]] = []
+    for boss in bosses:
+        if not boss_spans_envelope(boss, bbox):
+            candidate_rows.append((boss, ()))
+            continue
+        boss_occurrence = occurrence_for("bosses", boss)
+        if boss_occurrence is None:
+            candidate_rows.append((boss, ()))
+            continue
+        boss_faces = evidence.defining_faces(boss_occurrence)
+        if not boss_faces:
+            candidate_rows.append((boss, ()))
+            continue
+        axis_index = max(range(3), key=lambda index: abs(float(boss.axis[index])))
+        boss_axis = "xyz"[axis_index]
+        candidates = []
+        for blend in blends:
+            # `Blend.axis` was removed by recognisers 0.4.14, which moved the direction into a
+            # `StraightBlendPath`/`CircularBlendPath` (#1459). `blend_provider_key` is the one
+            # fail-closed reader of that released shape — deriving the axis here again would be
+            # a second, unvalidated copy of the provider boundary (ADR 3).
+            blend_axis, blend_radius = blend_provider_key(blend)[:2]
+            if (
+                blend_axis != boss_axis
+                or abs(boss.diameter - 2.0 * blend_radius) > diameter_tolerance
+            ):
+                continue
+            blend_occurrence = occurrence_for("blends", blend)
+            if (
+                blend_occurrence is not None
+                and evidence.defining_faces(blend_occurrence) == boss_faces
+            ):
+                candidates.append(blend)
+        candidate_rows.append((boss, tuple(candidates)))
+
+    claim_counts = Counter(
+        id(candidate) for _boss, candidates in candidate_rows for candidate in candidates
+    )
+    return tuple(
+        (boss, candidates[0])
+        for boss, candidates in candidate_rows
+        if len(candidates) == 1 and claim_counts[id(candidates[0])] == 1
+    )
+
 
 # These aggregate families have an unconditional one-record -> one-feature adapter in
 # model.detect. Remaining nested and classification-only families stay unclassified until a later
@@ -104,6 +249,7 @@ _MULTI_FEATURE_ABSORPTION_EXISTING_OWNER = {
 }
 _REASON_FAMILY = {
     "boss_adapter": "bosses",
+    "boss_blend_owner": "bosses",
     "boss_diameter_group_member": "bosses",
     "boss_groove_owner": "bosses",
     "boss_turned_step_owner": "bosses",
@@ -137,6 +283,7 @@ _FEATURE_ABSORPTION_EXISTING_OWNER = {
     "turned_step_groove_owner": ("grooves", "direct_adapter"),
 }
 _CHAINED_OWNER_FAMILY = {
+    "boss_blend_owner": "blends",
     "boss_groove_owner": "grooves",
     "boss_turned_step_owner": "turned_steps",
 }

--- a/tests/test_issue_1450_boss_blend_ownership.py
+++ b/tests/test_issue_1450_boss_blend_ownership.py
@@ -1,0 +1,345 @@
+"""#1450 — one cylindrical face must not become both a boss diameter and blend radius."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from runpy import run_path
+
+from b123d_recognisers.evidence import build_recognition_evidence
+from build123d import import_step
+
+from draftwright import build_drawing
+from draftwright.linting.coverage import lint_feature_coverage as coverage_lint
+from draftwright.recognition_ownership import boss_blend_owner_pairs, boss_spans_envelope
+from draftwright.sheet_emit import generate_sheet_script
+
+FIXTURE = Path(__file__).parent / "fixtures" / "grm04_drive_plate.step"
+
+
+def _occurrences(ownership, family: str):
+    return tuple(
+        occurrence
+        for occurrence in ownership.evidence.features
+        if ownership.evidence.family(occurrence) == family
+    )
+
+
+def test_grm04_lower_round_has_one_ir_owner_and_no_detached_diameter() -> None:
+    drawing = build_drawing(FIXTURE, title="GRM-04")
+    ownership = drawing.recognition_ownership()
+
+    assert ownership is not None
+    (boss_occurrence,) = _occurrences(ownership, "bosses")
+    binding = ownership.binding_for(boss_occurrence)
+
+    assert binding is not None
+    assert binding.disposition == "absorbed"
+    assert binding.reason_code == "boss_blend_owner"
+    assert binding.feature.kind == "blend"
+    assert binding.feature.radius == 4.0
+    assert not [feature for feature in drawing.model().features if feature.kind == "boss"]
+    assert [feature.radius for feature in drawing.model().features if feature.kind == "blend"] == [
+        3.0,
+        4.0,
+    ]
+    assert ownership.unexpectedly_missing == ()
+    assert not [issue for issue in drawing.lint() if issue.code == "feature_not_dimensioned"]
+
+
+def test_generated_grm04_sheet_emits_r4_but_not_a_second_diameter(tmp_path) -> None:
+    script_path = Path(
+        generate_sheet_script(
+            str(FIXTURE),
+            out=str(tmp_path / "grm04"),
+            title="GRM-04 DRIVE PLATE",
+            number="GRM-04",
+            page="A3",
+            scale=5,
+            scale_policy="strict",
+            zones=True,
+            projection="third",
+        )
+    )
+    script = script_path.read_text()
+
+    assert "radius=4" in script
+    assert 'sheet.dimension(blend2, "blend.radius")' in script
+    assert "sheet.diameter(diameter=8" not in script
+    assert '"boss.diameter"' not in script
+    rebuilt = run_path(str(script_path))["drawing"]
+    assert not [issue for issue in rebuilt.lint() if issue.code == "feature_not_dimensioned"]
+
+
+def test_scalar_equality_without_same_run_face_identity_does_not_deduplicate() -> None:
+    part = import_step(FIXTURE)
+    evidence = build_recognition_evidence(part, rotational=False)
+    (boss,) = evidence.result.bosses
+    lower, upper = sorted(evidence.result.blends, key=lambda blend: blend.radius, reverse=True)
+    bbox = part.bounding_box()
+
+    assert boss_blend_owner_pairs(
+        evidence,
+        (boss,),
+        (lower,),
+        bbox=bbox,
+        envelope_emittable=True,
+    ) == ((boss, lower),)
+    assert (
+        boss_blend_owner_pairs(
+            evidence,
+            (boss,),
+            (upper,),
+            bbox=bbox,
+            envelope_emittable=True,
+        )
+        == ()
+    )
+    assert (
+        boss_blend_owner_pairs(
+            evidence,
+            (boss,),
+            (lower,),
+            bbox=bbox,
+            envelope_emittable=False,
+        )
+        == ()
+    )
+
+
+def test_blend_ownership_requires_boss_length_to_be_covered_by_envelope() -> None:
+    part = import_step(FIXTURE)
+    evidence = build_recognition_evidence(part, rotational=False)
+    (boss,) = evidence.result.bosses
+
+    assert boss_spans_envelope(boss, part.bounding_box())
+
+    class ShortBoss:
+        axis = boss.axis
+        location = boss.location
+        height = boss.height / 2.0
+
+    assert not boss_spans_envelope(ShortBoss(), part.bounding_box())
+
+
+def test_absorption_fails_closed_when_the_boss_has_no_usable_face_evidence() -> None:
+    """The two fail-closed arms the PR describes but never exercised.
+
+    `boss_blend_owner_pairs` refuses a pair when the boss has no accepted occurrence, and
+    again when that occurrence carries no defining faces — "an evidence-less build, an
+    ambiguous face claim ... retains the existing boss path and fails closed". Both arms were
+    uncovered, so nothing established that a missing join refuses rather than absorbs, which
+    is the whole safety property: absorbing on absent evidence would silently delete a boss
+    diameter from the sheet.
+    """
+
+    part = import_step(FIXTURE)
+    evidence = build_recognition_evidence(part, rotational=False)
+    (boss,) = evidence.result.bosses
+    lower = max(evidence.result.blends, key=lambda blend: blend.radius)
+    bbox = part.bounding_box()
+
+    # Precondition: with real evidence this pair IS absorbed, so a later refusal is caused by
+    # the evidence being withdrawn and not by the pair having been ineligible all along.
+    assert boss_blend_owner_pairs(
+        evidence, (boss,), (lower,), bbox=bbox, envelope_emittable=True
+    ) == ((boss, lower),)
+
+    class _NoOccurrence:
+        """Evidence that accepts nothing: every `occurrence_for` lookup misses."""
+
+        result = evidence.result
+        features = ()
+
+        def family(self, occurrence):
+            raise AssertionError("no occurrence should be reachable")
+
+        def record(self, occurrence):
+            raise AssertionError("no occurrence should be reachable")
+
+        def defining_faces(self, occurrence):
+            raise AssertionError("no occurrence should be reachable")
+
+    assert (
+        boss_blend_owner_pairs(
+            _NoOccurrence(), (boss,), (lower,), bbox=bbox, envelope_emittable=True
+        )
+        == ()
+    )
+
+    class _NoFaces:
+        """Occurrences exist, but none of them names a defining face."""
+
+        result = evidence.result
+        features = evidence.features
+
+        def family(self, occurrence):
+            return evidence.family(occurrence)
+
+        def record(self, occurrence):
+            return evidence.record(occurrence)
+
+        def defining_faces(self, occurrence):
+            return ()
+
+    assert (
+        boss_blend_owner_pairs(_NoFaces(), (boss,), (lower,), bbox=bbox, envelope_emittable=True)
+        == ()
+    )
+
+
+def test_feature_coverage_skips_the_reconciliation_when_either_inventory_is_empty() -> None:
+    """A part with no boss or no blend must not pay a second solid `bounding_box()`.
+
+    `bosses`/`blends` are inventories, so an empty one is not `None`; testing `is not None`
+    measured the solid again on every lint of every part. That is what
+    `test_relint_recomputes_no_annotation_boxes` caught, and this pins the cheaper predicate
+    directly rather than relying on that guard's fixture happening to have no bosses.
+    """
+
+    from build123d import Box, Cylinder, Pos
+
+    from draftwright.linting import coverage as coverage_module
+
+    part = Box(60, 40, 20) - Pos(10, 5, 0) * Cylinder(4, 20)
+    evidence = build_recognition_evidence(part, rotational=False)
+    assert not evidence.result.bosses or not evidence.result.blends, (
+        "fixture must have an empty side for this to be the skipped path"
+    )
+
+    calls = 0
+    real = type(part).bounding_box
+
+    def counting(self, *args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return real(self, *args, **kwargs)
+
+    drawing = build_drawing(part)
+    original = type(part).bounding_box
+    try:
+        type(part).bounding_box = counting
+        coverage_module.lint_feature_coverage(
+            part,
+            drawing.items,
+            recognition_evidence=evidence,
+            registry=drawing.registry,
+        )
+    finally:
+        type(part).bounding_box = original
+
+    assert calls == 0, f"the empty-inventory path measured the solid {calls} time(s)"
+
+
+def test_detect_and_lint_decide_absorption_from_one_shared_predicate() -> None:
+    """Both sides must answer "is the envelope emittable?" identically, or the sheet lies.
+
+    They did not. `detect` called `_is_round`; `linting.coverage` inlined that function's body
+    with its `0.5` copied in, and — the part that matters — read `turned_profiles` off the
+    recognition result while detect uses the BUILD's set, which on a declared build is the
+    caller's (`profiles = () if prof is None else (prof,)`). Disagreement means the IR absorbs
+    a boss whose diameter lint still requires, reporting `feature_not_dimensioned` against a
+    diameter the plan deliberately removed.
+
+    Pinned structurally rather than by one fixture: a fixture only demonstrates the pair it
+    happens to contain, and the defect is that two formulas exist at all.
+    """
+
+    import inspect
+
+    from draftwright.linting import coverage as coverage_module
+    from draftwright.model import detect as detect_module
+    from draftwright.recognition_ownership import (
+        BOSS_BLEND_DIAMETER_TOL,
+        envelope_is_emittable,
+    )
+
+    # One formula: neither module may re-derive the roundness test locally. The check is the
+    # inlined comparison itself, not `bbox.size.X`, which both modules use for other things.
+    inlined = "abs(boss.diameter - bbox.size.X)"
+    for module in (coverage_module, detect_module):
+        source = inspect.getsource(module)
+        assert inlined not in source, f"{module.__name__} re-inlines the roundness test"
+        assert "envelope_is_emittable" in source, module.__name__
+    # ...and the check can fire: this IS the string that was in coverage.py before #1451.
+    assert inlined in "        abs(boss.diameter - bbox.size.X) <= 0.5"
+
+    # One tolerance: two independent `0.15` literals agreed only by luck.
+    detect_call = inspect.getsource(detect_module)
+    coverage_call = inspect.getsource(coverage_module)
+    for source in (detect_call, coverage_call):
+        assert "diameter_tolerance=BOSS_BLEND_DIAMETER_TOL" in source
+    assert BOSS_BLEND_DIAMETER_TOL == 0.15
+
+    # One input: lint takes the build's profile set, so a declared profile reaches both.
+    # Asserted BEHAVIOURALLY — that the argument changes the answer — because asserting the
+    # parameter merely exists left the original defect (lint re-deriving the set from the
+    # recognition result and ignoring what it was given) passing untouched under mutation.
+    signature = inspect.signature(coverage_module.lint_feature_coverage)
+    assert "turned_profiles" in signature.parameters
+    # Read the module file, not `Drawing._lint`: `test_private_test_attr_reads` ratchets
+    # private-attribute reads from tests downward, and this needs no such read.
+    drawing_source = (
+        Path(__file__).resolve().parent.parent / "src" / "draftwright" / "drawing.py"
+    ).read_text(encoding="utf-8")
+    assert "turned_profiles" in drawing_source, (
+        "drawing.py must hand lint the profile set it gave detect"
+    )
+
+    # And the predicate itself refuses on any one of the three grounds.
+    class _Bbox:
+        size = type("S", (), {"X": 40.0, "Y": 40.0})()
+
+    class _RoundBoss:
+        diameter = 40.0
+
+    assert envelope_is_emittable(bbox=_Bbox(), bosses=(), turned_profiles=(), polygonal_stock=())
+    assert not envelope_is_emittable(
+        bbox=_Bbox(), bosses=(_RoundBoss(),), turned_profiles=(), polygonal_stock=()
+    )
+    assert not envelope_is_emittable(
+        bbox=_Bbox(), bosses=(), turned_profiles=("a profile",), polygonal_stock=()
+    )
+    assert not envelope_is_emittable(
+        bbox=_Bbox(), bosses=(), turned_profiles=(), polygonal_stock=("stock",)
+    )
+
+
+def test_lint_honours_the_build_profile_set_rather_than_re_deriving_it() -> None:
+    """The behavioural half of the shared decision: the argument must change the answer.
+
+    GRM-04 has no turned profile, so recognition reports none and the boss is absorbed. A
+    build that DECLARED a profile makes the envelope non-emittable, and detect would then keep
+    the boss — so lint must keep its diameter in the physical inventory too. If lint re-derives
+    the profile set from the recognition result it cannot see the declaration, and the two
+    sides disagree. That is the defect this fixture exercises: it is not detectable by checking
+    that a parameter is present, only by checking that passing it changes the outcome.
+    """
+
+    part = import_step(FIXTURE)
+    evidence = build_recognition_evidence(part, rotational=False)
+    drawing = build_drawing(FIXTURE, title="GRM-04")
+
+    assert evidence.result.turned_profiles == (), "fixture must have no recognised profile"
+    assert evidence.result.bosses and evidence.result.blends, "fixture must have both to pair"
+
+    def _codes(**kwargs):
+        return sorted(
+            issue.code
+            for issue in coverage_lint(
+                part,
+                drawing.items,
+                recognition_evidence=evidence,
+                registry=drawing.registry,
+                **kwargs,
+            )
+        )
+
+    absorbed = _codes()
+    declared_profile = _codes(turned_profiles=("a declared turned profile",))
+
+    assert absorbed != declared_profile, (
+        "lint ignored the build's profile set and re-derived it from the recognition result"
+    )
+    # And in the direction that matters: declaring a profile stops the absorption, so the
+    # boss diameter returns to the inventory and its missing callout is reported again.
+    assert len(declared_profile) > len(absorbed), (absorbed, declared_profile)


### PR DESCRIPTION
A provider-proved same-face boss/blend pair now has one drafting owner. On GRM-04, the drawing retains R4 and the 4.5 envelope while removing the detached duplicate Ø8 callout.

The join requires unique same-run face evidence, matching circular geometry, and full-envelope axial coverage. Detection and independent lint share the envelope predicate and diameter tolerance, including the same declared turned-profile input. Generated-script physical lint follows that ownership decision. The existing 0.005 mm envelope tolerance remains conservative: a pair outside it is not absorbed.

Closes #1450.

## Architectural fit

Ownership remains at the recognition-to-IR boundary and uses provider face evidence. The shared predicate lives below detection and lint, preserving their import boundary. Existing compiled measurements and solver placement remain authoritative; no raw annotation placement or additional recognition run is introduced. No ADR text changes are required.

## Validation

On head `8de08e5c975e94c07039020527130421bdc217b6`, updated with the merged development-version bump:

- `scripts/pr-check --full` exited 0.
- 6,747 passed, 5 skipped, 2 expected failures.
- Total coverage 95.94%; changed-line coverage 97% (77 changed lines, 2 uncovered).
- Ruff, formatting, mypy, spelling and strict documentation build passed through the same gate.
- Earlier rendered GRM-04 evidence and mutation results are recorded in this PR's review history.

Hosted checks for this head must pass before merge. The local gate excludes the slow tier, which remains the existing post-merge main safety net.
