### PR TITLE
Reject conflicting AP242 nominal ownership before planning

### DIFF
--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -289,3 +289,9 @@ drop, or missing ink is not hidden by the ownership choice.
 ::: draftwright.sheet._Control
     options:
       filters: public
+
+Imported AP242 nominal-diameter ownership requires absolute agreement within `1e-6`
+with the canonical feature diameter, using the same rule as planning. A larger mismatch
+keeps the original source value and identity in a blocked dimension; it does not replace
+the canonical value or crash planning. Generated Sheet scripts retain the blocker, and
+`authored_dim_source_unresolved` reports the withheld source dimension through lint.

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -454,6 +454,10 @@ class NominalRequirement:
     source: str
     source_ids: tuple[str, ...]
 
+    def agrees_with(self, value: float) -> bool:
+        """Whether a canonical value can carry this nominal without changing its meaning."""
+        return abs(float(value) - self.value) <= 1e-6
+
     def __post_init__(self) -> None:
         if isinstance(self.value, bool):
             raise ValueError("nominal requirement value must be finite and positive")

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -521,7 +521,7 @@ def _decorated(model: PartModel, feature: Feature, param: DimParameter) -> DimPa
     from draftwright.model.ir import NominalRequirement, ToleranceDecoration
 
     nominal = model.decorations.get((feature, "nominal_requirement", param.parameter_id))
-    if isinstance(nominal, NominalRequirement) and abs(float(param.value) - nominal.value) > 1e-6:
+    if isinstance(nominal, NominalRequirement) and not nominal.agrees_with(param.value):
         raise ValueError(
             f"{nominal.source} nominal requirement {nominal.value:g} disagrees with "
             f"{param.parameter_id}={param.value:g}"

--- a/src/draftwright/model/pmi_lowering.py
+++ b/src/draftwright/model/pmi_lowering.py
@@ -504,6 +504,7 @@ def lower_ap242_nominal_diameters(model: PartModel) -> PartModel:
         ],
     ] = {}
     blocked: dict[int, str] = {}
+    nominal_conflicts: set[int] = set()
     for dimension_index, dimension in dimensions.items():
         if dimension.lowering_blockers or dimension.rendering_blockers:
             continue
@@ -529,7 +530,19 @@ def lower_ap242_nominal_diameters(model: PartModel) -> PartModel:
             )
             continue
         owner = matches[0]
-        proposals[dimension_index] = (owner, _nominal_owner_key(owner))
+        key = _nominal_owner_key(owner)
+        nominal = NominalRequirement(
+            value=dimension.value, source="ap242_pmi", source_ids=_source_ids(dimension)
+        )
+        parameter = next(p for p in owner.parameters() if p.parameter_id == key[2])
+        if not nominal.agrees_with(parameter.value):
+            nominal_conflicts.add(dimension_index)
+            blocked[dimension_index] = (
+                f"source nominal {dimension.value!r} disagrees with canonical "
+                f"{parameter.parameter_id}={parameter.value!r}"
+            )
+            continue
+        proposals[dimension_index] = (owner, key)
 
     decorations = dict(model.decorations)
     consumed: set[int] = set()
@@ -543,9 +556,7 @@ def lower_ap242_nominal_diameters(model: PartModel) -> PartModel:
             )
             consumed.add(dimension_index)
             continue
-        if isinstance(existing, NominalRequirement) and _same_number(
-            existing.value, dimension.value
-        ):
+        if isinstance(existing, NominalRequirement) and existing.agrees_with(dimension.value):
             decorations[key] = replace(
                 existing,
                 source_ids=tuple(dict.fromkeys((*existing.source_ids, *incoming_ids))),
@@ -562,6 +573,10 @@ def lower_ap242_nominal_diameters(model: PartModel) -> PartModel:
             continue
         if index in blocked and isinstance(feature, AuthoredDimension):
             feature = _block(feature, blocked[index])
+            if index in nominal_conflicts:
+                feature = replace(
+                    feature, rendering_blockers=(*feature.rendering_blockers, blocked[index])
+                )
         rebuilt.append(feature)
     return _apply_standalone_cylinder_blockers(
         replace(model, features=rebuilt, decorations=decorations)

--- a/tests/test_issue_1325_nominal_agreement.py
+++ b/tests/test_issue_1325_nominal_agreement.py
@@ -1,0 +1,107 @@
+"""PMI lowering must not produce nominal ownership that the planner rejects."""
+
+from dataclasses import replace
+
+import pytest
+from build123d import Box
+
+from draftwright.model import plan_dimensions
+from draftwright.model.ir import (
+    AuthoredDimension,
+    CylindricalReference,
+    Frame,
+    NominalRequirement,
+    PartModel,
+    StepFeature,
+)
+from draftwright.model.pmi_lowering import lower_ap242_nominal_diameters
+
+
+def _model(nominal, diameter):
+    frame = Frame((0, 0, 0), "z")
+    owner = StepFeature(frame=frame, length=10, diameter=diameter, span=((0, 0, -5), (0, 0, 5)))
+    dimension = AuthoredDimension(
+        frame=frame,
+        dimension_kind="diameter",
+        value=nominal,
+        label=f"ø{nominal:g}",
+        dominant_axis="Z",
+        ref_pts=((0, 0, 0),),
+        source_id="dimension:1325",
+        cylindrical_refs=(
+            CylindricalReference(
+                axis_origin=(0, 0, 0),
+                axis_direction=(0, 0, 1),
+                radius=diameter / 2,
+                axial_interval=(-5, 5),
+                sense="external",
+            ),
+        ),
+    )
+    return PartModel(Box(20, 20, 10).bounding_box(), "z", [owner, dimension])
+
+
+@pytest.mark.parametrize(
+    "nominal,diameter", [(4, 4.005), (4, 3.995), (4, 4.000002), (10000, 10000.005)]
+)
+def test_mismatched_nominal_is_blocked_before_planning(nominal, diameter):
+    model = _model(nominal, diameter)
+    # Topology correspondence is exact; only the stated nominal differs.
+    assert model.features[1].cylindrical_refs[0].diameter == diameter
+    assert abs(nominal - diameter) > 1e-6
+    lowered = lower_ap242_nominal_diameters(model)
+    plan_dimensions(lowered)
+    assert not lowered.decorations
+    retained = [f for f in lowered.features if isinstance(f, AuthoredDimension)]
+    assert len(retained) == 1 and retained[0].value == nominal
+    assert any("nominal" in reason for reason in retained[0].lowering_blockers)
+
+
+@pytest.mark.parametrize("delta", [0, 0.0000005, -0.0000005])
+def test_agreeing_nominal_keeps_canonical_owner(delta):
+    lowered = lower_ap242_nominal_diameters(_model(4, 4 + delta))
+    assert len(lowered.features) == 1
+    assert len(lowered.decorations) == 1
+    requirement = next(iter(lowered.decorations.values()))
+    assert requirement.value == 4
+    assert requirement.source_ids == ("dimension:1325",)
+    plan_dimensions(lowered)
+
+
+def test_direct_authored_conflict_still_fails_in_planner():
+    model = _model(4, 4.005)
+    owner = model.features[0]
+    model = replace(
+        model,
+        features=[owner],
+        decorations={
+            (owner, "nominal_requirement", "step.diameter"): NominalRequirement(
+                4, "ap242_pmi", ("dimension:1325",)
+            )
+        },
+    )
+    with pytest.raises(ValueError, match="nominal requirement"):
+        plan_dimensions(model)
+
+
+def test_mismatch_survives_generated_sheet_without_crashing_or_changing_source(tmp_path):
+    from draftwright.sheet_emit import emit_sheet_script
+
+    lowered = lower_ap242_nominal_diameters(_model(4, 4.005))
+    source = emit_sheet_script(
+        lowered,
+        "from build123d import Cylinder\npart = Cylinder(2.0025, 10)",
+        str(tmp_path / "nominal"),
+        title="Nominal mismatch",
+        number="1325",
+        formats=(),
+    )
+    namespace = {}
+    exec(compile(source, "<nominal-1325>", "exec"), namespace)
+    drawing = namespace["drawing"]
+    retained = [f for f in drawing.model().features if isinstance(f, AuthoredDimension)]
+    assert len(retained) == 1
+    assert retained[0].value == 4
+    assert retained[0].source_id == "dimension:1325"
+    assert retained[0].lowering_blockers
+    assert "authored_dim_source_unresolved" in {i.code for i in drawing.lint()}


### PR DESCRIPTION
A source diameter nominal such as 4 could acquire ownership of a 4.005 canonical diameter during AP242 lowering, then crash planning. Use one absolute `1e-6` agreement rule for nominal ownership and planning. Retain a mismatch with its original value, source identity and explicit lowering/rendering blockers, so a generated Sheet also reports the withheld dimension instead of crashing or appearing clean.

Fixes #1325.

Validation: four mismatch regressions fail on the original code. 41 focused tests pass, including execution of the generated Sheet and its unresolved-source lint finding. Disabling the new ownership guard in memory produces five failures, including the generated-script regression. The full local gate passes: 6,756 passed, 5 skipped, 2 xfailed; 95.95% overall coverage and 100% changed-line coverage. Final static checks also pass. Python 3.10/build123d 0.10 compatibility: all 41 focused PMI tests pass. Hosted CI is pending.

Google/ADR review: reviewed every changed line for design, functionality, complexity, tests, naming, comments and documentation. The first review found the generated-script lint gap; the rendering blocker and end-to-end check resolve it. All five live ADRs were assessed: existing lowering/planner pipeline (1), unchanged shared placement (2), no additional recognition (3), preserved source identity and generated declaration (4), and explicit refusal with original values retained (5). No ADR change is needed. Final review of the committed diff and validation evidence found no remaining substantive findings; no required changes remain. The source-dimension warning survives an executed generated script, and directly authored conflicting ownership still fails in the planner.


Merge coordination: the reviewed head is preserved in #1476. Its merge commit will incorporate this PR after all component and combined CI/Codecov checks are green. Auto-merge is disabled.
