### PR TITLE
Track exact Plate occurrence ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Added
 
+- Accepted Plate occurrences now retain exact conditional ownership. Genuine multi-axis plates
+  keep their direct `PlateFeature`; other slabs are absorbed only when released same-run AAG
+  evidence joins them to the exact retained face-level, riser-shoulder, or slot-pattern owner.
+  Multi-owner claims are conjunctive, while whole-envelope, polygonal-boss, disconnected,
+  ambiguous, or malformed cases remain visibly `unexpectedly_missing` rather than borrowing an
+  owner from matching values or traversal order (#1438, ADR 0017 Amendment 23).
+
 - `Drawing.write_report(path)` now atomically writes the versioned report as deterministic,
   strict UTF-8 JSON without coupling library export to sidecar generation. Report and filesystem
   failures leave any existing destination untouched, with best-effort temporary cleanup that does

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,7 @@ Compact map, bottom to top:
   `intents.py` (deferred-edit low IR), `recognition_cache.py` (ADR 0017 one-result
   lifecycle), `recognition_ownership.py` (run-local accepted-occurrence outcomes, including
   final-IR binding, group/pattern absorption, and settled ownerless consumer policy),
+  `plate_correspondence.py` (pure shared Plate-record/final-IR correspondence predicates),
   `recogniser_policy.py` (single Draftwright-owned unsupported/deferred/evidence-only policy),
   `recogniser_schema.py` (consumer-owned public record schema versions shared by validation and
   reporting), `reporting.py` (pure versioned projection over explicitly supplied finished-build

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -632,6 +632,30 @@ no recogniser call, provider API, correspondence inference, persistent topology 
 annotation path, or completeness claim; Amendment 21's raw-only fail-closed report boundary and
 all ADR 0010/0011/0013/0014/0015/0020 constraints remain unchanged.
 
+## Amendment 23 — Plate ownership is conditional and AAG-backed
+
+Accepted `Plate` occurrences now enter the conditional ownership family. A genuine multi-axis
+plate represented by Draftwright's existing direct adapter retains its exact `PlateFeature`.
+Otherwise, an occurrence is absorbed only when released same-run AAG evidence proves one of the
+existing compatibility projections: its defining face supports the exact retained `FaceLevel`,
+its defining face supports the exact `RiserEvidence` shoulder, or its defining face is shared by
+an exact `Slot` member whose existing ownership already names the retained slot-pattern feature.
+The corresponding final owners are respectively the step level, the envelope plus step level, or
+the envelope plus slot pattern.
+
+These multi-owner bindings are conjunctive: every recorded owner must remain in the final model or
+the occurrence becomes `unexpectedly_missing`; partial credit is forbidden. Numeric interval and
+support predicates live in one pure leaf shared by model conversion and Plate-completeness lint,
+but numbers, labels, ordering, equal-valued records, and topology traversal never establish report
+ownership by themselves. Whole-envelope and polygonal-boss compatibility remain completeness-only
+until a released recogniser relation proves exact occurrence lineage. Malformed, disconnected,
+ambiguous, and otherwise unproved cases therefore remain visibly `unexpectedly_missing`.
+
+This amendment adds no recognition scan, provider API, persistent topology ID, rendering or
+placement behavior, or inferred requirement. The raw automatic path records the conversion-time
+decision only; declared and provider-framed boundaries remain unchanged under ADRs 0011, 0013,
+0015, and 0020.
+
 ## Accepted Contract
 
 ### 1. One orchestration owns the recognition universe

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,8 @@ keep that table, this document, and `CLAUDE.md`'s compact map in step. The
 The dependency graph is a DAG (the #138 / ADR 0005 split is complete). Bottom to
 top: leaf modules (`layout.py`, `registry.py`, `fonts.py`, `_geometry.py`,
 `fits.py`, `intents.py`, `recognition_cache.py`, `recognition_ownership.py`,
-`recogniser_policy.py`, `recogniser_schema.py`, `reporting.py`, `recognition_frame.py`, and the
+`plate_correspondence.py`, `recogniser_policy.py`, `recogniser_schema.py`, `reporting.py`,
+`recognition_frame.py`, and the
 strict `blend_contract.py` provider-record boundary, and the `linting/` subpackage) →
 `_core.py` → stage modules (`export.py`,
 `repair.py`, `projection.py`, `compose.py`, `analysis.py`, `drawing.py`, the
@@ -196,7 +197,8 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   owns linting): `coverage.py` (`lint_feature_coverage` + `CoverageState`),
   `structural.py` (geometry/standards checks), `issues.py` (the `LintIssue` type),
   `gear_coverage.py` (declared gear table/profile reconciliation), and `suggest.py`
-  (`_suggest_fix`, #29 snippets). Depends only on `_core`,
+  (`_suggest_fix`, #29 snippets). Depends only on `_core`, the pure
+  `plate_correspondence` leaf,
   `b123d_recognisers` (typed hole records in `coverage.py`) + build123d_drafting.
   `_QUOTED_RE` (a lint-message label regex shared with the
   repair loop) lives in `_core`.
@@ -216,6 +218,10 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   owners, and settled
   unsupported/deferred/evidence-only occurrences are classified; remaining conditional
   cross-family records stay unclassified.
+- **`plate_correspondence.py`** — pure shared Plate-record/final-IR correspondence predicates.
+  Model assembly uses their feature dependency sets only while recording exact same-run
+  occurrence ownership; completeness lint uses the same predicates for requirement ownership.
+  The leaf imports neither consumer, recogniser implementation, nor drawing state.
 - **`recogniser_policy.py`** — the rank-0 Draftwright-owned source for reviewed unsupported,
   deferred, and geometry-only family policy. Both the cross-repository capability declaration and
   the run-local occurrence ledger project this same immutable data; recognition remains

--- a/src/draftwright/linting/plate_coverage.py
+++ b/src/draftwright/linting/plate_coverage.py
@@ -19,6 +19,20 @@ from b123d_recognisers import RecognitionResult
 
 from draftwright.linting._registry import satisfaction_ids, satisfaction_of
 from draftwright.linting.issues import LintIssue, is_placement_drop
+from draftwright.plate_correspondence import (
+    _between,
+    _depth_axis,
+    _envelope,
+    _envelope_owned_dependencies,
+    _polygonal_boss_dependencies,
+    _rounded,
+    _same,
+    _slot_pattern_dependencies,
+    _step_level_dependencies,
+    plate_center,
+    plate_key,
+    plate_span,
+)
 
 PlateRequirementState = Literal[
     "placed",
@@ -42,46 +56,6 @@ class PlateRequirementOutcome:
     requirement_count: int = 1
     features: tuple = ()
     dependencies: tuple[tuple[object, str], ...] = ()
-
-
-def _rounded(value) -> float:
-    return round(float(value), 3)
-
-
-def plate_center(plate) -> Point:
-    """Reconstruct the body-local slab witness retained on both sides of the IR waist."""
-    axis = str(plate.axis)
-    index = "xyz".index(axis)
-    other = [candidate for candidate in range(3) if candidate != index]
-    point = [0.0, 0.0, 0.0]
-    point[index] = (_rounded(plate.lo) + _rounded(plate.hi)) / 2
-    point[other[0]] = _rounded(plate.u)
-    point[other[1]] = _rounded(plate.v)
-    return tuple(_rounded(value) for value in point)  # type: ignore[return-value]
-
-
-def plate_span(plate) -> tuple[Point, Point]:
-    """Return the exact physical thickness witness used by ``PlateFeature.parameters``."""
-    axis = str(plate.axis)
-    index = "xyz".index(axis)
-    other = [candidate for candidate in range(3) if candidate != index]
-    start = [0.0, 0.0, 0.0]
-    end = [0.0, 0.0, 0.0]
-    start[index], end[index] = _rounded(plate.lo), _rounded(plate.hi)
-    start[other[0]] = end[other[0]] = _rounded(plate.u)
-    start[other[1]] = end[other[1]] = _rounded(plate.v)
-    return tuple(start), tuple(end)  # type: ignore[return-value]
-
-
-def plate_key(plate) -> tuple:
-    """Every compiler-significant fact retained by the provider record and public IR."""
-    return (
-        str(plate.axis),
-        _rounded(plate.lo),
-        _rounded(plate.hi),
-        _rounded(plate.u),
-        _rounded(plate.v),
-    )
 
 
 def _parameter_id(feature, source) -> str | None:
@@ -125,72 +99,6 @@ def _index_evidence(registry):
         and isinstance(getattr(measurement, "parameter", None), str)
     }
     return placed, Counter(placed_measurements), satisfied, dropped
-
-
-def _axis_parameter(axis: str) -> str:
-    return {"x": "width.length", "y": "depth.length", "z": "height.length"}[axis]
-
-
-def _envelope(features):
-    values = [item for item in features if getattr(item, "kind", None) == "envelope"]
-    return values[0] if len(values) == 1 else None
-
-
-def _same(value, expected) -> bool:
-    return _rounded(value) == _rounded(expected)
-
-
-def _between(value, bounds) -> bool:
-    lo, hi = sorted((_rounded(bounds[0]), _rounded(bounds[1])))
-    return lo <= _rounded(value) <= hi
-
-
-def _depth_axis(width_axis, long_axis) -> str | None:
-    width = str(width_axis)
-    long = str(long_axis)
-    if width not in {"x", "y", "z"} or long not in {"x", "y", "z"} or width == long:
-        return None
-    remaining = {"x", "y", "z"} - {width, long}
-    return next(iter(remaining)) if len(remaining) == 1 else None
-
-
-def _step_supports_source(source, step) -> bool:
-    """Require the Plate witness to lie on this level record's physical support."""
-    try:
-        point = plate_center(source)
-        supports = tuple(step.level_supports)
-        if not supports:
-            return False
-        if str(source.axis) == "z":
-            return any(
-                _between(point[0], support.x_span) and _between(point[1], support.y_span)
-                for support in supports
-            )
-        transverse = "x" if str(source.axis) == "y" else "y"
-        index = "xyz".index(transverse)
-        span_name = f"{transverse}_span"
-        return any(_between(point[index], getattr(support, span_name)) for support in supports)
-    except (AttributeError, TypeError, ValueError):
-        return False
-
-
-def _slot_pattern_supports_source(source, pattern) -> bool:
-    """Join a material web only to a pattern whose physical cut crosses its witness."""
-    try:
-        member = pattern.member
-        if str(source.axis) != str(member.width_axis):
-            return False
-        depth_axis = _depth_axis(member.width_axis, member.long_axis)
-        if depth_axis is None or str(pattern.frame.axis) != depth_axis:
-            return False
-        point = plate_center(source)
-        long_index = "xyz".index(str(member.long_axis))
-        depth_index = "xyz".index(depth_axis)
-        return _between(point[long_index], (member.lo, member.hi)) and _same(
-            point[depth_index], pattern.frame.origin[depth_index]
-        )
-    except (AttributeError, TypeError, ValueError):
-        return False
 
 
 def _recognised_slot_pattern_supports_source(source, pattern, validation_cache=None) -> bool:
@@ -331,41 +239,6 @@ def _validated_recognised_pattern(pattern, validation_cache=None):
     return result
 
 
-def _polygonal_boss_supports_source(source, boss) -> bool:
-    """Conservatively require the Plate witness inside the owner's support polygon."""
-    try:
-        axis = str(source.axis)
-        boss_axis = getattr(getattr(boss, "frame", None), "axis", getattr(boss, "axis", None))
-        if str(boss_axis) != axis:
-            return False
-        side_count = boss.side_count
-        directions = tuple(boss.flat_directions)
-        centres = tuple(boss.flat_centres)
-        if (
-            type(side_count) is not int
-            or side_count < 4
-            or side_count % 2
-            or len(directions) != side_count
-            or len(centres) != side_count
-            or len(set(directions)) != side_count
-            or len(set(centres)) != side_count
-        ):
-            return False
-        indices = [index for index in range(3) if index != "xyz".index(axis)]
-        point = tuple(plate_center(source)[index] for index in indices)
-        polygon = [tuple(float(centre[index]) for index in indices) for centre in centres]
-        signs = []
-        for start, end in zip(polygon, (*polygon[1:], polygon[0]), strict=True):
-            cross = (end[0] - start[0]) * (point[1] - start[1]) - (end[1] - start[1]) * (
-                point[0] - start[0]
-            )
-            if abs(cross) > 1e-6:
-                signs.append(cross > 0)
-        return bool(signs) and all(sign == signs[0] for sign in signs)
-    except (AttributeError, TypeError, ValueError):
-        return False
-
-
 def _valid_polygonal_boss_source(boss) -> bool:
     try:
         from draftwright.linting.polygonal_boss_coverage import (
@@ -456,154 +329,6 @@ def _shares_one_solid(membership, source, boss) -> bool:
         return bool(boss_owners[0] == (0,))
     except (AttributeError, OverflowError, TypeError, ValueError):
         return False
-
-
-def _step_level_dependencies(source, features) -> tuple[tuple[object, str], ...]:
-    """Exact legacy level/shoulder grammar that already states a Plate interval."""
-    try:
-        axis = str(source.axis)
-        lo, hi = _rounded(source.lo), _rounded(source.hi)
-        envelope = _envelope(features)
-        for step in (item for item in features if getattr(item, "kind", None) == "step_level"):
-            if not _step_supports_source(source, step):
-                continue
-            if axis == "z":
-                coordinates = tuple(_rounded(value) for value in (step.base, *step.levels))
-                if lo not in coordinates or hi not in coordinates:
-                    continue
-                count = int(lo != _rounded(step.base)) + int(hi != _rounded(step.base))
-                if count:
-                    return ((step, "step_height.length"),) * count
-                continue
-            if envelope is None:
-                continue
-            index = "xyz".index(axis)
-            bounds = (_rounded(envelope.bbox_min[index]), _rounded(envelope.bbox_max[index]))
-            shoulders = tuple(
-                _rounded(position)
-                for shoulder_axis, position in step.shoulders
-                if str(shoulder_axis) == axis
-            )
-            if not shoulders:
-                continue
-            boundaries = {bounds[0], *shoulders, bounds[1]}
-            if lo in boundaries and hi in boundaries:
-                return (
-                    (envelope, _axis_parameter(axis)),
-                    *((step, "step_position.length"),) * len(shoulders),
-                )
-    except (AttributeError, TypeError, ValueError):
-        return ()
-    return ()
-
-
-def _polygonal_boss_dependencies(source, features) -> tuple[tuple[object, str], ...]:
-    """Envelope minus an attached boss height can state the supporting slab thickness."""
-    try:
-        axis = str(source.axis)
-        index = "xyz".index(axis)
-        envelope = _envelope(features)
-        if envelope is None:
-            return ()
-        envelope_interval = (
-            _rounded(envelope.bbox_min[index]),
-            _rounded(envelope.bbox_max[index]),
-        )
-        source_interval = (_rounded(source.lo), _rounded(source.hi))
-        for boss in (item for item in features if getattr(item, "kind", None) == "polygonal_boss"):
-            if (
-                str(boss.frame.axis) != axis
-                or boss.span is None
-                or not _polygonal_boss_supports_source(source, boss)
-            ):
-                continue
-            boss_interval = tuple(sorted(_rounded(point[index]) for point in boss.span))
-            supports_below = (
-                source_interval[0] == envelope_interval[0]
-                and source_interval[1] == boss_interval[0]
-                and boss_interval[1] == envelope_interval[1]
-            )
-            supports_above = (
-                boss_interval[0] == envelope_interval[0]
-                and boss_interval[1] == source_interval[0]
-                and source_interval[1] == envelope_interval[1]
-            )
-            if supports_below or supports_above:
-                return (
-                    (envelope, _axis_parameter(axis)),
-                    (boss, "boss_height.length"),
-                )
-    except (AttributeError, TypeError, ValueError):
-        return ()
-    return ()
-
-
-def _slot_pattern_dependencies(source, features) -> tuple[tuple[object, str], ...]:
-    """Exact patterned slot cuts plus their envelope state every intervening material web."""
-    try:
-        axis = str(source.axis)
-        index = "xyz".index(axis)
-        envelope = _envelope(features)
-        if envelope is None:
-            return ()
-        for pattern in (
-            item for item in features if getattr(item, "kind", None) == "slot_pattern"
-        ):
-            member = pattern.member
-            if str(member.width_axis) != axis or not _slot_pattern_supports_source(
-                source, pattern
-            ):
-                continue
-            half_width = float(member.width) / 2
-            cuts = sorted(
-                (_rounded(point[index] - half_width), _rounded(point[index] + half_width))
-                for point in pattern.members
-            )
-            material = []
-            cursor = _rounded(envelope.bbox_min[index])
-            for cut_lo, cut_hi in cuts:
-                if cut_lo > cursor:
-                    material.append((cursor, cut_lo))
-                cursor = max(cursor, cut_hi)
-            envelope_hi = _rounded(envelope.bbox_max[index])
-            if cursor < envelope_hi:
-                material.append((cursor, envelope_hi))
-            if (_rounded(source.lo), _rounded(source.hi)) not in material:
-                continue
-            plane_axes = [candidate for candidate in "xyz" if candidate != pattern.frame.axis]
-            return (
-                (envelope, _axis_parameter(axis)),
-                *((pattern, parameter.parameter_id) for parameter in pattern.parameters()),
-                *(
-                    (pattern, f"{pattern.LOCATION_STEM}.location.{candidate}")
-                    for candidate in plane_axes
-                ),
-            )
-    except (AttributeError, TypeError, ValueError):
-        return ()
-    return ()
-
-
-def _envelope_owned_dependencies(source, features) -> tuple[tuple[object, str], ...]:
-    """A whole-axis slab is already the envelope size, never a second Plate requirement."""
-    try:
-        axis = str(source.axis)
-        index = "xyz".index(axis)
-        envelope = _envelope(features)
-        if (
-            envelope is not None
-            and _same(source.lo, envelope.bbox_min[index])
-            and _same(source.hi, envelope.bbox_max[index])
-            and all(
-                _same(plate_center(source)[other], envelope.frame.origin[other])
-                for other in range(3)
-                if other != index
-            )
-        ):
-            return ((envelope, _axis_parameter(axis)),)
-    except (AttributeError, TypeError, ValueError):
-        return ()
-    return ()
 
 
 def _alternate_dependencies(

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -137,6 +137,7 @@ from draftwright.model.ir import (
     StepLevelFeature,
     ThroughStepFeature,
 )
+from draftwright.plate_correspondence import plate_owner_dependencies
 from draftwright.recognition_frame import (
     groove_owns_turned_step_band,
     require_unambiguous_groove_owner,
@@ -1258,6 +1259,92 @@ def _through_step_plate_owner_record_ids(
     return frozenset(owners)
 
 
+def _evidence_occurrence_for_record(
+    evidence: RecognitionEvidence,
+    family: str,
+    record: object,
+):
+    """Return one exact same-run occurrence, never a value-equal substitute."""
+
+    matches = tuple(
+        occurrence
+        for occurrence in evidence.features
+        if evidence.family(occurrence) == family and evidence.record(occurrence) is record
+    )
+    return matches[0] if len(matches) == 1 else None
+
+
+def _plate_owner_has_evidence_scope(
+    evidence: RecognitionEvidence,
+    plate: Plate,
+    owners: tuple[Feature, ...],
+    *,
+    slot_pattern_members: dict[int, tuple[Slot, ...]],
+) -> bool:
+    """Require an exact AAG lineage for every cross-family Plate absorption."""
+
+    occurrence = _evidence_occurrence_for_record(evidence, "plates", plate)
+    if occurrence is None:
+        return False
+    defining_faces = evidence.defining_faces(occurrence)
+    kinds = tuple(owner.kind for owner in owners)
+
+    def shares_defining_face(family: str, record: object) -> bool:
+        candidate = _evidence_occurrence_for_record(evidence, family, record)
+        return candidate is not None and bool(defining_faces & evidence.defining_faces(candidate))
+
+    if kinds == ("step_level",):
+        step = owners[0]
+        if not isinstance(step, StepLevelFeature):
+            return False
+        try:
+            return any(
+                shares_defining_face("step_levels", level)
+                and any(
+                    abs(retained.level - level.z) <= 1e-6
+                    and retained.x_span == level.x_span
+                    and retained.y_span == level.y_span
+                    for retained in step.level_supports
+                )
+                for level in evidence.result.step_levels
+            )
+        except (AttributeError, TypeError, ValueError):
+            return False
+
+    if kinds == ("envelope", "step_level"):
+        step = owners[1]
+        if not isinstance(step, StepLevelFeature):
+            return False
+        try:
+            boundaries = {round(float(plate.lo), 3), round(float(plate.hi), 3)}
+            return any(
+                shares_defining_face("risers", riser)
+                and any(
+                    round(float(position), 3) in boundaries
+                    and any(
+                        axis == str(plate.axis) and abs(float(shoulder) - float(position)) <= 1e-6
+                        for axis, shoulder in step.shoulders
+                    )
+                    for position in riser.positions
+                )
+                for riser in evidence.result.risers
+                if str(riser.axis) == str(plate.axis)
+            )
+        except (AttributeError, TypeError, ValueError):
+            return False
+
+    if kinds == ("envelope", "slot_pattern"):
+        return any(
+            shares_defining_face("slots", member)
+            for member in slot_pattern_members.get(id(owners[1]), ())
+        )
+
+    # Whole-envelope and polygonal-boss derivations have no released AAG relation that proves
+    # the selected final IR belongs to this exact Plate occurrence. Keep them visibly missing
+    # instead of recovering correspondence from coordinates or traversal order.
+    return False
+
+
 def _through_step_legacy_owners(
     step,
     bbox,
@@ -1499,6 +1586,7 @@ def build_part_model(
     features: list[Feature] = []
     envelope_feature: Feature | None = None
     plate_features_by_record_id: dict[int, Feature] = {}
+    slot_pattern_members_by_feature_id: dict[int, tuple[Slot, ...]] = {}
     step_level_feature: Feature | None = None
 
     def append_direct(record: object) -> None:
@@ -2028,6 +2116,7 @@ def build_part_model(
         patterned_sl.update(pat.slots)
         slot_pattern_feature = _slot_pattern_feature(pat, list(pat.slots))
         features.append(slot_pattern_feature)
+        slot_pattern_members_by_feature_id[id(slot_pattern_feature)] = tuple(pat.slots)
         if ownership is not None:
             ownership.absorb(
                 tuple(pat.slots),
@@ -2307,6 +2396,8 @@ def build_part_model(
                 plate_feature = convert(pl, ctx)
                 features.append(plate_feature)
                 plate_features_by_record_id[id(pl)] = plate_feature
+                if ownership is not None:
+                    ownership.bind(pl, plate_feature, reason_code="plate_adapter")
 
     # Prismatic step-height ladder — horizontal face levels on a NON-turned part
     # (a turned part's steps are StepFeatures, dimensioned by the IR length chain).
@@ -2458,6 +2549,37 @@ def build_part_model(
                     through,
                     tuple(owner_features),
                     reason_code="through_step_legacy_projection",
+                )
+
+        reason_for_owner_kinds = {
+            ("step_level",): "plate_step_level_owner",
+            ("envelope", "step_level"): "plate_step_ladder_owner",
+            ("envelope", "slot_pattern"): "plate_slot_pattern_owner",
+        }
+        for plate in plates or ():
+            if ownership.has_owner(plate):
+                continue
+            dependencies = plate_owner_dependencies(plate, features)
+            owners = tuple(feature for feature, _parameter in dependencies)
+            unique_owners = tuple(
+                feature
+                for index, feature in enumerate(owners)
+                if not any(previous is feature for previous in owners[:index])
+            )
+            owner_kinds: tuple[Any, ...] = tuple(
+                getattr(feature, "kind", None) for feature in unique_owners
+            )
+            reason_code = reason_for_owner_kinds.get(owner_kinds)
+            if reason_code is not None and _plate_owner_has_evidence_scope(
+                ownership.evidence,
+                plate,
+                unique_owners,
+                slot_pattern_members=slot_pattern_members_by_feature_id,
+            ):
+                ownership.absorb_into_many(
+                    plate,
+                    unique_owners,
+                    reason_code=reason_code,
                 )
 
     # Machined flats on round stock (#148b) — a planar face truncating a cylinder,

--- a/src/draftwright/plate_correspondence.py
+++ b/src/draftwright/plate_correspondence.py
@@ -1,0 +1,318 @@
+"""Shared Plate-record to IR correspondence below conversion and completeness consumers."""
+
+from __future__ import annotations
+
+Point = tuple[float, float, float]
+
+
+def _rounded(value) -> float:
+    return round(float(value), 3)
+
+
+def plate_center(plate) -> Point:
+    """Reconstruct the body-local slab witness retained on both sides of the IR waist."""
+
+    axis = str(plate.axis)
+    index = "xyz".index(axis)
+    other = [candidate for candidate in range(3) if candidate != index]
+    point = [0.0, 0.0, 0.0]
+    point[index] = (_rounded(plate.lo) + _rounded(plate.hi)) / 2
+    point[other[0]] = _rounded(plate.u)
+    point[other[1]] = _rounded(plate.v)
+    return tuple(_rounded(value) for value in point)  # type: ignore[return-value]
+
+
+def plate_span(plate) -> tuple[Point, Point]:
+    """Return the exact physical thickness witness used by ``PlateFeature.parameters``."""
+
+    axis = str(plate.axis)
+    index = "xyz".index(axis)
+    other = [candidate for candidate in range(3) if candidate != index]
+    start = [0.0, 0.0, 0.0]
+    end = [0.0, 0.0, 0.0]
+    start[index], end[index] = _rounded(plate.lo), _rounded(plate.hi)
+    start[other[0]] = end[other[0]] = _rounded(plate.u)
+    start[other[1]] = end[other[1]] = _rounded(plate.v)
+    return tuple(start), tuple(end)  # type: ignore[return-value]
+
+
+def plate_key(plate) -> tuple:
+    """Every compiler-significant fact retained by the provider record and public IR."""
+
+    return (
+        str(plate.axis),
+        _rounded(plate.lo),
+        _rounded(plate.hi),
+        _rounded(plate.u),
+        _rounded(plate.v),
+    )
+
+
+def _axis_parameter(axis: str) -> str:
+    return {"x": "width.length", "y": "depth.length", "z": "height.length"}[axis]
+
+
+def _envelope(features):
+    values = [item for item in features if getattr(item, "kind", None) == "envelope"]
+    return values[0] if len(values) == 1 else None
+
+
+def _same(value, expected) -> bool:
+    return _rounded(value) == _rounded(expected)
+
+
+def _between(value, bounds) -> bool:
+    lo, hi = sorted((_rounded(bounds[0]), _rounded(bounds[1])))
+    return lo <= _rounded(value) <= hi
+
+
+def _depth_axis(width_axis, long_axis) -> str | None:
+    width = str(width_axis)
+    long = str(long_axis)
+    if width not in {"x", "y", "z"} or long not in {"x", "y", "z"} or width == long:
+        return None
+    remaining = {"x", "y", "z"} - {width, long}
+    return next(iter(remaining)) if len(remaining) == 1 else None
+
+
+def _step_supports_source(source, step) -> bool:
+    """Require the Plate witness to lie on this level record's physical support."""
+
+    try:
+        point = plate_center(source)
+        supports = tuple(step.level_supports)
+        if not supports:
+            return False
+        if str(source.axis) == "z":
+            return any(
+                _between(point[0], support.x_span) and _between(point[1], support.y_span)
+                for support in supports
+            )
+        transverse = "x" if str(source.axis) == "y" else "y"
+        index = "xyz".index(transverse)
+        span_name = f"{transverse}_span"
+        return any(_between(point[index], getattr(support, span_name)) for support in supports)
+    except (AttributeError, TypeError, ValueError):
+        return False
+
+
+def _slot_pattern_supports_source(source, pattern) -> bool:
+    """Join a material web only to a pattern whose physical cut crosses its witness."""
+
+    try:
+        member = pattern.member
+        if str(source.axis) != str(member.width_axis):
+            return False
+        depth_axis = _depth_axis(member.width_axis, member.long_axis)
+        if depth_axis is None or str(pattern.frame.axis) != depth_axis:
+            return False
+        point = plate_center(source)
+        long_index = "xyz".index(str(member.long_axis))
+        depth_index = "xyz".index(depth_axis)
+        return _between(point[long_index], (member.lo, member.hi)) and _same(
+            point[depth_index], pattern.frame.origin[depth_index]
+        )
+    except (AttributeError, TypeError, ValueError):
+        return False
+
+
+def _polygonal_boss_supports_source(source, boss) -> bool:
+    """Conservatively require the Plate witness inside the owner's support polygon."""
+
+    try:
+        axis = str(source.axis)
+        boss_axis = getattr(getattr(boss, "frame", None), "axis", getattr(boss, "axis", None))
+        if str(boss_axis) != axis:
+            return False
+        side_count = boss.side_count
+        directions = tuple(boss.flat_directions)
+        centres = tuple(boss.flat_centres)
+        if (
+            type(side_count) is not int
+            or side_count < 4
+            or side_count % 2
+            or len(directions) != side_count
+            or len(centres) != side_count
+            or len(set(directions)) != side_count
+            or len(set(centres)) != side_count
+        ):
+            return False
+        indices = [index for index in range(3) if index != "xyz".index(axis)]
+        point = tuple(plate_center(source)[index] for index in indices)
+        polygon = [tuple(float(centre[index]) for index in indices) for centre in centres]
+        signs = []
+        for start, end in zip(polygon, (*polygon[1:], polygon[0]), strict=True):
+            cross = (end[0] - start[0]) * (point[1] - start[1]) - (end[1] - start[1]) * (
+                point[0] - start[0]
+            )
+            if abs(cross) > 1e-6:
+                signs.append(cross > 0)
+        return bool(signs) and all(sign == signs[0] for sign in signs)
+    except (AttributeError, TypeError, ValueError):
+        return False
+
+
+def _step_level_dependencies(source, features) -> tuple[tuple[object, str], ...]:
+    """Exact legacy level/shoulder grammar that already states a Plate interval."""
+
+    try:
+        axis = str(source.axis)
+        lo, hi = _rounded(source.lo), _rounded(source.hi)
+        envelope = _envelope(features)
+        for step in (item for item in features if getattr(item, "kind", None) == "step_level"):
+            if not _step_supports_source(source, step):
+                continue
+            if axis == "z":
+                coordinates = tuple(_rounded(value) for value in (step.base, *step.levels))
+                if lo not in coordinates or hi not in coordinates:
+                    continue
+                count = int(lo != _rounded(step.base)) + int(hi != _rounded(step.base))
+                if count:
+                    return ((step, "step_height.length"),) * count
+                continue
+            if envelope is None:
+                continue
+            index = "xyz".index(axis)
+            bounds = (_rounded(envelope.bbox_min[index]), _rounded(envelope.bbox_max[index]))
+            shoulders = tuple(
+                _rounded(position)
+                for shoulder_axis, position in step.shoulders
+                if str(shoulder_axis) == axis
+            )
+            if not shoulders:
+                continue
+            boundaries = {bounds[0], *shoulders, bounds[1]}
+            if lo in boundaries and hi in boundaries:
+                return (
+                    (envelope, _axis_parameter(axis)),
+                    *((step, "step_position.length"),) * len(shoulders),
+                )
+    except (AttributeError, TypeError, ValueError):
+        return ()
+    return ()
+
+
+def _polygonal_boss_dependencies(source, features) -> tuple[tuple[object, str], ...]:
+    """Envelope minus an attached boss height can state the supporting slab thickness."""
+
+    try:
+        axis = str(source.axis)
+        index = "xyz".index(axis)
+        envelope = _envelope(features)
+        if envelope is None:
+            return ()
+        envelope_interval = (
+            _rounded(envelope.bbox_min[index]),
+            _rounded(envelope.bbox_max[index]),
+        )
+        source_interval = (_rounded(source.lo), _rounded(source.hi))
+        for boss in (item for item in features if getattr(item, "kind", None) == "polygonal_boss"):
+            if (
+                str(boss.frame.axis) != axis
+                or boss.span is None
+                or not _polygonal_boss_supports_source(source, boss)
+            ):
+                continue
+            boss_interval = tuple(sorted(_rounded(point[index]) for point in boss.span))
+            supports_below = (
+                source_interval[0] == envelope_interval[0]
+                and source_interval[1] == boss_interval[0]
+                and boss_interval[1] == envelope_interval[1]
+            )
+            supports_above = (
+                boss_interval[0] == envelope_interval[0]
+                and boss_interval[1] == source_interval[0]
+                and source_interval[1] == envelope_interval[1]
+            )
+            if supports_below or supports_above:
+                return (
+                    (envelope, _axis_parameter(axis)),
+                    (boss, "boss_height.length"),
+                )
+    except (AttributeError, TypeError, ValueError):
+        return ()
+    return ()
+
+
+def _slot_pattern_dependencies(source, features) -> tuple[tuple[object, str], ...]:
+    """Exact patterned slot cuts plus their envelope state every intervening material web."""
+
+    try:
+        axis = str(source.axis)
+        index = "xyz".index(axis)
+        envelope = _envelope(features)
+        if envelope is None:
+            return ()
+        for pattern in (
+            item for item in features if getattr(item, "kind", None) == "slot_pattern"
+        ):
+            member = pattern.member
+            if str(member.width_axis) != axis or not _slot_pattern_supports_source(
+                source, pattern
+            ):
+                continue
+            half_width = float(member.width) / 2
+            cuts = sorted(
+                (_rounded(point[index] - half_width), _rounded(point[index] + half_width))
+                for point in pattern.members
+            )
+            material = []
+            cursor = _rounded(envelope.bbox_min[index])
+            for cut_lo, cut_hi in cuts:
+                if cut_lo > cursor:
+                    material.append((cursor, cut_lo))
+                cursor = max(cursor, cut_hi)
+            envelope_hi = _rounded(envelope.bbox_max[index])
+            if cursor < envelope_hi:
+                material.append((cursor, envelope_hi))
+            if (_rounded(source.lo), _rounded(source.hi)) not in material:
+                continue
+            plane_axes = [candidate for candidate in "xyz" if candidate != pattern.frame.axis]
+            return (
+                (envelope, _axis_parameter(axis)),
+                *((pattern, parameter.parameter_id) for parameter in pattern.parameters()),
+                *(
+                    (pattern, f"{pattern.LOCATION_STEM}.location.{candidate}")
+                    for candidate in plane_axes
+                ),
+            )
+    except (AttributeError, TypeError, ValueError):
+        return ()
+    return ()
+
+
+def _envelope_owned_dependencies(source, features) -> tuple[tuple[object, str], ...]:
+    """A whole-axis slab is already the envelope size, never a second Plate requirement."""
+
+    try:
+        axis = str(source.axis)
+        index = "xyz".index(axis)
+        envelope = _envelope(features)
+        if (
+            envelope is not None
+            and _same(source.lo, envelope.bbox_min[index])
+            and _same(source.hi, envelope.bbox_max[index])
+            and all(
+                _same(plate_center(source)[other], envelope.frame.origin[other])
+                for other in range(3)
+                if other != index
+            )
+        ):
+            return ((envelope, _axis_parameter(axis)),)
+    except (AttributeError, TypeError, ValueError):
+        return ()
+    return ()
+
+
+def plate_owner_dependencies(source, features) -> tuple[tuple[object, str], ...]:
+    """Return the first exact final-IR dependency set that states this Plate interval."""
+
+    for establish in (
+        _envelope_owned_dependencies,
+        _step_level_dependencies,
+        _polygonal_boss_dependencies,
+        _slot_pattern_dependencies,
+    ):
+        if dependencies := establish(source, features):
+            return dependencies
+    return ()

--- a/src/draftwright/recognition_ownership.py
+++ b/src/draftwright/recognition_ownership.py
@@ -53,7 +53,7 @@ NESTED_FAMILIES = frozenset({"countersinks"})
 # These accepted occurrences have a supported consumer path, but the final owner depends on
 # Draftwright's cross-family classification.  The conversion site must record either the direct
 # adapter or the exact aggregate feature that intentionally absorbs the occurrence.
-CONDITIONAL_FAMILIES = frozenset({"bosses", "channels", "through_steps", "turned_steps"})
+CONDITIONAL_FAMILIES = frozenset({"bosses", "channels", "plates", "through_steps", "turned_steps"})
 
 OwnershipDisposition = Literal["represented", "absorbed"]
 PolicyDisposition = OwnerlessDisposition
@@ -75,6 +75,7 @@ _REPRESENTED_REASON_CODES = frozenset(
         "hole_adapter",
         "pmi_split_member",
         "pocket_adapter",
+        "plate_adapter",
         "slot_adapter",
         "through_step_adapter",
         "turned_step_adapter",
@@ -93,6 +94,14 @@ _ABSORBED_REASON_CODES = frozenset(
 _FEATURE_ABSORPTION_REASON_CODES = frozenset(
     {"channel_step_level_owner", "turned_step_groove_owner"}
 )
+_MULTI_FEATURE_ABSORPTION_OWNER_KINDS = {
+    "plate_slot_pattern_owner": ("envelope", "slot_pattern"),
+    "plate_step_ladder_owner": ("envelope", "step_level"),
+    "plate_step_level_owner": ("step_level",),
+}
+_MULTI_FEATURE_ABSORPTION_EXISTING_OWNER = {
+    "plate_slot_pattern_owner": ("slot_pattern", "slots", "slot_pattern_member"),
+}
 _REASON_FAMILY = {
     "boss_adapter": "bosses",
     "boss_diameter_group_member": "bosses",
@@ -107,6 +116,10 @@ _REASON_FAMILY = {
     "pmi_split_member": "holes",
     "pocket_adapter": "pockets",
     "pocket_pattern_member": "pockets",
+    "plate_adapter": "plates",
+    "plate_slot_pattern_owner": "plates",
+    "plate_step_ladder_owner": "plates",
+    "plate_step_level_owner": "plates",
     "slot_adapter": "slots",
     "slot_pattern_member": "slots",
     "through_step_adapter": "through_steps",
@@ -609,6 +622,57 @@ class RecognitionOwnershipBuilder:
                 feature,
                 disposition="absorbed",
                 reason_code=reason_code,
+            )
+        )
+
+    def absorb_into_many(
+        self,
+        record: object,
+        features: tuple[object, ...],
+        *,
+        reason_code: str,
+    ) -> None:
+        """Bind one exact Plate occurrence to its explicitly selected aggregate IR owners."""
+
+        expected_kinds = _MULTI_FEATURE_ABSORPTION_OWNER_KINDS.get(reason_code)
+        if expected_kinds is None:
+            raise ValueError("unknown multi-feature absorption reason_code")
+        occurrence = self._occurrence_for(record)
+        if self.evidence.family(occurrence) != _REASON_FAMILY[reason_code]:
+            raise ValueError(
+                "multi-feature absorption reason_code does not match occurrence family"
+            )
+        if type(features) is not tuple:
+            raise TypeError("multi-feature absorption owners must be an exact tuple")
+        if tuple(getattr(feature, "kind", None) for feature in features) != expected_kinds:
+            raise ValueError("multi-feature absorption reason_code does not match IR owners")
+        if id(occurrence) in self._bound_occurrence_ids:
+            raise ValueError("recognition occurrence already has an IR owner")
+        existing_owner = _MULTI_FEATURE_ABSORPTION_EXISTING_OWNER.get(reason_code)
+        if existing_owner is not None:
+            owner_kind, owner_family, owner_reason = existing_owner
+            owner = next(
+                feature for feature in features if getattr(feature, "kind", None) == owner_kind
+            )
+            if not any(
+                binding.disposition in {"represented", "absorbed"}
+                and binding.reason_code == owner_reason
+                and self.evidence.family(binding.occurrence) == owner_family
+                and any(candidate is owner for candidate in binding.features)
+                for binding in self._bindings
+            ):
+                raise ValueError(
+                    "multi-feature absorption requires an existing exact recognition owner"
+                )
+        self._bound_occurrence_ids.add(id(occurrence))
+        self._owned_feature_ids.update(id(feature) for feature in features)
+        self._bindings.append(
+            OccurrenceBinding(
+                occurrence,
+                features[0],
+                disposition="absorbed",
+                reason_code=reason_code,
+                additional_features=features[1:],
             )
         )
 

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -82,6 +82,9 @@ _LAYERS: dict[str, int] = {
     "recognition": 0,
     "recognition_cache": 0,
     "recognition_ownership": 0,
+    # Shared pure Plate-record/final-IR correspondence predicates. Both model assembly and
+    # completeness lint consume them without either layer importing the other.
+    "plate_correspondence": 0,
     "recogniser_policy": 0,
     # Consumer-owned public record schema versions, shared by the report projector and the
     # rank-7 cross-repository validator without either leaf depending on the validator.
@@ -458,6 +461,7 @@ _MODEL_MAY_IMPORT = {
     "fonts",
     "layout",
     "model",
+    "plate_correspondence",
     "recognition",
     "recognition_frame",
     # ADR 0017 Amendment 12: detect records exact run-local occurrence→IR ownership at the

--- a/tests/test_issue_1438_channel_ownership.py
+++ b/tests/test_issue_1438_channel_ownership.py
@@ -46,7 +46,13 @@ def _channel_occurrence(ownership):
 
 
 def test_conditional_family_roster_is_explicit() -> None:
-    assert CONDITIONAL_FAMILIES == {"bosses", "channels", "through_steps", "turned_steps"}
+    assert CONDITIONAL_FAMILIES == {
+        "bosses",
+        "channels",
+        "plates",
+        "through_steps",
+        "turned_steps",
+    }
 
 
 def test_multi_plate_channel_is_represented_by_its_exact_channel_feature() -> None:
@@ -95,7 +101,11 @@ def test_cross_axis_rebate_does_not_inherit_an_unrelated_z_step_ladder() -> None
     assert any(feature.kind == "step_level" for feature in drawing.model().features)
     assert ownership.binding_for(occurrence) is None
     assert ownership.status(occurrence) == "unexpectedly_missing"
-    assert ownership.unexpectedly_missing == (occurrence,)
+    assert tuple(
+        candidate
+        for candidate in ownership.unexpectedly_missing
+        if ownership.evidence.family(candidate) == "channels"
+    ) == (occurrence,)
 
 
 def test_disconnected_body_cannot_donate_a_channel_step_ladder_owner() -> None:
@@ -313,10 +323,18 @@ def test_unbound_channel_fails_closed_as_unexpectedly_missing() -> None:
     ownership = RecognitionOwnershipBuilder(evidence).snapshot()
     occurrence = _channel_occurrence(ownership)
 
-    assert ownership.expected_conditional == (occurrence,)
+    assert tuple(
+        candidate
+        for candidate in ownership.expected_conditional
+        if ownership.evidence.family(candidate) == "channels"
+    ) == (occurrence,)
     assert occurrence in ownership.owner_expected_occurrences
     assert ownership.status(occurrence) == "unexpectedly_missing"
-    assert ownership.unexpectedly_missing == (occurrence,)
+    assert tuple(
+        candidate
+        for candidate in ownership.unexpectedly_missing
+        if ownership.evidence.family(candidate) == "channels"
+    ) == (occurrence,)
 
 
 def test_feature_absorption_rejects_unknown_wrong_family_wrong_owner_and_duplicates() -> None:

--- a/tests/test_issue_1438_occurrence_ownership.py
+++ b/tests/test_issue_1438_occurrence_ownership.py
@@ -127,7 +127,11 @@ def test_every_advertised_direct_family_binds_to_finished_model(family, part_fac
         if ownership.evidence.family(occurrence) == family
     )
     assert occurrences
-    assert ownership.unexpectedly_missing == ()
+    assert not tuple(
+        occurrence
+        for occurrence in ownership.unexpectedly_missing
+        if ownership.evidence.family(occurrence) == family
+    )
     for occurrence in occurrences:
         binding = ownership.binding_for(occurrence)
         assert binding is not None

--- a/tests/test_issue_1438_pattern_ownership.py
+++ b/tests/test_issue_1438_pattern_ownership.py
@@ -92,7 +92,11 @@ def test_each_unpatterned_groupable_family_has_a_direct_final_owner() -> None:
         assert binding.reason_code == reason_code
         assert binding.feature.kind == feature_kind
         assert any(binding.feature is feature for feature in drawing.model().features)
-        assert ownership.unexpectedly_missing == ()
+        assert not tuple(
+            candidate
+            for candidate in ownership.unexpectedly_missing
+            if ownership.evidence.family(candidate) == family
+        )
 
 
 def test_same_spec_scattered_holes_are_explicitly_absorbed_by_one_group() -> None:

--- a/tests/test_issue_1438_plate_ownership.py
+++ b/tests/test_issue_1438_plate_ownership.py
@@ -1,0 +1,444 @@
+"""#1438 — every accepted Plate has exact direct, absorbed, or missing ownership."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+from b123d_recognisers.evidence import build_recognition_evidence
+from build123d import Align, Box, Compound, Pos, RegularPolygon, Rot, extrude
+
+from draftwright import build_drawing
+from draftwright import plate_correspondence as correspondence
+from draftwright import reporting as reporting_module
+from draftwright.model import detect as detect_module
+from draftwright.recognition_ownership import RecognitionOwnershipBuilder
+
+_CENTER = (Align.CENTER, Align.CENTER, Align.CENTER)
+_CENTER_MIN = (Align.CENTER, Align.CENTER, Align.MIN)
+
+
+def _namespace_with(value: SimpleNamespace, **changes) -> SimpleNamespace:
+    """Return a copied namespace for compact malformed-contract probes."""
+
+    return SimpleNamespace(**{**vars(value), **changes})
+
+
+def _tee():
+    return Box(80, 60, 10, align=_CENTER_MIN) + Pos(0, 0, 10) * Box(80, 10, 40, align=_CENTER_MIN)
+
+
+def _boss_on_plate():
+    return Box(100, 80, 10, align=_CENTER) + (
+        Pos(13, -7, 5) * Rot(0, 0, 11) * extrude(RegularPolygon(20, 6), 30)
+    )
+
+
+def _rebate(*, width: float = 60, opening: float = 20):
+    return Box(80, width, 30) - Pos(0, 0, 7.5) * Box(80, opening, 15)
+
+
+def _slotted_plate():
+    part = Box(60, 180, 20)
+    for y in (-45, -15, 15, 45):
+        part -= Pos(0, y, 0) * Box(30, 8, 20)
+    return part
+
+
+def _plate_bindings(drawing):
+    evidence = drawing.recognition_evidence()
+    ownership = drawing.recognition_ownership()
+    assert evidence is not None and ownership is not None
+    occurrences = tuple(
+        occurrence for occurrence in evidence.features if evidence.family(occurrence) == "plates"
+    )
+    return (
+        evidence,
+        ownership,
+        occurrences,
+        tuple(ownership.binding_for(occurrence) for occurrence in occurrences),
+    )
+
+
+def _plate_report(drawing):
+    return tuple(
+        occurrence
+        for occurrence in drawing.report()["recognition"]["occurrences"]
+        if occurrence["family"] == "plates"
+    )
+
+
+def test_multi_axis_plates_keep_distinct_direct_ir_owners() -> None:
+    drawing = build_drawing(_tee())
+    _evidence, ownership, occurrences, bindings = _plate_bindings(drawing)
+
+    assert len(occurrences) == len(bindings) == 2
+    assert all(binding is not None for binding in bindings)
+    assert all(
+        binding is not None
+        and binding.disposition == "represented"
+        and binding.reason_code == "plate_adapter"
+        and binding.feature.kind == "plate"
+        and any(binding.feature is feature for feature in drawing.model().features)
+        for binding in bindings
+    )
+    assert len({id(binding.feature) for binding in bindings if binding is not None}) == 2
+    assert ownership.unexpectedly_missing == ()
+    assert [item["owners"] for item in _plate_report(drawing)] == [
+        [{"id": "plate:1", "kind": "plate"}],
+        [{"id": "plate:2", "kind": "plate"}],
+    ]
+
+
+def test_axial_plate_is_absorbed_only_by_its_aag_backed_step_level() -> None:
+    drawing = build_drawing(_boss_on_plate())
+    _evidence, ownership, occurrences, bindings = _plate_bindings(drawing)
+
+    assert len(occurrences) == 1
+    (binding,) = bindings
+    assert binding is not None
+    assert binding.disposition == "absorbed"
+    assert binding.reason_code == "plate_step_level_owner"
+    assert [feature.kind for feature in binding.features] == ["step_level"]
+    assert ownership.unexpectedly_missing == ()
+    (projected,) = _plate_report(drawing)
+    assert projected["owners"] == [{"id": "step_level:1", "kind": "step_level"}]
+
+
+def test_side_plates_are_jointly_owned_by_envelope_and_step_ladder() -> None:
+    drawing = build_drawing(_rebate())
+    _evidence, ownership, occurrences, bindings = _plate_bindings(drawing)
+
+    assert len(occurrences) == 2
+    assert all(binding is not None for binding in bindings)
+    assert all(
+        binding is not None
+        and binding.disposition == "absorbed"
+        and binding.reason_code == "plate_step_ladder_owner"
+        and [feature.kind for feature in binding.features] == ["envelope", "step_level"]
+        for binding in bindings
+    )
+    assert ownership.unexpectedly_missing == ()
+    assert all(
+        occurrence["owners"]
+        == [
+            {"id": "envelope:1", "kind": "envelope"},
+            {"id": "step_level:1", "kind": "step_level"},
+        ]
+        for occurrence in _plate_report(drawing)
+    )
+
+
+def test_slot_cut_webs_share_the_exact_pattern_owner_of_adjacent_slots() -> None:
+    drawing = build_drawing(_slotted_plate())
+    evidence, ownership, occurrences, bindings = _plate_bindings(drawing)
+
+    assert len(occurrences) == 5
+    assert all(binding is not None for binding in bindings)
+    assert all(
+        binding is not None
+        and binding.disposition == "absorbed"
+        and binding.reason_code == "plate_slot_pattern_owner"
+        and [feature.kind for feature in binding.features] == ["envelope", "slot_pattern"]
+        for binding in bindings
+    )
+    pattern = next(
+        feature for feature in drawing.model().features if feature.kind == "slot_pattern"
+    )
+    slot_bindings = tuple(
+        ownership.binding_for(occurrence)
+        for occurrence in evidence.features
+        if evidence.family(occurrence) == "slots"
+    )
+    assert len(slot_bindings) == 4
+    assert all(
+        binding is not None
+        and binding.feature is pattern
+        and binding.reason_code == "slot_pattern_member"
+        for binding in slot_bindings
+    )
+    assert ownership.unexpectedly_missing == ()
+
+
+def test_equal_valued_disconnected_plates_cannot_borrow_a_slot_pattern() -> None:
+    slotted = _slotted_plate()
+    # These remote rebate walls deliberately have the same published intervals as two local webs.
+    remote = Pos(150, 0, 0) * _rebate(width=82, opening=38)
+    drawing = build_drawing(Compound(children=[slotted, remote]))
+    matching = tuple(
+        occurrence
+        for occurrence in _plate_report(drawing)
+        if (occurrence["record"]["lo"], occurrence["record"]["hi"])
+        in {(-41.0, -19.0), (19.0, 41.0)}
+    )
+
+    assert len(matching) == 4
+    local = tuple(item for item in matching if abs(item["record"]["u"]) < 1)
+    remote = tuple(item for item in matching if item["record"]["u"] > 100)
+    assert len(local) == len(remote) == 2
+    assert {item["disposition"] for item in local} == {"absorbed"}
+    assert {item["reason_code"] for item in local} == {"plate_slot_pattern_owner"}
+    assert {item["disposition"] for item in remote} == {"unexpectedly_missing"}
+    assert {item["reason_code"] for item in remote} == {"supported_owner_missing"}
+    assert all(item["owners"] == [] for item in remote)
+
+
+def test_removing_one_conjunctive_owner_revokes_every_plate_binding() -> None:
+    drawing = build_drawing(_slotted_plate())
+    evidence = drawing.recognition_evidence()
+    ownership = drawing.recognition_ownership()
+    model = drawing.model()
+    assert evidence is not None and ownership is not None
+
+    report = reporting_module.drawing_report(
+        evidence=evidence,
+        ownership=ownership,
+        model=replace(
+            model,
+            features=tuple(
+                feature for feature in model.features if feature.kind != "slot_pattern"
+            ),
+        ),
+        lint=drawing.lint_summary(),
+        source=None,
+    )
+    plates = tuple(
+        occurrence
+        for occurrence in report["recognition"]["occurrences"]
+        if occurrence["family"] == "plates"
+    )
+
+    assert len(plates) == 5
+    assert {occurrence["disposition"] for occurrence in plates} == {"unexpectedly_missing"}
+    assert {occurrence["reason_code"] for occurrence in plates} == {"recorded_owner_not_in_model"}
+    assert all(occurrence["owners"] == [] for occurrence in plates)
+
+
+def test_slot_pattern_absorption_requires_an_existing_exact_member_owner() -> None:
+    evidence = build_recognition_evidence(_slotted_plate())
+    (pattern,) = evidence.result.slot_patterns
+    plate = evidence.result.plates[0]
+    envelope = SimpleNamespace(kind="envelope")
+    pattern_feature = SimpleNamespace(kind="slot_pattern")
+    builder = RecognitionOwnershipBuilder(evidence)
+
+    with pytest.raises(ValueError, match="existing exact recognition owner"):
+        builder.absorb_into_many(
+            plate,
+            (envelope, pattern_feature),
+            reason_code="plate_slot_pattern_owner",
+        )
+
+    builder.absorb(pattern.slots, pattern_feature, reason_code="slot_pattern_member")
+    builder.absorb_into_many(
+        plate,
+        (envelope, pattern_feature),
+        reason_code="plate_slot_pattern_owner",
+    )
+    ownership = builder.snapshot()
+    plate_occurrence = next(
+        occurrence
+        for occurrence in evidence.features
+        if evidence.family(occurrence) == "plates" and evidence.record(occurrence) is plate
+    )
+    binding = ownership.binding_for(plate_occurrence)
+    assert binding is not None
+    assert binding.features == (envelope, pattern_feature)
+
+
+def test_multi_owner_builder_guards_the_closed_plate_contract() -> None:
+    evidence = build_recognition_evidence(_slotted_plate())
+    plate = evidence.result.plates[0]
+    slot = evidence.result.slots[0]
+    step = SimpleNamespace(kind="step_level")
+    builder = RecognitionOwnershipBuilder(evidence)
+
+    with pytest.raises(ValueError, match="unknown multi-feature absorption"):
+        builder.absorb_into_many(plate, (step,), reason_code="direct_adapter")
+    with pytest.raises(ValueError, match="does not match occurrence family"):
+        builder.absorb_into_many(slot, (step,), reason_code="plate_step_level_owner")
+    with pytest.raises(TypeError, match="exact tuple"):
+        builder.absorb_into_many(
+            plate,
+            [step],  # type: ignore[arg-type]
+            reason_code="plate_step_level_owner",
+        )
+    with pytest.raises(ValueError, match="does not match IR owners"):
+        builder.absorb_into_many(
+            plate,
+            (SimpleNamespace(kind="envelope"),),
+            reason_code="plate_step_level_owner",
+        )
+
+    builder.absorb_into_many(plate, (step,), reason_code="plate_step_level_owner")
+    with pytest.raises(ValueError, match="occurrence already"):
+        builder.absorb_into_many(plate, (step,), reason_code="plate_step_level_owner")
+
+
+def test_plate_aag_scope_rejects_foreign_or_wrongly_typed_owners() -> None:
+    evidence = build_recognition_evidence(_boss_on_plate())
+    plate = evidence.result.plates[0]
+    envelope = SimpleNamespace(kind="envelope")
+
+    assert not detect_module._plate_owner_has_evidence_scope(
+        evidence,
+        replace(plate),
+        (SimpleNamespace(kind="step_level"),),
+        slot_pattern_members={},
+    )
+    assert not detect_module._plate_owner_has_evidence_scope(
+        evidence,
+        plate,
+        (SimpleNamespace(kind="step_level"),),
+        slot_pattern_members={},
+    )
+    assert not detect_module._plate_owner_has_evidence_scope(
+        evidence,
+        plate,
+        (envelope, SimpleNamespace(kind="step_level")),
+        slot_pattern_members={},
+    )
+    assert not detect_module._plate_owner_has_evidence_scope(
+        evidence,
+        plate,
+        (SimpleNamespace(kind="polygonal_boss"),),
+        slot_pattern_members={},
+    )
+
+
+def test_plate_aag_scope_fails_closed_on_malformed_level_and_riser_records() -> None:
+    level_drawing = build_drawing(_boss_on_plate())
+    level_evidence = level_drawing.recognition_evidence()
+    assert level_evidence is not None
+    level_plate = level_evidence.result.plates[0]
+    level_owner = next(
+        feature for feature in level_drawing.model().features if feature.kind == "step_level"
+    )
+    (source_level,) = level_evidence.result.step_levels
+    malformed_level = SimpleNamespace(
+        z=None,
+        x_span=source_level.x_span,
+        y_span=source_level.y_span,
+    )
+    level_proxy = SimpleNamespace(
+        features=level_evidence.features,
+        family=level_evidence.family,
+        defining_faces=level_evidence.defining_faces,
+        record=lambda occurrence: (
+            malformed_level
+            if level_evidence.record(occurrence) is source_level
+            else level_evidence.record(occurrence)
+        ),
+        result=SimpleNamespace(step_levels=(malformed_level,)),
+    )
+    assert not detect_module._plate_owner_has_evidence_scope(
+        level_proxy,
+        level_plate,
+        (level_owner,),
+        slot_pattern_members={},
+    )
+
+    riser_drawing = build_drawing(_rebate())
+    riser_evidence = riser_drawing.recognition_evidence()
+    assert riser_evidence is not None
+    riser_plate = riser_evidence.result.plates[0]
+    riser_owner = next(
+        feature for feature in riser_drawing.model().features if feature.kind == "step_level"
+    )
+    source_riser = next(
+        riser for riser in riser_evidence.result.risers if str(riser.axis) == str(riser_plate.axis)
+    )
+    malformed_riser = SimpleNamespace(axis=source_riser.axis, positions=(None,))
+    riser_proxy = SimpleNamespace(
+        features=riser_evidence.features,
+        family=riser_evidence.family,
+        defining_faces=riser_evidence.defining_faces,
+        record=lambda occurrence: (
+            malformed_riser
+            if riser_evidence.record(occurrence) is source_riser
+            else riser_evidence.record(occurrence)
+        ),
+        result=SimpleNamespace(risers=(malformed_riser,)),
+    )
+    assert not detect_module._plate_owner_has_evidence_scope(
+        riser_proxy,
+        riser_plate,
+        (SimpleNamespace(kind="envelope"), riser_owner),
+        slot_pattern_members={},
+    )
+
+
+def test_shared_plate_correspondence_fails_closed_at_each_owner_boundary() -> None:
+    source = SimpleNamespace(axis="x", lo=-0.5, hi=0.5, u=0.0, v=0.0)
+    support = SimpleNamespace(x_span=(-10.0, 10.0), y_span=(-10.0, 10.0))
+    step = SimpleNamespace(
+        kind="step_level",
+        base=0.0,
+        levels=(),
+        level_supports=(support,),
+        shoulders=(),
+    )
+    envelope = SimpleNamespace(
+        kind="envelope",
+        bbox_min=(-10.0, -10.0, -10.0),
+        bbox_max=(10.0, 10.0, 10.0),
+        frame=SimpleNamespace(origin=(0.0, 0.0, 0.0)),
+    )
+
+    assert correspondence._depth_axis("x", "x") is None
+    assert not correspondence._step_supports_source(
+        source, _namespace_with(step, level_supports=())
+    )
+    assert not correspondence._step_supports_source(_namespace_with(source, axis="invalid"), step)
+
+    wrong_width = SimpleNamespace(member=SimpleNamespace(width_axis="y"))
+    assert not correspondence._slot_pattern_supports_source(source, wrong_width)
+    invalid_axes = SimpleNamespace(
+        member=SimpleNamespace(width_axis="x", long_axis="x"),
+        frame=SimpleNamespace(axis="z"),
+    )
+    assert not correspondence._slot_pattern_supports_source(source, invalid_axes)
+    assert not correspondence._slot_pattern_supports_source(source, SimpleNamespace())
+
+    assert not correspondence._polygonal_boss_supports_source(
+        source, SimpleNamespace(frame=SimpleNamespace(axis="y"))
+    )
+    malformed_polygon = SimpleNamespace(
+        frame=SimpleNamespace(axis="x"),
+        side_count=3,
+        flat_directions=(),
+        flat_centres=(),
+    )
+    assert not correspondence._polygonal_boss_supports_source(source, malformed_polygon)
+    assert not correspondence._polygonal_boss_supports_source(
+        source, SimpleNamespace(frame=SimpleNamespace(axis="x"))
+    )
+
+    zero_height = SimpleNamespace(axis="z", lo=0.0, hi=0.0, u=0.0, v=0.0)
+    assert correspondence._step_level_dependencies(zero_height, (step,)) == ()
+    assert correspondence._step_level_dependencies(source, (step,)) == ()
+    assert correspondence._step_level_dependencies(source, (envelope, step)) == ()
+    assert correspondence._step_level_dependencies(SimpleNamespace(), (step,)) == ()
+    assert correspondence._polygonal_boss_dependencies(SimpleNamespace(), (envelope,)) == ()
+
+    member = SimpleNamespace(width_axis="x", long_axis="y", lo=-5.0, hi=5.0, width=2.0)
+    pattern = SimpleNamespace(
+        kind="slot_pattern",
+        member=member,
+        frame=SimpleNamespace(axis="z", origin=(0.0, 0.0, 0.0)),
+        members=((0.0, 0.0, 0.0),),
+    )
+    assert correspondence._slot_pattern_dependencies(source, (envelope, pattern)) == ()
+    assert (
+        correspondence._slot_pattern_dependencies(
+            source, (envelope, SimpleNamespace(kind="slot_pattern"))
+        )
+        == ()
+    )
+
+    whole_axis = _namespace_with(source, lo=-10.0, hi=10.0)
+    assert correspondence._envelope_owned_dependencies(whole_axis, (envelope,)) == (
+        (envelope, "width.length"),
+    )
+    assert correspondence._envelope_owned_dependencies(SimpleNamespace(), (envelope,)) == ()

--- a/tests/test_issue_1438_report_projection.py
+++ b/tests/test_issue_1438_report_projection.py
@@ -60,10 +60,6 @@ def _coincident_body_local_evidence_part():
     return Compound(children=[stepped_block(), stepped_block()])
 
 
-def _unclassified_plate_part():
-    return Box(60, 40, 4) + Pos(0, -18, 12) * Box(60, 4, 20)
-
-
 def test_raw_report_has_the_closed_v1_shape_and_exact_owner() -> None:
     drawing = build_drawing(_through_step_part())
 
@@ -384,17 +380,25 @@ def test_report_refuses_an_unknown_ledger_status() -> None:
         )
 
 
-def test_raw_report_refuses_an_unclassified_accepted_occurrence() -> None:
-    drawing = build_drawing(_unclassified_plate_part())
+def test_report_refuses_an_unclassified_accepted_occurrence() -> None:
+    drawing = build_drawing(_through_step_part())
     evidence = drawing.recognition_evidence()
-    assert evidence is not None
-    assert any(evidence.family(occurrence) == "plates" for occurrence in evidence.features)
+    ownership = drawing.recognition_ownership()
+    model = drawing.model()
+    assert evidence is not None and ownership is not None
+    unclassified = replace(ownership, expected_conditional=(), bindings=())
 
     with pytest.raises(
         ReportUnavailableError,
-        match="accepted occurrence family 'plates' has no reportable disposition",
+        match="accepted occurrence family 'through_steps' has no reportable disposition",
     ):
-        drawing.report()
+        reporting_module.drawing_report(
+            evidence=evidence,
+            ownership=unclassified,
+            model=model,
+            lint=drawing.lint_summary(),
+            source=None,
+        )
 
 
 @pytest.mark.parametrize("boundary", ("declared", "framed"))


### PR DESCRIPTION
## Summary

- classify accepted Plate occurrences as direct, AAG-backed absorbed, or visibly unexpectedly missing
- share the existing Plate-to-IR semantic predicates between conversion ownership and completeness lint through a pure leaf
- require exact same-run defining-face evidence for step-level, riser/ladder, and slot-pattern ownership; keep multi-owner claims conjunctive
- leave whole-envelope, polygonal-boss, disconnected, ambiguous, and malformed cases fail-closed

## Architecture

ADR 0017 Amendment 23 records the bounded contract. This adds no recogniser call or API, second scan, persistent topology identity, placement/rendering change, or declared/provider-framed behavior.

## Validation

- Ruff: pass
- mypy: pass
- full fast suite: 6578 passed, 5 skipped, 2 xfailed
- overall coverage: 95.91%
- diff coverage: 100%
- three independent exact-head reviews: clean, no findings or nits

Part of #1438.