### PR TITLE
Expose layout advisories through structured lint

### DIFF
--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -289,3 +289,11 @@ drop, or missing ink is not hidden by the ownership choice.
 ::: draftwright.sheet._Control
     options:
       filters: public
+
+Layout advisories are also available as structured findings from `Drawing.lint()` and
+`lint(physical=False)`. `legibility_floor_breached` reports an explicit scale below the
+legibility floor when a legible automatic fit exists; `page_fit_uncertain` reports an
+unsuccessful layout fit; `layout_repack_stalled` reports unresolved measured-repack
+triggers; and `scale_fallback_applied` reports a computed scale or a completeness-driven
+scale fallback. These warnings contribute to the legibility component of `lint_summary()`.
+A successful measured fit replaces the earlier estimated fit warning.

--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -40,6 +40,14 @@ refused at declaration and constraints are never silently relaxed. The immutable
 snapshot is available as `sheet.view_constraints`, while `drawing.view_plan` is the distinct
 resolved result.
 
+Layout advisories are also available as structured findings from `Drawing.lint()` and
+`lint(physical=False)`. `legibility_floor_breached` reports an explicit scale below the
+legibility floor when a legible automatic fit exists; `page_fit_uncertain` reports an
+unsuccessful layout fit; `layout_repack_stalled` reports unresolved measured-repack
+triggers; and `scale_fallback_applied` reports a computed scale or a completeness-driven
+scale fallback. These warnings contribute to the legibility component of `lint_summary()`.
+A successful measured fit replaces the earlier estimated fit warning.
+
 ### Taking over a detected baseline
 
 `Sheet.from_part(part)` retains the detector's feature set and starts with implicit automatic
@@ -289,11 +297,3 @@ drop, or missing ink is not hidden by the ownership choice.
 ::: draftwright.sheet._Control
     options:
       filters: public
-
-Layout advisories are also available as structured findings from `Drawing.lint()` and
-`lint(physical=False)`. `legibility_floor_breached` reports an explicit scale below the
-legibility floor when a legible automatic fit exists; `page_fit_uncertain` reports an
-unsuccessful layout fit; `layout_repack_stalled` reports unresolved measured-repack
-triggers; and `scale_fallback_applied` reports a computed scale or a completeness-driven
-scale fallback. These warnings contribute to the legibility component of `lint_summary()`.
-A successful measured fit replaces the earlier estimated fit warning.

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -1202,6 +1202,7 @@ class Analysis:
     # Standing ISO 7200 title-block fields (#766) — defaulted, so they sit after the
     # non-default fields above. Defaults preserve the prior output: revision "A", the rest
     # blank (the TitleBlock helper's own defaults).
+    layout_advisories: tuple[tuple[str, str], ...] = ()
     material: str = ""
     date: str = ""
     revision: str = "A"

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -676,6 +676,7 @@ def _validate_explicit_scale(
     layout_required_tables=(),
     margin=_MARGIN,
     warn_advisory: bool = True,
+    advisories: list[tuple[str, str]] | None = None,
     views: tuple[str, ...] | None = None,
     include_iso: bool = True,
     iso_scale_factor: float | None = None,
@@ -701,7 +702,7 @@ def _validate_explicit_scale(
             f"below {_MIN_RENDER_MM:g} mm (OCCT arc construction fails). "
             f"Use scale ≥ {safe:.3g} or omit the scale for automatic selection."
         )
-    if not warn_advisory:
+    if not warn_advisory and advisories is None:
         return
     auto_scale, _, _, _ = choose_scale(
         x_size,
@@ -727,12 +728,16 @@ def _validate_explicit_scale(
         # No stacklevel that reaches user code: this fires deep in _analyse, and the public
         # entry points (make_drawing, Sheet.export, build_drawing) sit at different depths.
         # The message is self-contained (names the scale, the projection, and the fix).
-        warnings.warn(
+        message = (
             f"scale {SCALE!r} projects the smallest part dimension ({min_dim:.0f} mm) to "
             f"{min_view:.1f} mm, below the {_MIN_VIEW_MM:.0f} mm legibility floor — "
             f"annotations may crowd or overlap. Honouring the requested scale; use "
             f"scale ≥ {safe:.3g} or omit the scale for an automatic legible fit."
         )
+        if advisories is not None:
+            advisories.append(("legibility_floor_breached", message))
+        if warn_advisory:
+            warnings.warn(message)
 
 
 def _analyse(
@@ -1126,7 +1131,10 @@ def _analyse(
             bore_callout_width=bore_callout_width,
         )
 
+    layout_advisories: list[tuple[str, str]] = []
+
     def _pick_for_step_count(n_steps_i: int, strips_i: StripDepths) -> _ScalePick:
+        layout_advisories.clear()
         return choose_scale(
             x_size,
             y_size,
@@ -1140,6 +1148,7 @@ def _analyse(
             required_tables=layout_required_tables,
             margin=margin,
             arrangements=_arrangements,
+            advisories=layout_advisories,
             views=_views,
             include_iso=_include_iso,
             iso_scale_factor=planned_iso_scale,
@@ -1171,6 +1180,7 @@ def _analyse(
         layout_required_tables,
         margin=margin,
         warn_advisory=_reuse is None,
+        advisories=layout_advisories,
         views=_views,
         include_iso=_include_iso,
         iso_scale_factor=planned_iso_scale,
@@ -1264,6 +1274,7 @@ def _analyse(
     )
 
     return Analysis(
+        layout_advisories=tuple(layout_advisories),
         arrangement=ARRANGEMENT,
         planned_views=_views,
         planned_iso=_include_iso,

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -491,6 +491,17 @@ def detect_part_model(part, *, pmi="off") -> PartModel:
     return _detect_part_model_analysis(part, pmi=pmi)[0]
 
 
+def _layout_advisory(code: str, message: str) -> LintIssue:
+    """Validate the closed layout-advisory vocabulary at the lint boundary."""
+    if code == "legibility_floor_breached":
+        return LintIssue(severity="warning", code="legibility_floor_breached", message=message)
+    if code == "page_fit_uncertain":
+        return LintIssue(severity="warning", code="page_fit_uncertain", message=message)
+    if code == "scale_fallback_applied":
+        return LintIssue(severity="warning", code="scale_fallback_applied", message=message)
+    raise ValueError(f"unknown layout advisory: {code!r}")
+
+
 def _assemble(
     a,
     out,
@@ -824,6 +835,8 @@ def _assemble(
         # produce a confident "nothing was suppressed" (#996).
         _diagnostics = compile_dimensions(dwg.model()).diagnostics
     dwg._build.omissions = tuple(_diagnostics or ())
+    for code, message in a.layout_advisories:
+        dwg.registry.record_issue(_layout_advisory(code, message))
     return dwg
 
 
@@ -882,6 +895,7 @@ def _repack(
     no view actually moves).
     """
     if not _needs_repack(dwg, a):
+        dwg.registry.drop_issues({"page_fit_uncertain"})
         return None
     blocks = _measure_blocks(dwg, a)
 
@@ -940,6 +954,7 @@ def _repack(
         return g.auto_fits if auto_search else g.fits
 
     fit = next(((c, gg) for c in candidates if _candidate_fits(gg := _geom(c))), None)
+    repack_advisories: list[tuple[str, str]] = []
     if fit is not None:
         chosen, g = fit
     else:
@@ -961,6 +976,12 @@ def _repack(
             if lo > 0.0:
                 chosen = (lo, pw0, ph0, tb0)
                 g = _geom(chosen)
+                repack_advisories.append(
+                    (
+                        "scale_fallback_applied",
+                        f"No standard scale fits the measured layout; using computed {lo:g}",
+                    )
+                )
                 _log.warning(
                     "measure-repack: no standard sheet fits the measured layout; "
                     "using computed %s",
@@ -971,6 +992,9 @@ def _repack(
             # keep the largest candidate and let lint report the overflow (as before).
             chosen = candidates[-1]
             g = _geom(chosen)
+            repack_advisories.append(
+                ("page_fit_uncertain", f"No sheet/scale fits the measured layout; using {chosen}")
+            )
             _log.warning(
                 "measure-repack: no sheet/scale fits the measured layout; using %s", chosen
             )
@@ -983,11 +1007,22 @@ def _repack(
         abs(g.SV_X - a.SV_X),
         abs(g.SV_Y - a.SV_Y),
     )
+    # Seed fit warnings yield to the measured result; retain the explicit legibility
+    # advisory only at the scale for which it was evaluated.
+    advisories = tuple(
+        (code, message)
+        for code, message in a.layout_advisories
+        if code == "legibility_floor_breached" and s == a.SCALE
+    ) + tuple(repack_advisories)
     if s == a.SCALE and pw == a.PAGE_W and ph == a.PAGE_H and moved < _REPACK_TOL:
+        dwg.registry.drop_issues({"page_fit_uncertain", "scale_fallback_applied"})
+        for code, message in repack_advisories:
+            dwg.registry.record_issue(_layout_advisory(code, message))
         return None
     fv_zones, pv_zones, sv_zones = _build_zones(g, a.margin, ph)
     a2 = replace(
         a,
+        layout_advisories=advisories,
         SCALE=s,
         PAGE_W=pw,
         PAGE_H=ph,
@@ -1080,6 +1115,13 @@ def _repack_to_fixed_point(
         )
         if repacked is None:
             if _needs_repack(cur_dwg, cur_a):
+                cur_dwg.registry.record_issue(
+                    LintIssue(
+                        severity="warning",
+                        code="layout_repack_stalled",
+                        message=f"Measured repack stalled after {i} iterations with residual layout triggers",
+                    )
+                )
                 _log.warning(
                     "measure-repack: stalled after %d iteration(s) with residual layout triggers",
                     i,
@@ -1088,6 +1130,13 @@ def _repack_to_fixed_point(
         cur_a, cur_dwg = repacked
 
     if _needs_repack(cur_dwg, cur_a):
+        cur_dwg.registry.record_issue(
+            LintIssue(
+                severity="warning",
+                code="layout_repack_stalled",
+                message=f"Measured repack reached its {_REPACK_MAX_ITER} iteration limit with residual layout triggers",
+            )
+        )
         _log.warning(
             "measure-repack: reached iteration limit (%d) with residual layout triggers",
             _REPACK_MAX_ITER,
@@ -2638,6 +2687,14 @@ def build_drawing(
             blockers=blockers,
             attempted=attempted,
             attempts=attempts,
+        )
+        fallback.registry.record_issue(
+            LintIssue(
+                severity="warning",
+                code="scale_fallback_applied",
+                message=f"Requested scale {requested_scale:g} dropped required annotations; "
+                f"using complete fallback scale {fallback.scale:g}",
+            )
         )
         warnings.warn(
             f"requested scale {requested_scale:g} dropped required annotation outcomes; "

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -689,6 +689,7 @@ def choose_scale(
     views: tuple[str, ...] | None = None,
     include_iso: bool = True,
     iso_scale_factor: float | None = None,
+    advisories: list[tuple[str, str]] | None = None,
 ) -> tuple:
     """Return (SCALE, PAGE_W, PAGE_H, TB_W) for a 4-view layout.
 
@@ -734,6 +735,13 @@ def choose_scale(
             include_iso=include_iso,
             iso_scale_factor=iso_scale_factor,
         ):
+            if advisories is not None:
+                advisories.append(
+                    (
+                        "page_fit_uncertain",
+                        f"Requested scale {scale} on {page} may not fit the requested view layout",
+                    )
+                )
             _log.warning(
                 "Requested scale %s on %s page may not fit the requested view layout",
                 scale,
@@ -867,6 +875,10 @@ def choose_scale(
             iso_scale_factor=iso_scale_factor,
         )
         if s is not None:
+            if advisories is not None:
+                advisories.append(
+                    ("scale_fallback_applied", f"No standard scale fits; using computed {s:g}")
+                )
             _log.warning(
                 "No standard scale fits %.0f × %.0f × %.0f mm; using computed %s",
                 x_size,
@@ -875,6 +887,14 @@ def choose_scale(
                 format_drawing_scale(s),
             )
             return s, _pw, _ph, _tb
+    if advisories is not None:
+        advisories.append(
+            (
+                "page_fit_uncertain",
+                f"No layout fits {x_size:g} × {y_size:g} × {z_size:g} mm; "
+                f"falling back to {candidates[-1]}",
+            )
+        )
     _log.warning(
         "No layout fits %.0f × %.0f × %.0f mm; falling back to %s",
         x_size,

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -53,6 +53,10 @@ _OUTCOME_STATES = (
 # distinguish validation from layout.
 _LEGIBILITY_CODES = frozenset(
     {
+        "legibility_floor_breached",
+        "page_fit_uncertain",
+        "layout_repack_stalled",
+        "scale_fallback_applied",
         "annotation_out_of_bounds",
         "annotation_overlap",
         "annotation_ink_overlap",

--- a/tests/test_issue_1146_scale_completeness.py
+++ b/tests/test_issue_1146_scale_completeness.py
@@ -123,6 +123,7 @@ def test_default_fallback_returns_largest_complete_standard_scale_and_reports_de
         drawing = build_drawing(_scale_sensitive_plate(), page="A4", scale=1.0, repair=False)
 
     assert drawing.scale == 0.5
+    assert "scale_fallback_applied" in {i.code for i in drawing.lint(physical=False)}
     assert _placement_drops(drawing) == []
     assert drawing.scale_decision == {
         "policy": "fallback",

--- a/tests/test_issue_1396_layout_advisories.py
+++ b/tests/test_issue_1396_layout_advisories.py
@@ -1,5 +1,6 @@
 """Layout degradations are available without parsing Python warnings or logs."""
 
+import warnings
 from dataclasses import replace
 
 import pytest
@@ -95,3 +96,39 @@ def test_computed_scale_reaches_public_declared_lint():
     drawing = Sheet(Box(1e7, 1e7, 1e7)).authored_dimensions().build()
     assert 0 < drawing.scale < 0.0001
     assert "scale_fallback_applied" in _codes(drawing)
+
+
+@pytest.mark.parametrize("warn_advisory", [False, True])
+@pytest.mark.parametrize("collect_advisories", [False, True])
+def test_warning_delivery_and_diagnostic_collection_are_independent(
+    warn_advisory, collect_advisories
+):
+    from draftwright.analysis import _validate_explicit_scale
+
+    # This part has an automatic legible fit, while the requested scale is too small.
+    auto_scale, *_ = choose_scale(680, 860, 80)
+    assert 80 * 0.1 < 15 <= 80 * auto_scale
+    advisories = [] if collect_advisories else None
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _validate_explicit_scale(
+            0.1,
+            0.1,
+            680,
+            860,
+            80,
+            0,
+            None,
+            None,
+            False,
+            (),
+            warn_advisory=warn_advisory,
+            advisories=advisories,
+        )
+    assert len(caught) == int(warn_advisory)
+    if caught:
+        assert "legibility floor" in str(caught[0].message)
+    if collect_advisories:
+        assert len(advisories) == 1
+        assert advisories[0][0] == "legibility_floor_breached"
+        assert "legibility floor" in advisories[0][1]

--- a/tests/test_issue_1396_layout_advisories.py
+++ b/tests/test_issue_1396_layout_advisories.py
@@ -89,3 +89,9 @@ def test_measured_fit_retracts_seed_uncertainty():
     assert "page_fit_uncertain" in _codes(drawing)
     assert _repack(a, drawing, "", None, None) is None
     assert "page_fit_uncertain" not in _codes(drawing)
+
+
+def test_computed_scale_reaches_public_declared_lint():
+    drawing = Sheet(Box(1e7, 1e7, 1e7)).authored_dimensions().build()
+    assert 0 < drawing.scale < 0.0001
+    assert "scale_fallback_applied" in _codes(drawing)

--- a/tests/test_issue_1396_layout_advisories.py
+++ b/tests/test_issue_1396_layout_advisories.py
@@ -1,0 +1,91 @@
+"""Layout degradations are available without parsing Python warnings or logs."""
+
+from dataclasses import replace
+
+import pytest
+from build123d import Box
+
+from draftwright import Sheet, build_drawing
+from draftwright.analysis import _analyse
+from draftwright.builder import _assemble, _repack_to_fixed_point
+from draftwright.compose import choose_scale
+
+
+def _codes(drawing):
+    return {issue.code for issue in drawing.lint(physical=False)}
+
+
+def test_legibility_warning_reaches_declared_and_detected_lint():
+    part = Box(680, 860, 80)
+    for declared in (False, True):
+        with pytest.warns(UserWarning, match="legibility floor"):
+            if declared:
+                drawing = Sheet(part, scale=0.1).authored_dimensions().build()
+            else:
+                drawing = build_drawing(part, scale=0.1, scale_policy="permissive")
+        assert drawing.scale == 0.1
+        assert (
+            sum(i.code == "legibility_floor_breached" for i in drawing.lint(physical=False)) == 1
+        )
+        assert (
+            "legibility_floor_breached"
+            in drawing.lint_summary()["quality"]["legibility"]["by_code"]
+        )
+
+
+def test_legible_explicit_scale_has_no_legibility_finding():
+    drawing = Sheet(Box(20, 20, 20), scale=1).authored_dimensions().build()
+    assert "legibility_floor_breached" not in _codes(drawing)
+
+
+@pytest.mark.parametrize("scale,page", [(100, "A4"), (None, (1, 1))])
+def test_infeasible_scale_selection_records_the_warning(scale, page, caplog):
+    advisories = []
+    choose_scale(100, 100, 100, scale=scale, page=page, advisories=advisories)
+    assert "fit" in caplog.text
+    assert [code for code, _ in advisories] == ["page_fit_uncertain"]
+
+
+def test_seed_layout_advisory_reaches_assembled_drawing():
+    a = _analyse(Box(20, 20, 20), title="", number="", tolerance="", drawn_by="", out="")
+    a = replace(a, layout_advisories=(("page_fit_uncertain", "fixture seed fit failure"),))
+    drawing = _assemble(a, "", None, None, auto_dims=False)
+    assert "page_fit_uncertain" in _codes(drawing)
+
+
+@pytest.mark.parametrize("limit", [0, 2])
+def test_unresolved_repack_is_machine_visible(monkeypatch, limit):
+    import draftwright.builder as builder
+
+    a = _analyse(Box(20, 20, 20), title="", number="", tolerance="", drawn_by="", out="")
+    drawing = _assemble(a, "", None, None, auto_dims=False)
+    monkeypatch.setattr(builder, "_REPACK_MAX_ITER", limit)
+    monkeypatch.setattr(builder, "_needs_repack", lambda *args: True)
+    monkeypatch.setattr(builder, "_repack", lambda *args, **kwargs: None)
+    _repack_to_fixed_point(a, drawing, "", None, None)
+    assert "layout_repack_stalled" in _codes(drawing)
+
+
+def test_unknown_layout_advisory_is_refused():
+    from draftwright.builder import _layout_advisory
+
+    with pytest.raises(ValueError, match="unknown layout advisory"):
+        _layout_advisory("misspelled_finding", "must not silently evade classification")
+
+
+def test_computed_scale_is_reported_by_scale_selection():
+    advisories = []
+    scale, *_ = choose_scale(1e7, 1e7, 1e7, advisories=advisories)
+    assert 0 < scale < 0.0001
+    assert [code for code, _ in advisories] == ["scale_fallback_applied"]
+
+
+def test_measured_fit_retracts_seed_uncertainty():
+    from draftwright.builder import _repack
+
+    a = _analyse(Box(20, 20, 20), title="", number="", tolerance="", drawn_by="", out="")
+    a = replace(a, layout_advisories=(("page_fit_uncertain", "fixture seed fit failure"),))
+    drawing = _assemble(a, "", None, None, auto_dims=False)
+    assert "page_fit_uncertain" in _codes(drawing)
+    assert _repack(a, drawing, "", None, None) is None
+    assert "page_fit_uncertain" not in _codes(drawing)

--- a/tests/test_issue_1421_rectangular_blind_slot_semantics.py
+++ b/tests/test_issue_1421_rectangular_blind_slot_semantics.py
@@ -191,6 +191,12 @@ def test_every_nonempty_authored_parameter_subset_survives_rendering(
     assert annotation.label == expected_label
     assert {key["parameter_id"] for key in drawing.measurement_keys(name)} == set(parameters)
     issues = drawing.lint()
+    stalled = [issue for issue in issues if issue.code == "layout_repack_stalled"]
+    assert len(stalled) == (
+        parameters
+        == ("rectangular_blind_slot_width.length", "rectangular_blind_slot_length.length")
+    )
+    issues = [issue for issue in issues if issue.code != "layout_repack_stalled"]
     assert len(issues) == 3 - len(parameters)
     assert {issue.code for issue in issues} <= {"rectangular_blind_slot_requirement_suppressed"}
 

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -2904,21 +2904,24 @@ class TestComposeThenPackRepack:
         from types import SimpleNamespace
 
         import draftwright.builder as builder
+        from draftwright.registry import AnnotationRegistry
 
         calls = []
 
         def fake_repack(a, dwg, *args, **kwargs):
             calls.append((a.pass_id, dwg.pass_id))
             pass_id = len(calls)
-            return SimpleNamespace(pass_id=pass_id), SimpleNamespace(pass_id=pass_id)
+            return SimpleNamespace(
+                pass_id=pass_id, registry=AnnotationRegistry()
+            ), SimpleNamespace(pass_id=pass_id, registry=AnnotationRegistry())
 
         monkeypatch.setattr(builder, "_repack", fake_repack)
         monkeypatch.setattr(builder, "_needs_repack", lambda dwg, a: True)
 
         with caplog.at_level(logging.WARNING):
             out_a, out_dwg = builder._repack_to_fixed_point(
-                SimpleNamespace(pass_id=0),
-                SimpleNamespace(pass_id=0),
+                SimpleNamespace(pass_id=0, registry=AnnotationRegistry()),
+                SimpleNamespace(pass_id=0, registry=AnnotationRegistry()),
                 "out",
                 None,
                 False,
@@ -2932,14 +2935,15 @@ class TestComposeThenPackRepack:
         from types import SimpleNamespace
 
         import draftwright.builder as builder
+        from draftwright.registry import AnnotationRegistry
 
         monkeypatch.setattr(builder, "_repack", lambda *args, **kwargs: None)
         monkeypatch.setattr(builder, "_needs_repack", lambda dwg, a: True)
 
         with caplog.at_level(logging.WARNING):
             out = builder._repack_to_fixed_point(
-                SimpleNamespace(pass_id=0),
-                SimpleNamespace(pass_id=0),
+                SimpleNamespace(pass_id=0, registry=AnnotationRegistry()),
+                SimpleNamespace(pass_id=0, registry=AnnotationRegistry()),
                 "out",
                 None,
                 False,


### PR DESCRIPTION
Layout selection and measured repack could warn that a drawing was degraded while `Drawing.lint()` reported no corresponding finding. Carry explicit legibility and fit advisories through analysis into the existing lint registry; report stalled repacks and scale fallbacks there too. A successful measured fit clears its earlier estimated fit warning. The four diagnostic codes contribute to the existing legibility component.

Fixes #1396.

Validation on the final head: all 15 dedicated tests pass; the full local gate exits 0 with 6,762 passed, 5 skipped and 2 xfailed, 95.95% overall coverage and 97% changed-line coverage. Static gates pass. Removing each of the four diagnostic codes causes a regression failure; the new delivery regression also catches an early return that incorrectly discards collected diagnostics when warnings are suppressed. All 15 dedicated tests also pass on Python 3.10/build123d 0.10. Hosted CI is pending.

Google/ADR review: reviewed design, correctness, complexity, tests, naming, comments and documentation. Review identified stale seed warnings and an indirect-code classification gap; measured-fit cleanup and a closed conversion into lint findings address them. One blind-slot fixture had a real pre-existing repack stall which was only logged; its test now asserts the structured finding rather than claiming clean lint.

All five live ADRs were assessed: typed analysis state feeds the existing registry (1), placement/repack policy remains shared and bounded (2), no recognition is added (3), declared and detected builds share these diagnostics (4), and previously invisible degradation is explicit without changing completeness denominators (5). No ADR text change is needed. Final review of the committed diff and complete validation evidence found no remaining substantive findings. The diagnostic mutation checks fail independently for all four codes; successful-fit cleanup and the closed-code rejection also have explicit regression tests.


Merge coordination: the reviewed head is preserved in #1476. Its merge commit will incorporate this PR after all component and combined CI/Codecov checks are green. Auto-merge is disabled.

The additional delivery cases cover both branches previously marked partial by Codecov: structured diagnostics survive suppressed Python warnings, and warnings work without a collector. The remaining uncovered changed line is the measured computed-scale fallback. Every hosted check, including Codecov, remains a merge gate.
