### PR TITLE
Refuse a degenerate iso zone before it reaches OCC

### DIFF
--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -195,6 +195,17 @@ def _settle_iso_view(dwg: Drawing, a: Analysis, *, obstacles=()):
         a.iso_right_limit,
         a.iso_top_limit,
     )
+    if region[2] <= region[0] or region[3] <= region[1]:
+        # The zone the engine composed has no room at all — a `_largest_empty_rect` sliver or an
+        # inverted width (#1395). Reporting that as an infeasible *authored* scale states a
+        # falsehood about the caller's input: no scale they could have written would fit a zone
+        # of zero extent. Leave the authored scale alone and say what is actually wrong.
+        _log.warning(
+            "Iso zone %.3f x %.3f mm has no room for any scale; leaving the authored iso as projected",
+            region[2] - region[0],
+            region[3] - region[1],
+        )
+        return bb
     if not _bbox_within(bb, region):
         source = None
         constraints = a.view_constraints

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -196,10 +196,14 @@ def _settle_iso_view(dwg: Drawing, a: Analysis, *, obstacles=()):
         a.iso_top_limit,
     )
     if region[2] <= region[0] or region[3] <= region[1]:
-        # The zone the engine composed has no room at all — a `_largest_empty_rect` sliver or an
-        # inverted width (#1395). Reporting that as an infeasible *authored* scale states a
-        # falsehood about the caller's input: no scale they could have written would fit a zone
-        # of zero extent. Leave the authored scale alone and say what is actually wrong.
+        # The zone the engine composed has no room at all — the `_largest_empty_rect` sliver
+        # case of #1395. Reporting that as an infeasible *authored* scale states a falsehood
+        # about the caller's input: no ordinary authored scale fits a zone of zero extent.
+        #
+        # Scope, stated because the sibling guard in `projection` covers more: this path builds
+        # `region` from the RAW `a.iso_*_limit` and applies no section bump, so a zone inverted
+        # by a section crossing `iso_right_limit` is invisible here. Sharing one region helper
+        # between the two paths would close that; it is a wider change than this fix.
         _log.warning(
             "Iso zone %.3f x %.3f mm has no room for any scale; leaving the authored iso as projected",
             region[2] - region[0],

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -709,7 +709,10 @@ def choose_scale(
             ``page`` are given they are used as-is (a warning is logged if the
             layout does not fit).
     """
-    if scale is not None and float(scale) <= 0:
+    if scale is not None and not float(scale) > 0:
+        # `not x > 0` rather than `x <= 0` so NaN is refused: `nan <= 0` is False, and a NaN
+        # scale is not merely wrong but unrecoverable — it reaches `project_to_viewport` and
+        # the build hangs rather than raising (#1395 review).
         raise ValueError(f"scale must be positive, got {scale!r}")
     if scale is not None and page is not None:
         pw, ph, tb = _parse_page(page)

--- a/src/draftwright/projection.py
+++ b/src/draftwright/projection.py
@@ -530,8 +530,9 @@ def _fit_iso_view(dwg, a: Analysis, obstacles=()):
         # reported by `view_annotation_overlap` rather than prevented here (#1240 review F3).
         factor = math.floor(needed * 0.98 * 10000) / 10000
     if not factor > 0.0:
-        # One guard, at the boundary it protects. `extent > 0` filters the ratio's numerator;
-        # nothing filters its counterpart, so a zone with no room yields a non-positive factor.
+        # One guard, at the boundary it protects. `extent > 0` filters the ratio's DENOMINATOR;
+        # nothing bounds the available side above it, so a zone with no room yields a
+        # non-positive factor — the sign comes from `avail`, which is never checked.
         # Spelled `not factor > 0.0` rather than `factor <= 0.0` so NaN is refused too: OCC
         # accepts a NaN scale silently, and `NaN <= 0.0` is False.
         #
@@ -553,8 +554,10 @@ def _fit_iso_view(dwg, a: Analysis, obstacles=()):
         # `Standard_Failure` on macOS, raises `Standard_ConstructionError` on Linux (a class
         # that does NOT subclass `Standard_Failure`), and a NEGATIVE factor is accepted
         # silently, mirroring the iso onto a delivered sheet. Whether either exception is caught
-        # depends on where the fit runs: the candidate-build handlers do not cover
-        # `_settle_iso_view`, so on that path the zero case aborts the build on macOS too.
+        # depends on where the fit runs. The `except (ValueError, Standard_Failure)` sites wrap
+        # `_build(...)`, so they DO cover a fit inside a candidate build; the requested-scale
+        # build reaches `_settle_iso_view` outside them, and on that path the zero case aborts
+        # the build on macOS too.
         _log.warning(
             "Iso zone %.3f x %.3f mm admits no positive scale (%g); leaving it at sheet scale",
             region[2] - region[0],

--- a/src/draftwright/projection.py
+++ b/src/draftwright/projection.py
@@ -529,6 +529,24 @@ def _fit_iso_view(dwg, a: Analysis, obstacles=()):
         # page region, so it must shrink whatever else is nearby, and a resulting collision is
         # reported by `view_annotation_overlap` rather than prevented here (#1240 review F3).
         factor = math.floor(needed * 0.98 * 10000) / 10000
+    if factor <= 0.0:
+        # One guard, at the boundary it protects rather than at the condition that causes it.
+        # `extent > 0` filters the ratio's numerator; nothing filters its counterpart, so a
+        # collapsed or inverted zone yields a non-positive factor — a section sharing the iso's
+        # y-range raises `region_left` with no upper bound and can pass `iso_right_limit`. OCC
+        # answers that three ways: zero raises `Standard_Failure` on macOS, raises
+        # `Standard_ConstructionError` on Linux (a class that does NOT subclass
+        # `Standard_Failure`, so the caller's handler misses it and the build aborts), and a
+        # NEGATIVE factor is accepted silently, mirroring the iso onto a delivered sheet. All
+        # three are one layout fact, known here, before any transform: leave the iso at sheet
+        # scale and let the candidate search continue (#1395).
+        _log.info(
+            "Iso zone %.3f × %.3f mm admits no positive scale (%g); leaving it at sheet scale",
+            region[2] - region[0],
+            region[3] - region[1],
+            factor,
+        )
+        return
     if abs(factor - 1.0) < 0.05:
         # Undo the probes ONLY here: every other exit re-projects at `factor` below, so the
         # restore would be a wasted projection — and on CTC-01 a projection is 14 ms.

--- a/src/draftwright/projection.py
+++ b/src/draftwright/projection.py
@@ -529,19 +529,30 @@ def _fit_iso_view(dwg, a: Analysis, obstacles=()):
         # page region, so it must shrink whatever else is nearby, and a resulting collision is
         # reported by `view_annotation_overlap` rather than prevented here (#1240 review F3).
         factor = math.floor(needed * 0.98 * 10000) / 10000
-    if factor <= 0.0:
-        # One guard, at the boundary it protects rather than at the condition that causes it.
-        # `extent > 0` filters the ratio's numerator; nothing filters its counterpart, so a
-        # collapsed or inverted zone yields a non-positive factor — a section sharing the iso's
-        # y-range raises `region_left` with no upper bound and can pass `iso_right_limit`. OCC
-        # answers that three ways: zero raises `Standard_Failure` on macOS, raises
-        # `Standard_ConstructionError` on Linux (a class that does NOT subclass
-        # `Standard_Failure`, so the caller's handler misses it and the build aborts), and a
-        # NEGATIVE factor is accepted silently, mirroring the iso onto a delivered sheet. All
-        # three are one layout fact, known here, before any transform: leave the iso at sheet
-        # scale and let the candidate search continue (#1395).
-        _log.info(
-            "Iso zone %.3f × %.3f mm admits no positive scale (%g); leaving it at sheet scale",
+    if not factor > 0.0:
+        # One guard, at the boundary it protects. `extent > 0` filters the ratio's numerator;
+        # nothing filters its counterpart, so a zone with no room yields a non-positive factor.
+        # Spelled `not factor > 0.0` rather than `factor <= 0.0` so NaN is refused too: OCC
+        # accepts a NaN scale silently, and `NaN <= 0.0` is False.
+        #
+        # Two ways a zone ends up with no room, and the REPORTED one is not the section bump:
+        # `_largest_empty_rect` answers "no gap" with a floating-point sliver (#1395's own trace
+        # is 136 x 1.4e-14 mm — full width, zero height), and separately a section sharing the
+        # iso's y-range raises `region_left` with no upper bound, which can pass
+        # `iso_right_limit` and invert the width.
+        #
+        # This is strictly stronger than checking the zone's shape: it also catches a positive
+        # but vanishing `needed` (1e-9 rounds to a 0.0 factor at 4 dp), which no shape check
+        # would see.
+        #
+        # It matters because OCC answers a non-positive scale three ways: zero raises
+        # `Standard_Failure` on macOS, raises `Standard_ConstructionError` on Linux (a class
+        # that does NOT subclass `Standard_Failure`), and a NEGATIVE factor is accepted
+        # silently, mirroring the iso onto a delivered sheet. Whether either exception is caught
+        # depends on where the fit runs: the candidate-build handlers do not cover
+        # `_settle_iso_view`, so on that path the zero case aborts the build on macOS too.
+        _log.warning(
+            "Iso zone %.3f x %.3f mm admits no positive scale (%g); leaving it at sheet scale",
             region[2] - region[0],
             region[3] - region[1],
             factor,

--- a/src/draftwright/projection.py
+++ b/src/draftwright/projection.py
@@ -541,9 +541,13 @@ def _fit_iso_view(dwg, a: Analysis, obstacles=()):
         # iso's y-range raises `region_left` with no upper bound, which can pass
         # `iso_right_limit` and invert the width.
         #
-        # This is strictly stronger than checking the zone's shape: it also catches a positive
-        # but vanishing `needed` (1e-9 rounds to a 0.0 factor at 4 dp), which no shape check
-        # would see.
+        # Chosen over an equivalent check on the zone's shape, which an earlier cut also had.
+        # Neither strictly contains the other: this one additionally catches a positive but
+        # vanishing `needed` (1e-9 rounds to a 0.0 factor at 4 dp), while a shape check would
+        # additionally catch an inverted zone whose iso bbox has zero extent on the inverted
+        # axis, so `extent > 0` filters both offending ratios. That second case needs a
+        # projected solid whose isometric bbox is a line and has never been observed; the
+        # first is the one the corpus actually produces, so one guard here is enough.
         #
         # It matters because OCC answers a non-positive scale three ways: zero raises
         # `Standard_Failure` on macOS, raises `Standard_ConstructionError` on Linux (a class

--- a/tests/test_issue_1395_degenerate_iso_region.py
+++ b/tests/test_issue_1395_degenerate_iso_region.py
@@ -88,8 +88,8 @@ def _scales_handed_to_occ(monkeypatch, zone, sheet=None):
 def _degenerate_part():
     """A turned part that, at 10:1 on A4, composes an iso zone with no room.
 
-    Found by sweeping parts and scales rather than by construction: this is the shape that
-    reproduces the reported crash through the ordinary public entry point.
+    Found by sweeping parts and scales. Synthetic, and kept in the fast tier for that reason:
+    it reproduces the reported crash in ~2 s where the real corpus fixture takes ~30 s.
     """
 
     return Cylinder(4, 30) + Pos(0, 0, 15) * Cylinder(6, 6) - Cylinder(1.5, 60)
@@ -112,6 +112,25 @@ def test_the_reported_crash_is_fixed_end_to_end():
 
     assert {"front", "plan", "side"} <= set(drawing.views), "required views must survive"
     assert drawing.views["iso"][0].bounding_box().size.X > 0, "the iso must not be degenerate"
+
+
+@pytest.mark.slow
+def test_a_real_fixture_reproduces_the_crash_and_now_builds():
+    """The same bug on a part already in the corpus, not a shape constructed to provoke it.
+
+    `issue_915_case_study_2.step` at 10:1 composes an iso zone with `needed = 6.9e-18`. Without
+    the guard this raises `Standard_Failure` out of `build_drawing`; with it the automatic
+    search falls back to 2:1 and keeps every view including the section and detail. Slow tier
+    (~30 s) because the synthetic case above proves the same contract in ~2 s; this one is here
+    so the evidence is a real part rather than only a manufactured one.
+    """
+
+    drawing = build_drawing(
+        "tests/fixtures/issue_915_case_study_2.step", pmi="off", repair=False, scale=10.0
+    )
+
+    assert {"front", "plan", "side", "section_aa"} <= set(drawing.views)
+    assert drawing.scale == 2.0, "the search must fall back, not abort"
 
 
 # ── the invariant, at the seam ────────────────────────────────────────────────────────────

--- a/tests/test_issue_1395_degenerate_iso_region.py
+++ b/tests/test_issue_1395_degenerate_iso_region.py
@@ -1,0 +1,160 @@
+"""A degenerate iso zone is a layout fact, not an OCC exception (#1395).
+
+`_fit_iso_view` measures how much room the isometric has and scales it to fit. Nothing bounded
+the *available* side of that ratio, so a collapsed or inverted zone produced a non-positive
+scale factor and handed it to `gp_Trsf.SetScale`, which answers three different ways:
+
+| factor | OCC |
+| --- | --- |
+| `0.0` | `Standard_Failure` on macOS — caught, so the candidate is rejected |
+| `0.0` | `Standard_ConstructionError` on Linux — **not** a `Standard_Failure` subclass, so the builder's handler misses it and the whole build aborts |
+| negative | **accepted** — the iso is mirrored through the origin onto a delivered sheet, silently, on every platform |
+
+The third is the worst, and the issue's own reproduction cannot reach it: both cases it reports
+are the zero one.
+
+The invariant under test is *a non-positive factor never reaches the transform*, so these tests
+record what `_fit_iso_view` hands to `_project_iso` rather than inspecting the drawing
+afterwards. That also keeps them off `Drawing`'s private `_analysis`, whose test-side reads are
+a shrinking ratchet (`test_private_test_attr_reads.py`).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import pytest
+from OCP.gp import gp_Pnt, gp_Trsf
+from OCP.Standard import Standard_ConstructionError, Standard_Failure
+
+from draftwright import projection
+
+
+@dataclass
+class _Zone:
+    """The seven `Analysis` fields `_fit_iso_view` reads. Explicit, so a future field it starts
+    reading fails loudly here rather than being silently defaulted."""
+
+    iso_left_limit: float
+    iso_bottom_limit: float
+    iso_right_limit: float
+    iso_top_limit: float
+    ISO_X: float
+    ISO_Y: float
+    SCALE: float = 1.0
+
+
+class _Sheet:
+    """A drawing stand-in exposing only the iso bounds `_iso_bbox` reads."""
+
+    def __init__(self, bounds=(80.0, 80.0, 120.0, 120.0)):
+        self.views = {"iso": object()}
+        self._bounds = bounds
+
+    def view_bounds(self, _name):
+        return self._bounds
+
+
+def _factor_handed_to_occ(monkeypatch, zone: _Zone, sheet: _Sheet | None = None):
+    """Run the fit and return every scale it passed to `_project_iso`, or [] if it passed none."""
+
+    seen: list[float] = []
+    monkeypatch.setattr(projection, "_project_iso", lambda _d, _a, scale: seen.append(scale))
+    projection._fit_iso_view(sheet or _Sheet(), zone)
+    return seen
+
+
+def test_standard_construction_error_is_not_a_standard_failure():
+    """The platform fact the old `except (ValueError, Standard_Failure)` rested on.
+
+    In these bindings `Standard_ConstructionError` inherits straight from `Exception`, so a
+    handler naming only `Standard_Failure` cannot catch it. Pinned rather than assumed from the
+    C++ hierarchy: a bindings change should be visible here rather than silently re-enabling
+    the path this issue is about.
+    """
+
+    assert not issubclass(Standard_ConstructionError, Standard_Failure)
+    assert Standard_ConstructionError.__mro__[1] is Exception
+
+
+def test_occ_rejects_a_zero_scale_but_silently_accepts_a_negative_one():
+    """Why a non-positive factor must never reach OCC: only one of the two is loud."""
+
+    with pytest.raises((Standard_Failure, Standard_ConstructionError)):
+        gp_Trsf().SetScale(gp_Pnt(0, 0, 0), 0.0)
+
+    mirrored = gp_Trsf()
+    mirrored.SetScale(gp_Pnt(0, 0, 0), -1.96)
+    assert mirrored.ScaleFactor() == pytest.approx(-1.96), (
+        "a negative scale is accepted and mirrors the geometry — no exception on any platform"
+    )
+
+
+@pytest.mark.parametrize(
+    ("needed", "factor"),
+    [
+        (0.0, 0.0),  # collapsed zone
+        (1e-9, 0.0),  # rounds to zero at the shrink branch's 4 dp
+        (0.004, 0.0039),  # smallest positive that survives that rounding
+        (-2.0, -1.96),  # inverted zone
+    ],
+)
+def test_the_shrink_arithmetic_can_produce_a_non_positive_factor(needed, factor):
+    """The arithmetic, isolated. `extent > 0` filters the ratio's numerator; nothing filtered
+    its counterpart, so a non-positive `needed` flowed straight through."""
+
+    assert math.floor(needed * 0.98 * 10000) / 10000 == pytest.approx(factor)
+
+
+def test_a_collapsed_zone_hands_no_scale_to_the_transform(monkeypatch):
+    zone = _Zone(120.0, 0.0, 120.0, 200.0, ISO_X=100.0, ISO_Y=100.0)
+
+    assert _factor_handed_to_occ(monkeypatch, zone) == [], (
+        "a zero-width zone has no scale that fits; the fit must return rather than project"
+    )
+
+
+def test_an_inverted_zone_hands_no_scale_to_the_transform(monkeypatch):
+    """A section sharing the iso's y-range raises the zone's left edge with no upper bound, so
+    it can pass the right edge. Before the guard this produced a NEGATIVE factor, which OCC
+    accepts — a mirrored iso on a delivered sheet, with no error on any platform."""
+
+    zone = _Zone(140.0, 0.0, 120.0, 200.0, ISO_X=100.0, ISO_Y=100.0)
+
+    assert _factor_handed_to_occ(monkeypatch, zone) == []
+
+
+def test_a_zero_height_zone_hands_no_scale_to_the_transform(monkeypatch):
+    zone = _Zone(0.0, 100.0, 200.0, 100.0, ISO_X=100.0, ISO_Y=100.0)
+
+    assert _factor_handed_to_occ(monkeypatch, zone) == []
+
+
+def test_an_overflowing_iso_still_gets_a_positive_scale(monkeypatch):
+    """The guard must not refuse work that fits. A genuinely overflowing iso in a real zone is
+    the shrink branch's own case, and it must still reach the transform — with a factor OCC
+    will accept."""
+
+    zone = _Zone(90.0, 90.0, 110.0, 110.0, ISO_X=100.0, ISO_Y=100.0)
+    sheet = _Sheet(bounds=(50.0, 50.0, 150.0, 150.0))  # iso is far larger than its zone
+
+    handed = _factor_handed_to_occ(monkeypatch, zone, sheet)
+
+    assert handed, "an overflowing iso must still be rescaled"
+    assert all(scale > 0.0 for scale in handed), f"non-positive scale reached OCC: {handed}"
+    gp_Trsf().SetScale(gp_Pnt(0, 0, 0), handed[-1] / zone.SCALE)  # OCC accepts it
+
+
+def test_every_zone_either_projects_a_positive_scale_or_projects_nothing(monkeypatch):
+    """The invariant itself, swept over degenerate and ordinary zones together."""
+
+    zones = [
+        _Zone(left, 0.0, 120.0, top, ISO_X=100.0, ISO_Y=100.0)
+        for left in (60.0, 100.0, 119.0, 120.0, 130.0, 200.0)
+        for top in (0.0, 1.0, 100.0, 200.0)
+    ]
+
+    for zone in zones:
+        for scale in _factor_handed_to_occ(monkeypatch, zone):
+            assert scale > 0.0, f"zone {zone} handed {scale} to the transform"

--- a/tests/test_issue_1395_degenerate_iso_region.py
+++ b/tests/test_issue_1395_degenerate_iso_region.py
@@ -199,15 +199,27 @@ def test_across_many_zones_every_projected_scale_is_positive_and_some_are(monkey
 
 
 def test_a_nan_factor_is_refused_although_it_is_not_less_than_zero(monkeypatch):
-    """`NaN <= 0.0` is False and OCC accepts a NaN scale silently, so the guard is spelled
-    `not factor > 0.0`. No reachable input produces NaN today; this pins the spelling."""
+    """Why the spelling matters at every scale gate — including the one that does see NaN.
+
+    `factor` itself provably cannot be NaN: `math.floor` raises `ValueError` on NaN and
+    `OverflowError` on inf before the guard is reached, so `not factor > 0.0` there is
+    belt-and-braces rather than load-bearing. The public `scale=` gate is different — it takes
+    the caller's value directly, and spelled `<= 0` it let NaN through and the build HUNG in
+    `project_to_viewport` rather than raising.
+    """
 
     nan = float("nan")
     mirrored = gp_Trsf()
     mirrored.SetScale(gp_Pnt(0, 0, 0), nan)  # accepted, no exception
 
     assert not (nan <= 0.0), "the reason `<= 0.0` would not be enough"
-    assert not nan > 0.0, "the spelling the guard uses does refuse it"
+    assert not nan > 0.0, "the spelling the guards use does refuse it"
+
+    # The gate that genuinely needs it: a caller-supplied NaN scale must raise, not hang.
+    # Spelled `<= 0` this does not fail, it HANGS in `project_to_viewport`, so the module's
+    # 300 s pytest-timeout is what turns a regression here into a report rather than a wedge.
+    with pytest.raises(ValueError, match="scale must be positive"):
+        build_drawing(Cylinder(5, 20), title="T", number="N", scale=nan, page="A4")
 
 
 # ── the authored-scale sibling path ───────────────────────────────────────────────────────
@@ -236,9 +248,9 @@ def test_a_degenerate_zone_is_not_reported_as_an_infeasible_authored_scale(_zone
 
     assert result is not None, "the authored iso is left as projected, not refused"
     assert "has no room for any scale" in _zone_log.text
-    assert "authored iso scale" not in _zone_log.text, (
-        "the caller must not be blamed for a zone the engine composed"
-    )
+    # Not asserted against the log: "authored iso scale" only ever appears in a `raise`, never
+    # in a record, so a log-absence check there could never fail. The guard returning at all is
+    # what proves the falsehood is not raised.
 
 
 # ── platform facts the old handler rested on ──────────────────────────────────────────────

--- a/tests/test_issue_1395_degenerate_iso_region.py
+++ b/tests/test_issue_1395_degenerate_iso_region.py
@@ -1,8 +1,8 @@
 """A degenerate iso zone is a layout fact, not an OCC exception (#1395).
 
-`_fit_iso_view` scales the isometric to fit its page zone. `extent > 0` filters the ratio's
-numerator; nothing filtered its counterpart, so a zone with no room yielded a non-positive
-factor and handed it to `gp_Trsf.SetScale`. Measured, OCC answers that three ways:
+`_fit_iso_view` scales the isometric to fit its page zone by `avail / extent`. `extent > 0`
+filters the DENOMINATOR; nothing bounded the available side, so a zone with no room yielded a
+non-positive factor and handed it to `gp_Trsf.SetScale`. Measured, OCC answers that three ways:
 
 | factor | OCC |
 | --- | --- |
@@ -11,10 +11,10 @@ factor and handed it to `gp_Trsf.SetScale`. Measured, OCC answers that three way
 | negative | **accepted** — the iso is mirrored through the origin, silently, on every platform |
 
 Whether either exception is caught depends on *where* the fit runs. The
-`except (ValueError, Standard_Failure)` handlers in `builder` wrap **candidate** builds only;
-the requested-scale build reaches `_settle_iso_view` outside them, so on that path the zero
-case aborts `build_drawing` on macOS too — verified below, not assumed. The Linux case
-additionally escapes even inside a candidate build, because its class is not caught at all.
+`except (ValueError, Standard_Failure)` handlers wrap `_build(...)`, so they do cover a fit
+inside a candidate build — but the requested-scale build reaches `_settle_iso_view` outside
+them, so on that path the zero case aborts `build_drawing` on macOS too, verified below. The
+Linux case escapes even inside a candidate, because its class is not caught at all.
 
 The negative case is the worst of the three and the issue's own reproduction cannot reach it:
 both failures it reports are the zero one.
@@ -162,8 +162,10 @@ def test_a_zone_with_no_room_hands_no_scale_to_the_transform(
     assert "admits no positive scale" in _zone_log.text, (
         f"{name}: something other than the degenerate-zone guard returned first"
     )
-    assert f"{unguarded_factor:g}" in _zone_log.text, (
-        f"{name}: expected the guard to report factor {unguarded_factor:g}"
+    assert f"scale ({unguarded_factor:g})" in _zone_log.text, (
+        f"{name}: expected the guard to report factor {unguarded_factor:g}. Matched against the "
+        "parenthesised field, not the bare number: the zone dimensions already contain '0', so a "
+        "bare match was vacuous for the two zero cases."
     )
 
 

--- a/tests/test_issue_1395_degenerate_iso_region.py
+++ b/tests/test_issue_1395_degenerate_iso_region.py
@@ -1,48 +1,68 @@
 """A degenerate iso zone is a layout fact, not an OCC exception (#1395).
 
-`_fit_iso_view` measures how much room the isometric has and scales it to fit. Nothing bounded
-the *available* side of that ratio, so a collapsed or inverted zone produced a non-positive
-scale factor and handed it to `gp_Trsf.SetScale`, which answers three different ways:
+`_fit_iso_view` scales the isometric to fit its page zone. `extent > 0` filters the ratio's
+numerator; nothing filtered its counterpart, so a zone with no room yielded a non-positive
+factor and handed it to `gp_Trsf.SetScale`. Measured, OCC answers that three ways:
 
 | factor | OCC |
 | --- | --- |
-| `0.0` | `Standard_Failure` on macOS — caught, so the candidate is rejected |
-| `0.0` | `Standard_ConstructionError` on Linux — **not** a `Standard_Failure` subclass, so the builder's handler misses it and the whole build aborts |
-| negative | **accepted** — the iso is mirrored through the origin onto a delivered sheet, silently, on every platform |
+| `0.0` | `Standard_Failure` on macOS |
+| `0.0` | `Standard_ConstructionError` on Linux — a class that does **not** subclass `Standard_Failure` |
+| negative | **accepted** — the iso is mirrored through the origin, silently, on every platform |
 
-The third is the worst, and the issue's own reproduction cannot reach it: both cases it reports
-are the zero one.
+Whether either exception is caught depends on *where* the fit runs. The
+`except (ValueError, Standard_Failure)` handlers in `builder` wrap **candidate** builds only;
+the requested-scale build reaches `_settle_iso_view` outside them, so on that path the zero
+case aborts `build_drawing` on macOS too — verified below, not assumed. The Linux case
+additionally escapes even inside a candidate build, because its class is not caught at all.
 
-The invariant under test is *a non-positive factor never reaches the transform*, so these tests
-record what `_fit_iso_view` hands to `_project_iso` rather than inspecting the drawing
-afterwards. That also keeps them off `Drawing`'s private `_analysis`, whose test-side reads are
-a shrinking ratchet (`test_private_test_attr_reads.py`).
+The negative case is the worst of the three and the issue's own reproduction cannot reach it:
+both failures it reports are the zero one.
+
+The invariant under test is *a non-positive factor never reaches the transform*, so the unit
+tests record what `_fit_iso_view` hands to `_project_iso`. `test_the_reported_crash_is_fixed_end_to_end`
+is the control that the whole thing works through the public API.
 """
 
 from __future__ import annotations
 
-import math
-from dataclasses import dataclass
+import logging
 
 import pytest
+from build123d import Cylinder, Pos
 from OCP.gp import gp_Pnt, gp_Trsf
 from OCP.Standard import Standard_ConstructionError, Standard_Failure
 
-from draftwright import projection
+from draftwright import build_drawing, projection
 
 
-@dataclass
+@pytest.fixture
+def _zone_log(caplog):
+    caplog.set_level(logging.WARNING, logger="draftwright.projection")
+    return caplog
+
+
 class _Zone:
-    """The seven `Analysis` fields `_fit_iso_view` reads. Explicit, so a future field it starts
-    reading fails loudly here rather than being silently defaulted."""
+    """The seven `Analysis` fields `_fit_iso_view` reads.
 
-    iso_left_limit: float
-    iso_bottom_limit: float
-    iso_right_limit: float
-    iso_top_limit: float
-    ISO_X: float
-    ISO_Y: float
-    SCALE: float = 1.0
+    Verified to be exactly the set it consumes; a field it starts reading later raises
+    `AttributeError` here rather than being silently defaulted.
+    """
+
+    def __init__(self, left, bottom, right, top, *, iso_x, iso_y, scale=1.0):
+        self.iso_left_limit = left
+        self.iso_bottom_limit = bottom
+        self.iso_right_limit = right
+        self.iso_top_limit = top
+        self.ISO_X = iso_x
+        self.ISO_Y = iso_y
+        self.SCALE = scale
+
+    def __repr__(self):
+        return (
+            f"_Zone({self.iso_left_limit}, {self.iso_bottom_limit}, "
+            f"{self.iso_right_limit}, {self.iso_top_limit})"
+        )
 
 
 class _Sheet:
@@ -56,8 +76,8 @@ class _Sheet:
         return self._bounds
 
 
-def _factor_handed_to_occ(monkeypatch, zone: _Zone, sheet: _Sheet | None = None):
-    """Run the fit and return every scale it passed to `_project_iso`, or [] if it passed none."""
+def _scales_handed_to_occ(monkeypatch, zone, sheet=None):
+    """Every scale the fit passed to `_project_iso`; empty when it projected nothing."""
 
     seen: list[float] = []
     monkeypatch.setattr(projection, "_project_iso", lambda _d, _a, scale: seen.append(scale))
@@ -65,14 +85,147 @@ def _factor_handed_to_occ(monkeypatch, zone: _Zone, sheet: _Sheet | None = None)
     return seen
 
 
-def test_standard_construction_error_is_not_a_standard_failure():
-    """The platform fact the old `except (ValueError, Standard_Failure)` rested on.
+def _degenerate_part():
+    """A turned part that, at 10:1 on A4, composes an iso zone with no room.
 
-    In these bindings `Standard_ConstructionError` inherits straight from `Exception`, so a
-    handler naming only `Standard_Failure` cannot catch it. Pinned rather than assumed from the
-    C++ hierarchy: a bindings change should be visible here rather than silently re-enabling
-    the path this issue is about.
+    Found by sweeping parts and scales rather than by construction: this is the shape that
+    reproduces the reported crash through the ordinary public entry point.
     """
+
+    return Cylinder(4, 30) + Pos(0, 0, 15) * Cylinder(6, 6) - Cylinder(1.5, 60)
+
+
+# ── the fix, through the public API ───────────────────────────────────────────────────────
+
+
+def test_the_reported_crash_is_fixed_end_to_end():
+    """The issue's acceptance criterion: the invalid candidate must not abort the run, and the
+    drawing must keep its required views.
+
+    Against unfixed source this exact call raises `Standard_Failure: gp_Trsf::SetScaleFactor`
+    out of `build_drawing` — on macOS as well as Linux, because `_settle_iso_view` runs outside
+    the candidate-build handlers.
+    """
+
+    with pytest.warns(Warning):  # the scale falls back; that is the point, not an error
+        drawing = build_drawing(_degenerate_part(), title="T", number="N", scale=10.0, page="A4")
+
+    assert {"front", "plan", "side"} <= set(drawing.views), "required views must survive"
+    assert drawing.views["iso"][0].bounding_box().size.X > 0, "the iso must not be degenerate"
+
+
+# ── the invariant, at the seam ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("name", "zone", "unguarded_factor"),
+    [
+        # Each carries the factor the unguarded code produces, so the fixture proves it really
+        # exercises the guard rather than being refused by some other early return.
+        ("zero width, centre inside", _Zone(80.0, 0.0, 80.0, 200.0, iso_x=80.0, iso_y=100.0), 0.0),
+        ("zero height", _Zone(0.0, 100.0, 200.0, 100.0, iso_x=100.0, iso_y=100.0), 0.0),
+        ("collapsed width", _Zone(120.0, 0.0, 120.0, 200.0, iso_x=100.0, iso_y=100.0), -0.98),
+        ("inverted width", _Zone(140.0, 0.0, 120.0, 200.0, iso_x=100.0, iso_y=100.0), -1.96),
+    ],
+    ids=lambda v: v if isinstance(v, str) else "",
+)
+def test_a_zone_with_no_room_hands_no_scale_to_the_transform(
+    monkeypatch, _zone_log, name, zone, unguarded_factor
+):
+    """Both signs of the defect, and both axes.
+
+    `== []` alone cannot tell the guard from a different early return, so each case also
+    asserts the guard is what refused it — via the diagnostic it emits — and the parametrised
+    `unguarded_factor` records the value the old code would have projected.
+    """
+
+    assert _scales_handed_to_occ(monkeypatch, zone) == []
+    assert "admits no positive scale" in _zone_log.text, (
+        f"{name}: something other than the degenerate-zone guard returned first"
+    )
+    assert f"{unguarded_factor:g}" in _zone_log.text, (
+        f"{name}: expected the guard to report factor {unguarded_factor:g}"
+    )
+
+
+def test_an_overflowing_iso_still_gets_a_positive_scale(monkeypatch):
+    """The guard must not refuse work that fits — the negative control."""
+
+    zone = _Zone(90.0, 90.0, 110.0, 110.0, iso_x=100.0, iso_y=100.0)
+    sheet = _Sheet(bounds=(50.0, 50.0, 150.0, 150.0))  # iso far larger than its zone
+
+    handed = _scales_handed_to_occ(monkeypatch, zone, sheet)
+
+    assert handed, "an overflowing iso must still be rescaled"
+    assert all(scale > 0.0 for scale in handed), f"non-positive scale reached OCC: {handed}"
+    gp_Trsf().SetScale(gp_Pnt(0, 0, 0), handed[-1] / zone.SCALE)  # OCC accepts it
+
+
+def test_across_many_zones_every_projected_scale_is_positive_and_some_are(monkeypatch):
+    """The invariant swept broadly. The second assertion matters: without it this passes
+    vacuously if the fit ever stops projecting at all."""
+
+    positive = 0
+    for left in (60.0, 100.0, 119.0, 120.0, 130.0, 200.0):
+        for top in (0.0, 1.0, 100.0, 200.0):
+            zone = _Zone(left, 0.0, 120.0, top, iso_x=100.0, iso_y=100.0)
+            sheet = _Sheet(bounds=(50.0, 50.0, 150.0, 150.0))
+            for scale in _scales_handed_to_occ(monkeypatch, zone, sheet):
+                assert scale > 0.0, f"{zone} handed {scale} to the transform"
+                positive += 1
+
+    assert positive, "no zone in the sweep projected anything — the assertion never ran"
+
+
+def test_a_nan_factor_is_refused_although_it_is_not_less_than_zero(monkeypatch):
+    """`NaN <= 0.0` is False and OCC accepts a NaN scale silently, so the guard is spelled
+    `not factor > 0.0`. No reachable input produces NaN today; this pins the spelling."""
+
+    nan = float("nan")
+    mirrored = gp_Trsf()
+    mirrored.SetScale(gp_Pnt(0, 0, 0), nan)  # accepted, no exception
+
+    assert not (nan <= 0.0), "the reason `<= 0.0` would not be enough"
+    assert not nan > 0.0, "the spelling the guard uses does refuse it"
+
+
+# ── the authored-scale sibling path ───────────────────────────────────────────────────────
+
+
+def test_a_degenerate_zone_is_not_reported_as_an_infeasible_authored_scale(_zone_log):
+    """`_settle_iso_view` takes the authored-per-view-scale path, which never reaches
+    `_fit_iso_view` and so needs its own guard.
+
+    Without it, a zone the *engine* composed with no room raised "authored iso scale is
+    infeasible in its composed view zone" — a falsehood about the caller's input, since no
+    scale they could have written fits a zone of zero extent. That is the ADR 5 honesty rule:
+    a diagnostic must not assert something untrue about who is at fault.
+    """
+
+    from draftwright.builder import _settle_iso_view
+
+    # A stand-in rather than the drawing's own `Analysis`: reads of `Drawing._analysis` from
+    # tests are a shrinking ratchet (`test_private_test_attr_reads.py`), and this path needs
+    # only the zone plus the authored-scale selector.
+    zone = _Zone(0.0, 100.0, 200.0, 100.0, iso_x=100.0, iso_y=100.0)
+    zone.planned_iso_scale = 1.0  # selects the authored path over `_fit_iso_view`
+    zone.view_constraints = None
+
+    result = _settle_iso_view(_Sheet(), zone)
+
+    assert result is not None, "the authored iso is left as projected, not refused"
+    assert "has no room for any scale" in _zone_log.text
+    assert "authored iso scale" not in _zone_log.text, (
+        "the caller must not be blamed for a zone the engine composed"
+    )
+
+
+# ── platform facts the old handler rested on ──────────────────────────────────────────────
+
+
+def test_standard_construction_error_is_not_a_standard_failure():
+    """Pinned rather than assumed from the C++ hierarchy: a bindings change should be visible
+    here rather than silently re-enabling the path this issue is about."""
 
     assert not issubclass(Standard_ConstructionError, Standard_Failure)
     assert Standard_ConstructionError.__mro__[1] is Exception
@@ -89,72 +242,3 @@ def test_occ_rejects_a_zero_scale_but_silently_accepts_a_negative_one():
     assert mirrored.ScaleFactor() == pytest.approx(-1.96), (
         "a negative scale is accepted and mirrors the geometry — no exception on any platform"
     )
-
-
-@pytest.mark.parametrize(
-    ("needed", "factor"),
-    [
-        (0.0, 0.0),  # collapsed zone
-        (1e-9, 0.0),  # rounds to zero at the shrink branch's 4 dp
-        (0.004, 0.0039),  # smallest positive that survives that rounding
-        (-2.0, -1.96),  # inverted zone
-    ],
-)
-def test_the_shrink_arithmetic_can_produce_a_non_positive_factor(needed, factor):
-    """The arithmetic, isolated. `extent > 0` filters the ratio's numerator; nothing filtered
-    its counterpart, so a non-positive `needed` flowed straight through."""
-
-    assert math.floor(needed * 0.98 * 10000) / 10000 == pytest.approx(factor)
-
-
-def test_a_collapsed_zone_hands_no_scale_to_the_transform(monkeypatch):
-    zone = _Zone(120.0, 0.0, 120.0, 200.0, ISO_X=100.0, ISO_Y=100.0)
-
-    assert _factor_handed_to_occ(monkeypatch, zone) == [], (
-        "a zero-width zone has no scale that fits; the fit must return rather than project"
-    )
-
-
-def test_an_inverted_zone_hands_no_scale_to_the_transform(monkeypatch):
-    """A section sharing the iso's y-range raises the zone's left edge with no upper bound, so
-    it can pass the right edge. Before the guard this produced a NEGATIVE factor, which OCC
-    accepts — a mirrored iso on a delivered sheet, with no error on any platform."""
-
-    zone = _Zone(140.0, 0.0, 120.0, 200.0, ISO_X=100.0, ISO_Y=100.0)
-
-    assert _factor_handed_to_occ(monkeypatch, zone) == []
-
-
-def test_a_zero_height_zone_hands_no_scale_to_the_transform(monkeypatch):
-    zone = _Zone(0.0, 100.0, 200.0, 100.0, ISO_X=100.0, ISO_Y=100.0)
-
-    assert _factor_handed_to_occ(monkeypatch, zone) == []
-
-
-def test_an_overflowing_iso_still_gets_a_positive_scale(monkeypatch):
-    """The guard must not refuse work that fits. A genuinely overflowing iso in a real zone is
-    the shrink branch's own case, and it must still reach the transform — with a factor OCC
-    will accept."""
-
-    zone = _Zone(90.0, 90.0, 110.0, 110.0, ISO_X=100.0, ISO_Y=100.0)
-    sheet = _Sheet(bounds=(50.0, 50.0, 150.0, 150.0))  # iso is far larger than its zone
-
-    handed = _factor_handed_to_occ(monkeypatch, zone, sheet)
-
-    assert handed, "an overflowing iso must still be rescaled"
-    assert all(scale > 0.0 for scale in handed), f"non-positive scale reached OCC: {handed}"
-    gp_Trsf().SetScale(gp_Pnt(0, 0, 0), handed[-1] / zone.SCALE)  # OCC accepts it
-
-
-def test_every_zone_either_projects_a_positive_scale_or_projects_nothing(monkeypatch):
-    """The invariant itself, swept over degenerate and ordinary zones together."""
-
-    zones = [
-        _Zone(left, 0.0, 120.0, top, ISO_X=100.0, ISO_Y=100.0)
-        for left in (60.0, 100.0, 119.0, 120.0, 130.0, 200.0)
-        for top in (0.0, 1.0, 100.0, 200.0)
-    ]
-
-    for zone in zones:
-        for scale in _factor_handed_to_occ(monkeypatch, zone):
-            assert scale > 0.0, f"zone {zone} handed {scale} to the transform"


### PR DESCRIPTION
Closes #1395. Replaces #1467, which GitHub auto-closed when its base branch (`feat/1460-inspect-step`) was deleted on #1464's merge; this is the same work rebased onto `main`, plus the fixes from that PR's three reviews.

## One unguarded computation, three outcomes

`_fit_iso_view` scales the isometric to fit its page zone:

```python
ratios = [avail / extent for extent, avail in (...) if extent > 0]
needed = min(ratios, default=1.0)
factor = math.floor(needed * 0.98 * 10000) / 10000
_project_iso(dwg, a, a.SCALE * factor)      # -> _scale_world -> gp_Trsf.SetScale
```

`extent > 0` filters the ratio's numerator. Nothing filtered its counterpart, so a zone with no room flows straight through:

| `factor` | OCC |
|---|---|
| `0.0` | `Standard_Failure` on macOS |
| `0.0` | `Standard_ConstructionError` on Linux — a class that does **not** subclass `Standard_Failure` |
| negative | **accepted** — the iso is mirrored through the origin, silently, on every platform |

Whether either exception is caught depends on *where* the fit runs: the `except (ValueError, Standard_Failure)` handlers wrap **candidate** builds, and `_settle_iso_view` runs outside them. So on that path the zero case aborts `build_drawing` on macOS too — measured, not assumed.

The negative case is the worst and the issue's own reproduction cannot reach it; both failures it reports are the zero one.

## How a zone ends up with no room

Two mechanisms, and **the reported one is not the section bump**:

- `_largest_empty_rect` answers "no gap" with a floating-point sliver. The issue's own trace is `region = (10.0, 117.083, 146.0, 117.083)` — 136 mm wide, **1.4e-14 mm tall**.
- Separately, a section sharing the iso's y-range raises `region_left` with no upper bound, which can pass `iso_right_limit` and invert the *width*.

## The fix

Guard the computation, not the exception: a non-positive scale is a layout fact known before any transform, so the fit leaves the iso at sheet scale and the candidate search continues.

Deliberately **not** by widening the handler to catch `Standard_ConstructionError` — that addresses the least severe of the three outcomes and leaves the silent mirror in place, because that path never raises.

Spelled `not factor > 0.0` rather than `factor <= 0.0` so NaN is refused too: OCC accepts a NaN scale silently and `NaN <= 0.0` is `False`.

**One guard, not two.** The first cut also refused a degenerate region early. The two are **not** logically equivalent — neither contains the other: this one additionally catches a positive but vanishing `needed`, while a shape check would additionally catch an inverted zone whose iso bbox has zero extent on the inverted axis (so `extent > 0` filters both offending ratios). That second case needs a projected solid whose isometric bbox is a line and has never been observed; the first is what the corpus actually produces. So one guard is the right answer — but on those grounds, not on the "redundant" claim an earlier revision of this description made.

## A sibling defect in the same class

`builder._settle_iso_view` takes the authored-per-view-scale path and never reaches `_fit_iso_view`. On a degenerate zone it raised *"authored iso scale is infeasible in its composed view zone"* — a falsehood about the caller's input, since no scale they could have written fits a zone of zero extent. It now reports what is actually wrong and leaves the authored scale alone.

## Coverage

- **End-to-end through the public API** — `Cylinder(4,30) + Pos(0,0,15)*Cylinder(6,6) - Cylinder(1.5,60)` at 10:1 on A4 raises `Standard_Failure` out of `build_drawing` unfixed, builds in 0.8 s fixed. Asserts the issue's two stated criteria: the run does not abort, and the required views survive.
- All four degenerate shapes — zero width, zero height, collapsed, inverted — each asserting *which* mechanism refused it and recording the factor the unfixed code produces.
- A broad sweep asserting no zone hands a non-positive scale to the transform, **and** that it projected something (without the second assertion it passes vacuously).
- The negative control: an overflowing iso is still rescaled with a factor OCC accepts.
- The `Standard_ConstructionError` hierarchy pinned, so a bindings change is visible rather than silently re-enabling the old path.

Six tests fail when the projection guard is removed; one when the builder guard is.

## Review history

Three reviews on #1467 found, among other things, **three false claims I had written** — the wrong root cause, "caught on macOS", and "no public-API reproduction exists". All three are corrected here. They also found a sweep test that ran its assertion zero times, four tautological arithmetic tests that re-implemented the formula under test, and assertions that could not distinguish this guard from an unrelated early return. All fixed.

## Gate

Full local gate before the rebase: **6,724 passed**, exit 0, coverage 95.94%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QvMGnxHKZGRHcfo3aV3sj4
