### PR TITLE
Begin SectionRecess migration with pocket parity baseline

### DIFF
--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -95,11 +95,10 @@ validate result-local references, bind exact same-run occurrences, migrate patte
 refusals, and update independent lint, reports and inspection together. A build already holding an
 aggregate must project it rather than invoke the document builder for a second recognition run.
 
-Adoption is currently blocked by [Quiddity #505](https://github.com/pzfreo/quiddity/issues/505):
-the released provider reads `.area` from a build123d 0.10 `ShapeList` while proving support, so
-ordinary pocket recognition raises before this adapter runs. The compatibility tests retain
-that failure; the migration needs a released provider fix before it can pass Draftwright's
-supported Python/build123d matrix.
+The comparison pins Quiddity 0.2.1, which fixes
+[Quiddity #505](https://github.com/pzfreo/quiddity/issues/505): support proofs now handle
+build123d 0.10 `ShapeList` boolean results. The pocket corpus exercises this public recognition
+path across the supported Python/build123d matrix before consumer adaptation.
 
 `bosses` is the fully consumed reference family. `repeating-radial-profiles` is the opposite
 reference: it remains geometry-only critique evidence for a separately authored gear declaration,

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -70,6 +70,37 @@ issue. The contract test derives package record outputs, converter registries, l
 and emitter branches independently, so copying a new name into the declaration alone cannot make CI
 pass.
 
+### Quiddity migration baseline
+
+The first [#1471](https://github.com/pzfreo/draftwright/issues/1471) migration slice tests the
+released Quiddity SectionRecess document against the existing authored pocket corpus. Quiddity is
+pinned in the development dependencies for this comparison. Production continues to use the
+existing recogniser dependency and capability declaration.
+
+The private pocket adapter in `model/detect.py` reads primitive schema-2 occurrence geometry and
+produces the existing `PocketFeature`. It admits principal-axis closed rectangles and open
+rectangular corner/edge chains, preserves the opening direction, and refuses unsupported shapes,
+sloped ends, invalid frames and malformed measurements. An open chain remains edge-anchored; its
+missing boundary is never reconstructed as a physical edge.
+
+`tests/test_issue_1471_section_recess_pockets.py` checks independently authored dimensions,
+opposed and side openings, disconnected bodies, topology variants, the existing drawing path,
+executed generated Sheet scripts and authored omission. The baseline tests for pocket patterns,
+channels and both blind-slot families remain the acceptance floor for their later adapters.
+
+This is preparation for adoption, not a new automatic detection mode. The adapter does not yet
+participate in the production registry, bind occurrence ownership or provide Quiddity-based lint.
+Its comparison drawings use the pinned provider for physical critique. The eventual cutover must
+validate result-local references, bind exact same-run occurrences, migrate patterns and explicit
+refusals, and update independent lint, reports and inspection together. A build already holding an
+aggregate must project it rather than invoke the document builder for a second recognition run.
+
+Adoption is currently blocked by [Quiddity #505](https://github.com/pzfreo/quiddity/issues/505):
+the released provider reads `.area` from a build123d 0.10 `ShapeList` while proving support, so
+ordinary pocket recognition raises before this adapter runs. The compatibility tests retain
+that failure; the migration needs a released provider fix before it can pass Draftwright's
+supported Python/build123d matrix.
+
 `bosses` is the fully consumed reference family. `repeating-radial-profiles` is the opposite
 reference: it remains geometry-only critique evidence for a separately authored gear declaration,
 with no inferred gear feature added to fill the table.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ dev = [
     "pytest-timeout>=2",
     "pytest-xdist>=3",
     # Released provider used by the migration parity tests; production remains on 0.4.14.
-    "quiddity==0.2.0",
+    "quiddity==0.2.1",
     "ruff>=0.4",
     "tomli>=2; python_version < '3.11'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,8 @@ dev = [
     "pytest-split>=0.8",
     "pytest-timeout>=2",
     "pytest-xdist>=3",
+    # Released provider used by the migration parity tests; production remains on 0.4.14.
+    "quiddity==0.2.0",
     "ruff>=0.4",
     "tomli>=2; python_version < '3.11'",
 ]

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -785,7 +785,7 @@ def _convert_section_recess_pocket(record: Mapping, *, schema_version: int) -> P
     length = world_bounds[span_index][1] - world_bounds[span_index][0]
     if not all(isfinite(n) for n in (*center, width, length, high - low)):
         raise ValueError("projected pocket measurements must be finite")
-    if width <= 0 or length <= 0:
+    if any(hi <= lo for lo, hi in world_bounds.values()):
         raise ValueError("projected pocket extents must remain positive")
     return PocketFeature(
         frame=Frame(origin=(center[0], center[1], center[2]), axis="xyz"[run_index]),

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -15,7 +15,7 @@ for any part.
 from __future__ import annotations
 
 from collections import Counter
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from contextvars import ContextVar
 from dataclasses import dataclass, replace
 from math import isfinite, ulp
@@ -625,6 +625,181 @@ def _member_pocket(pk: Pocket) -> PocketFeature:
 
 def _convert_pocket(pk: Pocket, ctx: ConvContext) -> PocketFeature:
     return _member_pocket(pk)
+
+
+class _UnsupportedSectionRecess(ValueError):
+    """Valid recess geometry outside the first migration adapter's drawing vocabulary."""
+
+
+def _section_object(value: object, keys: set[str], name: str) -> Mapping:
+    if not isinstance(value, Mapping) or set(value) != keys:
+        raise ValueError(f"{name} must contain exactly {sorted(keys)}")
+    return value
+
+
+def _section_numbers(value: object, count: int, name: str) -> tuple[float, ...]:
+    if (
+        not isinstance(value, (tuple, list))
+        or type(value) not in (tuple, list)
+        or len(value) != count
+    ):
+        raise ValueError(f"{name} must contain {count} finite numbers")
+    if any(type(item) not in (int, float) for item in value):
+        raise ValueError(f"{name} requires built-in non-boolean numbers")
+    try:
+        result = tuple(float(item) for item in value)
+    except OverflowError as exc:
+        raise ValueError(f"{name} must be finite") from exc
+    if not all(isfinite(item) for item in result):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _section_axis(vector: tuple[float, ...]) -> tuple[int, int]:
+    index = max(range(3), key=lambda i: abs(vector[i]))
+    sign = 1 if vector[index] > 0 else -1
+    if any(abs(value - (sign if i == index else 0)) > 1e-9 for i, value in enumerate(vector)):
+        raise _UnsupportedSectionRecess("pocket requires principal section and run directions")
+    return index, sign
+
+
+def _convert_section_recess_pocket(record: Mapping, *, schema_version: int) -> PocketFeature:
+    """Lower a schema-2 document's rectangular pocket into the existing drafting IR.
+
+    This private migration adapter consumes JSON primitives from a released SectionRecess.
+    It performs no recognition and returns no provider references. It is not yet wired into
+    production detection: the aggregate, ownership and independent lint cutover must land
+    together before the runtime dependency changes (#1471). The caller remains responsible
+    for validating result-local references and recording ownership from the exact source run.
+
+    Closed rectangles and open rectangular corner/edge cuts share the existing PocketFeature
+    grammar. Open cuts keep ``edge_anchored=True``; no closing edge is manufactured. Curved,
+    general polygonal, sloped-end and free-axis sections are explicitly refused by this slice.
+    """
+
+    if type(schema_version) is not int or schema_version != 2:
+        raise ValueError("unsupported SectionRecess schema version")
+    row = _section_object(
+        record, {"index", "body", "geometry", "classification", "evidence"}, "occurrence"
+    )
+    if any(type(row[key]) is not int or row[key] < 0 for key in ("index", "body")):
+        raise ValueError("occurrence and body indices must be non-negative integers")
+    evidence = _section_object(
+        row["evidence"], {"defining_faces", "constituent_faces"}, "evidence"
+    )
+    for refs in evidence.values():
+        if (
+            type(refs) not in (tuple, list)
+            or any(type(ref) is not int or ref < 0 for ref in refs)
+            or list(refs) != sorted(set(refs))
+        ):
+            raise ValueError("face references must be sorted unique non-negative integers")
+    if not evidence["defining_faces"] or not set(evidence["defining_faces"]) <= set(
+        evidence["constituent_faces"]
+    ):
+        raise ValueError("pocket requires defining faces contained in constituent faces")
+    classification = _section_object(
+        row["classification"], {"feature_kind", "section_shape"}, "classification"
+    )
+    kind, shape = classification["feature_kind"], classification["section_shape"]
+    if (kind, shape) not in (("pocket", "rectangular"), ("edge_open_recess", "polygonal")):
+        raise _UnsupportedSectionRecess("recess is outside the rectangular pocket vocabulary")
+    geometry = _section_object(
+        row["geometry"], {"type", "frame", "run_interval", "profile", "ends"}, "geometry"
+    )
+    if geometry["type"] != "section_recess":
+        raise ValueError("expected section_recess geometry")
+    frame = _section_object(geometry["frame"], {"origin", "run", "u", "v"}, "frame")
+    origin = _section_numbers(frame["origin"], 3, "frame origin")
+    run, u, v = (_section_numbers(frame[key], 3, key) for key in ("run", "u", "v"))
+    run_index, run_sign = _section_axis(run)
+    u_index, u_sign = _section_axis(u)
+    v_index, v_sign = _section_axis(v)
+    if len({run_index, u_index, v_index}) != 3:
+        raise ValueError("section frame directions must be perpendicular")
+    cross = (u[1] * v[2] - u[2] * v[1], u[2] * v[0] - u[0] * v[2], u[0] * v[1] - u[1] * v[0])
+    if any(abs(a - b) > 1e-9 for a, b in zip(cross, run)):
+        raise ValueError("section frame must be right-handed")
+    low, high = _section_numbers(geometry["run_interval"], 2, "run interval")
+    if high <= low:
+        raise ValueError("run interval must increase")
+    ends = _section_object(geometry["ends"], {"low", "high"}, "ends")
+    conditions = []
+    for key in ("low", "high"):
+        end = _section_object(ends[key], {"condition", "gradient"}, "end")
+        conditions.append(end["condition"])
+        if any(_section_numbers(end["gradient"], 2, "end gradient")):
+            raise _UnsupportedSectionRecess("pocket requires perpendicular run ends")
+    if sorted(conditions, key=str) != ["capped", "open"]:
+        raise ValueError("pocket requires exactly one capped and one open end")
+
+    edge_anchored = kind == "edge_open_recess"
+    profile = _section_object(
+        geometry["profile"],
+        {"closure", "boundary", "opening"} if edge_anchored else {"closure", "boundary"},
+        "profile",
+    )
+    if profile["closure"] != ("open" if edge_anchored else "closed"):
+        raise ValueError("profile closure disagrees with pocket classification")
+    boundary = profile["boundary"]
+    if type(boundary) not in (tuple, list) or len(boundary) not in (
+        (3, 4) if edge_anchored else (4,)
+    ):
+        raise _UnsupportedSectionRecess("pocket requires a rectangular boundary or open chain")
+    points = []
+    for item in boundary:
+        vertex = _section_object(item, {"point", "bulge"}, "profile vertex")
+        point = _section_numbers(vertex["point"], 2, "profile point")
+        if _section_numbers([vertex["bulge"]], 1, "bulge")[0] != 0:
+            raise _UnsupportedSectionRecess("curved profiles need their own drafting semantics")
+        points.append(point)
+    if edge_anchored:
+        opening = profile["opening"]
+        if type(opening) not in (tuple, list) or len(opening) != 2:
+            raise ValueError("opening must join the two loose endpoints")
+        endpoints = tuple(_section_numbers(point, 2, "opening point") for point in opening)
+        if endpoints != (points[-1], points[0]):
+            raise ValueError("opening must join the two loose endpoints")
+    bounds = [(min(p[i] for p in points), max(p[i] for p in points)) for i in range(2)]
+    if any(hi <= lo for lo, hi in bounds):
+        raise ValueError("pocket section must have positive extents")
+    if len(set(points)) != len(points) or any(
+        p[0] not in bounds[0] or p[1] not in bounds[1] for p in points
+    ):
+        raise _UnsupportedSectionRecess("profile does not follow rectangular supports")
+    chain = points if edge_anchored else [*points, points[0]]
+    if any(sum(a[i] != b[i] for i in range(2)) != 1 for a, b in zip(chain, chain[1:])):
+        raise _UnsupportedSectionRecess("profile contains a diagonal or crossing support")
+
+    world_bounds = {
+        run_index: sorted(origin[run_index] + run_sign * n for n in (low, high)),
+        u_index: sorted(origin[u_index] + u_sign * n for n in bounds[0]),
+        v_index: sorted(origin[v_index] + v_sign * n for n in bounds[1]),
+    }
+    span_index = max(
+        (u_index, v_index), key=lambda i: (world_bounds[i][1] - world_bounds[i][0], i)
+    )
+    width_index = v_index if span_index == u_index else u_index
+    center = tuple(lo / 2 + hi / 2 for lo, hi in (world_bounds[i] for i in range(3)))
+    width = world_bounds[width_index][1] - world_bounds[width_index][0]
+    length = world_bounds[span_index][1] - world_bounds[span_index][0]
+    if not all(isfinite(n) for n in (*center, width, length, high - low)):
+        raise ValueError("projected pocket measurements must be finite")
+    if width <= 0 or length <= 0:
+        raise ValueError("projected pocket extents must remain positive")
+    return PocketFeature(
+        frame=Frame(origin=(center[0], center[1], center[2]), axis="xyz"[run_index]),
+        width_axis="xyz"[width_index],
+        long_axis="xyz"[span_index],
+        width=width,
+        length=length,
+        depth=high - low,
+        w_center=center[width_index],
+        lo=world_bounds[span_index][0],
+        hi=world_bounds[span_index][1],
+        edge_anchored=edge_anchored,
+        open_sign=run_sign * (1 if conditions[1] == "open" else -1),
+    )
 
 
 def _convert_channel(channel: Channel, ctx: ConvContext) -> ChannelFeature:

--- a/tests/test_issue_1471_section_recess_pockets.py
+++ b/tests/test_issue_1471_section_recess_pockets.py
@@ -1,0 +1,351 @@
+"""First Quiddity migration slice: released geometry against authored pocket facts.
+
+The two providers run separately for comparison. Only primitive JSON enters the new adapter;
+the declared-model drawing still uses the pinned production provider for physical lint. This
+proves the new pocket lowering and existing back end, not completion of provider adoption.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+import quiddity
+from build123d import Box, Pos, import_step
+
+from draftwright import Sheet, build_drawing
+from draftwright.audit import diff_builds
+from draftwright.model.detect import (
+    _convert_section_recess_pocket,
+    _UnsupportedSectionRecess,
+)
+from draftwright.sheet_emit import emit_sheet_script
+
+_CORPUS = Path(__file__).parent / "fixtures/evaluation/corpus-pockets-v1.json"
+_CASES = json.loads(_CORPUS.read_text())["cases"]
+
+
+def _parameters(feature):
+    return {
+        "width": feature.width,
+        "length": feature.length,
+        "depth": feature.depth,
+        "edge_anchored": feature.edge_anchored,
+    }
+
+
+@pytest.fixture(scope="module", params=_CASES, ids=lambda case: case["id"])
+def pocket_case(request):
+    case = request.param
+    path = _CORPUS.parent / case["fixture"]
+    assert hashlib.sha256(path.read_bytes()).hexdigest() == case["sha256"]
+    part = import_step(path)
+    result = quiddity.build_section_recess_document(part).to_dict()
+    converted = []
+    refused = []
+    for source in result["occurrences"]:
+        try:
+            converted.append(
+                _convert_section_recess_pocket(source, schema_version=result["schema_version"])
+            )
+        except _UnsupportedSectionRecess:
+            refused.append(source)
+    assert not result["refusals"]
+    return case, path, part, result, converted, refused
+
+
+def test_released_pockets_match_the_independently_authored_corpus(pocket_case):
+    case, _path, _part, _result, converted, refused = pocket_case
+    assert len(converted) == len(case["facts"])
+    assert len(refused) == (1 if case["id"] == "pocket-prismatic-owner-negative" else 0)
+    remaining = list(converted)
+    for fact in case["facts"]:
+        expected = fact["identity"]
+        matches = [
+            feature
+            for feature in remaining
+            if feature.frame.origin == pytest.approx(expected["location"]["value"], abs=1e-6)
+        ]
+        assert len(matches) == 1
+        feature = matches[0]
+        remaining.remove(feature)
+        assert feature.frame.axis == expected["depth_axis"]["value"]
+        assert feature.long_axis == expected["long_axis"]["value"]
+        assert feature.width_axis == expected["width_axis"]["value"]
+        assert feature.open_sign == expected["open_sign"]["value"]
+        for name, value in _parameters(feature).items():
+            assert value == fact["parameters"][name]["value"]
+    assert remaining == []
+
+
+def test_pocket_lowering_preserves_drawing_and_generated_sheet(pocket_case, tmp_path):
+    case, path, _part, _result, converted, _refused = pocket_case
+    before = build_drawing(path)
+    model = before.model()
+    old_pockets = [feature for feature in model.features if feature.kind == "pocket"]
+    # Equality covers the entire consumer geometry, not merely parameter values. Ordering is
+    # not a cross-provider promise; establish one-to-one equality before replacing each owner.
+    assert len(old_pockets) == len(converted)
+    remaining = list(converted)
+    features = []
+    for feature in model.features:
+        if feature.kind == "pocket":
+            match = next(candidate for candidate in remaining if candidate == feature)
+            remaining.remove(match)
+            features.append(match)
+        else:
+            features.append(feature)
+    assert not remaining
+    candidate = replace(model, features=features)
+    after = build_drawing(path, model=candidate)
+    delta = diff_builds(before, after)
+    assert delta["dimensions_lost"] == {}
+    assert delta["dimensions_gained"] == {}
+    assert delta["dimensions_changed"] == {}
+    assert delta["measurements_substituted"] == {}
+    assert [(i.severity, i.code) for i in after.lint()] == [
+        (i.severity, i.code) for i in before.lint()
+    ]
+
+    source = emit_sheet_script(
+        candidate,
+        f"from build123d import import_step\npart = import_step({str(path)!r})",
+        str(tmp_path / case["id"]),
+        title=case["id"],
+        number="1471",
+        formats=(),
+    )
+    namespace = {"__name__": "__migration_test__"}
+    exec(compile(source, "<generated migration sheet>", "exec"), namespace)
+    rebuilt = namespace["drawing"]
+    generated = [feature for feature in rebuilt.model().features if feature.kind == "pocket"]
+    assert sorted(generated, key=lambda feature: feature.frame.origin) == sorted(
+        converted, key=lambda feature: feature.frame.origin
+    )
+    assert not [issue for issue in rebuilt.lint() if issue.code == "pocket_requirement_missing"]
+
+
+def _record():
+    """Independently specified 30 x 12 x 6 pocket opening toward +Z."""
+    return {
+        "index": 0,
+        "body": 0,
+        "geometry": {
+            "type": "section_recess",
+            "frame": {
+                "origin": [22.0, -11.0, 0.0],
+                "run": [0.0, 0.0, 1.0],
+                "u": [1.0, 0.0, 0.0],
+                "v": [0.0, 1.0, 0.0],
+            },
+            "run_interval": [4.0, 10.0],
+            "profile": {
+                "closure": "closed",
+                "boundary": [
+                    {"point": [-15.0, -6.0], "bulge": 0.0},
+                    {"point": [15.0, -6.0], "bulge": 0.0},
+                    {"point": [15.0, 6.0], "bulge": 0.0},
+                    {"point": [-15.0, 6.0], "bulge": 0.0},
+                ],
+            },
+            "ends": {
+                "low": {"condition": "capped", "gradient": [0.0, 0.0]},
+                "high": {"condition": "open", "gradient": [0.0, 0.0]},
+            },
+        },
+        "classification": {"feature_kind": "pocket", "section_shape": "rectangular"},
+        "evidence": {"defining_faces": [0, 1, 2, 3], "constituent_faces": [0, 1, 2, 3, 4]},
+    }
+
+
+def test_migration_corpus_keeps_its_independent_denominator():
+    assert len(_CASES) == 10
+    assert sum(len(case["facts"]) for case in _CASES) == 13
+
+
+def _change(record, path, value):
+    target = record
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = value
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("index",), True),
+        (("body",), -1),
+        (("evidence", "defining_faces"), []),
+        (("evidence", "defining_faces"), [99]),
+        (("evidence", "constituent_faces"), [1, 0]),
+        (("evidence", "constituent_faces"), [False, 1, 2, 3]),
+        (("geometry", "type"), "pocket"),
+        (("geometry", "frame", "origin"), [0, 0]),
+        (("geometry", "frame", "origin", 0), True),
+        (("geometry", "frame", "origin", 0), float("nan")),
+        (("geometry", "frame", "origin", 0), 10**1000),
+        (("geometry", "frame", "u"), [0, 0, 1]),
+        (("geometry", "frame", "v"), [0, -1, 0]),
+        (("geometry", "run_interval"), [10, 4]),
+        (("geometry", "ends", "high", "condition"), "capped"),
+        (("geometry", "profile", "closure"), "open"),
+        (("geometry", "profile", "boundary", 0), {"point": [0, 0]}),
+        (("geometry", "profile", "boundary", 0, "bulge"), "0"),
+        (("geometry", "profile", "boundary", 0, "point"), [0, float("inf")]),
+    ],
+)
+def test_malformed_geometry_cannot_enter_the_ir(path, value):
+    record = _record()
+    assert _convert_section_recess_pocket(record, schema_version=2).width == 12
+    _change(record, path, value)
+    with pytest.raises(ValueError):
+        _convert_section_recess_pocket(record, schema_version=2)
+
+
+@pytest.mark.parametrize("version", [1, 3, True, 2.0, "2"])
+def test_only_the_released_schema_is_admitted(version):
+    with pytest.raises(ValueError, match="schema"):
+        _convert_section_recess_pocket(_record(), schema_version=version)
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("classification", "section_shape"), "obround"),
+        (("geometry", "frame", "u"), [0.8, 0.6, 0]),
+        (("geometry", "ends", "low", "gradient"), [0.1, 0]),
+        (("geometry", "profile", "boundary", 0, "bulge"), 1.0),
+        (("geometry", "profile", "boundary", 0, "point"), [-10, 0]),
+        (("geometry", "profile", "boundary"), []),
+    ],
+)
+def test_unsupported_sections_are_not_replaced_by_bounding_rectangles(path, value):
+    record = _record()
+    _change(record, path, value)
+    with pytest.raises(_UnsupportedSectionRecess):
+        _convert_section_recess_pocket(record, schema_version=2)
+
+
+def test_negative_run_and_reversed_profile_keep_the_physical_pocket():
+    record = _record()
+    expected = _convert_section_recess_pocket(record, schema_version=2)
+    frame = record["geometry"]["frame"]
+    frame["run"] = [0, 0, -1]
+    frame["v"] = [0, -1, 0]
+    record["geometry"]["run_interval"] = [-10, -4]
+    record["geometry"]["ends"] = {
+        "low": {"condition": "open", "gradient": [0, 0]},
+        "high": {"condition": "capped", "gradient": [0, 0]},
+    }
+    for vertex in record["geometry"]["profile"]["boundary"]:
+        vertex["point"][1] *= -1
+    assert _convert_section_recess_pocket(record, schema_version=2) == expected
+
+
+def test_crossing_vertex_order_is_refused():
+    record = _record()
+    boundary = record["geometry"]["profile"]["boundary"]
+    boundary[1], boundary[2] = boundary[2], boundary[1]
+    with pytest.raises(_UnsupportedSectionRecess, match="diagonal"):
+        _convert_section_recess_pocket(record, schema_version=2)
+
+
+def test_adapter_does_not_mutate_or_retain_provider_json():
+    record = _record()
+    original = copy.deepcopy(record)
+    feature = _convert_section_recess_pocket(record, schema_version=2)
+    assert record == original
+    record["geometry"]["run_interval"][1] = 100
+    assert feature.depth == 6
+    assert feature.frame.origin == (22, -11, 7)
+
+
+def _open_record(*, corner=True):
+    record = _record()
+    record["classification"] = {"feature_kind": "edge_open_recess", "section_shape": "polygonal"}
+    profile = record["geometry"]["profile"]
+    profile["closure"] = "open"
+    if corner:
+        profile["boundary"].pop()
+    profile["opening"] = [profile["boundary"][-1]["point"], profile["boundary"][0]["point"]]
+    return record
+
+
+@pytest.mark.parametrize("corner", [True, False])
+def test_open_corner_and_edge_keep_only_the_existing_pocket_measurements(corner):
+    feature = _convert_section_recess_pocket(_open_record(corner=corner), schema_version=2)
+    assert _parameters(feature) == {"width": 12, "length": 30, "depth": 6, "edge_anchored": True}
+    assert feature.frame.origin == (22, -11, 7)
+    assert feature.open_sign == 1
+
+
+@pytest.mark.parametrize("opening", [[], [[0, 0], [1, 1]]])
+def test_opening_must_reference_the_observed_loose_endpoints(opening):
+    record = _open_record()
+    record["geometry"]["profile"]["opening"] = opening
+    with pytest.raises(ValueError, match="loose endpoints"):
+        _convert_section_recess_pocket(record, schema_version=2)
+
+
+def test_zero_section_and_unrepresentable_world_extents_are_refused():
+    record = _record()
+    for vertex in record["geometry"]["profile"]["boundary"]:
+        vertex["point"][0] = 0
+    with pytest.raises(ValueError, match="positive extents"):
+        _convert_section_recess_pocket(record, schema_version=2)
+    record = _record()
+    record["geometry"]["frame"]["origin"][0] = 1e308
+    with pytest.raises(ValueError, match="remain positive"):
+        _convert_section_recess_pocket(record, schema_version=2)
+    record = _record()
+    record["geometry"]["run_interval"] = [-1e308, 1e308]
+    with pytest.raises(ValueError, match="must be finite"):
+        _convert_section_recess_pocket(record, schema_version=2)
+
+
+def test_lowering_an_existing_document_does_not_recognise_again(monkeypatch):
+    import b123d_recognisers
+
+    import draftwright.model.detect as detect
+
+    def forbidden(*args, **kwargs):
+        pytest.fail("the adapter must only project its supplied document")
+
+    monkeypatch.setattr(quiddity, "build_section_recess_document", forbidden)
+    monkeypatch.setattr(quiddity, "build_raw_recognition_result", forbidden)
+    monkeypatch.setattr(b123d_recognisers, "build_raw_recognition_result", forbidden)
+    monkeypatch.setattr(detect, "build_recognition_evidence", forbidden)
+    assert _convert_section_recess_pocket(_record(), schema_version=2).depth == 6
+
+
+def test_declared_omission_still_withholds_the_whole_pocket_callout():
+    part = Box(100, 60, 20) - Pos(22, -11, 7) * Box(30, 12, 6)
+    feature = _convert_section_recess_pocket(_record(), schema_version=2)
+
+    def callouts(parameters):
+        sheet = Sheet(part)
+        sheet.authored_dimensions()
+        handle = sheet.pocket(
+            **_parameters(feature),
+            long_axis=feature.long_axis,
+            width_axis=feature.width_axis,
+            depth_axis=feature.frame.axis,
+            at=feature.frame.origin,
+            w_center=feature.w_center,
+            lo=feature.lo,
+            hi=feature.hi,
+            open_sign=feature.open_sign,
+        )
+        for parameter in parameters:
+            sheet.dimension(handle, parameter)
+        drawing = sheet.build()
+        return [name for name in drawing.annotations() if name.startswith("m_pocket_")]
+
+    assert (
+        len(callouts(("pocket_width.length", "pocket_length.length", "pocket_depth.length"))) == 1
+    )
+    assert callouts(("pocket_width.length",)) == []

--- a/tests/test_issue_1471_section_recess_pockets.py
+++ b/tests/test_issue_1471_section_recess_pockets.py
@@ -349,3 +349,13 @@ def test_declared_omission_still_withholds_the_whole_pocket_callout():
         len(callouts(("pocket_width.length", "pocket_length.length", "pocket_depth.length"))) == 1
     )
     assert callouts(("pocket_width.length",)) == []
+
+
+@pytest.mark.parametrize("axis", [0, 1, 2])
+def test_translation_must_not_collapse_any_world_extent(axis):
+    record = _record()
+    record["geometry"]["frame"]["origin"][axis] = 1e308
+    # Adding the finite local extent cannot change this floating-point coordinate.
+    assert 1e308 + 30 == 1e308
+    with pytest.raises(ValueError, match="remain positive"):
+        _convert_section_recess_pocket(record, schema_version=2)

--- a/uv.lock
+++ b/uv.lock
@@ -782,7 +782,7 @@ dev = [
     { name = "pytest-split", specifier = ">=0.8" },
     { name = "pytest-timeout", specifier = ">=2" },
     { name = "pytest-xdist", specifier = ">=3" },
-    { name = "quiddity", specifier = "==0.2.0" },
+    { name = "quiddity", specifier = "==0.2.1" },
     { name = "ruff", specifier = ">=0.4" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2" },
 ]
@@ -2592,15 +2592,15 @@ wheels = [
 
 [[package]]
 name = "quiddity"
-version = "0.2.0"
+version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/f2/024b4a77613075b49a001e2d44496b063f82c6aa91c952ff80bd0089b519/quiddity-0.2.0.tar.gz", hash = "sha256:ceb152a7e7009eccdb1ba548ac91a62f85ad298cf4d0e4a30e0a0149245c9d31", size = 13749033, upload-time = "2026-09-05T16:27:33.001Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/fd/cc5f0db511da23d4e99ee41a6f881212e11516779fbb73651cad0e8b0c60/quiddity-0.2.1.tar.gz", hash = "sha256:d30ba4d92eaf7e934e6e012a4d69f290f408e2159fb4fae9cd762ba366835693", size = 13764527, upload-time = "2026-09-06T00:32:08.899Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/d7/c9d2fdbfc0ed1f9d65b713426701e568ea0a558ca5c426ec2b49b8992b98/quiddity-0.2.0-py3-none-any.whl", hash = "sha256:d2fd89d031b8ad955045615b5cdfabb506a6547fcaf89905d7f97e3e82242c57", size = 462108, upload-time = "2026-09-05T16:27:31.25Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e5/bf380667467987d06b8c10b864cb188b7d149d7f9f8fa54b7150e6507664/quiddity-0.2.1-py3-none-any.whl", hash = "sha256:947867ad028412a1cef272ce29f48b0583d2a8009dea13b2b59be58abdb1df30", size = 466048, upload-time = "2026-09-06T00:32:06.499Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -745,6 +745,7 @@ dev = [
     { name = "pytest-split" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
+    { name = "quiddity" },
     { name = "ruff" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
@@ -781,6 +782,7 @@ dev = [
     { name = "pytest-split", specifier = ">=0.8" },
     { name = "pytest-timeout", specifier = ">=2" },
     { name = "pytest-xdist", specifier = ">=3" },
+    { name = "quiddity", specifier = "==0.2.0" },
     { name = "ruff", specifier = ">=0.4" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2" },
 ]
@@ -2586,6 +2588,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
+name = "quiddity"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/f2/024b4a77613075b49a001e2d44496b063f82c6aa91c952ff80bd0089b519/quiddity-0.2.0.tar.gz", hash = "sha256:ceb152a7e7009eccdb1ba548ac91a62f85ad298cf4d0e4a30e0a0149245c9d31", size = 13749033, upload-time = "2026-09-05T16:27:33.001Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/d7/c9d2fdbfc0ed1f9d65b713426701e568ea0a558ca5c426ec2b49b8992b98/quiddity-0.2.0-py3-none-any.whl", hash = "sha256:d2fd89d031b8ad955045615b5cdfabb506a6547fcaf89905d7f97e3e82242c57", size = 462108, upload-time = "2026-09-05T16:27:31.25Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Quiddity replaces the old specialised recess records with SectionRecess schema 2. This first migration slice establishes pocket parity before the production provider changes: a private adapter in `model/detect.py` lowers supported rectangular pockets and open rectangular chains into the existing immutable PocketFeature.

Part of #1471. This PR does not complete the production migration.

## Scope

- Pin Quiddity as a development-only comparison dependency; production remains on `b123d-recognisers==0.4.14`.
- Validate schema, evidence references, principal frames, profile supports, ends and finite positive world extents. Explicitly refuse unsupported geometry.
- Compare ten independently authored STEP cases containing thirteen expected pocket occurrences; check measurements, drawing parity, executed generated Sheet scripts, omission and refusal behavior.
- Keep the adapter disconnected from production until aggregate adoption, same-run ownership and independent Quiddity coverage are ready. Result-local roster validation remains the future caller's responsibility. The comparison's existing-provider lint is not proof of a Quiddity-based independent critic.

## Released crash fix and merge gate

Quiddity **0.2.1 is published on PyPI** and this PR now pins that exact development dependency and its hashed artifacts. On Python 3.10.20/build123d 0.10.0, the public pocket reproduction returns one occurrence and no refusals; the complete 64-test migration module passes. The same module also passes on Python 3.14.7/build123d 0.11.1. Production remains pinned to b123d-recognisers 0.4.14.

This component is included by its original commits in #1476. Merge that combined PR with a merge commit only after every component and combined check, including both Codecov statuses, is green, and final Google/all-five-ADR review has no substantive findings. Auto-merge remains disabled. Draftwright publication follows successful integration and release validation.

## Current validation

At `cf77606c`, using released Quiddity 0.2.1:

- Canonical full local gate: 6,811 passed, 5 skipped, 2 xfailed; 95.96% overall coverage and 100% changed-line coverage.
- Migration module: 64 passed on each of Python 3.10/build123d 0.10.0 and Python 3.14/build123d 0.11.1. The public crash reproduction also passes on both.
- Five verified mutations are caught: wrong width, opening sign, edge anchoring, curved-profile acceptance, and collapsed world depth.
- The existing-provider baseline and representative before/after drawing comparison remain recorded in #1471. Older-kernel compatibility now passes against the published fix.

## Google and ADR review

Reviewed design, functionality, complexity, tests, naming, comments, style and documentation. Review found that translation could collapse depth while the guard checked only width/length; the failing depth regression now passes, and restoring the old guard makes it fail again.

ADR 1: conversion remains at the existing IR boundary. ADR 2: existing shared placement consumes the unchanged PocketFeature grammar. ADR 3: the adapter performs no recognition and carries no provider objects into IR; runtime ownership is explicitly unfinished. ADR 4: generated declarations execute and omission behavior is checked. ADR 5: unsupported geometry and malformed evidence are refused, and the comparison's completeness limits are stated explicitly. No ADR text changes are needed. The 0.2.1 adoption changes only the development pin, artifact hashes and obsolete blocker documentation; review confirms that the adapter and production boundaries remain unchanged. Full local validation against the release exits 0, and all five repeated mutation checks are caught. Final local Google/all-five-ADR review has no substantive findings. Hosted CI and both Codecov statuses remain required before merge.
