### PR TITLE
Write recognition reports atomically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- `Drawing.write_report(path)` now atomically writes the versioned report as deterministic,
+  strict UTF-8 JSON without coupling library export to sidecar generation. Report and filesystem
+  failures leave any existing destination untouched, with best-effort temporary cleanup that does
+  not mask the primary error (#1438, ADR 0017 Amendment 22).
+
 - Raw automatic drawings now expose `Drawing.report()`, a strict version-1 JSON-compatible
   projection of every accepted recognition occurrence, its explicit consumer disposition and
   report-local final IR owner(s), plus the existing lint summary. The published schema never

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -616,6 +616,22 @@ placement and changes no PDF/SVG/DXF/PNG content. ADR 0010's annotation registry
 recognition-free declared build, ADR 0013's released provider boundary, ADR 0014's shared solve,
 ADR 0015's compiler waist, and ADR 0020's framed boundary remain unchanged.
 
+## Amendment 22 — Report persistence is explicit and atomic
+
+`Drawing.write_report(path)` persists the same schema-v1 document returned by `Drawing.report()`
+as deterministic, strict, indented UTF-8 JSON. It writes and flushes a uniquely named sibling
+temporary file before atomically replacing the destination, and removes that temporary on any
+failure when the filesystem permits cleanup. A cleanup error never masks the primary persistence
+failure. Report construction happens before temporary-file creation, so an unavailable or invalid
+report cannot disturb an existing destination. Parent directories remain caller-owned.
+
+Persistence is an explicit library operation, not a side effect of `Drawing.export()`. It does not
+render, place, or change PDF/SVG/DXF/PNG content. Output manifests, generated-Python snapshots,
+declared runtime reconciliation, and CLI/script sidecars remain later slices. This amendment adds
+no recogniser call, provider API, correspondence inference, persistent topology identity,
+annotation path, or completeness claim; Amendment 21's raw-only fail-closed report boundary and
+all ADR 0010/0011/0013/0014/0015/0020 constraints remain unchanged.
+
 ## Accepted Contract
 
 ### 1. One orchestration owns the recognition universe

--- a/docs/reference/reports.md
+++ b/docs/reference/reports.md
@@ -9,7 +9,15 @@ from draftwright import build_drawing
 
 drawing = build_drawing("part.step")
 report = drawing.report()
+drawing.write_report("part.draftwright.json")
 ```
+
+`write_report(path)` writes the same report as deterministic, indented UTF-8 JSON with a trailing
+newline and returns the destination path as a string. The write is atomic within the destination
+directory: Draftwright first flushes a sibling temporary file, then replaces the destination. A
+report or filesystem failure leaves an existing destination unchanged. Temporary-file cleanup is
+best-effort when the filesystem itself refuses it, and a cleanup error never masks the primary
+failure. Parent directories are not created implicitly.
 
 The closed top-level schema is published as
 [`draftwright-report-v1.schema.json`](draftwright-report-v1.schema.json). `schema` is always
@@ -41,6 +49,6 @@ ownership from values, labels, rendered coordinates, topology traversal, or a se
 scan. Declared reconciliation and framed evidence remain explicit later contracts rather than
 holes disguised as an empty report.
 
-The report is in-memory only in this slice. Atomic JSON writing, output manifests, generated-Python
-gap snapshots, and CLI/script sidecars follow as separate vertical slices. Calling `report()` does
-not alter PDF, SVG, DXF, or PNG content.
+Output manifests, generated-Python gap snapshots, and CLI/script sidecars follow as separate
+vertical slices. Calling `report()` or `write_report()` does not alter PDF, SVG, DXF, or PNG
+content; library export does not write a report unless the caller requests one.

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1033,6 +1033,20 @@ class Drawing:
             source=source,
         )
 
+    def write_report(self, path: str | os.PathLike[str]) -> str:
+        """Atomically write :meth:`report` as deterministic UTF-8 JSON.
+
+        The destination is replaced only after the complete strict-JSON document has been
+        flushed to a temporary file in the same directory. A report or filesystem failure leaves
+        an existing destination untouched; temporary-file cleanup is best-effort when the
+        filesystem itself refuses it. This method does not export or modify any visual drawing
+        artefact.
+        """
+
+        from draftwright.reporting import _write_report_document
+
+        return _write_report_document(self.report(), path)
+
     # --- build-context compat properties (#639): one BuildState, thin views.
     # _part_model and the two caches are GETTER-ONLY by design (#691 review):
     # zero assignment sites exist in src/ or tests/, and a future wholesale

--- a/src/draftwright/reporting.py
+++ b/src/draftwright/reporting.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import json
+import os
 from collections import Counter
 from importlib.metadata import version as distribution_version
 from os import PathLike
 from pathlib import Path
+from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Any, cast
 
 from draftwright.recogniser_schema import consumed_record_schema_versions_for_type
@@ -199,6 +201,48 @@ def drawing_report(
         },
         "lint": lint,
     }
+
+
+def _write_report_document(report: dict[str, object], path: str | PathLike[str]) -> str:
+    """Atomically write one strict, deterministic UTF-8 report document."""
+
+    destination = Path(path)
+    payload = (
+        json.dumps(
+            report,
+            allow_nan=False,
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n"
+    )
+    temporary: Path | None = None
+    try:
+        with NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            newline="\n",
+            prefix=".draftwright-report-",
+            suffix=".tmp",
+            dir=destination.parent,
+            delete=False,
+        ) as handle:
+            temporary = Path(handle.name)
+            handle.write(payload)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, destination)
+    except BaseException:
+        if temporary is not None:
+            try:
+                temporary.unlink(missing_ok=True)
+            except OSError:
+                # Cleanup is best-effort: never hide the write/replace failure that tells the
+                # caller whether the requested report reached its destination.
+                pass
+        raise
+    return str(destination)
 
 
 __all__ = [

--- a/tests/test_issue_1438_report_writer.py
+++ b/tests/test_issue_1438_report_writer.py
@@ -1,0 +1,136 @@
+"""#1438 — report persistence is explicit, deterministic, and atomic."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+from build123d import Box, Pos
+
+from draftwright import ReportUnavailableError, build_drawing
+from draftwright import reporting as reporting_module
+
+
+def _through_step_part():
+    return Box(40, 30, 20) - Pos(15, 10, 0) * Box(20, 20, 30)
+
+
+def test_write_report_persists_the_exact_in_memory_document(tmp_path: Path) -> None:
+    drawing = build_drawing(_through_step_part(), reproducible=True)
+    destination = tmp_path / "part.draftwright.json"
+
+    returned = drawing.write_report(destination)
+
+    assert returned == str(destination)
+    assert destination.read_bytes().endswith(b"\n")
+    assert json.loads(destination.read_text(encoding="utf-8")) == drawing.report()
+    assert list(tmp_path.iterdir()) == [destination]
+
+
+def test_repeated_writes_are_byte_deterministic(tmp_path: Path) -> None:
+    drawing = build_drawing(_through_step_part(), reproducible=True)
+    destination = tmp_path / "part.draftwright.json"
+
+    drawing.write_report(destination)
+    first = destination.read_bytes()
+    drawing.write_report(destination)
+
+    assert destination.read_bytes() == first
+
+
+def test_valid_near_name_limit_destination_does_not_overflow_temporary_name(
+    tmp_path: Path,
+) -> None:
+    try:
+        name_max = os.pathconf(tmp_path, "PC_NAME_MAX")
+    except (AttributeError, OSError, ValueError):
+        pytest.skip("filesystem component limit is not available")
+    suffix = ".json"
+    destination = tmp_path / ("r" * (name_max - len(suffix)) + suffix)
+    drawing = build_drawing(_through_step_part())
+
+    drawing.write_report(destination)
+
+    assert json.loads(destination.read_text(encoding="utf-8")) == drawing.report()
+    assert list(tmp_path.iterdir()) == [destination]
+
+
+def test_report_refusal_cannot_touch_an_existing_destination(tmp_path: Path) -> None:
+    drawing = build_drawing(_through_step_part(), model=[])
+    destination = tmp_path / "part.draftwright.json"
+    destination.write_text("keep me\n", encoding="utf-8")
+
+    with pytest.raises(ReportUnavailableError):
+        drawing.write_report(destination)
+
+    assert destination.read_text(encoding="utf-8") == "keep me\n"
+    assert list(tmp_path.iterdir()) == [destination]
+
+
+def test_non_finite_json_cannot_touch_an_existing_destination(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    drawing = build_drawing(_through_step_part())
+    destination = tmp_path / "part.draftwright.json"
+    destination.write_text("keep me\n", encoding="utf-8")
+    monkeypatch.setattr(drawing, "report", lambda: {"invalid": float("nan")})
+
+    with pytest.raises(ValueError, match="Out of range float values"):
+        drawing.write_report(destination)
+
+    assert destination.read_text(encoding="utf-8") == "keep me\n"
+    assert list(tmp_path.iterdir()) == [destination]
+
+
+def test_failed_atomic_replace_keeps_the_old_file_and_cleans_the_temporary(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    drawing = build_drawing(_through_step_part())
+    destination = tmp_path / "part.draftwright.json"
+    destination.write_text("old\n", encoding="utf-8")
+
+    def fail_replace(_source, _destination):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(reporting_module.os, "replace", fail_replace)
+    with pytest.raises(OSError, match="replace failed"):
+        drawing.write_report(destination)
+
+    assert destination.read_text(encoding="utf-8") == "old\n"
+    assert list(tmp_path.iterdir()) == [destination]
+
+
+def test_cleanup_failure_does_not_mask_the_primary_replace_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    drawing = build_drawing(_through_step_part())
+    destination = tmp_path / "part.draftwright.json"
+    destination.write_text("old\n", encoding="utf-8")
+    original_unlink = Path.unlink
+
+    def fail_replace(_source, _destination):
+        raise OSError("replace failed")
+
+    def fail_cleanup(_path, *, missing_ok=False):
+        raise PermissionError("cleanup failed")
+
+    monkeypatch.setattr(reporting_module.os, "replace", fail_replace)
+    monkeypatch.setattr(Path, "unlink", fail_cleanup)
+    with pytest.raises(OSError, match="replace failed"):
+        drawing.write_report(destination)
+
+    assert destination.read_text(encoding="utf-8") == "old\n"
+    temporary = next(path for path in tmp_path.iterdir() if path != destination)
+    original_unlink(temporary)
+
+
+def test_missing_parent_is_not_created(tmp_path: Path) -> None:
+    drawing = build_drawing(_through_step_part())
+    destination = tmp_path / "missing" / "part.draftwright.json"
+
+    with pytest.raises(FileNotFoundError):
+        drawing.write_report(destination)
+
+    assert not destination.parent.exists()


### PR DESCRIPTION
## Summary

- add explicit Drawing.write_report(path) persistence for the versioned report
- serialize deterministic strict UTF-8 JSON before touching the destination
- flush and fsync a uniquely named sibling temporary, then atomically replace
- preserve existing destinations on failure and keep cleanup best-effort without masking the primary error
- document ADR 0017 Amendment 22 and the public report-writing contract

Closes part of #1438.

## Review

Three independent Google-style exact-head reviews are CLEAN with no required findings or optional nits. ADR 0017 Amendment 22 and related architecture boundaries pass. Reviewed head: fef3f0532b99216c5687abbf88728a98eda779fc.

## Validation

- Ruff: pass
- mypy: pass
- pytest: 6,567 passed, 5 skipped, 2 xfailed
- total coverage: 95.72%
- diff coverage: 100%
- focused boundary regressions cover near-NAME_MAX destinations and cleanup-error preservation
