### PR TITLE
Emit report sidecars from the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Added
 
+- Direct CLI rendering now writes `<output>.draftwright.json` by default, after successful visual
+  export, and prints its path with the requested artefacts. `--no-report` is the explicit opt-out;
+  library `Drawing.export()` remains free of report-writing side effects (#1438, ADR 0017
+  Amendment 25).
+
 - Generated Sheet Python now embeds a deterministic, versioned, JSON-compatible snapshot of
   actionable accepted-occurrence gaps from the exact recognition run that produced its model.
   The compact snapshot carries only unsupported, deferred, evidence-only, and unexpectedly

--- a/README.md
+++ b/README.md
@@ -40,13 +40,14 @@ Point it at a STEP file — that's the whole workflow:
 
 ```
 draftwright my_part.step --title "Mounting Plate" --number DWG-001
-# writes my_part.pdf (the default)
+# writes my_part.pdf and my_part.draftwright.json (the defaults)
 ```
 
 Choose formats, scale, and page; or emit an editable drawing script:
 
 ```
 draftwright my_part.step --format pdf,dxf     # also: svg, all
+draftwright my_part.step --no-report          # opt out of the JSON sidecar
 draftwright my_part.step --scale 2 --page A3  # override the auto scale / page
 draftwright my_part.step --scale 1 --page A4 --scale-policy strict
 draftwright my_part.step --script             # write an editable declarative Sheet script

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -688,6 +688,28 @@ comparison, output manifests, and CLI sidecar default remain later slices. The s
 compiles nor places annotations, changes no visual output, and preserves ADRs 0010, 0011, 0013,
 0014, 0015, 0017's one-run lifecycle, and 0020's framed boundary.
 
+## Amendment 25 — Direct CLI rendering writes the machine report by default
+
+The direct rendering path now calls `Drawing.write_report(<output>.draftwright.json)` after all
+requested visual formats export successfully and prints that path after the visual paths.
+`--no-report` is the explicit opt-out. The sidecar therefore uses the same strict, atomic report
+surface as a library caller. A failed visual export does not create or update the sidecar; an
+already-existing sidecar is deliberately left untouched rather than being treated as output of the
+failed invocation. Output manifests and cross-run freshness validation remain later slices.
+
+This ordering is intentionally non-transactional. The CLI prints each successfully exported visual
+path before attempting the report write. If that atomic write then fails, the command exits nonzero
+without printing a report path; the visual files and any pre-existing sidecar remain untouched.
+Consumers must not treat an old sidecar as evidence for the failed invocation. A future output
+manifest is the contract that will bind one successful invocation's artefacts together.
+
+This is CLI orchestration, not a new side effect of `Drawing.export()`: library export remains
+unchanged and visually identical, and report persistence still requires an explicit method call.
+The build-owned evidence and ownership used by export lint and report are reused; no second scan,
+provider API, persistent identity, placement path, or completeness claim is introduced. Declared
+generated-script reconciliation, report-only CLI operation, and output manifests remain later
+slices under the existing ADR 0010/0011/0013/0014/0015/0017/0020 boundaries.
+
 ## Accepted Contract
 
 ### 1. One orchestration owns the recognition universe

--- a/docs/reference/reports.md
+++ b/docs/reference/reports.md
@@ -71,7 +71,20 @@ snapshot contains no `FeatureRef`, `FaceRef`, topology index, object address, an
 or Python object representation. An empty snapshot says
 `no_unrepresented_accepted_occurrences`; it does not claim physical completeness.
 
+Direct CLI rendering writes `<output>.draftwright.json` after the requested visual formats by
+default and prints the sidecar path after the visual paths. `--no-report` opts out. The CLI calls
+the same explicit atomic `Drawing.write_report(...)` surface; `Drawing.export(...)` itself still
+does not write a report. A visual-export failure does not create or update the sidecar; any
+pre-existing sidecar remains untouched and is not evidence of that failed invocation. Report-only
+generation, cross-run freshness validation, and output manifests remain later slices.
+
+The visual/report sequence is not a transaction: each successfully exported visual path is printed
+before the report write is attempted. If that write fails, the command exits nonzero without
+printing a report path; the visual files and any pre-existing sidecar remain. Until an output
+manifest binds one invocation's artefacts, consumers must not associate that old sidecar with the
+failed run.
+
 The fresh runtime report and its future reconciliation with this embedded snapshot remain a later
-slice, as do output manifests and CLI/script sidecars. Calling `report()` or `write_report()` does
+slice, as do output manifests and generated-script sidecars. Calling `report()` or `write_report()` does
 not alter PDF, SVG, DXF, or PNG content; library export does not write a report unless the caller
 requests one.

--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -14,6 +14,7 @@ import os
 from enum import Enum
 from importlib.metadata import PackageNotFoundError
 from importlib.metadata import version as _pkg_version
+from pathlib import Path
 
 import typer
 
@@ -69,10 +70,22 @@ def _parse_formats(value: str) -> list[str]:
 
 
 def _emit(dwg, formats: list[str]) -> list[str]:
-    """Write the requested formats and return their paths in *formats* order. ``export`` handles
-    the SVG→PDF→PNG intermediate chain and removes any it wasn't asked to keep."""
+    """Write requested visual artefacts and return their paths in *formats* order.
+
+    ``export`` handles the SVG→PDF→PNG intermediate chain and removes any it was not asked to
+    keep.
+    """
     paths = dwg.export(formats=formats)
     return [paths[f] for f in formats]
+
+
+def _write_report_sidecar(dwg, visual_paths: list[str]) -> str:
+    """Write the CLI report beside export's authoritative normalized output stem."""
+    # Drawing.export accepts an output such as ``part.pdf`` and strips the recognized suffix
+    # before writing; deriving the stem from its returned path keeps every suffix (including
+    # PDF/PNG, which builder does not pre-strip) on one naming contract.
+    report_stem = str(Path(visual_paths[0]).with_suffix(""))
+    return str(dwg.write_report(f"{report_stem}.draftwright.json"))
 
 
 def _looks_like_object_spec(s: str) -> bool:
@@ -157,6 +170,11 @@ def main(
         "--format",
         "-f",
         help="Comma-list of output formats: pdf, svg, dxf, png (or 'all'). E.g. --format pdf,png",
+    ),
+    no_report: bool = typer.Option(
+        False,
+        "--no-report",
+        help="Skip the default JSON report beside rendered output",
     ),
     verbose: bool = typer.Option(
         False,
@@ -262,8 +280,11 @@ def main(
         projection=projection or None,
         zones=zones,
     )
-    for path in _emit(dwg, formats):
+    visual_paths = _emit(dwg, formats)
+    for path in visual_paths:
         print(path)
+    if not no_report:
+        print(_write_report_sidecar(dwg, visual_paths))
 
 
 def _cli() -> None:

--- a/tests/test_issue_1438_cli_report_sidecar.py
+++ b/tests/test_issue_1438_cli_report_sidecar.py
@@ -1,0 +1,132 @@
+"""#1438 — direct CLI rendering emits an explicit machine-readable sidecar."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from typer.testing import CliRunner
+
+from draftwright.cli import app
+
+
+class _Drawing:
+    def __init__(self, out: Path) -> None:
+        self.out = str(out)
+        self.calls: list[tuple[str, object]] = []
+
+    def export(self, *, formats):
+        formats = tuple(formats)
+        self.calls.append(("export", formats))
+        stem = self.out
+        for suffix in (".svg", ".dxf", ".pdf", ".png"):
+            if stem.endswith(suffix):
+                stem = stem[: -len(suffix)]
+                break
+        return {name: f"{stem}.{name}" for name in formats}
+
+    def write_report(self, path):
+        self.calls.append(("write_report", path))
+        return path
+
+
+@pytest.mark.parametrize(
+    ("extra", "expect_report"),
+    [([], True), (["--no-report"], False)],
+)
+def test_direct_cli_report_default_and_explicit_opt_out(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    extra: list[str],
+    expect_report: bool,
+) -> None:
+    import draftwright.builder as builder
+
+    output = tmp_path / "part"
+    drawing = _Drawing(output)
+    monkeypatch.setattr(builder, "build_drawing", lambda **_kwargs: drawing)
+
+    result = CliRunner().invoke(
+        app,
+        ["source.step", "--out", str(output), "--format", "pdf,dxf", *extra],
+    )
+
+    assert result.exit_code == 0, result.output
+    expected_calls: list[tuple[str, object]] = [("export", ("pdf", "dxf"))]
+    expected_paths = [f"{output}.pdf", f"{output}.dxf"]
+    if expect_report:
+        expected_calls.append(("write_report", f"{output}.draftwright.json"))
+        expected_paths.append(f"{output}.draftwright.json")
+    assert drawing.calls == expected_calls
+    assert result.output.splitlines() == expected_paths
+
+
+def test_report_is_not_attempted_when_visual_export_fails(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import draftwright.builder as builder
+
+    class _FailingDrawing(_Drawing):
+        def export(self, *, formats):
+            self.calls.append(("export", tuple(formats)))
+            raise OSError("visual export failed")
+
+    drawing = _FailingDrawing(tmp_path / "part")
+    monkeypatch.setattr(builder, "build_drawing", lambda **_kwargs: drawing)
+
+    result = CliRunner().invoke(app, ["source.step", "--out", drawing.out])
+
+    assert result.exit_code == 1
+    assert isinstance(result.exception, OSError)
+    assert drawing.calls == [("export", ("pdf",))]
+
+
+@pytest.mark.parametrize("suffix", ["", ".svg", ".dxf", ".pdf", ".png"])
+def test_report_uses_the_visual_exports_normalized_stem(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, suffix: str
+) -> None:
+    import draftwright.builder as builder
+
+    requested_output = tmp_path / f"part{suffix}"
+    drawing = _Drawing(requested_output)
+    monkeypatch.setattr(builder, "build_drawing", lambda **_kwargs: drawing)
+
+    result = CliRunner().invoke(
+        app,
+        ["source.step", "--out", str(requested_output), "--format", "pdf"],
+    )
+
+    expected_stem = tmp_path / "part"
+    assert result.exit_code == 0, result.output
+    assert drawing.calls == [
+        ("export", ("pdf",)),
+        ("write_report", f"{expected_stem}.draftwright.json"),
+    ]
+    assert result.output.splitlines() == [
+        f"{expected_stem}.pdf",
+        f"{expected_stem}.draftwright.json",
+    ]
+
+
+def test_report_failure_propagates_after_printing_visuals_but_not_a_report_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import draftwright.builder as builder
+
+    class _FailingReportDrawing(_Drawing):
+        def write_report(self, path):
+            self.calls.append(("write_report", path))
+            raise OSError("report write failed")
+
+    drawing = _FailingReportDrawing(tmp_path / "part")
+    monkeypatch.setattr(builder, "build_drawing", lambda **_kwargs: drawing)
+
+    result = CliRunner().invoke(app, ["source.step", "--out", drawing.out])
+
+    assert result.exit_code == 1
+    assert isinstance(result.exception, OSError)
+    assert drawing.calls == [
+        ("export", ("pdf",)),
+        ("write_report", f"{drawing.out}.draftwright.json"),
+    ]
+    assert result.output.splitlines() == [f"{drawing.out}.pdf"]

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -3353,8 +3353,13 @@ def test_cli_inherits_automatic_detail_default(monkeypatch):
     forwarded = []
 
     class _Drawing:
+        out = "out"
+
         def export(self, *, formats):
             return {name: f"out.{name}" for name in formats}
+
+        def write_report(self, path):
+            return path
 
     def _build(*args, **kwargs):
         forwarded.append(kwargs)

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -1632,8 +1632,13 @@ class TestCli:
         seen = []
 
         class DrawingStub:
+            out = str(tmp_path / "out")
+
             def export(self, *, formats):
                 return {name: str(tmp_path / f"out.{name}") for name in formats}
+
+            def write_report(self, path):
+                return path
 
         def build_stub(**kwargs):
             seen.append(kwargs["pmi"])


### PR DESCRIPTION
## Summary

- write `<normalized-output>.draftwright.json` by default after successful direct CLI visual export
- print successful visual paths before the atomic report attempt, then print the report path only on success
- provide `--no-report` as the explicit opt-out while leaving `Drawing.export()` and generated-script behavior unchanged
- document and test normalized `.svg`/`.dxf`/`.pdf`/`.png` stems and the deliberately non-transactional export/report failure states

Refs #1438
Refs #1256

## Contracts

- Uses the existing public `Drawing.write_report()` boundary and the build-owned recognition aggregate; no second recognition scan.
- Visual export, placement, and library export semantics remain unchanged.
- A visual-export failure does not create or update a sidecar. A report-write failure exits nonzero after printing successful visual paths, prints no report path, and leaves visual files and any old sidecar untouched.
- No persistent topology IDs, raw annotation coordinates, provider-private APIs, or inferred manufacturing intent.

## Exact review identity

- Base: `ce01e589e959d25d476b353b86cfb861c0689dbc`
- Head: `e04a061cba7697ad31a6f4b33666ec36279fca72`
- Tree: `d83909efc72f207ba410b7595a353c9b66baf5f4`

Three fresh independent Google-style exact-head reviews are CLEAN with no findings or nits: ADR/architecture, behavioural contract, and code/test quality. ADRs 0010, 0011, 0013, 0014, 0015, 0017 Amendment 25, and 0020 pass. No upstream recogniser/API change is needed.

## Verification

- `BASE_REF=ce01e589e959d25d476b353b86cfb861c0689dbc scripts/pr-check --full`
  - 6,598 passed, 5 skipped, 2 expected xfailed
  - 95.91% total line+branch coverage
  - 100% changed-line coverage
- Ruff lint/format, mypy, codespell, and strict MkDocs all pass.
- Focused compatibility/review suites pass.
- Real STEP CLI smoke tests produced ordered visual + valid JSON sidecar paths, including a normalized suffix case.
