### PR TITLE
Embed recognition gaps in generated Python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 ### Added
 
+- Generated Sheet Python now embeds a deterministic, versioned, JSON-compatible snapshot of
+  actionable accepted-occurrence gaps from the exact recognition run that produced its model.
+  The compact snapshot carries only unsupported, deferred, evidence-only, and unexpectedly
+  missing public records; STEP inputs are read once and recognition uses a private copy of the
+  exact bytes named by the embedded basename and SHA-256, with a best-effort final replay-target
+  check before writing. The hash is a later reconciliation boundary, not a lock on the mutable
+  source path. It is explicitly generation-time evidence, never current completeness authority
+  (#1438, ADR 0017 Amendment 24).
+
 - Accepted Plate occurrences now retain exact conditional ownership. Genuine multi-axis plates
   keep their direct `PlateFeature`; other slabs are absorbed only when released same-run AAG
   evidence joins them to the exact retained face-level, riser-shoulder, or slot-pattern owner.

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -656,6 +656,38 @@ placement behavior, or inferred requirement. The raw automatic path records the 
 decision only; declared and provider-framed boundaries remain unchanged under ADRs 0011, 0013,
 0015, and 0020.
 
+## Amendment 24 — Generated Python carries a bounded recognition-gap snapshot
+
+`generate_sheet_script(...)` now retains the exact `Analysis` that produced its detected model and
+embeds `DRAFTWRIGHT_RECOGNITION_SNAPSHOT`, a versioned JSON-compatible Python dictionary projected
+from that run's evidence and ownership ledger. The compact snapshot includes only accepted
+occurrences with `unsupported`, `deferred`, `evidence_only`, or `unexpectedly_missing`
+dispositions. Ordinary represented and absorbed facts remain the existing editable semantic Sheet
+declarations rather than being duplicated into a second model.
+
+The snapshot is explicitly generation-time evidence, not present authority. It carries the public
+record and consumer schema version, deterministic report-local occurrence ID, disposition, reason,
+and tracking issue, but no provider reference, face reference, topology index, object address,
+annotation coordinate, or persistent identity. For a STEP source, the generator resolves the
+replay seam once, reads one immutable byte snapshot, and hashes those exact bytes. Recognition,
+PMI, and any semantic-correction build consume a private copy of the same bytes, so path mutation,
+symlink retargeting, and A→B→A replacement cannot split provenance from the generated model. Only
+the original input basename and byte SHA-256 are embedded; the private copy is discarded. Before
+committing the script, the generator makes a best-effort final observation and refuses a replay
+target that is then missing or has a different digest. It cannot lock that pathname against a
+later replacement, including one concurrent with the output write; the embedded digest is the
+comparison boundary for the later fresh-runtime reconciliation slice, not a freshness guarantee
+for a mutable source path. A live build123d object truthfully has no file hash. An empty snapshot is
+named
+`no_unrepresented_accepted_occurrences`, never complete or manufacturing-ready.
+
+This slice adds no recognition call: model and snapshot project the same build-owned analysis.
+It does not yet make the generated declared build a raw-report authority or reconcile an edited
+script with current recognition; the visible runtime `write_report(...)` call, fresh drift
+comparison, output manifests, and CLI sidecar default remain later slices. The snapshot neither
+compiles nor places annotations, changes no visual output, and preserves ADRs 0010, 0011, 0013,
+0014, 0015, 0017's one-run lifecycle, and 0020's framed boundary.
+
 ## Accepted Contract
 
 ### 1. One orchestration owns the recognition universe

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -229,10 +229,10 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
 - **`recogniser_schema.py`** — the rank-0 Draftwright-owned table of public provider record
   schema versions consumed by adapters. The report projector and rank-7 cross-repository
   validator share this leaf, so the engine never imports the validator to learn schema metadata.
-- **`reporting.py`** — the rank-0 pure schema-v1 projector. `Drawing` owns all reads from its
-  `BuildState` and passes the exact evidence, ownership, final model, lint summary, and source
-  metadata down explicitly; reporting never reaches through `Drawing` private state or triggers
-  recognition, placement, or export.
+- **`reporting.py`** — the rank-0 pure schema-v1 report and generation-snapshot projector.
+  `Drawing` owns all report reads from its `BuildState`, while generated Python passes the exact
+  retained evidence, ownership, detected model, and source digest explicitly. Reporting never
+  reaches through `Drawing` private state or triggers recognition, placement, or export.
 - **`recognition_frame.py`** — the ADR 0020 prepared local-frame boundary. It calls the public
   provider preparation seam, classifies the exact normalized solid from its already-scanned
   cylinders, runs one paired aggregate, propagates typed refusal without fallback, and exposes
@@ -292,12 +292,13 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   alias shim was deleted at 0.4.0, #720).
 - **`sheet_emit.py`** — **the** script emitter, behind `--script` (#940 retired the
   imperative alternative): generates an editable `Sheet` script from a detected
-  model — one named binding per feature, an explicit dimension source. Facade tier;
-  imports `builder` downward at module level. The old builder→cli→sheet_emit
+  model — one named binding per feature, an explicit dimension source, and a bounded
+  generation-time recognition-gap snapshot. Facade tier; imports `builder` and the pure
+  `reporting` projector downward at module level. The old builder→cli→sheet_emit
   lazy cycle is **gone** (#523): the `_cli` compat shim moved from `builder` to
   `cli.py` (beside the Typer `app`), so `builder` no longer imports `cli` and
   `_LAZY_UPWARD_EXEMPT` is now empty. The graph is a plain DAG —
-  `cli → {builder, sheet_emit}`, `sheet_emit → builder`, `builder → ∅`.
+  `cli → {builder, sheet_emit}`, `sheet_emit → {builder, reporting}`, `builder → ∅`.
 - **`score.py` / `recognition/`** — temporary public compatibility re-exports of
   `b123d_recognisers`, identity-preserving and scheduled for removal in 0.6.0. There are no
   embedded recogniser modules. Engine code imports the external package directly; private

--- a/docs/reference/reports.md
+++ b/docs/reference/reports.md
@@ -49,6 +49,29 @@ ownership from values, labels, rendered coordinates, topology traversal, or a se
 scan. Declared reconciliation and framed evidence remain explicit later contracts rather than
 holes disguised as an empty report.
 
-Output manifests, generated-Python gap snapshots, and CLI/script sidecars follow as separate
-vertical slices. Calling `report()` or `write_report()` does not alter PDF, SVG, DXF, or PNG
-content; library export does not write a report unless the caller requests one.
+`generate_sheet_script(...)` also embeds
+`DRAFTWRIGHT_RECOGNITION_SNAPSHOT`, a version-1 JSON-compatible Python dictionary containing only
+the actionable accepted occurrences that were not represented by ordinary feature declarations
+when the script was generated: `unsupported`, `deferred`, `evidence_only`, and
+`unexpectedly_missing`. Each gap retains its report-local ID, provider family, public record,
+record schema version, disposition, deterministic reason, and tracking issue. Represented and
+absorbed occurrences remain expressed by the existing semantic Sheet declarations and are not
+duplicated into this compact block.
+
+The snapshot is generation-time evidence, not current authority. For a STEP source it records the
+original input basename and SHA-256 of one immutable byte snapshot. Recognition, PMI, and any
+semantic-correction build use a private copy of those exact bytes, preventing path or symlink
+changes during recognition from splitting the model and its provenance. Immediately before
+writing, generation also makes a best-effort check and fails if the resolved replay target is then
+missing or has a different digest. The pathname is not locked against later or concurrent
+replacement: the embedded hash is the comparison boundary for fresh runtime reconciliation, not a
+claim that a mutable path remains current. A live build123d object has no stable source-file hash
+and says so with `None`. The
+snapshot contains no `FeatureRef`, `FaceRef`, topology index, object address, annotation coordinate,
+or Python object representation. An empty snapshot says
+`no_unrepresented_accepted_occurrences`; it does not claim physical completeness.
+
+The fresh runtime report and its future reconciliation with this embedded snapshot remain a later
+slice, as do output manifests and CLI/script sidecars. Calling `report()` or `write_report()` does
+not alter PDF, SVG, DXF, or PNG content; library export does not write a report unless the caller
+requests one.

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -449,11 +449,9 @@ def _check_dimension_sources(model: PartModel) -> None:
         )
 
 
-def detect_part_model(part, *, pmi="off") -> PartModel:
-    """The **detected** :class:`PartModel` for *part* — feature recognition + analysis only,
-    with no view projection, annotation, repack, repair, or export (ADR 0011 #453). The cheap
-    seed path behind :meth:`draftwright.Sheet.from_part`, so pure feature inspection no longer
-    pays for a full drawing (nor its layout/rendering failure modes)."""
+def _detect_part_model_analysis(part, *, pmi="off") -> tuple[PartModel, Analysis]:
+    """Return one detected model together with the exact analysis run that produced it."""
+
     a = _analyse(
         part, title="", number="", tolerance="ISO 2768-m", drawn_by="", out="model", pmi=pmi
     )
@@ -465,7 +463,17 @@ def detect_part_model(part, *, pmi="off") -> PartModel:
     # hand-built Analysis with no stored model still detects.
     # `Analysis.model` is `object | None` (it sits below the IR in the DAG), so the cast is
     # what says the stored value is the same PartModel `build_model` would have rebuilt.
-    return cast("PartModel", a.model if a.model is not None else build_model(a))
+    model = cast("PartModel", a.model if a.model is not None else build_model(a))
+    return model, a
+
+
+def detect_part_model(part, *, pmi="off") -> PartModel:
+    """The **detected** :class:`PartModel` for *part* — feature recognition + analysis only,
+    with no view projection, annotation, repack, repair, or export (ADR 0011 #453). The cheap
+    seed path behind :meth:`draftwright.Sheet.from_part`, so pure feature inspection no longer
+    pays for a full drawing (nor its layout/rendering failure modes)."""
+
+    return _detect_part_model_analysis(part, pmi=pmi)[0]
 
 
 def _assemble(

--- a/src/draftwright/reporting.py
+++ b/src/draftwright/reporting.py
@@ -1,4 +1,4 @@
-"""Versioned machine-readable projection of one drawing's accepted recognition evidence."""
+"""Versioned machine-readable drawing reports and generation-time gap snapshots."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from importlib.metadata import version as distribution_version
 from os import PathLike
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 from draftwright.recogniser_schema import consumed_record_schema_versions_for_type
 
@@ -32,16 +32,20 @@ _DISPOSITIONS = (
 _ATTENTION_DISPOSITIONS = frozenset(
     {"unsupported", "deferred", "evidence_only", "unexpectedly_missing"}
 )
+_SNAPSHOT_SCHEMA = "draftwright-recognition-snapshot"
+_SNAPSHOT_SCHEMA_VERSION = 1
+
+JsonValue: TypeAlias = None | bool | int | float | str | list["JsonValue"] | dict[str, "JsonValue"]
 
 
 class ReportUnavailableError(RuntimeError):
     """The drawing cannot yet produce a truthful occurrence-level report."""
 
 
-def _json_value(value: object) -> object:
+def _json_value(value: object) -> JsonValue:
     """Return isolated strict JSON primitives, rejecting NaN/Infinity and repr fallbacks."""
 
-    return json.loads(json.dumps(value, allow_nan=False, sort_keys=True))
+    return cast(JsonValue, json.loads(json.dumps(value, allow_nan=False, sort_keys=True)))
 
 
 def _record_schema_version(family: str, record: object) -> int:
@@ -58,6 +62,13 @@ def _source(source: str | PathLike[str] | None) -> dict[str, str | None]:
     if isinstance(source, (str, PathLike)):
         return {"kind": "step", "name": Path(source).name}
     return {"kind": "build123d", "name": None}
+
+
+def _producer() -> dict[str, str]:
+    return {
+        "draftwright": distribution_version("draftwright"),
+        "b123d-recognisers": distribution_version("b123d-recognisers"),
+    }
 
 
 def _feature_ids(model: object) -> dict[int, tuple[object, dict[str, str]]]:
@@ -187,10 +198,7 @@ def drawing_report(
         "schema": REPORT_SCHEMA,
         "schema_version": REPORT_SCHEMA_VERSION,
         "status": "needs-attention" if needs_attention else "bounded-clear",
-        "producer": {
-            "draftwright": distribution_version("draftwright"),
-            "b123d-recognisers": distribution_version("b123d-recognisers"),
-        },
+        "producer": _producer(),
         "source": _source(source),
         "outputs": {},
         "recognition": {
@@ -201,6 +209,69 @@ def drawing_report(
         },
         "lint": lint,
     }
+
+
+def _generation_snapshot(
+    *,
+    evidence: RecognitionEvidence | None,
+    ownership: RecognitionOwnership | None,
+    model: PartModel | None,
+    source: str | PathLike[str] | None,
+    source_sha256: str | None,
+) -> dict[str, JsonValue]:
+    """Project generation-time accepted-occurrence gaps without compiling or rendering."""
+
+    occurrences, _summary = _occurrences(evidence, ownership, model)
+    gaps = [
+        {
+            key: occurrence[key]
+            for key in (
+                "id",
+                "family",
+                "record_type",
+                "record_schema_version",
+                "record",
+                "disposition",
+                "reason_code",
+                "tracking",
+            )
+        }
+        for occurrence in occurrences
+        if occurrence["disposition"] in _ATTENTION_DISPOSITIONS
+    ]
+    summary = {
+        "total": len(gaps),
+        **{
+            disposition: sum(gap["disposition"] == disposition for gap in gaps)
+            for disposition in (
+                "unsupported",
+                "deferred",
+                "evidence_only",
+                "unexpectedly_missing",
+            )
+        },
+    }
+    snapshot_source: dict[str, str | None] = {
+        **_source(source),
+        "sha256": source_sha256,
+    }
+    return cast(
+        dict[str, JsonValue],
+        {
+            "schema": _SNAPSHOT_SCHEMA,
+            "schema_version": _SNAPSHOT_SCHEMA_VERSION,
+            "status": (
+                "accepted_occurrences_unrepresented"
+                if gaps
+                else "no_unrepresented_accepted_occurrences"
+            ),
+            "coverage": "accepted-occurrence-gaps",
+            "producer": _producer(),
+            "source": snapshot_source,
+            "summary": summary,
+            "gaps": gaps,
+        },
+    )
 
 
 def _write_report_document(report: dict[str, object], path: str | PathLike[str]) -> str:

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -29,17 +29,24 @@ fixtures (#472).
 
 from __future__ import annotations
 
+import hashlib
 import math
+import pprint
 import re
 from collections.abc import Mapping, Sequence
+from contextlib import ExitStack
 from dataclasses import dataclass, fields, is_dataclass
 from numbers import Real
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from typing import Literal, cast
 
 from build123d import Shape
 
-from draftwright.builder import build_drawing, detect_part_model
+from draftwright.builder import (
+    _detect_part_model_analysis,
+    build_drawing,
+)
 from draftwright.fits import FitClass
 from draftwright.model.ir import (
     KnurlRequirement,
@@ -48,6 +55,7 @@ from draftwright.model.ir import (
     ThreadRequirement,
     ToleranceDecoration,
 )
+from draftwright.reporting import JsonValue, _generation_snapshot, _json_value
 from draftwright.view_plan import ViewConstraints
 
 
@@ -1934,6 +1942,7 @@ def emit_sheet_script(
     formats: Sequence[str] = ("pdf",),
     settled_layout: Mapping | None = None,
     view_constraints: ViewConstraints | None = None,
+    recognition_snapshot: Mapping[str, JsonValue] | None = None,
 ) -> str:
     """The generated declarative ``Sheet`` script text for a detected *model*.
 
@@ -1966,8 +1975,18 @@ def emit_sheet_script(
     without pretending an edited authored set is still automatic. ``view_constraints`` lets a
     caller emitting an adopted :class:`~draftwright.Sheet` preserve its independent principal
     and derived source choices plus semantic view declarations; targets remain stable feature
-    bindings rather than raw page coordinates."""
+    bindings rather than raw page coordinates.
+
+    ``recognition_snapshot``, when supplied by the generation front door, must contain only
+    strict JSON values. It is normalized through that boundary before becoming a Python literal,
+    so cyclic, non-finite, or arbitrary repr-bearing objects cannot make the emitted script
+    syntactically invalid."""
     _validate_scale_policy(scale, scale_policy)
+    normalized_snapshot = (
+        cast(dict[str, JsonValue], _json_value(dict(recognition_snapshot)))
+        if recognition_snapshot is not None
+        else None
+    )
     # The script declares this model — `model` plus an envelope when the overall height would
     # otherwise be unnameable under the mirrored (authored) set. BEFORE the import scan, since
     # a synthesised envelope needs `EnvelopeFeature` imported like a detected one.
@@ -2077,6 +2096,16 @@ def emit_sheet_script(
             else []
         ),
         "",
+        *(
+            [
+                "# Generation-time evidence only: the fresh runtime report remains authoritative.",
+                "DRAFTWRIGHT_RECOGNITION_SNAPSHOT = "
+                + pprint.pformat(normalized_snapshot, sort_dicts=False, width=99),
+                "",
+            ]
+            if normalized_snapshot is not None
+            else []
+        ),
         part_expr,
         "",
         f"sheet = Sheet(part, {', '.join(ctor)})",
@@ -2336,35 +2365,85 @@ def generate_sheet_script(
             break
     title = title or (Path(stem).name.replace("_", " ").upper() if not is_shape else "DRAWING")
 
+    # A STEP path is mutable and may be a retargetable symlink. Resolve its replay seam once,
+    # then read one immutable byte snapshot. Recognition, PMI, and any semantic-correction build
+    # all consume a private copy of those exact hashed bytes; no endpoint re-hash can be fooled by
+    # an A→B→A replacement during recognition (ADR 0017 Amendment 24).
+    source_display = None if is_shape else Path(step_file)
+    source_resolved = None if source_display is None else source_display.resolve()
+    source_bytes = None if source_resolved is None else source_resolved.read_bytes()
+    source_sha256 = None if source_bytes is None else hashlib.sha256(source_bytes).hexdigest()
+
     if part_expr is not None:
         pass  # caller-supplied seam (e.g. an import of a live module, #469)
     elif is_shape:
         part_expr = "part = ...   # ← wire in your build123d object (built above)"
     else:
         # absolute so the generated script runs from any working directory
-        abspath = str(Path(step_file).resolve())
+        assert source_resolved is not None
+        abspath = str(source_resolved)
         part_expr = f"from build123d import import_step\npart = import_step({abspath!r})"
 
-    model = detect_part_model(step_file, pmi=pmi)
-    settled_layout = None
-    # The two current semantic correction passes apply to turned shoulder chains (#443)
-    # and prismatic step ladders that requested a recovery detail (#1155). Generated
-    # scripts mirror the selected dimensions as AUTHORED lines, correctly disabling those
-    # automatic-only retries on re-run. Resolve just these candidate families once during
-    # generation; if a correction actually wins, carry its result into the editable script.
-    # Ordinary parts retain the cheap detect-only generation path.
-    may_need_semantic_correction = model.orientation is not None or any(
-        feature.kind == "step_level" for feature in model.features
-    )
-    if scale is None and may_need_semantic_correction:
-        settled = build_drawing(
-            step_file,
+    with ExitStack() as source_stack:
+        detection_source: str | Shape | Path = step_file
+        if source_bytes is not None:
+            snapshot_dir = Path(
+                source_stack.enter_context(TemporaryDirectory(prefix="draftwright-source-"))
+            )
+            snapshot_name = source_resolved.name if source_resolved is not None else "source.step"
+            detection_source = snapshot_dir / snapshot_name
+            detection_source.write_bytes(source_bytes)
+
+        model, analysis = _detect_part_model_analysis(detection_source, pmi=pmi)
+        recognition_snapshot = _generation_snapshot(
+            evidence=analysis.recognition_evidence,
+            ownership=analysis.recognition_ownership,
+            model=model,
+            source=source_display,
+            source_sha256=source_sha256,
+        )
+        settled_layout = None
+        # Generated scripts mirror dimensions as an authored set. Resolve the two established
+        # semantic-correction families against the same immutable STEP snapshot as recognition.
+        may_need_semantic_correction = model.orientation is not None or any(
+            feature.kind == "step_level" for feature in model.features
+        )
+        if scale is None and may_need_semantic_correction:
+            settled = build_drawing(
+                detection_source,
+                title=title,
+                number=number,
+                tolerance=tolerance,
+                drawn_by=drawn_by,
+                page=page,
+                scale_policy=scale_policy,
+                material=material,
+                date=date,
+                revision=revision,
+                company=company,
+                frame=frame,
+                zones=zones,
+                projection=projection,
+                pmi=pmi,
+                model=model,
+            )
+            if settled.scale_decision.get("status") == "automatic_replanned":
+                settled_layout = {
+                    "scale": settled.scale,
+                    "page": (settled.page_w, settled.page_h),
+                    "views": tuple(settled.views),
+                }
+        script = emit_sheet_script(
+            model,
+            part_expr,
+            stem,
             title=title,
             number=number,
-            tolerance=tolerance,
             drawn_by=drawn_by,
-            page=page,
+            tolerance=tolerance,
+            scale=scale,
             scale_policy=scale_policy,
+            page=page,
             material=material,
             date=date,
             revision=revision,
@@ -2372,39 +2451,24 @@ def generate_sheet_script(
             frame=frame,
             zones=zones,
             projection=projection,
-            pmi=pmi,
-            model=model,
+            object_ref=is_shape,
+            object_candidates=object_candidates,
+            source_part=step_file if isinstance(step_file, Shape) else None,
+            formats=formats,
+            settled_layout=settled_layout,
+            recognition_snapshot=recognition_snapshot,
         )
-        if settled.scale_decision.get("status") == "automatic_replanned":
-            settled_layout = {
-                "scale": settled.scale,
-                "page": (settled.page_w, settled.page_h),
-                "views": tuple(settled.views),
-            }
-    script = emit_sheet_script(
-        model,
-        part_expr,
-        stem,
-        title=title,
-        number=number,
-        drawn_by=drawn_by,
-        tolerance=tolerance,
-        scale=scale,
-        scale_policy=scale_policy,
-        page=page,
-        material=material,
-        date=date,
-        revision=revision,
-        company=company,
-        frame=frame,
-        zones=zones,
-        projection=projection,
-        object_ref=is_shape,  # a live Shape / resolved object-spec has objects to reference (#771)
-        object_candidates=object_candidates,
-        source_part=step_file if isinstance(step_file, Shape) else None,
-        formats=formats,
-        settled_layout=settled_layout,
-    )
+    if source_resolved is not None:
+        try:
+            replay_sha256 = hashlib.sha256(source_resolved.read_bytes()).hexdigest()
+        except OSError as error:
+            raise RuntimeError(
+                "STEP replay source became unavailable while generating its recognition snapshot"
+            ) from error
+        if replay_sha256 != source_sha256:
+            raise RuntimeError(
+                "STEP replay source changed while generating its recognition snapshot"
+            )
     py_path = f"{stem}.py"
     Path(py_path).write_text(script, encoding="utf-8")  # the script has box-drawing / × / ← glyphs
     return py_path

--- a/tests/test_issue_1146_scale_completeness.py
+++ b/tests/test_issue_1146_scale_completeness.py
@@ -546,7 +546,9 @@ def test_script_emitter_rejects_nondefault_policy_without_scale(tmp_path, monkey
     def detection_must_not_run(*_args, **_kwargs):
         raise AssertionError("invalid script options must fail before model detection")
 
-    monkeypatch.setattr("draftwright.sheet_emit.detect_part_model", detection_must_not_run)
+    monkeypatch.setattr(
+        "draftwright.sheet_emit._detect_part_model_analysis", detection_must_not_run
+    )
 
     with pytest.raises(ValueError, match="only when an explicit scale"):
         generate_sheet_script(

--- a/tests/test_issue_1438_generation_snapshot.py
+++ b/tests/test_issue_1438_generation_snapshot.py
@@ -1,0 +1,313 @@
+"""#1438 — generated Python carries a bounded generation-time recognition-gap snapshot."""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+from build123d import Align, Box, Cylinder, Pos, RegularPolygon, Rot, export_step, extrude
+
+from draftwright import build_drawing
+from draftwright import reporting as reporting_module
+from draftwright import sheet_emit as sheet_emit_module
+from draftwright.sheet_emit import emit_sheet_script, generate_sheet_script
+
+_CENTER = (Align.CENTER, Align.CENTER, Align.CENTER)
+
+
+def _oriented_slot_part():
+    part = Box(120, 90, 10)
+    for x in (-30, 0, 30):
+        part -= Pos(x, 0, 0) * Rot(0, 0, 30) * Box(24, 6, 20, align=_CENTER)
+    return part
+
+
+def _mixed_absorbed_unsupported_part():
+    part = Box(80, 60, 10, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    for x, y in ((-20, -10), (15, 12)):
+        part -= Pos(x, y, 0) * Cylinder(2, 10, align=(Align.CENTER, Align.CENTER, Align.MIN))
+    return part - extrude(RegularPolygon(6, 6), amount=12, both=True)
+
+
+def _step_projection_evidence_part():
+    aligned = (Align.MIN, Align.MIN, Align.MIN)
+    return Box(60, 40, 20, align=aligned) - Pos(30, 0, 10) * Box(30, 40, 10, align=aligned)
+
+
+def _through_step_part():
+    return Box(40, 30, 20) - Pos(15, 10, 0) * Box(20, 20, 30)
+
+
+def _generation_snapshot_for(part, *, lose_bindings: bool = False) -> dict[str, object]:
+    drawing = build_drawing(part)
+    ownership = drawing.recognition_ownership()
+    if lose_bindings:
+        assert ownership is not None
+        ownership = replace(ownership, bindings=())
+    return reporting_module._generation_snapshot(
+        evidence=drawing.recognition_evidence(),
+        ownership=ownership,
+        model=drawing.model(),
+        source=None,
+        source_sha256=None,
+    )
+
+
+def _snapshot(source: str) -> dict[str, object]:
+    module = ast.parse(source)
+    assignment = next(
+        statement
+        for statement in module.body
+        if isinstance(statement, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "DRAFTWRIGHT_RECOGNITION_SNAPSHOT"
+            for target in statement.targets
+        )
+    )
+    value = ast.literal_eval(assignment.value)
+    assert isinstance(value, dict)
+    return value
+
+
+def test_generated_python_exposes_each_deferred_oriented_slot_without_execution(
+    tmp_path: Path,
+) -> None:
+    script = generate_sheet_script(_oriented_slot_part(), out=str(tmp_path / "oriented"))
+    source = Path(script).read_text(encoding="utf-8")
+
+    snapshot = _snapshot(source)
+
+    assert snapshot["schema"] == "draftwright-recognition-snapshot"
+    assert snapshot["schema_version"] == 1
+    assert snapshot["status"] == "accepted_occurrences_unrepresented"
+    assert snapshot["coverage"] == "accepted-occurrence-gaps"
+    assert snapshot["source"] == {"kind": "build123d", "name": None, "sha256": None}
+    assert snapshot["summary"] == {
+        "total": 3,
+        "unsupported": 0,
+        "deferred": 3,
+        "evidence_only": 0,
+        "unexpectedly_missing": 0,
+    }
+    gaps = snapshot["gaps"]
+    assert isinstance(gaps, list)
+    assert [gap["id"] for gap in gaps] == [
+        "oriented_slots:1",
+        "oriented_slots:2",
+        "oriented_slots:3",
+    ]
+    assert {gap["family"] for gap in gaps} == {"oriented_slots"}
+    assert {gap["record_type"] for gap in gaps} == {"OrientedSlot"}
+    assert {gap["record_schema_version"] for gap in gaps} == {1}
+    assert {gap["disposition"] for gap in gaps} == {"deferred"}
+    assert {gap["reason_code"] for gap in gaps} == {"consumer_semantics_deferred"}
+    assert {gap["tracking"] for gap in gaps} == {
+        "https://github.com/pzfreo/draftwright/issues/1430"
+    }
+    assert [gap["record"]["center"] for gap in gaps] == [
+        [-30.0, 0.0, 0.0],
+        [0.0, 0.0, 0.0],
+        [30.0, 0.0, 0.0],
+    ]
+    assert json.loads(json.dumps(snapshot, allow_nan=False, sort_keys=True)) == snapshot
+    assert "FeatureRef" not in source
+    assert "FaceRef" not in source
+
+
+def test_empty_snapshot_names_its_bounded_claim_truthfully(tmp_path: Path) -> None:
+    script = generate_sheet_script(Box(40, 30, 20), out=str(tmp_path / "plain"))
+
+    snapshot = _snapshot(Path(script).read_text(encoding="utf-8"))
+
+    assert snapshot["status"] == "no_unrepresented_accepted_occurrences"
+    assert snapshot["summary"]["total"] == 0
+    assert snapshot["gaps"] == []
+    assert "complete" not in snapshot["status"]
+
+
+def test_snapshot_filters_absorbed_occurrences_while_retaining_unsupported_gap() -> None:
+    snapshot = _generation_snapshot_for(_mixed_absorbed_unsupported_part())
+
+    assert [(gap["family"], gap["disposition"]) for gap in snapshot["gaps"]] == [
+        ("passages", "unsupported")
+    ]
+    assert snapshot["summary"] == {
+        "total": 1,
+        "unsupported": 1,
+        "deferred": 0,
+        "evidence_only": 0,
+        "unexpectedly_missing": 0,
+    }
+
+
+def test_snapshot_filters_represented_occurrence_while_retaining_evidence_gaps() -> None:
+    snapshot = _generation_snapshot_for(_step_projection_evidence_part())
+
+    assert {(gap["family"], gap["disposition"]) for gap in snapshot["gaps"]} == {
+        ("step_levels", "evidence_only"),
+        ("risers", "evidence_only"),
+    }
+    assert all(gap["family"] != "through_steps" for gap in snapshot["gaps"])
+
+
+def test_snapshot_projects_supported_owner_loss_as_an_unexpected_gap() -> None:
+    snapshot = _generation_snapshot_for(_through_step_part(), lose_bindings=True)
+
+    assert [(gap["family"], gap["disposition"]) for gap in snapshot["gaps"]] == [
+        ("through_steps", "unexpectedly_missing")
+    ]
+
+
+def test_step_snapshot_carries_exact_source_identity_and_hash_deterministically(
+    tmp_path: Path,
+) -> None:
+    step = tmp_path / "source.step"
+    export_step(Box(40, 30, 20), str(step))
+    expected_hash = hashlib.sha256(step.read_bytes()).hexdigest()
+
+    first = generate_sheet_script(str(step), out=str(tmp_path / "first"))
+    second = generate_sheet_script(str(step), out=str(tmp_path / "second"))
+    first_snapshot = _snapshot(Path(first).read_text(encoding="utf-8"))
+    second_snapshot = _snapshot(Path(second).read_text(encoding="utf-8"))
+
+    assert first_snapshot == second_snapshot
+    assert first_snapshot["source"] == {
+        "kind": "step",
+        "name": "source.step",
+        "sha256": expected_hash,
+    }
+
+
+def test_recognition_uses_immutable_bytes_during_an_aba_source_replacement(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    step = tmp_path / "source.step"
+    export_step(Box(40, 30, 20), str(step))
+    original_bytes = step.read_bytes()
+    alternate = tmp_path / "alternate.step"
+    export_step(_oriented_slot_part(), str(alternate))
+    original = sheet_emit_module._detect_part_model_analysis
+
+    def detect_during_aba(source, *, pmi="off"):
+        step.write_bytes(alternate.read_bytes())
+        try:
+            return original(source, pmi=pmi)
+        finally:
+            step.write_bytes(original_bytes)
+
+    monkeypatch.setattr(sheet_emit_module, "_detect_part_model_analysis", detect_during_aba)
+
+    script = generate_sheet_script(str(step), out=str(tmp_path / "stable"))
+    snapshot = _snapshot(Path(script).read_text(encoding="utf-8"))
+
+    assert snapshot["source"]["sha256"] == hashlib.sha256(original_bytes).hexdigest()
+    assert snapshot["gaps"] == []
+    assert step.read_bytes() == original_bytes
+
+
+def test_persistent_source_replacement_fails_before_writing_the_script(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    step = tmp_path / "source.step"
+    alternate = tmp_path / "alternate.step"
+    export_step(Box(40, 30, 20), str(step))
+    export_step(_oriented_slot_part(), str(alternate))
+    original = sheet_emit_module._detect_part_model_analysis
+
+    def detect_then_replace(source, *, pmi="off"):
+        result = original(source, pmi=pmi)
+        step.write_bytes(alternate.read_bytes())
+        return result
+
+    monkeypatch.setattr(sheet_emit_module, "_detect_part_model_analysis", detect_then_replace)
+
+    with pytest.raises(RuntimeError, match="STEP replay source changed"):
+        generate_sheet_script(str(step), out=str(tmp_path / "replaced"))
+
+    assert not (tmp_path / "replaced.py").exists()
+
+
+def test_source_deletion_fails_before_writing_the_script(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    step = tmp_path / "source.step"
+    export_step(Box(40, 30, 20), str(step))
+    original = sheet_emit_module._detect_part_model_analysis
+
+    def detect_then_delete(source, *, pmi="off"):
+        result = original(source, pmi=pmi)
+        step.unlink()
+        return result
+
+    monkeypatch.setattr(sheet_emit_module, "_detect_part_model_analysis", detect_then_delete)
+
+    with pytest.raises(RuntimeError, match="STEP replay source became unavailable"):
+        generate_sheet_script(str(step), out=str(tmp_path / "deleted"))
+
+    assert not (tmp_path / "deleted.py").exists()
+
+
+def test_symlink_retarget_cannot_split_replay_source_from_recognition(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    first = tmp_path / "first.step"
+    second = tmp_path / "second.step"
+    export_step(Box(40, 30, 20), str(first))
+    export_step(_oriented_slot_part(), str(second))
+    source = tmp_path / "source.step"
+    try:
+        source.symlink_to(first)
+    except OSError as error:
+        pytest.skip(f"symlinks unavailable: {error}")
+    original = sheet_emit_module._detect_part_model_analysis
+
+    def retarget_then_detect(snapshot_source, *, pmi="off"):
+        source.unlink()
+        source.symlink_to(second)
+        return original(snapshot_source, pmi=pmi)
+
+    monkeypatch.setattr(sheet_emit_module, "_detect_part_model_analysis", retarget_then_detect)
+
+    script = generate_sheet_script(str(source), out=str(tmp_path / "linked"))
+    script_source = Path(script).read_text(encoding="utf-8")
+    snapshot = _snapshot(script_source)
+
+    assert repr(str(first.resolve())) in script_source
+    assert repr(str(second.resolve())) not in script_source
+    assert snapshot["source"] == {
+        "kind": "step",
+        "name": "source.step",
+        "sha256": hashlib.sha256(first.read_bytes()).hexdigest(),
+    }
+    assert snapshot["gaps"] == []
+
+
+@pytest.mark.parametrize("bad_snapshot", ({"value": object()},))
+def test_emitter_rejects_non_json_snapshot_values_before_writing_python(bad_snapshot) -> None:
+    model, _analysis = sheet_emit_module._detect_part_model_analysis(Box(10, 10, 10))
+
+    with pytest.raises(TypeError, match="not JSON serializable"):
+        emit_sheet_script(
+            model,
+            "part = None",
+            "bad",
+            title="BAD",
+            number="BAD",
+            recognition_snapshot=bad_snapshot,
+        )
+
+    cyclic: dict[str, object] = {}
+    cyclic["self"] = cyclic
+    with pytest.raises(ValueError, match="Circular reference"):
+        emit_sheet_script(
+            model,
+            "part = None",
+            "bad",
+            title="BAD",
+            number="BAD",
+            recognition_snapshot=cyclic,  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
## Outcome

Generated Sheet Python now embeds a compact, deterministic, versioned recognition-gap snapshot that an AI can inspect without executing the script.

## Contract

- Projects only unsupported, deferred, evidence-only, and unexpectedly-missing accepted occurrences from the exact Analysis that produced the model.
- Keeps represented and absorbed facts in the ordinary semantic Sheet declarations.
- Uses only strict JSON-compatible public record values; no FeatureRef, FaceRef, topology index, object address, or annotation coordinate.
- For STEP input, recognition, PMI, and semantic correction consume one private immutable copy of the exact bytes named by the embedded SHA-256.
- Makes a best-effort final replay-target digest observation while documenting that a mutable pathname is not locked and requires later runtime reconciliation.
- Preserves recognition-free generated declared replay and makes no visual-output or placement change.

## Review and ADR audit

Exact head: e003248dbbb31de33dd86bacd0cd61cc8887e6fe
Exact tree: 7dbb38e96b2725e7ab1fc4f4374d04526ed4ee98
Base: fea791e3cbeb49fcbfb3c3423eaafd90492f1249

Three fresh independent Google-style exact-head reviews are clean. Two report no findings or nits; the ADR review has one explicitly optional memory-streaming nit. ADRs 0010, 0011, 0013, 0014, 0015, 0017, and 0020 were audited; ADR 0017 Amendment 24 and the architecture map describe the bounded snapshot and exact guarantees. No recogniser API change is needed.

## Verification

- Canonical fast suite with branch coverage: 6,589 passed, 5 skipped, 2 expected xfails
- Total line and branch coverage: 95.91%
- Changed source coverage: 100% across 55 lines
- Ruff lint and format: green
- mypy: green
- codespell: green
- strict documentation build: green

Closes no issue; advances #1438 and #1256.