### PR TITLE
Project physical requirement outcomes into report v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Added
 
+- Report schema v1 now projects one recognition-owned physical requirement ledger shared with
+  completeness. Each bounded requirement identifies its accepted source occurrence(s), final IR
+  owner(s), semantic parameter where applicable, placement/satisfaction state, annotation names,
+  and representation rationale. The roster is evaluated once per report and fails closed when
+  exact same-run evidence or provenance is absent; it does not create a second recognition scan,
+  persistent topology identity, inferred manufacturing intent, or visual change (#1438, ADR 0017
+  Amendment 26).
+
 - Direct CLI rendering now writes `<output>.draftwright.json` by default, after successful visual
   export, and prints its path with the requested artefacts. `--no-report` is the explicit opt-out;
   library `Drawing.export()` remains free of report-writing side effects (#1438, ADR 0017
@@ -34,10 +42,10 @@
   projection of every accepted recognition occurrence, its explicit consumer disposition and
   report-local final IR owner(s), plus the existing lint summary. The published schema never
   serializes provider references, topology IDs, object addresses, or transient member positions;
-  it marks requirement coverage as not yet projected and calls a clean result `bounded-clear`, not
-  manufacturing-ready. Paths without exact occurrence ownership and raw paths with an unclassified
-  accepted occurrence fail explicitly rather than emit an empty or inferred report. Rendering
-  remains unchanged (#1438, ADR 0017 Amendment 21).
+  it makes requirement coverage an explicit field (subsequently populated by Amendment 26) and
+  calls a clean result `bounded-clear`, not manufacturing-ready. Paths without exact occurrence
+  ownership and raw paths with an unclassified accepted occurrence fail explicitly rather than
+  emit an empty or inferred report. Rendering remains unchanged (#1438, ADR 0017 Amendment 21).
 
 - Accepted `FaceLevel` and `RiserEvidence` occurrences now receive explicit `evidence_only`
   outcomes. The released records remain shared substrate for the supported correlated height

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,19 +43,19 @@ Compact map, bottom to top:
   `plate_correspondence.py` (pure shared Plate-record/final-IR correspondence predicates),
   `recogniser_policy.py` (single Draftwright-owned unsupported/deferred/evidence-only policy),
   `recogniser_schema.py` (consumer-owned public record schema versions shared by validation and
-  reporting), `reporting.py` (pure versioned projection over explicitly supplied finished-build
-  state),
+  reporting),
   `recognition_frame.py` (ADR 0020 prepared local-frame boundary and fail-closed
   body-local occurrence joins), `blend_contract.py` (strict released-Blend schema and
   occurrence identity),
-  `_warnings.py`, `_pmi_part21.py`, and the `linting/` subpackage
-  (draftwright owns lint, ADR 0007).
+  `_warnings.py`, and `_pmi_part21.py`.
 - **`_core.py`** — shared primitives: the `Analysis` namespace, dim/format helpers,
   page/slot/margin constants.
 - **Stage modules** — `analysis.py` (classification + one-shot feature inventory),
   `projection.py` (HLR + material lowering), `compose.py` (the ADR 0004 outer
   compose-then-pack layout), `export.py` (SVG→PDF→PNG chain, DXF), `repair.py`
-  (the ADR 0002 lint→repair safety net), `pmi.py` (STEP AP242 PMI),
+  (the ADR 0002 lint→repair safety net), `pmi.py` (STEP AP242 PMI), `linting/`
+  (draftwright-owned lint and recognition requirement ledgers, ADR 0007), `reporting.py`
+  (versioned projection over explicitly supplied finished-build state and those ledgers),
   `model/` (the ADR 0015 IR waist: `ir`/`detect`/`planner`/`declare`/`compiled`),
   `drawing.py` (the `Drawing` result object; single-owner `BuildState`), and
   `annotations/` (the render passes; `orchestrator.py` owns `_PASS_SEQUENCE`, the one

--- a/docs/adr/0005-pipeline-architecture-and-state-ownership.md
+++ b/docs/adr/0005-pipeline-architecture-and-state-ownership.md
@@ -327,3 +327,11 @@ history. They are not current work instructions. The lasting decision is:
 
 This amendment is the reader's current entry point. The dated sections above
 explain how the package reached it.
+
+**Amendment (2026-09-03) — reporting consumes recognition-owned requirement ledgers
+(#1438):** `reporting.py` is no longer a rank-0 leaf. A truthful report must expose the
+same typed physical-requirement denominator as completeness, so the shared aggregation
+lives in `linting/requirements.py` and both `linting/quality.py` and `reporting.py`
+consume it. Reporting therefore sits beside linting at rank 2. It still receives finished
+build state explicitly and never reaches through `Drawing` internals; the executable DAG
+guard prevents this reviewed dependency from becoming a cycle or an upward edge.

--- a/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
+++ b/docs/adr/0017-recognition-inventory-correspondence-and-measurement-provenance.md
@@ -23,7 +23,9 @@
   owner selected for every accepted round-boss occurrence. Amendment 20 gives every accepted
   face-level and riser evidence occurrence an explicit evidence-only outcome. Amendment 21
   publishes the first bounded, versioned JSON projection
-  of the completed raw occurrence-disposition ledger.
+  of the completed raw occurrence-disposition ledger. Amendments 22–25 add atomic persistence,
+  Plate ownership, generated-Python gap evidence, and direct CLI sidecars. Amendment 26 projects
+  the existing typed physical-requirement outcomes without rebuilding a denominator from IR.
 - **Date:** 2026-08-03
 - **Deciders:** Paul Fremantle (pzfreo)
 
@@ -709,6 +711,42 @@ The build-owned evidence and ownership used by export lint and report are reused
 provider API, persistent identity, placement path, or completeness claim is introduced. Declared
 generated-script reconciliation, report-only CLI operation, and output manifests remain later
 slices under the existing ADR 0010/0011/0013/0014/0015/0017/0020 boundaries.
+
+## Amendment 26 — Reports project the recognition-owned semantic requirement ledger
+
+Schema-v1 reports now reuse the same family-specific typed outcomes that feed conditional
+completeness. A report-level requirement is therefore owned by the recognised physical source,
+not manufactured by enumerating `PartModel.parameters()`. Each typed outcome retains the exact
+same-run public source-record object or objects that establish it. The report translates those
+run-local identities to occurrence IDs, final recorded owners, semantic states, and exact
+annotation names where the ADR-0010 registry exposes measurement or structured-satisfaction
+provenance.
+
+This shape preserves physical cardinality. Pattern/group members share one set of requirement IDs;
+nested countersinks reference the same hole-owned seat requirements; already-conveyed alternate
+requirements remain inapplicable rather than entering the denominator again; and an outcome whose
+specific parameter vocabulary cannot be proved expands its recognition-owned cardinality into
+explicit `unverifiable` rows. Correlated IR surfaces such as `StepLevelFeature.parameters()` are
+never flattened or treated as unique identities merely because they expose repeated parameter
+IDs. Removing registry provenance changes the typed state and therefore the report instead of
+leaving stale credit.
+
+This amendment finalizes schema version 1 before its first release: the report commits landed after
+v0.4.17 and remain in the unreleased v0.4.18 development line. It may therefore replace the
+placeholder `not-projected` requirement shape without breaking a published v1 consumer. Once this
+shape ships, report-owned objects remain closed and any incompatible change requires a new schema
+version as the reference contract states.
+
+The compiled plan may help an existing family ledger verify the exact rendered member of a
+correlated grammar, but it never determines what physical requirements exist. A report evaluates
+the typed requirement roster once and passes that same immutable result to completeness and JSON
+projection. Existing family verification may query the already-held working solid (for example,
+Plate correspondence); the report does not start a second recognition scan or derive another
+physical denominator. It does not compare public record values, rely on provider order to recover
+ownership, serialize object identities, or place annotations. `bounded-clear` remains explicitly
+conditional on recognised/audited geometry and says nothing about unrecognised geometry or missing
+manufacturing intent. ADRs 0010, 0011, 0013, 0014, 0015, and 0020 therefore retain their existing
+boundaries; this amendment only exposes already-audited semantic evidence through the report.
 
 ## Accepted Contract
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,12 +11,12 @@ keep that table, this document, and `CLAUDE.md`'s compact map in step. The
 The dependency graph is a DAG (the #138 / ADR 0005 split is complete). Bottom to
 top: leaf modules (`layout.py`, `registry.py`, `fonts.py`, `_geometry.py`,
 `fits.py`, `intents.py`, `recognition_cache.py`, `recognition_ownership.py`,
-`plate_correspondence.py`, `recogniser_policy.py`, `recogniser_schema.py`, `reporting.py`,
-`recognition_frame.py`, and the
-strict `blend_contract.py` provider-record boundary, and the `linting/` subpackage) →
+`plate_correspondence.py`, `recogniser_policy.py`, `recogniser_schema.py`,
+`recognition_frame.py`, and the strict `blend_contract.py` provider-record boundary) →
 `_core.py` → stage modules (`export.py`,
-`repair.py`, `projection.py`, `compose.py`, `analysis.py`, `drawing.py`, the
-`model/` IR subpackage, the `annotations/` subpackage) → `builder.py` → the
+`repair.py`, `projection.py`, `compose.py`, `analysis.py`, `drawing.py`, `reporting.py`,
+the `linting/` subpackage, the `model/` IR subpackage, the `annotations/` subpackage) →
+`builder.py` → the
 user-facing surfaces: the `make_drawing.py` / `annotate.py` compat facades, the
 fluent `Sheet` facade (`sheet.py`), the Sheet-script emitter
 (`sheet_emit.py`), the recognition-evaluation package (`evaluation/`), and the

--- a/docs/reference/draftwright-report-v1.schema.json
+++ b/docs/reference/draftwright-report-v1.schema.json
@@ -43,13 +43,17 @@
     "recognition": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["coverage", "identity_scope", "occurrences", "summary"],
+      "required": ["coverage", "identity_scope", "occurrences", "requirements", "summary"],
       "properties": {
         "coverage": { "const": "accepted-occurrences" },
         "identity_scope": { "const": "report-local" },
         "occurrences": {
           "type": "array",
           "items": { "$ref": "#/$defs/occurrence" }
+        },
+        "requirements": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/requirement_outcome" }
         },
         "summary": { "$ref": "#/$defs/summary" }
       }
@@ -69,13 +73,70 @@
         "kind": { "type": "string", "minLength": 1 }
       }
     },
-    "requirements": {
+    "requirement_refs": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["coverage", "outcomes"],
+      "required": ["coverage", "ids"],
       "properties": {
-        "coverage": { "const": "not-projected" },
-        "outcomes": { "type": "array", "maxItems": 0 }
+        "coverage": {
+          "enum": ["ledger", "not-projected", "not-applicable", "deferred", "unavailable"]
+        },
+        "ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        }
+      }
+    },
+    "requirement_outcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "family",
+        "occurrence_ids",
+        "owner_ids",
+        "parameter_id",
+        "state",
+        "reason_code",
+        "annotations",
+        "representation",
+        "representation_reason"
+      ],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "family": { "type": "string", "minLength": 1 },
+        "occurrence_ids": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "owner_ids": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "parameter_id": { "type": ["string", "null"], "minLength": 1 },
+        "state": {
+          "enum": [
+            "placed",
+            "satisfied_by_structured_note",
+            "suppressed",
+            "dropped",
+            "missing",
+            "unverifiable",
+            "unsupported"
+          ]
+        },
+        "reason_code": { "type": "string", "minLength": 1 },
+        "annotations": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "uniqueItems": true
+        },
+        "representation": { "type": ["string", "null"] },
+        "representation_reason": { "type": ["string", "null"] }
       }
     },
     "occurrence": {
@@ -115,7 +176,7 @@
           "type": "array",
           "items": { "$ref": "#/$defs/owner" }
         },
-        "requirements": { "$ref": "#/$defs/requirements" }
+        "requirements": { "$ref": "#/$defs/requirement_refs" }
       }
     },
     "summary": {

--- a/docs/reference/reports.md
+++ b/docs/reference/reports.md
@@ -2,7 +2,8 @@
 
 `Drawing.report()` returns a JSON-compatible Draftwright report. Version 1 is deliberately a
 bounded first contract: it projects the accepted occurrences from one raw automatic recognition
-run, their exact consumer dispositions and final IR owners, and `Drawing.lint_summary()`.
+run, their exact consumer dispositions and final IR owners, the recognition-owned semantic
+requirement ledger, and `Drawing.lint_summary()`.
 
 ```python
 from draftwright import build_drawing
@@ -26,20 +27,39 @@ The schema deliberately closes its report-owned objects. Adding a field to one o
 changing a meaning, or removing a field requires a new schema version. Only the explicitly open
 payload containers (`record`, `outputs`, and `lint`) can gain producer-owned fields under version 1.
 
-Occurrence IDs and owner IDs are deterministic **within one report**. They are allocated from the
-provider's accepted-occurrence order and Draftwright's final IR order; they are not persistent
-topology IDs and must not be stored as identities across recognition runs. `record` is the public
-recogniser record's JSON projection, and `record_schema_version` comes from Draftwright's installed
-consumer capability declaration.
+Occurrence, owner, and requirement IDs are deterministic **within one report**. They are allocated
+from the provider's accepted-occurrence order, Draftwright's final IR order, and the existing typed
+semantic completeness ledgers; they are not persistent topology IDs and must not be stored as
+identities across recognition runs. `record` is the public recogniser record's JSON projection,
+and `record_schema_version` comes from Draftwright's installed consumer capability declaration.
+
+`recognition.requirements` contains each auditable physical requirement once. Its
+`occurrence_ids` point to the exact accepted records that establish the requirement and its
+`owner_ids` point to the final IR consumers. Grouped hole/slot/pocket members and nested
+countersinks therefore share requirement IDs instead of duplicating a physical denominator. Each
+row reports the semantic state (`placed`, structured-note satisfaction, `suppressed`, `dropped`,
+`missing`, `unverifiable`, or `unsupported`) and any annotation names that carry exact registry
+measurement/satisfaction provenance. An empty `annotations` list does not mean no ink exists: some
+compound renderer facts have typed semantic evidence without an independently addressable
+annotation identity.
+
+An occurrence's `requirements.coverage` is `ledger` when it references those rows,
+`not-applicable` for evidence-only or already-conveyed physical evidence, `deferred` when the
+consumer requirement grammar is undecided, `unavailable` when an expected owner disappeared, and
+`not-projected` for a supported family that does not yet have a typed semantic outcome ledger.
+The report reuses the same family-specific outcomes as `lint_summary().quality.completeness`; it
+never reconstructs the physical denominator from final IR parameters or the compiled plan.
 
 The six dispositions are `represented`, `absorbed`, `unsupported`, `deferred`, `evidence_only`,
-and `unexpectedly_missing`. A known unsupported, deferred, evidence-only, or missing occurrence
-makes top-level `status` be `needs-attention`. Otherwise it is `bounded-clear`.
+and `unexpectedly_missing`. A known unsupported, deferred, evidence-only, or missing occurrence,
+an unprojected/unavailable requirement boundary, or any non-credit requirement outcome makes
+top-level `status` be `needs-attention`. Otherwise it is `bounded-clear`.
 
-`bounded-clear` does **not** mean manufacturing-ready or physically complete. Version 1 marks every
-occurrence's requirement coverage as `not-projected`; later evidence-gated slices will add the
-feature → requirement → annotation outcomes needed for readiness. It also covers accepted
-recogniser output, not every physical feature a recogniser might fail to find.
+`bounded-clear` does **not** mean manufacturing-ready or physically complete. A non-credit semantic
+requirement state makes the report require attention, but the report still covers accepted
+recogniser output rather than every physical feature a recogniser might fail to find. Material,
+thread, fit, tolerance, finish, and process intent also remain separately authored readiness facts;
+the report never invents them.
 
 Version 1 refuses declared, provider-framed, foreign-result, and bare drawings with
 `ReportUnavailableError` because those paths do not carry exact run-local occurrence ownership.
@@ -85,6 +105,8 @@ manifest binds one invocation's artefacts, consumers must not associate that old
 failed run.
 
 The fresh runtime report and its future reconciliation with this embedded snapshot remain a later
-slice, as do output manifests and generated-script sidecars. Calling `report()` or `write_report()` does
-not alter PDF, SVG, DXF, or PNG content; library export does not write a report unless the caller
-requests one.
+slice, as do output manifests and generated-script sidecars. Exact reconciliation is tracked
+upstream because a later editable run needs a released source-bound replay receipt; Draftwright
+does not substitute record equality, ordering, topology IDs, or geometric proximity. Calling
+`report()` or `write_report()` does not alter PDF, SVG, DXF, or PNG content; library export does not
+write a report unless the caller requests one.

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -15,6 +15,8 @@ import os
 import sys
 import tempfile
 import warnings
+from collections.abc import Mapping
+from contextvars import ContextVar
 from dataclasses import dataclass
 from dataclasses import field as dataclasses_field
 from itertools import permutations
@@ -270,6 +272,24 @@ _GEOMETRY_AWARE_CODES = frozenset(
 # severity/code counts in the summary are the authoritative output.
 _SCORE_ERROR_PENALTY = 0.2
 _SCORE_WARNING_PENALTY = 0.05
+
+# ``Drawing.report()`` and the completeness component must project one identical physical
+# requirement roster.  Keep that report-scoped evidence task-local so the public
+# ``lint_summary()`` signature and subclass dispatch remain unchanged.
+_REPORT_REQUIREMENTS: ContextVar[tuple[object, Mapping[str, tuple[Any, ...]], object] | None] = (
+    ContextVar("draftwright_report_requirements", default=None)
+)
+
+
+@contextlib.contextmanager
+def _reuse_report_requirements(
+    owner: object, outcomes: Mapping[str, tuple[Any, ...]], dimension_plan: object
+):
+    token = _REPORT_REQUIREMENTS.set((owner, outcomes, dimension_plan))
+    try:
+        yield
+    finally:
+        _REPORT_REQUIREMENTS.reset(token)
 
 
 @dataclass
@@ -1004,10 +1024,11 @@ class Drawing:
         """Return the versioned machine-readable recognition and drawing report.
 
         Schema version 1 projects accepted raw recognition occurrences, their exact run-local
-        consumer dispositions and final IR owners, plus the existing structured lint summary.
+        consumer dispositions, final IR owners, recognition-owned semantic requirement outcomes,
+        and the existing structured lint summary.
         Report IDs are deterministic within this document only; they are not topology or durable
-        feature identifiers. ``bounded-clear`` is not manufacturing readiness because requirement
-        outcomes are not projected yet.
+        feature identifiers. ``bounded-clear`` is not manufacturing readiness because recognition
+        can miss geometry and material, process, finish, fit, and tolerance intent remains authored.
 
         A declared, framed, injected, or bare drawing whose exact occurrence ownership is
         unavailable, or a raw drawing with an unclassified accepted occurrence, raises
@@ -1024,13 +1045,34 @@ class Drawing:
         model = self.model()
         # Preserve schema-v1's fail-before-critique boundary. In particular, a declared drawing
         # with no conversion-time ownership must refuse without lint lazily running recognition.
-        validate_report_inputs(evidence, ownership, model)
+        evidence, ownership, model = validate_report_inputs(evidence, ownership, model)
+        from draftwright.linting.requirements import recognized_requirement_outcomes
+        from draftwright.model.compiled import compile_dimensions
+
+        dimension_plan = compile_dimensions(model)
+        requirement_outcomes = recognized_requirement_outcomes(
+            evidence.result,
+            tuple(model.features),
+            self.registry,
+            self._build.omissions,
+            dimension_plan=dimension_plan,
+            part=self._working_part,
+        )
+
+        with _reuse_report_requirements(self, requirement_outcomes, dimension_plan):
+            lint = self.lint_summary()
+
         return drawing_report(
             evidence=evidence,
             ownership=ownership,
             model=model,
-            lint=self.lint_summary(),
+            lint=lint,
             source=source,
+            registry=self.registry,
+            omissions=self._build.omissions,
+            dimension_plan=dimension_plan,
+            part=self._working_part,
+            requirement_outcomes=requirement_outcomes,
         )
 
     def write_report(self, path: str | os.PathLike[str]) -> str:
@@ -4006,6 +4048,8 @@ class Drawing:
         )
         from draftwright.model.compiled import compile_dimensions
 
+        candidate = _REPORT_REQUIREMENTS.get()
+        report_requirements = candidate if candidate is not None and candidate[0] is self else None
         quality = quality_components(
             recognition=self._build.recognition,
             features=getattr(self._part_model, "features", ()),
@@ -4042,7 +4086,14 @@ class Drawing:
             error_penalty=_SCORE_ERROR_PENALTY,
             warning_penalty=_SCORE_WARNING_PENALTY,
             dimension_plan=(
-                compile_dimensions(self._part_model) if self._part_model is not None else None
+                report_requirements[2]
+                if report_requirements is not None
+                else (
+                    compile_dimensions(self._part_model) if self._part_model is not None else None
+                )
+            ),
+            requirement_outcomes=(
+                report_requirements[1] if report_requirements is not None else None
             ),
             _aggregation=aggregation,
         )

--- a/src/draftwright/linting/blend_coverage.py
+++ b/src/draftwright/linting/blend_coverage.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 from b123d_recognisers import RecognitionResult
@@ -35,6 +35,7 @@ class BlendRequirementOutcome:
     requirement_count: int = 1
     features: tuple = ()
     parameter_id: str = "blend.radius"
+    source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
 
 
 def _source_at(key: tuple | None) -> tuple[float, float, float]:
@@ -148,7 +149,11 @@ def blend_requirement_outcomes(
             ):
                 feature = matches[offset]
         if feature is None or not _has_parameter(feature):
-            outcomes.append(BlendRequirementOutcome(_source_at(key), "unverifiable"))
+            outcomes.append(
+                BlendRequirementOutcome(
+                    _source_at(key), "unverifiable", source_records=(source_record,)
+                )
+            )
             continue
         identity = (id(feature), "blend.radius")
         if identity in placed:
@@ -169,7 +174,14 @@ def blend_requirement_outcomes(
                 )
                 else "missing"
             )
-        outcomes.append(BlendRequirementOutcome(_source_at(key), state, features=(feature,)))
+        outcomes.append(
+            BlendRequirementOutcome(
+                _source_at(key),
+                state,
+                features=(feature,),
+                source_records=(source_record,),
+            )
+        )
     return outcomes
 
 

--- a/src/draftwright/linting/chamfer_coverage.py
+++ b/src/draftwright/linting/chamfer_coverage.py
@@ -10,7 +10,7 @@ evidence.
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 from b123d_recognisers import RecognitionResult
@@ -37,6 +37,7 @@ class ChamferRequirementOutcome:
     requirement_count: int = 1
     features: tuple = ()
     parameter_id: str = "chamfer.length"
+    source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -133,7 +134,9 @@ def chamfer_requirement_outcomes(
         matches = ir_by_key.get(key, ())
         feature = matches[0] if len(matches) == source_counts[key] == 1 else None
         if feature is None or not _has_parameter(feature):
-            outcomes.append(ChamferRequirementOutcome(key[1], "unverifiable"))
+            outcomes.append(
+                ChamferRequirementOutcome(key[1], "unverifiable", source_records=(source,))
+            )
             continue
         identity = (feature, parameter)
         if identity in placed:
@@ -154,7 +157,9 @@ def chamfer_requirement_outcomes(
                 )
                 else "missing"
             )
-        outcomes.append(ChamferRequirementOutcome(key[1], state, features=(feature,)))
+        outcomes.append(
+            ChamferRequirementOutcome(key[1], state, features=(feature,), source_records=(source,))
+        )
     return outcomes
 
 

--- a/src/draftwright/linting/channel_coverage.py
+++ b/src/draftwright/linting/channel_coverage.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 from b123d_recognisers import RecognitionResult, has_multi_axis_plates
@@ -27,6 +27,8 @@ class ChannelRequirementOutcome:
     feature_kind: str
     parameter_id: str
     state: ChannelRequirementState
+    features: tuple = ()
+    source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -166,6 +168,8 @@ def channel_requirement_outcomes(
                         dropped=dropped,
                         registry=registry,
                     ),
+                    features=(feature,) if feature is not None else (),
+                    source_records=(source,),
                 )
             )
     return outcomes

--- a/src/draftwright/linting/circular_blind_step_coverage.py
+++ b/src/draftwright/linting/circular_blind_step_coverage.py
@@ -9,7 +9,7 @@ each requirement to its drawing outcome without using labels or page coordinates
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from math import hypot, isclose, isfinite
 from typing import Literal
 
@@ -38,6 +38,7 @@ class CircularBlindStepRequirementOutcome:
     state: CircularBlindStepRequirementState
     requirement_count: int = 1
     features: tuple = ()
+    source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -276,7 +277,12 @@ def circular_blind_step_requirement_outcomes(
         )
         if feature is None or not _has_parameters(feature):
             outcomes.extend(
-                CircularBlindStepRequirementOutcome(_source_at(source), parameter, "unverifiable")
+                CircularBlindStepRequirementOutcome(
+                    _source_at(source),
+                    parameter,
+                    "unverifiable",
+                    source_records=(source,),
+                )
                 for parameter in parameters
             )
             continue
@@ -302,7 +308,11 @@ def circular_blind_step_requirement_outcomes(
                 )
             outcomes.append(
                 CircularBlindStepRequirementOutcome(
-                    _source_at(source), parameter, state, features=(feature,)
+                    _source_at(source),
+                    parameter,
+                    state,
+                    features=(feature,),
+                    source_records=(source,),
                 )
             )
     return outcomes

--- a/src/draftwright/linting/fillet_coverage.py
+++ b/src/draftwright/linting/fillet_coverage.py
@@ -9,7 +9,7 @@ outcome. Labels, annotation names, views, and page coordinates are not correspon
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 from b123d_recognisers import RecognitionResult
@@ -36,6 +36,7 @@ class FilletRequirementOutcome:
     requirement_count: int = 1
     features: tuple = ()
     parameter_id: str = "fillet.radius"
+    source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -130,7 +131,9 @@ def fillet_requirement_outcomes(
         matches = ir_by_key.get(key, ())
         feature = matches[0] if len(matches) == source_counts[key] == 1 else None
         if feature is None or not _has_parameter(feature):
-            outcomes.append(FilletRequirementOutcome(key[1], "unverifiable"))
+            outcomes.append(
+                FilletRequirementOutcome(key[1], "unverifiable", source_records=(source,))
+            )
             continue
         identity = (feature, parameter)
         if identity in placed:
@@ -151,7 +154,9 @@ def fillet_requirement_outcomes(
                 )
                 else "missing"
             )
-        outcomes.append(FilletRequirementOutcome(key[1], state, features=(feature,)))
+        outcomes.append(
+            FilletRequirementOutcome(key[1], state, features=(feature,), source_records=(source,))
+        )
     return outcomes
 
 

--- a/src/draftwright/linting/flat_coverage.py
+++ b/src/draftwright/linting/flat_coverage.py
@@ -8,7 +8,7 @@ projected geometry, annotation names, and page coordinates are never evidence.
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 from b123d_recognisers import RecognitionResult
@@ -46,6 +46,9 @@ class FlatRequirementOutcome:
     stock_span: tuple[float, float]
     across: float
     state: FlatRequirementState
+    features: tuple = ()
+    parameter_id: str = "flat.length"
+    source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
 
 
 def _rounded_pair(values) -> tuple[float, float]:
@@ -102,8 +105,11 @@ def flat_requirement_outcomes(
         )
 
     physical: dict[_FlatRequirementKey, set[tuple[float, float, float]]] = defaultdict(set)
+    source_records: dict[_FlatRequirementKey, list[object]] = defaultdict(list)
     for flat in recognition.flats:
-        physical[_key(flat)].add(_source_point(flat))
+        requirement = _key(flat)
+        physical[requirement].add(_source_point(flat))
+        source_records[requirement].append(flat)
     if not physical:
         return []
 
@@ -181,6 +187,8 @@ def flat_requirement_outcomes(
                 stock_span=requirement.stock_span,
                 across=requirement.across,
                 state=state,
+                features=tuple(matched),
+                source_records=tuple(source_records[requirement]),
             )
         )
     return outcomes

--- a/src/draftwright/linting/groove_coverage.py
+++ b/src/draftwright/linting/groove_coverage.py
@@ -11,7 +11,7 @@ correspondence evidence.
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 from b123d_recognisers import RecognitionResult
@@ -39,6 +39,7 @@ class GrooveRequirementOutcome:
     state: GrooveRequirementState
     requirement_count: int = 1
     features: tuple = ()
+    source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
 
 
 def groove_key(groove) -> tuple:
@@ -129,7 +130,13 @@ def groove_requirement_outcomes(
                 GrooveRequirementOutcome((0.0, 0.0, 0.0), "?", "unverifiable", requirement_count=1)
             ]
         return [
-            GrooveRequirementOutcome((0.0, 0.0, 0.0), "?", "unverifiable", requirement_count=2)
+            GrooveRequirementOutcome(
+                (0.0, 0.0, 0.0),
+                "?",
+                "unverifiable",
+                requirement_count=2,
+                source_records=(_source,),
+            )
             for _source in sources
         ]
     if not sources:
@@ -163,7 +170,13 @@ def groove_requirement_outcomes(
     for _source, source_key in zip(sources, source_keys, strict=True):
         if source_key is None:
             outcomes.append(
-                GrooveRequirementOutcome((0.0, 0.0, 0.0), "?", "unverifiable", requirement_count=2)
+                GrooveRequirementOutcome(
+                    (0.0, 0.0, 0.0),
+                    "?",
+                    "unverifiable",
+                    requirement_count=2,
+                    source_records=(_source,),
+                )
             )
             continue
         matches = ir_by_key.get(source_key, ())
@@ -171,7 +184,15 @@ def groove_requirement_outcomes(
         parameter_ids = _parameter_ids(feature) if feature is not None else None
         at = source_key[1]
         if parameter_ids is None or malformed_ir:
-            outcomes.append(GrooveRequirementOutcome(at, "?", "unverifiable", requirement_count=2))
+            outcomes.append(
+                GrooveRequirementOutcome(
+                    at,
+                    "?",
+                    "unverifiable",
+                    requirement_count=2,
+                    source_records=(_source,),
+                )
+            )
             continue
         outcomes.extend(
             GrooveRequirementOutcome(
@@ -187,6 +208,7 @@ def groove_requirement_outcomes(
                     registry=registry,
                 ),
                 features=(feature,),
+                source_records=(_source,),
             )
             for parameter in parameter_ids
         )

--- a/src/draftwright/linting/hole_coverage.py
+++ b/src/draftwright/linting/hole_coverage.py
@@ -8,7 +8,7 @@ suppressed, and dropped outcomes. Rendered labels and annotation names are never
 from __future__ import annotations
 
 from collections import Counter, defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from math import hypot
 from typing import Literal
 
@@ -56,6 +56,7 @@ class HoleRequirementOutcome:
     #: to go and check.
     members: tuple[tuple[float, float, float], ...] = ()
     features: tuple = ()
+    source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -802,7 +803,7 @@ def hole_requirement_outcomes(
     # Carries the group's member SITES explicitly (#1217 PR 2). The source object is the
     # representative `holes[0]`, so deriving members from it yields one site for a group of
     # eight — which a consumer attributing per hole then silently misses seven of.
-    sources: list[tuple[HoleSourceKind, object, tuple, int, tuple]] = []
+    sources: list[tuple[HoleSourceKind, object, tuple, int, tuple, tuple[object, ...]]] = []
     for (spec, _direction), holes in loose_groups.items():
         axis_index = "xyz".index(spec[0])
         through = spec[3]
@@ -813,7 +814,7 @@ def hole_requirement_outcomes(
                 site[axis_index] = 0.0
             member_sites.append((site[0], site[1], site[2]))
         members = tuple(sorted(member_sites))
-        sources.append(("hole", holes[0], (spec, members), len(holes), members))
+        sources.append(("hole", holes[0], (spec, members), len(holes), members, tuple(holes)))
     sources.extend(
         (
             "hole_pattern",
@@ -821,6 +822,7 @@ def hole_requirement_outcomes(
             _pattern_key(pattern),
             len(pattern.holes),
             tuple(_members(pattern)),
+            tuple(pattern.holes),
         )
         for pattern in recognition.hole_patterns
     )
@@ -870,7 +872,7 @@ def hole_requirement_outcomes(
     # recognition-owned sources is ambiguous even when only one source would otherwise
     # propose it as an exact match.
     owner_source_indices: dict[int, set[int]] = defaultdict(set)
-    for index, (kind, _source, key, _member_count, _sites) in enumerate(sources):
+    for index, (kind, _source, key, _member_count, _sites, _records) in enumerate(sources):
         if kind == "hole":
             spec, members = key
         else:
@@ -894,7 +896,7 @@ def hole_requirement_outcomes(
     # remain unverifiable.
     exact_proposals: list[tuple] = []
     exact_evidence: list[bool] = []
-    for kind, _source, key, _member_count, _sites in sources:
+    for kind, _source, key, _member_count, _sites, _records in sources:
         if kind == "hole":
             source_spec, source_members = key
             spec_features = hole_features_by_spec.get(source_spec, ())
@@ -940,7 +942,7 @@ def hole_requirement_outcomes(
     # simultaneously certify another source at its projected cutter centre.
 
     residual_proposals: dict[int, tuple] = {}
-    for index, (kind, source, key, _member_count, _sites) in enumerate(sources):
+    for index, (kind, source, key, _member_count, _sites, _records) in enumerate(sources):
         if matches_by_source[index]:
             continue
         # A partial, duplicate, or multiply-claimed exact owner is contradictory
@@ -1004,7 +1006,9 @@ def hole_requirement_outcomes(
         if omission.feature is not None and omission.authored
     }
     outcomes = []
-    for index, (kind, source, _key, member_count, source_sites) in enumerate(sources):
+    for index, (kind, source, _key, member_count, source_sites, source_records) in enumerate(
+        sources
+    ):
         matched = matches_by_source[index]
         representative = matched[0] if matched else None
         parameters = (
@@ -1027,6 +1031,7 @@ def hole_requirement_outcomes(
                     "unverifiable",
                     requirement_count=_physical_requirement_count(kind, source, member_count),
                     members=source_sites,
+                    source_records=source_records,
                 )
             )
             continue
@@ -1053,6 +1058,7 @@ def hole_requirement_outcomes(
                     representation_reason=representation_reason,
                     members=source_sites,
                     features=tuple(matched),
+                    source_records=source_records,
                 )
             )
     # The current HoleRecord waist has one countersink slot.  A second seat on the
@@ -1090,7 +1096,15 @@ def hole_requirement_outcomes(
         # that finds nothing to join is correctly informed. Closing the gap properly means the
         # waist carrying more than one countersink slot, which is #1229's real remainder.
         outcomes.extend(
-            HoleRequirementOutcome("hole", at, 1, parameter, "unverifiable", members=())
+            HoleRequirementOutcome(
+                "hole",
+                at,
+                1,
+                parameter,
+                "unverifiable",
+                members=(),
+                source_records=(countersink,),
+            )
             for parameter in ("countersink.diameter", "countersink.angle")
         )
     return outcomes

--- a/src/draftwright/linting/pad_coverage.py
+++ b/src/draftwright/linting/pad_coverage.py
@@ -12,7 +12,7 @@ evidence.
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 from b123d_recognisers import RecognitionResult
@@ -44,6 +44,7 @@ class PadRequirementOutcome:
     state: PadRequirementState
     requirement_count: int = 1
     features: tuple = ()
+    source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -319,7 +320,15 @@ def pad_requirement_outcomes(
         at = pad_attachment_point(source)
         location = pad_center(source)
         if parameter_ids is None:
-            outcomes.append(PadRequirementOutcome(at, "?", "unverifiable", requirement_count=5))
+            outcomes.append(
+                PadRequirementOutcome(
+                    at,
+                    "?",
+                    "unverifiable",
+                    requirement_count=5,
+                    source_records=(source,),
+                )
+            )
             continue
         outcomes.extend(
             PadRequirementOutcome(
@@ -338,6 +347,7 @@ def pad_requirement_outcomes(
                     registry=registry,
                 ),
                 features=(feature,),
+                source_records=(source,),
             )
             for parameter in parameter_ids
         )

--- a/src/draftwright/linting/paired_ramp_step_coverage.py
+++ b/src/draftwright/linting/paired_ramp_step_coverage.py
@@ -9,7 +9,7 @@ then follow each requirement to its drawing outcome.
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 from b123d_recognisers import PairedRampStep, RecognitionResult
@@ -36,6 +36,7 @@ class PairedRampRequirementOutcome:
     state: PairedRampRequirementState
     requirement_count: int = 1
     features: tuple = ()
+    source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -152,7 +153,12 @@ def paired_ramp_step_requirement_outcomes(
         )
         if feature is None or not _has_parameters(feature):
             outcomes.extend(
-                PairedRampRequirementOutcome(_source_at(source), parameter, "unverifiable")
+                PairedRampRequirementOutcome(
+                    _source_at(source),
+                    parameter,
+                    "unverifiable",
+                    source_records=(source,),
+                )
                 for parameter in parameters
             )
             continue
@@ -178,7 +184,11 @@ def paired_ramp_step_requirement_outcomes(
                 )
             outcomes.append(
                 PairedRampRequirementOutcome(
-                    _source_at(source), parameter, state, features=(feature,)
+                    _source_at(source),
+                    parameter,
+                    state,
+                    features=(feature,),
+                    source_records=(source,),
                 )
             )
     return outcomes

--- a/src/draftwright/linting/plate_coverage.py
+++ b/src/draftwright/linting/plate_coverage.py
@@ -11,7 +11,7 @@ evidence.
 from __future__ import annotations
 
 from collections import Counter, defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from math import isfinite
 from typing import Literal
 
@@ -56,6 +56,7 @@ class PlateRequirementOutcome:
     requirement_count: int = 1
     features: tuple = ()
     dependencies: tuple[tuple[object, str], ...] = ()
+    source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
 
 
 def _parameter_id(feature, source) -> str | None:
@@ -695,10 +696,13 @@ def plate_requirement_outcomes(
                         "thickness.length",
                         "inapplicable",
                         dependencies=dependencies,
+                        source_records=(source_record,),
                     )
                 )
                 continue
-            outcomes.append(PlateRequirementOutcome(at, "?", "unverifiable"))
+            outcomes.append(
+                PlateRequirementOutcome(at, "?", "unverifiable", source_records=(source_record,))
+            )
             continue
         outcomes.append(
             PlateRequirementOutcome(
@@ -716,6 +720,7 @@ def plate_requirement_outcomes(
                 ),
                 features=(feature,),
                 dependencies=derived_dependencies.get(feature, ()),
+                source_records=(source_record,),
             )
         )
     return outcomes

--- a/src/draftwright/linting/pocket_coverage.py
+++ b/src/draftwright/linting/pocket_coverage.py
@@ -9,7 +9,7 @@ views, projections, and page coordinates are never evidence.
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 from b123d_recognisers import RecognitionResult
@@ -40,6 +40,7 @@ class PocketRequirementOutcome:
     state: PocketRequirementState
     requirement_count: int = 1
     features: tuple = ()
+    source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -247,11 +248,14 @@ def pocket_requirement_outcomes(
                     "?",
                     "unverifiable",
                     requirement_count=_physical_requirement_count(source),
+                    source_records=(source,),
                 )
             )
             if source.edge_anchored:
                 outcomes.extend(
-                    PocketRequirementOutcome(at, parameter, "inapplicable")
+                    PocketRequirementOutcome(
+                        at, parameter, "inapplicable", source_records=(source,)
+                    )
                     for parameter in (
                         "location_pocket.location.x",
                         "location_pocket.location.y",
@@ -277,6 +281,7 @@ def pocket_requirement_outcomes(
                     registry=registry,
                 ),
                 features=(feature,),
+                source_records=(source,),
             )
             for parameter in parameter_ids
         )

--- a/src/draftwright/linting/pocket_pattern_coverage.py
+++ b/src/draftwright/linting/pocket_pattern_coverage.py
@@ -10,7 +10,7 @@ annotation names, views, and page coordinates are never correspondence evidence.
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from math import hypot
 from typing import Literal
 
@@ -41,6 +41,7 @@ class PocketPatternRequirementOutcome:
     requirement_count: int = 1
     members: tuple[tuple[float, float, float], ...] = ()
     features: tuple = ()
+    source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -317,6 +318,7 @@ def pocket_pattern_requirement_outcomes(
                     "unverifiable",
                     requirement_count=_physical_requirement_count(source),
                     members=members,
+                    source_records=tuple(source.pockets),
                 )
             )
             continue
@@ -340,6 +342,7 @@ def pocket_pattern_requirement_outcomes(
                 ),
                 members=members,
                 features=(feature,),
+                source_records=tuple(source.pockets),
             )
             for parameter in parameter_ids
         )

--- a/src/draftwright/linting/polygonal_boss_coverage.py
+++ b/src/draftwright/linting/polygonal_boss_coverage.py
@@ -12,7 +12,7 @@ leader tips, projections and page coordinates are never correspondence evidence.
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from math import atan2, cos, hypot, isclose, isfinite, pi
 from typing import Literal
 
@@ -42,6 +42,7 @@ class PolygonalBossRequirementOutcome:
     state: PolygonalBossRequirementState
     requirement_count: int = 1
     features: tuple = ()
+    source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -326,6 +327,7 @@ def polygonal_boss_requirement_outcomes(
                     "?",
                     "unverifiable",
                     requirement_count=2,
+                    source_records=(source,),
                 )
             )
             continue
@@ -343,6 +345,7 @@ def polygonal_boss_requirement_outcomes(
                     registry=registry,
                 ),
                 features=(feature,),
+                source_records=(source,),
             )
             for parameter in parameter_ids
         )

--- a/src/draftwright/linting/polygonal_stock_coverage.py
+++ b/src/draftwright/linting/polygonal_stock_coverage.py
@@ -13,7 +13,7 @@ source-to-IR correspondence evidence.
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from math import atan2, cos, hypot, isfinite, pi, sin
 from typing import Literal
 
@@ -57,6 +57,7 @@ class PolygonalStockOutcome:
     state: PolygonalStockState
     requirement_count: int = 1
     features: tuple = ()
+    source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -354,7 +355,15 @@ def polygonal_stock_outcomes(
     # PolygonalStock is a whole-part proof, so the public aggregate contract is zero-or-one.
     # Any larger inventory is one malformed family observation, never extra denominator credit.
     if len(sources) != 1:
-        return [PolygonalStockOutcome(None, "?", "unverifiable", requirement_count=2)]
+        return [
+            PolygonalStockOutcome(
+                None,
+                "?",
+                "unverifiable",
+                requirement_count=2,
+                source_records=sources,
+            )
+        ]
     source = sources[0]
     try:
         if not isinstance(source, PolygonalStock):
@@ -363,7 +372,15 @@ def polygonal_stock_outcomes(
         key = polygonal_stock_key(source)
         at = polygonal_stock_center(source)
     except (AttributeError, OverflowError, TypeError, ValueError):
-        return [PolygonalStockOutcome(None, "?", "unverifiable", requirement_count=2)]
+        return [
+            PolygonalStockOutcome(
+                None,
+                "?",
+                "unverifiable",
+                requirement_count=2,
+                source_records=(source,),
+            )
+        ]
 
     ir_by_key: dict[tuple, list] = defaultdict(list)
     for feature in features:
@@ -384,7 +401,15 @@ def polygonal_stock_outcomes(
     feature = matches[0] if len(matches) == 1 else None
     parameter_ids = _parameter_ids(feature, source) if feature is not None else None
     if parameter_ids is None:
-        return [PolygonalStockOutcome(at, "?", "unverifiable", requirement_count=2)]
+        return [
+            PolygonalStockOutcome(
+                at,
+                "?",
+                "unverifiable",
+                requirement_count=2,
+                source_records=(source,),
+            )
+        ]
     return [
         PolygonalStockOutcome(
             at,
@@ -399,6 +424,7 @@ def polygonal_stock_outcomes(
                 registry=registry,
             ),
             features=(feature,),
+            source_records=(source,),
         )
         for parameter in parameter_ids
     ]

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -31,34 +31,11 @@ and read ``excludes`` for what the denominator cannot see.
 from __future__ import annotations
 
 from collections import Counter
+from collections.abc import Mapping
+from typing import Any
 
-from draftwright.linting.blend_coverage import blend_requirement_outcomes
-from draftwright.linting.chamfer_coverage import chamfer_requirement_outcomes
-from draftwright.linting.channel_coverage import channel_requirement_outcomes
-from draftwright.linting.circular_blind_step_coverage import (
-    circular_blind_step_requirement_outcomes,
-)
-from draftwright.linting.fillet_coverage import fillet_requirement_outcomes
-from draftwright.linting.flat_coverage import flat_requirement_outcomes
-from draftwright.linting.groove_coverage import groove_requirement_outcomes
-from draftwright.linting.hole_coverage import hole_requirement_outcomes
 from draftwright.linting.issues import LintIssue, is_placement_drop
-from draftwright.linting.pad_coverage import pad_requirement_outcomes
-from draftwright.linting.paired_ramp_step_coverage import paired_ramp_step_requirement_outcomes
-from draftwright.linting.plate_coverage import plate_requirement_outcomes
-from draftwright.linting.pocket_coverage import pocket_requirement_outcomes
-from draftwright.linting.pocket_pattern_coverage import pocket_pattern_requirement_outcomes
-from draftwright.linting.polygonal_boss_coverage import polygonal_boss_requirement_outcomes
-from draftwright.linting.polygonal_stock_coverage import polygonal_stock_outcomes
-from draftwright.linting.rectangular_blind_slot_coverage import (
-    rectangular_blind_slot_requirement_outcomes,
-)
-from draftwright.linting.round_bottom_blind_slot_coverage import (
-    round_bottom_blind_slot_requirement_outcomes,
-)
-from draftwright.linting.slot_coverage import slot_requirement_outcomes
-from draftwright.linting.through_step_coverage import through_step_requirement_outcomes
-from draftwright.linting.turned_step_coverage import turned_step_requirement_outcomes
+from draftwright.linting.requirements import recognized_requirement_outcomes
 
 _OUTCOME_STATES = (
     "placed",
@@ -635,7 +612,15 @@ def _empty_completeness(reason: str, unrecognised: int) -> dict:
 
 
 def _completeness_component(
-    recognition, features, registry, omissions, issues, *, dimension_plan=None, part=None
+    recognition,
+    features,
+    registry,
+    omissions,
+    issues,
+    *,
+    dimension_plan=None,
+    part=None,
+    requirement_outcomes: Mapping[str, tuple[Any, ...]] | None = None,
 ) -> dict:
     unrecognised = sum(issue.code == _UNRECOGNISED_GEOMETRY_CODE for issue in issues)
     if recognition is None:
@@ -643,60 +628,18 @@ def _completeness_component(
 
     # Every family has its own typed outcome record; this heterogeneous aggregation only uses
     # their shared runtime ``state``/``requirement_count`` protocol.
-    outcomes: dict[str, list] = {
-        "chamfers": chamfer_requirement_outcomes(recognition, features, registry, omissions),
-        "blends": blend_requirement_outcomes(recognition, features, registry, omissions),
-        "channels": channel_requirement_outcomes(recognition, features, registry, omissions),
-        "circular_blind_steps": circular_blind_step_requirement_outcomes(
-            recognition, features, registry, omissions
-        ),
-        "fillets": fillet_requirement_outcomes(recognition, features, registry, omissions),
-        "paired_ramp_steps": paired_ramp_step_requirement_outcomes(
-            recognition, features, registry, omissions
-        ),
-        "through_steps": through_step_requirement_outcomes(
+    outcomes = (
+        requirement_outcomes
+        if requirement_outcomes is not None
+        else recognized_requirement_outcomes(
             recognition,
             features,
             registry,
             omissions,
-            plan=dimension_plan,
-        ),
-        "turned_steps": turned_step_requirement_outcomes(
-            recognition, features, registry, omissions
-        ),
-        "flats": flat_requirement_outcomes(recognition, features, registry, omissions),
-        "grooves": groove_requirement_outcomes(recognition, features, registry, omissions),
-        "holes": [],
-        "hole_patterns": [],
-        "pads": pad_requirement_outcomes(recognition, features, registry, omissions),
-        "plates": plate_requirement_outcomes(
-            recognition, features, registry, omissions, part=part
-        ),
-        "polygonal_bosses": polygonal_boss_requirement_outcomes(
-            recognition, features, registry, omissions
-        ),
-        "polygonal_stock": polygonal_stock_outcomes(recognition, features, registry, omissions),
-        "pockets": pocket_requirement_outcomes(recognition, features, registry, omissions),
-        "pocket_patterns": pocket_pattern_requirement_outcomes(
-            recognition, features, registry, omissions
-        ),
-        "rectangular_blind_slots": rectangular_blind_slot_requirement_outcomes(
-            recognition, features, registry, omissions
-        ),
-        "round_bottom_blind_slots": round_bottom_blind_slot_requirement_outcomes(
-            recognition, features, registry, omissions
-        ),
-        "slots": [],
-        "slot_patterns": [],
-    }
-    for outcome in slot_requirement_outcomes(recognition, features, registry, omissions):
-        outcomes["slot_patterns" if outcome.source_kind == "slot_pattern" else "slots"].append(
-            outcome
+            dimension_plan=dimension_plan,
+            part=part,
         )
-    for hole_outcome in hole_requirement_outcomes(recognition, features, registry, omissions):
-        outcomes[
-            "hole_patterns" if hole_outcome.source_kind == "hole_pattern" else "holes"
-        ].append(hole_outcome)
+    )
 
     counts: Counter = Counter()
     by_family: dict[str, int] = {}
@@ -789,6 +732,7 @@ def quality_components(
     has_asserted_content: bool,
     dimension_plan=None,
     part=None,
+    requirement_outcomes: Mapping[str, tuple[Any, ...]] | None = None,
     _aggregation=None,
 ) -> dict:
     """Return independently usable drawing-quality observations.
@@ -824,6 +768,7 @@ def quality_components(
             issues,
             dimension_plan=dimension_plan,
             part=part,
+            requirement_outcomes=requirement_outcomes,
         ),
         "restraint": {
             "available": False,

--- a/src/draftwright/linting/rectangular_blind_slot_coverage.py
+++ b/src/draftwright/linting/rectangular_blind_slot_coverage.py
@@ -10,7 +10,7 @@ views, projected geometry, leader tips and page coordinates are never correspond
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from math import isfinite
 from numbers import Real
 from typing import Literal
@@ -45,6 +45,7 @@ class RectangularBlindSlotRequirementOutcome:
     state: RectangularBlindSlotRequirementState
     requirement_count: int = 1
     features: tuple = ()
+    source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -243,7 +244,10 @@ def rectangular_blind_slot_requirement_outcomes(
         if parameter_ids is None:
             outcomes.extend(
                 RectangularBlindSlotRequirementOutcome(
-                    _source_at(source), parameter, "unverifiable"
+                    _source_at(source),
+                    parameter,
+                    "unverifiable",
+                    source_records=(source,),
                 )
                 for parameter in _PARAMETERS
             )
@@ -270,7 +274,11 @@ def rectangular_blind_slot_requirement_outcomes(
                 )
             outcomes.append(
                 RectangularBlindSlotRequirementOutcome(
-                    _source_at(source), parameter, state, features=(feature,)
+                    _source_at(source),
+                    parameter,
+                    state,
+                    features=(feature,),
+                    source_records=(source,),
                 )
             )
     return outcomes

--- a/src/draftwright/linting/requirements.py
+++ b/src/draftwright/linting/requirements.py
@@ -1,0 +1,102 @@
+"""Recognition-owned semantic requirement ledgers shared by lint and reports."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from types import MappingProxyType
+from typing import Any
+
+from draftwright.linting.blend_coverage import blend_requirement_outcomes
+from draftwright.linting.chamfer_coverage import chamfer_requirement_outcomes
+from draftwright.linting.channel_coverage import channel_requirement_outcomes
+from draftwright.linting.circular_blind_step_coverage import (
+    circular_blind_step_requirement_outcomes,
+)
+from draftwright.linting.fillet_coverage import fillet_requirement_outcomes
+from draftwright.linting.flat_coverage import flat_requirement_outcomes
+from draftwright.linting.groove_coverage import groove_requirement_outcomes
+from draftwright.linting.hole_coverage import hole_requirement_outcomes
+from draftwright.linting.pad_coverage import pad_requirement_outcomes
+from draftwright.linting.paired_ramp_step_coverage import paired_ramp_step_requirement_outcomes
+from draftwright.linting.plate_coverage import plate_requirement_outcomes
+from draftwright.linting.pocket_coverage import pocket_requirement_outcomes
+from draftwright.linting.pocket_pattern_coverage import pocket_pattern_requirement_outcomes
+from draftwright.linting.polygonal_boss_coverage import polygonal_boss_requirement_outcomes
+from draftwright.linting.polygonal_stock_coverage import polygonal_stock_outcomes
+from draftwright.linting.rectangular_blind_slot_coverage import (
+    rectangular_blind_slot_requirement_outcomes,
+)
+from draftwright.linting.round_bottom_blind_slot_coverage import (
+    round_bottom_blind_slot_requirement_outcomes,
+)
+from draftwright.linting.slot_coverage import slot_requirement_outcomes
+from draftwright.linting.through_step_coverage import through_step_requirement_outcomes
+from draftwright.linting.turned_step_coverage import turned_step_requirement_outcomes
+
+
+def recognized_requirement_outcomes(
+    recognition,
+    features,
+    registry,
+    omissions,
+    *,
+    dimension_plan=None,
+    part=None,
+) -> Mapping[str, tuple[Any, ...]]:
+    """Return typed physical-requirement ledgers shared by lint and reports.
+
+    The denominator is recognition-owned: callers may project or count these outcomes,
+    but must not reconstruct physical requirements from final IR parameters.
+    """
+
+    outcomes: dict[str, list] = {
+        "chamfers": chamfer_requirement_outcomes(recognition, features, registry, omissions),
+        "blends": blend_requirement_outcomes(recognition, features, registry, omissions),
+        "channels": channel_requirement_outcomes(recognition, features, registry, omissions),
+        "circular_blind_steps": circular_blind_step_requirement_outcomes(
+            recognition, features, registry, omissions
+        ),
+        "fillets": fillet_requirement_outcomes(recognition, features, registry, omissions),
+        "paired_ramp_steps": paired_ramp_step_requirement_outcomes(
+            recognition, features, registry, omissions
+        ),
+        "through_steps": through_step_requirement_outcomes(
+            recognition, features, registry, omissions, plan=dimension_plan
+        ),
+        "turned_steps": turned_step_requirement_outcomes(
+            recognition, features, registry, omissions
+        ),
+        "flats": flat_requirement_outcomes(recognition, features, registry, omissions),
+        "grooves": groove_requirement_outcomes(recognition, features, registry, omissions),
+        "holes": [],
+        "hole_patterns": [],
+        "pads": pad_requirement_outcomes(recognition, features, registry, omissions),
+        "plates": plate_requirement_outcomes(
+            recognition, features, registry, omissions, part=part
+        ),
+        "polygonal_bosses": polygonal_boss_requirement_outcomes(
+            recognition, features, registry, omissions
+        ),
+        "polygonal_stock": polygonal_stock_outcomes(recognition, features, registry, omissions),
+        "pockets": pocket_requirement_outcomes(recognition, features, registry, omissions),
+        "pocket_patterns": pocket_pattern_requirement_outcomes(
+            recognition, features, registry, omissions
+        ),
+        "rectangular_blind_slots": rectangular_blind_slot_requirement_outcomes(
+            recognition, features, registry, omissions
+        ),
+        "round_bottom_blind_slots": round_bottom_blind_slot_requirement_outcomes(
+            recognition, features, registry, omissions
+        ),
+        "slots": [],
+        "slot_patterns": [],
+    }
+    for outcome in slot_requirement_outcomes(recognition, features, registry, omissions):
+        outcomes["slot_patterns" if outcome.source_kind == "slot_pattern" else "slots"].append(
+            outcome
+        )
+    for hole_outcome in hole_requirement_outcomes(recognition, features, registry, omissions):
+        outcomes[
+            "hole_patterns" if hole_outcome.source_kind == "hole_pattern" else "holes"
+        ].append(hole_outcome)
+    return MappingProxyType({family: tuple(items) for family, items in outcomes.items()})

--- a/src/draftwright/linting/round_bottom_blind_slot_coverage.py
+++ b/src/draftwright/linting/round_bottom_blind_slot_coverage.py
@@ -10,7 +10,7 @@ views, projected geometry, leader tips and page coordinates are never correspond
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from math import isfinite
 from numbers import Real
 from typing import Literal
@@ -45,6 +45,7 @@ class RoundBottomBlindSlotRequirementOutcome:
     state: RoundBottomBlindSlotRequirementState
     requirement_count: int = 1
     features: tuple = ()
+    source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -249,7 +250,10 @@ def round_bottom_blind_slot_requirement_outcomes(
         if parameter_ids is None:
             outcomes.extend(
                 RoundBottomBlindSlotRequirementOutcome(
-                    _source_at(source), parameter, "unverifiable"
+                    _source_at(source),
+                    parameter,
+                    "unverifiable",
+                    source_records=(source,),
                 )
                 for parameter in _PARAMETERS
             )
@@ -276,7 +280,11 @@ def round_bottom_blind_slot_requirement_outcomes(
                 )
             outcomes.append(
                 RoundBottomBlindSlotRequirementOutcome(
-                    _source_at(source), parameter, state, features=(feature,)
+                    _source_at(source),
+                    parameter,
+                    state,
+                    features=(feature,),
+                    source_records=(source,),
                 )
             )
     return outcomes

--- a/src/draftwright/linting/slot_coverage.py
+++ b/src/draftwright/linting/slot_coverage.py
@@ -9,7 +9,7 @@ Presentation is never evidence.
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 from b123d_recognisers import RecognitionResult
@@ -42,6 +42,8 @@ class SlotRequirementOutcome:
     # recognition-derived requirement vocabulary. Preserve that cardinality so deleting a
     # declaration cannot shrink a completeness denominator (#1127).
     requirement_count: int = 1
+    features: tuple = ()
+    source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -237,8 +239,10 @@ def slot_requirement_outcomes(
         )
 
     pattern_members = {member for pattern in recognition.slot_patterns for member in pattern.slots}
-    sources: list[tuple[SlotSourceKind, object, tuple, tuple[float, float, float], int]] = [
-        ("slot", slot, _slot_key(slot), _slot_source_at(slot), 1)
+    sources: list[
+        tuple[SlotSourceKind, object, tuple, tuple[float, float, float], int, tuple[object, ...]]
+    ] = [
+        ("slot", slot, _slot_key(slot), _slot_source_at(slot), 1, (slot,))
         for slot in recognition.slots
         if slot not in pattern_members
     ]
@@ -249,6 +253,7 @@ def slot_requirement_outcomes(
             _pattern_key(pattern),
             _pattern_source_at(pattern),
             len(pattern.slots),
+            tuple(pattern.slots),
         )
         for pattern in recognition.slot_patterns
     )
@@ -256,7 +261,7 @@ def slot_requirement_outcomes(
         return []
 
     source_counts: dict[tuple[str, tuple], int] = defaultdict(int)
-    for kind, _source, key, _at, _count in sources:
+    for kind, _source, key, _at, _count, _records in sources:
         source_counts[(kind, key)] += 1
     ir_by_key: dict[tuple[str, tuple], list] = defaultdict(list)
     for feature in features:
@@ -282,7 +287,7 @@ def slot_requirement_outcomes(
     }
 
     outcomes: list[SlotRequirementOutcome] = []
-    for kind, _source, key, at, member_count in sources:
+    for kind, _source, key, at, member_count, source_records in sources:
         matches = ir_by_key.get((kind, key), ())
         feature = matches[0] if len(matches) == source_counts[(kind, key)] == 1 else None
         parameter_ids = (
@@ -299,6 +304,7 @@ def slot_requirement_outcomes(
                     "?",
                     "unverifiable",
                     requirement_count=_physical_requirement_count(kind, _source),
+                    source_records=source_records,
                 )
             )
             continue
@@ -317,6 +323,8 @@ def slot_requirement_outcomes(
                     dropped=dropped,
                     registry=registry,
                 ),
+                features=(feature,),
+                source_records=source_records,
             )
             for parameter in parameter_ids
         )

--- a/src/draftwright/linting/through_step_coverage.py
+++ b/src/draftwright/linting/through_step_coverage.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import math
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Literal
 
 from b123d_recognisers import RecognitionResult, ThroughStep
@@ -40,6 +40,8 @@ class ThroughStepRequirementOutcome:
     state: ThroughStepRequirementState
     requirement_count: int = 1
     features: tuple = ()
+    measurement_ids: tuple[tuple[object, str], ...] = ()
+    source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
 
 
 @dataclass(frozen=True)
@@ -555,6 +557,12 @@ def through_step_requirement_outcomes(
                             rendered,
                             approved_by_id,
                         ),
+                        measurement_ids=tuple(
+                            term.identity
+                            for alternative in plans[parameter]
+                            for term in alternative
+                        ),
+                        source_records=(source,),
                     )
                     for parameter in expected
                 )
@@ -565,7 +573,12 @@ def through_step_requirement_outcomes(
             or not _has_parameters(feature, record_parameters)
         ):
             outcomes.extend(
-                ThroughStepRequirementOutcome(_source_at(source), parameter, "unverifiable")
+                ThroughStepRequirementOutcome(
+                    _source_at(source),
+                    parameter,
+                    "unverifiable",
+                    source_records=(source,),
+                )
                 for parameter in expected
             )
             continue
@@ -591,7 +604,12 @@ def through_step_requirement_outcomes(
                 )
             outcomes.append(
                 ThroughStepRequirementOutcome(
-                    _source_at(source), parameter, state, features=(feature,)
+                    _source_at(source),
+                    parameter,
+                    state,
+                    features=(feature,),
+                    measurement_ids=((feature, parameter),),
+                    source_records=(source,),
                 )
             )
     return outcomes

--- a/src/draftwright/linting/turned_step_coverage.py
+++ b/src/draftwright/linting/turned_step_coverage.py
@@ -10,7 +10,7 @@ are deliberately not correspondence evidence.
 from __future__ import annotations
 
 from collections import defaultdict
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from math import isfinite
 from numbers import Real
 from typing import Literal
@@ -53,6 +53,7 @@ class TurnedStepRequirementOutcome:
     features: tuple = ()
     representation_feature: object | None = None
     representation_parameter: str | None = None
+    source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
 
 
 def _number(value, *, digits: int | None = 6) -> float:
@@ -329,7 +330,14 @@ def turned_step_requirement_outcomes(
         # Snapshot an iterable impostor once so a generator cannot be consumed by ownership
         # and then silently shrink this denominator on the conservative fallback.
         return [
-            TurnedStepRequirementOutcome(None, None, None, parameter, "unverifiable")
+            TurnedStepRequirementOutcome(
+                None,
+                None,
+                None,
+                parameter,
+                "unverifiable",
+                source_records=(_source,),
+            )
             for _source in raw_steps
             for parameter in ("step.length", "step.diameter")
         ]
@@ -347,7 +355,14 @@ def turned_step_requirement_outcomes(
         # malformed or ownership is ambiguous, retaining every raw band as unverifiable is
         # conservative; guessing an owner would either invent or erase requirements.
         return [
-            TurnedStepRequirementOutcome(None, None, None, parameter, "unverifiable")
+            TurnedStepRequirementOutcome(
+                None,
+                None,
+                None,
+                parameter,
+                "unverifiable",
+                source_records=(_source,),
+            )
             for _source in raw_steps
             for parameter in ("step.length", "step.diameter")
         ]
@@ -419,13 +434,20 @@ def turned_step_requirement_outcomes(
         )
 
     outcomes: list[TurnedStepRequirementOutcome] = []
-    for (profile, _source), source_key, source_profile_id in zip(
+    for (profile, source), source_key, source_profile_id in zip(
         sources, source_keys, source_profile_ids, strict=True
     ):
         if source_key is None:
             for parameter in ("step.length", "step.diameter"):
                 outcomes.append(
-                    TurnedStepRequirementOutcome(None, None, None, parameter, "unverifiable")
+                    TurnedStepRequirementOutcome(
+                        None,
+                        None,
+                        None,
+                        parameter,
+                        "unverifiable",
+                        source_records=(source,),
+                    )
                 )
             continue
         key = source_key
@@ -440,7 +462,14 @@ def turned_step_requirement_outcomes(
         for parameter in ("step.length", "step.diameter"):
             if feature is None or malformed or not _has_parameters(feature):
                 outcomes.append(
-                    TurnedStepRequirementOutcome(key[0], key[1], key[2], parameter, "unverifiable")
+                    TurnedStepRequirementOutcome(
+                        key[0],
+                        key[1],
+                        key[2],
+                        parameter,
+                        "unverifiable",
+                        source_records=(source,),
+                    )
                 )
                 continue
             representation = feature
@@ -490,6 +519,7 @@ def turned_step_requirement_outcomes(
                     features=(feature,),
                     representation_feature=representation,
                     representation_parameter=representation_parameter,
+                    source_records=(source,),
                 )
             )
     return outcomes

--- a/src/draftwright/reporting.py
+++ b/src/draftwright/reporting.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import os
 from collections import Counter
+from collections.abc import Mapping
 from importlib.metadata import version as distribution_version
 from os import PathLike
 from pathlib import Path
@@ -87,6 +88,251 @@ def _feature_ids(model: object) -> dict[int, tuple[object, dict[str, str]]]:
     return result
 
 
+_REQUIREMENT_STATES = frozenset(
+    {
+        "placed",
+        "satisfied_by_structured_note",
+        "suppressed",
+        "dropped",
+        "missing",
+        "unverifiable",
+        "inapplicable",
+    }
+)
+_REQUIREMENT_REASON = {
+    "placed": "semantic_measurement_placed",
+    "satisfied_by_structured_note": "semantic_structured_note_satisfaction",
+    "suppressed": "authored_requirement_suppressed",
+    "dropped": "semantic_requirement_dropped",
+    "missing": "semantic_requirement_missing",
+    "unverifiable": "semantic_requirement_unverifiable",
+    "unsupported": "consumer_semantics_unsupported",
+}
+
+
+def _exact_occurrence_id(
+    record: object,
+    occurrence_ids: dict[int, tuple[object, str]],
+) -> str:
+    candidate = occurrence_ids.get(id(record))
+    if candidate is None or candidate[0] is not record:
+        raise ReportUnavailableError(
+            "a recognized requirement outcome is not bound to this evidence authority"
+        )
+    return candidate[1]
+
+
+def _outcome_records(outcome: object) -> tuple[object, ...]:
+    records = tuple(getattr(outcome, "source_records", ()))
+    parameter = getattr(outcome, "parameter_id", None)
+    if isinstance(parameter, str) and parameter.startswith("countersink."):
+        records += tuple(
+            countersink
+            for record in records
+            if (countersink := getattr(record, "csink", None)) is not None
+        )
+    unique: list[object] = []
+    seen: set[int] = set()
+    for record in records:
+        if id(record) not in seen:
+            seen.add(id(record))
+            unique.append(record)
+    return tuple(unique)
+
+
+def _outcome_measurements(outcome: object) -> tuple[tuple[object, str], ...]:
+    explicit = tuple(getattr(outcome, "measurement_ids", ()))
+    if explicit:
+        return explicit
+    representation = getattr(outcome, "representation_feature", None)
+    representation_parameter = getattr(outcome, "representation_parameter", None)
+    if representation is not None and isinstance(representation_parameter, str):
+        return ((representation, representation_parameter),)
+    parameter = getattr(outcome, "parameter_id", None)
+    if not isinstance(parameter, str) or parameter == "?":
+        return ()
+    return tuple((feature, parameter) for feature in getattr(outcome, "features", ()))
+
+
+AnnotationIndex = dict[tuple[int, str], tuple[object, tuple[str, ...]]]
+
+
+def _annotation_index(registry: object) -> AnnotationIndex:
+    """Index exact semantic provenance once for linear report projection."""
+
+    names = getattr(registry, "names", None)
+    measurement_of = getattr(registry, "measurement_of", None)
+    satisfaction_of = getattr(registry, "satisfaction_of", None)
+    if not callable(names) or not callable(measurement_of) or not callable(satisfaction_of):
+        raise ReportUnavailableError("annotation provenance registry is unavailable")
+    registered_names = tuple(names())
+    if any(type(name) is not str or not name for name in registered_names):
+        raise ReportUnavailableError("annotation provenance registry contains an invalid name")
+    building: dict[tuple[int, str], tuple[object, set[str]]] = {}
+    for name in sorted(registered_names):
+        attached = tuple(measurement_of(name)) + tuple(satisfaction_of(name))
+        for identity in attached:
+            feature = getattr(identity, "feature", None)
+            parameter = getattr(identity, "parameter", None)
+            if feature is None or type(parameter) is not str or not parameter:
+                continue
+            key = (id(feature), parameter)
+            candidate = building.get(key)
+            if candidate is None:
+                building[key] = (feature, {name})
+            elif candidate[0] is not feature:
+                raise ReportUnavailableError("annotation provenance identity is ambiguous")
+            else:
+                candidate[1].add(name)
+    return {key: (feature, tuple(sorted(values))) for key, (feature, values) in building.items()}
+
+
+def _annotation_names(index: AnnotationIndex, outcome: object) -> list[str]:
+    result: set[str] = set()
+    for feature, parameter in _outcome_measurements(outcome):
+        candidate = index.get((id(feature), parameter))
+        if candidate is not None and candidate[0] is feature:
+            result.update(candidate[1])
+    return sorted(result)
+
+
+def _requirements(
+    *,
+    evidence: RecognitionEvidence,
+    model: PartModel,
+    occurrences: list[dict[str, Any]],
+    registry: object,
+    omissions: tuple[object, ...],
+    dimension_plan: object | None,
+    part: object | None,
+    requirement_outcomes: Mapping[str, tuple[Any, ...]] | None = None,
+) -> tuple[list[dict[str, Any]], dict[str, list[str]], set[str]]:
+    """Project the recognition-owned semantic denominator exactly once."""
+
+    if requirement_outcomes is None:
+        from draftwright.linting.requirements import recognized_requirement_outcomes
+
+        requirement_outcomes = recognized_requirement_outcomes(
+            evidence.result,
+            tuple(model.features),
+            registry,
+            omissions,
+            dimension_plan=dimension_plan,
+            part=part,
+        )
+
+    occurrence_ids: dict[int, tuple[object, str]] = {}
+    occurrences_by_id = {str(item["id"]): item for item in occurrences}
+    occurrence_order = {str(item["id"]): index for index, item in enumerate(occurrences)}
+    owner_order = {
+        owner["id"]: index for index, (_feature, owner) in enumerate(_feature_ids(model).values())
+    }
+    for reference, projected in zip(evidence.features, occurrences, strict=True):
+        record = evidence.record(reference)
+        if id(record) in occurrence_ids:
+            raise ReportUnavailableError("evidence repeats the same recognition record object")
+        occurrence_ids[id(record)] = (record, str(projected["id"]))
+
+    annotation_index = _annotation_index(registry)
+    requirements: list[dict[str, Any]] = []
+    by_occurrence: dict[str, list[str]] = {key: [] for key in occurrences_by_id}
+    inapplicable_occurrences: set[str] = set()
+
+    for family, outcomes in requirement_outcomes.items():
+        for outcome in outcomes:
+            state = getattr(outcome, "state", None)
+            if state not in _REQUIREMENT_STATES:
+                raise ReportUnavailableError(
+                    f"recognized requirement family {family!r} has invalid state {state!r}"
+                )
+            source_records = _outcome_records(outcome)
+            if not source_records:
+                raise ReportUnavailableError(
+                    f"recognized requirement family {family!r} has no exact source records"
+                )
+            source_ids = sorted(
+                {_exact_occurrence_id(record, occurrence_ids) for record in source_records},
+                key=occurrence_order.__getitem__,
+            )
+            if state == "inapplicable":
+                inapplicable_occurrences.update(source_ids)
+                continue
+            count = getattr(outcome, "requirement_count", 1)
+            if isinstance(count, bool) or not isinstance(count, int) or count < 1:
+                raise ReportUnavailableError(
+                    f"recognized requirement family {family!r} has invalid cardinality"
+                )
+            parameter = getattr(outcome, "parameter_id", None)
+            if type(parameter) is not str or not parameter:
+                raise ReportUnavailableError(
+                    f"recognized requirement family {family!r} has invalid parameter identity"
+                )
+            parameter_id = parameter if parameter != "?" else None
+            if parameter_id is not None and count != 1:
+                raise ReportUnavailableError(
+                    f"recognized requirement family {family!r} has ambiguous parameter cardinality"
+                )
+            owner_ids = sorted(
+                {
+                    str(owner["id"])
+                    for occurrence_id in source_ids
+                    for owner in occurrences_by_id[occurrence_id]["owners"]
+                },
+                key=owner_order.__getitem__,
+            )
+            annotations = _annotation_names(annotation_index, outcome)
+            representation = getattr(outcome, "representation", None)
+            representation_reason = getattr(outcome, "representation_reason", None)
+            if representation is not None and type(representation) is not str:
+                raise ReportUnavailableError(
+                    f"recognized requirement family {family!r} has invalid representation"
+                )
+            if representation_reason is not None and type(representation_reason) is not str:
+                raise ReportUnavailableError(
+                    f"recognized requirement family {family!r} has invalid representation reason"
+                )
+            for _index in range(count):
+                requirement_id = f"requirement:{len(requirements) + 1}"
+                requirements.append(
+                    {
+                        "id": requirement_id,
+                        "family": family,
+                        "occurrence_ids": source_ids,
+                        "owner_ids": owner_ids,
+                        "parameter_id": parameter_id,
+                        "state": state,
+                        "reason_code": _REQUIREMENT_REASON[state],
+                        "annotations": annotations,
+                        "representation": representation,
+                        "representation_reason": representation_reason,
+                    }
+                )
+                for occurrence_id in source_ids:
+                    by_occurrence[occurrence_id].append(requirement_id)
+
+    for occurrence in occurrences:
+        if occurrence["disposition"] != "unsupported":
+            continue
+        occurrence_id = str(occurrence["id"])
+        requirement_id = f"requirement:{len(requirements) + 1}"
+        requirements.append(
+            {
+                "id": requirement_id,
+                "family": occurrence["family"],
+                "occurrence_ids": [occurrence_id],
+                "owner_ids": [],
+                "parameter_id": None,
+                "state": "unsupported",
+                "reason_code": _REQUIREMENT_REASON["unsupported"],
+                "annotations": [],
+                "representation": None,
+                "representation_reason": None,
+            }
+        )
+        by_occurrence[occurrence_id].append(requirement_id)
+    return requirements, by_occurrence, inapplicable_occurrences
+
+
 def validate_report_inputs(
     evidence: RecognitionEvidence | None,
     ownership: RecognitionOwnership | None,
@@ -108,7 +354,13 @@ def _occurrences(
     evidence: RecognitionEvidence | None,
     ownership: RecognitionOwnership | None,
     model: PartModel | None,
-) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    *,
+    registry: object | None = None,
+    omissions: tuple[object, ...] = (),
+    dimension_plan: object | None = None,
+    part: object | None = None,
+    requirement_outcomes: Mapping[str, tuple[Any, ...]] | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], dict[str, int]]:
     evidence, ownership, model = validate_report_inputs(evidence, ownership, model)
 
     feature_ids = _feature_ids(model)
@@ -165,13 +417,48 @@ def _occurrences(
                 "reason_code": reason_code,
                 "tracking": tracking,
                 "owners": owners,
-                "requirements": {"coverage": "not-projected", "outcomes": []},
+                "requirements": {
+                    "coverage": "not-projected",
+                    "ids": [],
+                },
             }
         )
 
+    requirements: list[dict[str, Any]] = []
+    if registry is not None:
+        requirements, by_occurrence, inapplicable = _requirements(
+            evidence=evidence,
+            model=model,
+            occurrences=projected,
+            registry=registry,
+            omissions=omissions,
+            dimension_plan=dimension_plan,
+            part=part,
+            requirement_outcomes=requirement_outcomes,
+        )
+        for projected_occurrence in projected:
+            occurrence_id = str(projected_occurrence["id"])
+            requirement_ids = by_occurrence[occurrence_id]
+            if requirement_ids:
+                coverage = "ledger"
+            elif (
+                occurrence_id in inapplicable
+                or projected_occurrence["disposition"] == "evidence_only"
+            ):
+                coverage = "not-applicable"
+            elif projected_occurrence["disposition"] == "deferred":
+                coverage = "deferred"
+            elif projected_occurrence["disposition"] == "unexpectedly_missing":
+                coverage = "unavailable"
+            else:
+                coverage = "not-projected"
+            projected_occurrence["requirements"] = {
+                "coverage": coverage,
+                "ids": requirement_ids,
+            }
     summary = {"total": len(projected)}
     summary.update({status: disposition_counts[status] for status in _DISPOSITIONS})
-    return projected, summary
+    return projected, requirements, summary
 
 
 def drawing_report(
@@ -181,18 +468,40 @@ def drawing_report(
     model: PartModel | None,
     lint: dict[str, object],
     source: str | PathLike[str] | None,
+    registry: object | None = None,
+    omissions: tuple[object, ...] = (),
+    dimension_plan: object | None = None,
+    part: object | None = None,
+    requirement_outcomes: Mapping[str, tuple[Any, ...]] | None = None,
 ) -> dict[str, object]:
     """Build the strict schema-v1 report for one raw automatic drawing.
 
-    ``bounded-clear`` means only that this report found no known occurrence-disposition or lint
-    blocker. It is deliberately not manufacturing readiness: schema v1 does not yet project the
-    compiler's feature→requirement→annotation outcome ledger.
+    ``bounded-clear`` means only that this report found no known occurrence, semantic
+    requirement, or lint blocker. It is deliberately not manufacturing readiness: recognition
+    can miss physical geometry and manufacturing intent remains separately authored.
     """
 
-    occurrences, summary = _occurrences(evidence, ownership, model)
+    occurrences, requirements, summary = _occurrences(
+        evidence,
+        ownership,
+        model,
+        registry=registry,
+        omissions=omissions,
+        dimension_plan=dimension_plan,
+        part=part,
+        requirement_outcomes=requirement_outcomes,
+    )
     lint = cast(dict[str, object], _json_value(lint))
     needs_attention = not bool(lint.get("passed")) or any(
         summary[disposition] for disposition in _ATTENTION_DISPOSITIONS
+    )
+    needs_attention = needs_attention or any(
+        requirement["state"] not in {"placed", "satisfied_by_structured_note"}
+        for requirement in requirements
+    )
+    needs_attention = needs_attention or any(
+        occurrence["requirements"]["coverage"] in {"not-projected", "deferred", "unavailable"}
+        for occurrence in occurrences
     )
     return {
         "schema": REPORT_SCHEMA,
@@ -205,6 +514,7 @@ def drawing_report(
             "coverage": "accepted-occurrences",
             "identity_scope": "report-local",
             "occurrences": occurrences,
+            "requirements": requirements,
             "summary": summary,
         },
         "lint": lint,
@@ -221,7 +531,7 @@ def _generation_snapshot(
 ) -> dict[str, JsonValue]:
     """Project generation-time accepted-occurrence gaps without compiling or rendering."""
 
-    occurrences, _summary = _occurrences(evidence, ownership, model)
+    occurrences, _requirements, _summary = _occurrences(evidence, ownership, model)
     gaps = [
         {
             key: occurrence[key]

--- a/src/draftwright/reporting.py
+++ b/src/draftwright/reporting.py
@@ -131,13 +131,7 @@ def _outcome_records(outcome: object) -> tuple[object, ...]:
             for record in records
             if (countersink := getattr(record, "csink", None)) is not None
         )
-    unique: list[object] = []
-    seen: set[int] = set()
-    for record in records:
-        if id(record) not in seen:
-            seen.add(id(record))
-            unique.append(record)
-    return tuple(unique)
+    return records
 
 
 def _outcome_measurements(outcome: object) -> tuple[tuple[object, str], ...]:

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -97,14 +97,14 @@ _LAYERS: dict[str, int] = {
     # construction — it imports nothing from the engine, so the thing it measures can never
     # come to depend on it.
     "audit": 0,
-    # Pure schema-v1 projection over explicitly supplied finished-build state. Drawing owns the
-    # state reads and passes them down; this leaf never reaches through Drawing internals.
-    "reporting": 0,
     "model": 0,  # the ADR 0008 IR waist — depends only on rank-0 leaves (guarded below too)
     # 1 — the shared drawing/layout primitives
     "_core": 1,
     # 2 — core-consumers: depend on _core, sit below the stages
     "linting": 2,
+    # Schema-v1 projection over explicitly supplied finished-build state. It consumes linting's
+    # recognition-owned typed requirement ledgers but never reaches through Drawing internals.
+    "reporting": 2,
     "pmi": 2,
     "export": 2,
     "repair": 2,

--- a/tests/test_issue_1438_boss_ownership.py
+++ b/tests/test_issue_1438_boss_ownership.py
@@ -58,6 +58,23 @@ def test_a_plain_prismatic_boss_is_represented_by_its_exact_feature() -> None:
     assert ownership.unexpectedly_missing == ()
 
 
+def test_report_marks_a_supported_family_without_a_requirement_ledger_for_attention() -> None:
+    drawing = build_drawing(Box(60, 60, 10) + Pos(0, 0, 9) * Cylinder(12, 8))
+    report = drawing.report()
+    bosses = [
+        occurrence
+        for occurrence in report["recognition"]["occurrences"]
+        if occurrence["family"] == "bosses"
+    ]
+
+    assert bosses
+    assert all(
+        occurrence["requirements"] == {"coverage": "not-projected", "ids": []}
+        for occurrence in bosses
+    )
+    assert report["status"] == "needs-attention"
+
+
 def test_equal_diameter_bosses_retain_occurrence_membership_in_one_existing_owner() -> None:
     drawing = build_drawing(_two_equal_bosses())
     ownership = drawing.recognition_ownership()

--- a/tests/test_issue_1438_nested_ownership.py
+++ b/tests/test_issue_1438_nested_ownership.py
@@ -76,6 +76,34 @@ def test_each_countersink_is_absorbed_by_its_exact_hole_owner() -> None:
     assert ownership.unexpectedly_missing == ()
 
 
+def test_grouped_nested_occurrences_reference_shared_requirements_without_duplication() -> None:
+    recognition = build_drawing(_same_spec_countersinks()).report()["recognition"]
+    countersinks = [
+        occurrence
+        for occurrence in recognition["occurrences"]
+        if occurrence["family"] == "countersinks"
+    ]
+    holes = [
+        occurrence for occurrence in recognition["occurrences"] if occurrence["family"] == "holes"
+    ]
+
+    assert len(countersinks) == len(holes) == 2
+    assert countersinks[0]["requirements"] == countersinks[1]["requirements"]
+    countersink_requirement_ids = countersinks[0]["requirements"]["ids"]
+    assert len(countersink_requirement_ids) == 2
+    requirements = {requirement["id"]: requirement for requirement in recognition["requirements"]}
+    assert {
+        requirements[requirement_id]["parameter_id"]
+        for requirement_id in countersink_requirement_ids
+    } == {"countersink.diameter", "countersink.angle"}
+    assert all(
+        requirement["occurrence_ids"] == ["countersinks:1", "countersinks:2", "holes:1", "holes:2"]
+        for requirement in (
+            requirements[requirement_id] for requirement_id in countersink_requirement_ids
+        )
+    )
+
+
 def test_unbound_countersink_fails_closed_as_unexpectedly_missing() -> None:
     evidence = build_recognition_evidence(_mixed_countersinks())
     ownership = RecognitionOwnershipBuilder(evidence).snapshot()

--- a/tests/test_issue_1438_report_projection.py
+++ b/tests/test_issue_1438_report_projection.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import json
 import math
+import subprocess
+import sys
+from collections import Counter
 from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
@@ -16,8 +19,11 @@ from jsonschema.validators import validator_for
 from draftwright import ReportUnavailableError, build_drawing
 from draftwright import analysis as analysis_module
 from draftwright import reporting as reporting_module
+from draftwright.linting import requirements as requirement_module
+from draftwright.registry import AnnotationRegistry
 
 _SCHEMA_PATH = Path(__file__).parents[1] / "docs/reference/draftwright-report-v1.schema.json"
+_EVALUATION_FIXTURES = Path(__file__).parent / "fixtures" / "evaluation"
 
 
 def _schema() -> dict:
@@ -101,8 +107,37 @@ def test_raw_report_has_the_closed_v1_shape_and_exact_owner() -> None:
         "reason_code": "through_step_adapter",
         "tracking": None,
         "owners": [{"id": "through_step:1", "kind": "through_step"}],
-        "requirements": {"coverage": "not-projected", "outcomes": []},
+        "requirements": {
+            "coverage": "ledger",
+            "ids": ["requirement:1", "requirement:2"],
+        },
     }
+    assert recognition["requirements"] == [
+        {
+            "id": "requirement:1",
+            "family": "through_steps",
+            "occurrence_ids": ["through_steps:1"],
+            "owner_ids": ["through_step:1"],
+            "parameter_id": "through_step_leg.length.y",
+            "state": "placed",
+            "reason_code": "semantic_measurement_placed",
+            "annotations": ["dim_through_step_z0_y"],
+            "representation": None,
+            "representation_reason": None,
+        },
+        {
+            "id": "requirement:2",
+            "family": "through_steps",
+            "occurrence_ids": ["through_steps:1"],
+            "owner_ids": ["through_step:1"],
+            "parameter_id": "through_step_leg.length.x",
+            "state": "placed",
+            "reason_code": "semantic_measurement_placed",
+            "annotations": ["dim_through_step_z0_x"],
+            "representation": None,
+            "representation_reason": None,
+        },
+    ]
     assert recognition["summary"] == {
         "total": 1,
         "represented": 1,
@@ -117,6 +152,253 @@ def test_raw_report_has_the_closed_v1_shape_and_exact_owner() -> None:
     schema = _schema()
     validator_for(schema).check_schema(schema)
     validator_for(schema)(schema).validate(report)
+
+
+def test_grouped_occurrences_share_one_physical_requirement_ledger() -> None:
+    report = build_drawing(_grouped_holes_part()).report()
+    recognition = report["recognition"]
+    holes = [
+        occurrence for occurrence in recognition["occurrences"] if occurrence["family"] == "holes"
+    ]
+
+    assert len(holes) == 2
+    assert holes[0]["requirements"] == holes[1]["requirements"]
+    requirement_ids = holes[0]["requirements"]["ids"]
+    assert len(requirement_ids) == 5
+    assert len(recognition["requirements"]) == 5
+    assert all(
+        requirement["occurrence_ids"] == ["holes:1", "holes:2"]
+        for requirement in recognition["requirements"]
+    )
+    assert {requirement["owner_ids"][0] for requirement in recognition["requirements"]} == {
+        holes[0]["owners"][0]["id"]
+    }
+
+
+def test_requirement_ledger_counts_match_the_existing_completeness_authority() -> None:
+    report = build_drawing(_grouped_holes_part()).report()
+    counts = Counter(requirement["state"] for requirement in report["recognition"]["requirements"])
+    completeness = report["lint"]["quality"]["completeness"]
+
+    assert len(report["recognition"]["requirements"]) == completeness["requirements"]
+    for state in (
+        "placed",
+        "satisfied_by_structured_note",
+        "suppressed",
+        "dropped",
+        "missing",
+        "unverifiable",
+        "unsupported",
+    ):
+        assert counts[state] == completeness[state]
+
+
+def test_report_computes_the_shared_requirement_roster_once(monkeypatch) -> None:
+    drawing = build_drawing(_grouped_holes_part())
+    original = requirement_module.hole_requirement_outcomes
+    calls = 0
+
+    def counted(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(requirement_module, "hole_requirement_outcomes", counted)
+
+    drawing.report()
+
+    assert calls == 1
+
+
+def test_report_preserves_no_argument_lint_summary_dispatch(monkeypatch) -> None:
+    drawing = build_drawing(_grouped_holes_part())
+    original = drawing.lint_summary
+    calls = 0
+
+    def lint_summary():
+        nonlocal calls
+        calls += 1
+        return original()
+
+    monkeypatch.setattr(drawing, "lint_summary", lint_summary)
+
+    drawing.report()
+
+    assert calls == 1
+
+
+def test_report_requirement_reuse_is_bound_to_the_exact_drawing(monkeypatch) -> None:
+    outer = build_drawing(_grouped_holes_part())
+    nested = build_drawing(_through_step_part())
+    original = outer.lint_summary
+    nested_requirement_counts = []
+
+    def lint_summary():
+        nested_requirement_counts.append(
+            nested.lint_summary()["quality"]["completeness"]["requirements"]
+        )
+        return original()
+
+    monkeypatch.setattr(outer, "lint_summary", lint_summary)
+
+    outer.report()
+
+    assert nested_requirement_counts == [2]
+
+
+@pytest.mark.parametrize(
+    "fixture",
+    (
+        "blind-hole.step",
+        "chamfer-plain.step",
+        "countersink-mixed-pair.step",
+        "fillet-plain.step",
+        "flat-double-d.step",
+        "groove-lone-z.step",
+        "pad-z-positive.step",
+        "pattern-grid.step",
+        "plate-u-additive.step",
+        "pocket-lone.step",
+        "pocket-pattern-linear.step",
+        "polygonal-boss-z.step",
+        "polygonal-stock-x.step",
+        "turned-step-axis-z.step",
+    ),
+)
+def test_report_requirement_projection_matches_typed_family_ledgers(fixture: str) -> None:
+    report = build_drawing(_EVALUATION_FIXTURES / fixture).report()
+    recognition = report["recognition"]
+    requirements = recognition["requirements"]
+    counts = Counter(requirement["state"] for requirement in requirements)
+    completeness = report["lint"]["quality"]["completeness"]
+    occurrence_ids = {occurrence["id"] for occurrence in recognition["occurrences"]}
+    owner_ids = {
+        owner["id"] for occurrence in recognition["occurrences"] for owner in occurrence["owners"]
+    }
+
+    assert len(requirements) == completeness["requirements"]
+    assert all(
+        set(requirement["occurrence_ids"]) <= occurrence_ids for requirement in requirements
+    )
+    assert all(set(requirement["owner_ids"]) <= owner_ids for requirement in requirements)
+    for state in (
+        "placed",
+        "satisfied_by_structured_note",
+        "suppressed",
+        "dropped",
+        "missing",
+        "unverifiable",
+        "unsupported",
+    ):
+        assert counts[state] == completeness[state]
+
+
+def test_severed_annotation_provenance_loses_requirement_credit(monkeypatch) -> None:
+    monkeypatch.setattr(AnnotationRegistry, "measurement_of", lambda _self, _name: ())
+
+    report = build_drawing(_through_step_part()).report()
+    requirements = report["recognition"]["requirements"]
+
+    assert requirements
+    assert {requirement["state"] for requirement in requirements} == {"unverifiable"}
+    assert all(requirement["annotations"] == [] for requirement in requirements)
+    assert report["status"] == "needs-attention"
+
+
+def test_requirement_without_exact_source_record_fails_closed(monkeypatch) -> None:
+    drawing = build_drawing(_through_step_part())
+
+    monkeypatch.setattr(
+        requirement_module,
+        "recognized_requirement_outcomes",
+        lambda *_args, **_kwargs: {
+            "through_steps": [
+                SimpleNamespace(
+                    state="placed",
+                    source_records=(),
+                    parameter_id="through_step_leg.length.x",
+                    requirement_count=1,
+                )
+            ]
+        },
+    )
+
+    with pytest.raises(ReportUnavailableError, match="no exact source records"):
+        drawing.report()
+
+
+def test_annotation_provenance_is_indexed_once_per_report() -> None:
+    features = [object() for _ in range(500)]
+    names = tuple(f"annotation:{index}" for index in range(len(features)))
+    calls = Counter()
+
+    class Registry:
+        def names(self):
+            calls["names"] += 1
+            return names
+
+        def measurement_of(self, name):
+            calls["measurement_of"] += 1
+            index = int(name.partition(":")[2])
+            return (SimpleNamespace(feature=features[index], parameter="diameter"),)
+
+        def satisfaction_of(self, _name):
+            calls["satisfaction_of"] += 1
+            return ()
+
+    index = reporting_module._annotation_index(Registry())
+    projected = [
+        reporting_module._annotation_names(
+            index,
+            SimpleNamespace(features=(feature,), parameter_id="diameter"),
+        )
+        for feature in features
+    ]
+
+    assert projected == [[name] for name in names]
+    assert calls == {
+        "names": 1,
+        "measurement_of": len(names),
+        "satisfaction_of": len(names),
+    }
+
+
+def test_annotation_index_deduplicates_many_names_per_measurement() -> None:
+    feature = object()
+    names = tuple(f"annotation:{index}" for index in range(500))
+
+    class Registry:
+        def names(self):
+            return names
+
+        def measurement_of(self, _name):
+            return (SimpleNamespace(feature=feature, parameter="diameter"),)
+
+        def satisfaction_of(self, name):
+            return (
+                (SimpleNamespace(feature=feature, parameter="diameter"),)
+                if name == names[0]
+                else ()
+            )
+
+    index = reporting_module._annotation_index(Registry())
+
+    assert reporting_module._annotation_names(
+        index,
+        SimpleNamespace(features=(feature,), parameter_id="diameter"),
+    ) == sorted(names)
+
+
+def test_importing_the_public_report_exception_does_not_load_the_cad_kernel() -> None:
+    probe = (
+        "import sys; from draftwright import ReportUnavailableError; "
+        "print('build123d' in sys.modules or 'OCP' in sys.modules)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, check=True
+    )
+
+    assert result.stdout.strip() == "False"
 
 
 def test_separate_deferred_occurrences_keep_distinct_report_local_ids() -> None:
@@ -202,6 +484,27 @@ def test_report_projects_each_settled_consumer_outcome(
     assert all(bool(occurrence["owners"]) is has_owner for occurrence in occurrences)
     if has_owner:
         assert len({occurrence["owners"][0]["id"] for occurrence in occurrences}) == 1
+    if disposition == "unsupported":
+        assert all(
+            occurrence["requirements"]["coverage"] == "ledger" for occurrence in occurrences
+        )
+        requirement_by_id = {
+            requirement["id"]: requirement for requirement in report["recognition"]["requirements"]
+        }
+        assert all(
+            requirement_by_id[occurrence["requirements"]["ids"][0]]["state"] == "unsupported"
+            for occurrence in occurrences
+        )
+    elif disposition == "deferred":
+        assert all(
+            occurrence["requirements"] == {"coverage": "deferred", "ids": []}
+            for occurrence in occurrences
+        )
+    elif disposition == "evidence_only":
+        assert all(
+            occurrence["requirements"] == {"coverage": "not-applicable", "ids": []}
+            for occurrence in occurrences
+        )
     assert report["recognition"]["summary"][disposition] >= len(occurrences)
     expected_status = "bounded-clear" if disposition == "absorbed" else "needs-attention"
     assert report["status"] == expected_status
@@ -444,3 +747,8 @@ def test_documented_schema_has_the_same_closed_top_level() -> None:
     unknown["unknown"] = True
     with pytest.raises(ValidationError):
         validator_for(schema)(schema).validate(unknown)
+
+    unknown_requirement = build_drawing(_through_step_part()).report()
+    unknown_requirement["recognition"]["requirements"][0]["unknown"] = True
+    with pytest.raises(ValidationError):
+        validator_for(schema)(schema).validate(unknown_requirement)

--- a/tests/test_issue_1438_report_projection.py
+++ b/tests/test_issue_1438_report_projection.py
@@ -327,6 +327,134 @@ def test_requirement_without_exact_source_record_fails_closed(monkeypatch) -> No
         drawing.report()
 
 
+def test_report_rejects_repeated_evidence_record_identity(monkeypatch) -> None:
+    drawing = build_drawing(_grouped_holes_part())
+    evidence = drawing.recognition_evidence()
+    assert evidence is not None and len(evidence.features) > 1
+    record = evidence.record(evidence.features[0])
+    monkeypatch.setattr(type(evidence), "record", lambda _self, _reference: record)
+
+    with pytest.raises(ReportUnavailableError, match="repeats the same recognition record"):
+        drawing.report()
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    (
+        ({"state": "invalid"}, "invalid state"),
+        ({"source_records": (object(),)}, "not bound to this evidence authority"),
+        ({"requirement_count": 0}, "invalid cardinality"),
+        ({"parameter_id": None}, "invalid parameter identity"),
+        ({"requirement_count": 2}, "ambiguous parameter cardinality"),
+        ({"representation": 1}, "invalid representation"),
+        ({"representation_reason": 1}, "invalid representation reason"),
+    ),
+)
+def test_report_rejects_malformed_typed_outcomes(monkeypatch, changes, message) -> None:
+    drawing = build_drawing(_through_step_part())
+    evidence = drawing.recognition_evidence()
+    assert evidence is not None
+    record = evidence.record(evidence.features[0])
+    values = {
+        "state": "placed",
+        "source_records": (record,),
+        "parameter_id": "diameter",
+        "requirement_count": 1,
+        "representation": None,
+        "representation_reason": None,
+    }
+    values.update(changes)
+    monkeypatch.setattr(
+        requirement_module,
+        "recognized_requirement_outcomes",
+        lambda *_args, **_kwargs: {"through_steps": (SimpleNamespace(**values),)},
+    )
+
+    with pytest.raises(ReportUnavailableError, match=message):
+        drawing.report()
+
+
+def test_report_collapses_duplicate_requirement_source_occurrence_ids(monkeypatch) -> None:
+    drawing = build_drawing(_through_step_part())
+    evidence = drawing.recognition_evidence()
+    assert evidence is not None
+    record = evidence.record(evidence.features[0])
+    outcome = SimpleNamespace(
+        state="placed",
+        source_records=(record, record),
+        parameter_id="diameter",
+        requirement_count=1,
+        representation=None,
+        representation_reason=None,
+    )
+    monkeypatch.setattr(
+        requirement_module,
+        "recognized_requirement_outcomes",
+        lambda *_args, **_kwargs: {"through_steps": (outcome,)},
+    )
+
+    report = drawing.report()
+
+    assert report["recognition"]["requirements"][0]["occurrence_ids"] == ["through_steps:1"]
+
+
+def test_report_refuses_a_registry_without_the_provenance_contract(monkeypatch) -> None:
+    drawing = build_drawing(_through_step_part())
+    monkeypatch.setattr(
+        requirement_module, "recognized_requirement_outcomes", lambda *_a, **_k: {}
+    )
+    monkeypatch.setattr(drawing, "lint_summary", lambda: {"passed": True})
+    monkeypatch.setattr(AnnotationRegistry, "names", None)
+
+    with pytest.raises(ReportUnavailableError, match="registry is unavailable"):
+        drawing.report()
+
+
+def test_report_refuses_invalid_annotation_names(monkeypatch) -> None:
+    drawing = build_drawing(_through_step_part())
+    monkeypatch.setattr(
+        requirement_module, "recognized_requirement_outcomes", lambda *_a, **_k: {}
+    )
+    monkeypatch.setattr(drawing, "lint_summary", lambda: {"passed": True})
+    monkeypatch.setattr(AnnotationRegistry, "names", lambda _self: (1,))
+
+    with pytest.raises(ReportUnavailableError, match="invalid name"):
+        drawing.report()
+
+
+def test_report_ignores_a_registry_entry_without_semantic_identity(monkeypatch) -> None:
+    drawing = build_drawing(_through_step_part())
+    evidence = drawing.recognition_evidence()
+    assert evidence is not None
+    record = evidence.record(evidence.features[0])
+    outcome = SimpleNamespace(
+        state="placed",
+        source_records=(record,),
+        measurement_ids=((None, "diameter"),),
+        parameter_id="diameter",
+        requirement_count=1,
+        representation=None,
+        representation_reason=None,
+    )
+    monkeypatch.setattr(
+        requirement_module,
+        "recognized_requirement_outcomes",
+        lambda *_a, **_k: {"through_steps": (outcome,)},
+    )
+    monkeypatch.setattr(drawing, "lint_summary", lambda: {"passed": True})
+    monkeypatch.setattr(AnnotationRegistry, "names", lambda _self: ("annotation",))
+    monkeypatch.setattr(
+        AnnotationRegistry,
+        "measurement_of",
+        lambda _self, _name: (SimpleNamespace(feature=None, parameter="diameter"),),
+    )
+    monkeypatch.setattr(AnnotationRegistry, "satisfaction_of", lambda _self, _name: ())
+
+    report = drawing.report()
+
+    assert report["recognition"]["requirements"][0]["annotations"] == []
+
+
 def test_annotation_provenance_is_indexed_once_per_report() -> None:
     features = [object() for _ in range(500)]
     names = tuple(f"annotation:{index}" for index in range(len(features)))


### PR DESCRIPTION
## Symptom and evidence

- User-visible problem: report v1 accounts for accepted recognition occurrences but did not expose the recognition-owned physical requirements they imply, their final annotation state, or the exact annotations carrying them.
- Fixture/reproducer: the #1438 report corpus covers 1:1, grouped, nested countersink, pattern, Plate, evidence-only, deferred, unsupported, and unexpectedly-missing paths.
- Before/after result: reports previously left per-occurrence requirement coverage as `not-projected`; they now expose a deterministic top-level `recognition.requirements` ledger and link each occurrence to its exact requirement IDs.
- Mutation that makes the guard fail: missing same-run source records, corrupt annotation provenance, invalid states/cardinality/parameter identity, ambiguous owner identity, and removed supported conversions all fail closed in focused report tests.

## Contract and scope

- Smallest contract this change tests: one immutable recognition-owned requirement roster is evaluated once per report, shared with completeness, and projected using exact same-run source/IR/provenance identity.
- Relevant ADRs: 0005 and 0017 are narrowly amended; 0010, 0011, 0013, 0014, 0015, and 0020 were explicitly audited and remain unchanged.
- Explicitly deferred: generated-script runtime correlation remains parked on b123d-recognisers#485; framed report adoption is a separate slice. No recogniser API change is required here.

## Validation

- [x] `scripts/pr-check --quick`
- [x] `scripts/pr-check` before final review
- [x] The named mutation was observed failing before the implementation passed it
- [x] Automatic, declared, and generated-script paths were checked where affected
- [x] Recognition and repeated-lint call counts were checked where affected

Exact local gate at `bb0ddab6af54137c74675612009851928f06a21a`: 6,624 passed, 5 skipped, 2 expected xfails; 95.87% total coverage and 94% changed-line coverage; Ruff, formatting, mypy, docs, schema, and diff checks clean.

Three independent Google-style exact-head reviews are CLEAN with no required findings or optional nits: ADR/architecture, report contract, and implementation quality.

## Stop check

- [x] No two consecutive review rounds invalidated the same core association strategy
- [x] New prerequisites were split or the work was explicitly reclassified as discovery

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/pzfreo/draftwright/blob/main/CLA.md) and agree to it. If I am contributing on behalf of an organisation, I am authorised to agree on its behalf.

Refs #1438
