### PR TITLE
Fix duplicate Sheet feature registration

### DIFF
--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -1170,8 +1170,11 @@ class Sheet:
     # -- feature declaration --------------------------------------------------
 
     def add(self, feature) -> _Params:
-        """Append a pre-built IR :class:`~draftwright.model.Feature` (escape hatch for
+        """Register a pre-built IR :class:`~draftwright.model.Feature` (escape hatch for
         the constructors this façade does not surface directly, e.g. PMI).
+
+        Adding the exact feature object already in :attr:`features` returns a handle to
+        its existing registration. Equal-valued distinct objects remain separate features.
 
         Returns a handle, like every declaration verb (#922). It matters here more than it
         looks: the ENVELOPE is emitted through this escape hatch rather than through
@@ -1181,6 +1184,10 @@ class Sheet:
         in the middle of the file, which is worse than being absent everywhere. A raw
         ``ControlFrame`` or ``DatumRef`` may name a handle as its ``origin``; ``add`` resolves
         and token-binds that provenance exactly like the public GD&T verbs."""
+        if isinstance(feature, Feature):
+            token = self._declared_token(feature, verb="add()")
+            if token is not None:
+                return _Params(self, self._index_of_token(token))
         src_token = None
         if (
             getattr(feature, "kind", None) in ("control_frame", "datum_ref", "note")

--- a/tests/test_issue_1390_sheet_registration.py
+++ b/tests/test_issue_1390_sheet_registration.py
@@ -1,0 +1,52 @@
+"""Repeated registration must not multiply manufacturing callout counts."""
+
+from dataclasses import replace
+
+import pytest
+from build123d import Axis, Box, Cylinder, Pos
+
+from draftwright import Sheet
+from draftwright.model import ChamferFeature, chamfer
+
+
+def test_add_returns_existing_registration_and_preserves_handle_after_reorder():
+    sheet = Sheet(Box(20, 20, 10)).authored_dimensions()
+    feature = chamfer(leg1=0.5, at=(0, 0, 5), axis="z")
+    first = sheet.add(feature)
+    second = sheet.add(feature)
+    assert len(sheet.features) == 1
+    sheet.add(replace(feature, leg1=1.0))
+    sheet.features.reverse()
+    sheet.dimension(second, "chamfer.length")
+    assert sheet.model().authored_dimensions[0].feature is feature
+    sheet.dimension(first, "chamfer.length")
+    assert len(sheet.features) == 2
+
+
+def test_equal_but_distinct_features_remain_distinct_registrations():
+    sheet = Sheet(Box(20, 20, 10)).authored_dimensions()
+    feature = chamfer(leg1=0.5, at=(0, 0, 5), axis="z")
+    other = replace(feature)
+    assert other == feature and other is not feature
+    sheet.add(feature)
+    sheet.add(other)
+    assert len(sheet.features) == 2
+    assert sheet.features[0] is feature and sheet.features[1] is other
+
+
+@pytest.mark.parametrize("repeat", [False, True])
+def test_detected_chamfer_keeps_single_rendered_count(repeat):
+    part = Cylinder(5, 10) + Pos(0, 0, 7.5) * Cylinder(2.5, 5)
+    part = part.chamfer(0.5, None, part.edges().group_by(Axis.Z)[0])
+    sheet = Sheet.from_part(part, scale=2, page="A4")
+    features = [f for f in sheet.features if isinstance(f, ChamferFeature)]
+    assert len(features) == 1
+    feature = features[0]
+    sheet.authored_dimensions()
+    target = sheet.add(feature) if repeat else feature
+    sheet.dimension(target, "chamfer.length")
+    drawing = sheet.build()
+    assert sum(isinstance(f, ChamferFeature) for f in drawing.model().features) == 1
+    annotations = drawing.annotations_of(feature)
+    labels = [a.label for a in annotations.values() if hasattr(a, "label")]
+    assert labels == ["C0.5"]


### PR DESCRIPTION
Repeated `Sheet.add(feature)` calls could register one feature twice and turn a single chamfer into a `2× C0.5` manufacturing instruction. Return a handle to the existing registration when the exact feature object is already managed by the sheet. Equal-valued distinct objects retain separate registrations.

Fixes #1390.

Validation: the regression fails twice on the original code; the fix passes 178 focused tests covering registration, rendered chamfer count, retained handles after reorder, GD&T and notes. The full local gate passes: 6,751 passed, 5 skipped, 2 xfailed; 95.94% overall coverage and 100% changed-line coverage. Hosted CI is pending.

Review: checked every changed line using Google's engineering-practices checklist. The correction uses the existing identity resolver and introduces no geometry matching. Reviewed all five live ADRs: the shared pipeline and placement are unchanged (1/2), no recognition is added (3), declared identity remains token-bound (4), and the rendered manufacturing count is tested (5). No ADR text change is required. Final review: no substantive findings remain. Disabling the reuse guard in memory makes the two duplicate-registration regressions fail (2 failed, 2 passed); the mutation was verified to apply. The final diff retains the documented identity semantics and has no unresolved required changes.
