### PR TITLE
Integrate reviewed patch fixes and validate Sheet inputs

### DIFF
--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -95,11 +95,10 @@ validate result-local references, bind exact same-run occurrences, migrate patte
 refusals, and update independent lint, reports and inspection together. A build already holding an
 aggregate must project it rather than invoke the document builder for a second recognition run.
 
-Adoption is currently blocked by [Quiddity #505](https://github.com/pzfreo/quiddity/issues/505):
-the released provider reads `.area` from a build123d 0.10 `ShapeList` while proving support, so
-ordinary pocket recognition raises before this adapter runs. The compatibility tests retain
-that failure; the migration needs a released provider fix before it can pass Draftwright's
-supported Python/build123d matrix.
+The comparison pins Quiddity 0.2.1, which fixes
+[Quiddity #505](https://github.com/pzfreo/quiddity/issues/505): support proofs now handle
+build123d 0.10 `ShapeList` boolean results. The pocket corpus exercises this public recognition
+path across the supported Python/build123d matrix before consumer adaptation.
 
 `bosses` is the fully consumed reference family. `repeating-radial-profiles` is the opposite
 reference: it remains geometry-only critique evidence for a separately authored gear declaration,

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -70,6 +70,37 @@ issue. The contract test derives package record outputs, converter registries, l
 and emitter branches independently, so copying a new name into the declaration alone cannot make CI
 pass.
 
+### Quiddity migration baseline
+
+The first [#1471](https://github.com/pzfreo/draftwright/issues/1471) migration slice tests the
+released Quiddity SectionRecess document against the existing authored pocket corpus. Quiddity is
+pinned in the development dependencies for this comparison. Production continues to use the
+existing recogniser dependency and capability declaration.
+
+The private pocket adapter in `model/detect.py` reads primitive schema-2 occurrence geometry and
+produces the existing `PocketFeature`. It admits principal-axis closed rectangles and open
+rectangular corner/edge chains, preserves the opening direction, and refuses unsupported shapes,
+sloped ends, invalid frames and malformed measurements. An open chain remains edge-anchored; its
+missing boundary is never reconstructed as a physical edge.
+
+`tests/test_issue_1471_section_recess_pockets.py` checks independently authored dimensions,
+opposed and side openings, disconnected bodies, topology variants, the existing drawing path,
+executed generated Sheet scripts and authored omission. The baseline tests for pocket patterns,
+channels and both blind-slot families remain the acceptance floor for their later adapters.
+
+This is preparation for adoption, not a new automatic detection mode. The adapter does not yet
+participate in the production registry, bind occurrence ownership or provide Quiddity-based lint.
+Its comparison drawings use the pinned provider for physical critique. The eventual cutover must
+validate result-local references, bind exact same-run occurrences, migrate patterns and explicit
+refusals, and update independent lint, reports and inspection together. A build already holding an
+aggregate must project it rather than invoke the document builder for a second recognition run.
+
+Adoption is currently blocked by [Quiddity #505](https://github.com/pzfreo/quiddity/issues/505):
+the released provider reads `.area` from a build123d 0.10 `ShapeList` while proving support, so
+ordinary pocket recognition raises before this adapter runs. The compatibility tests retain
+that failure; the migration needs a released provider fix before it can pass Draftwright's
+supported Python/build123d matrix.
+
 `bosses` is the fully consumed reference family. `repeating-radial-profiles` is the opposite
 reference: it remains geometry-only critique evidence for a separately authored gear declaration,
 with no inferred gear feature added to fill the table.

--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -289,3 +289,11 @@ drop, or missing ink is not hidden by the ownership choice.
 ::: draftwright.sheet._Control
     options:
       filters: public
+
+Layout advisories are also available as structured findings from `Drawing.lint()` and
+`lint(physical=False)`. `legibility_floor_breached` reports an explicit scale below the
+legibility floor when a legible automatic fit exists; `page_fit_uncertain` reports an
+unsuccessful layout fit; `layout_repack_stalled` reports unresolved measured-repack
+triggers; and `scale_fallback_applied` reports a computed scale or a completeness-driven
+scale fallback. These warnings contribute to the legibility component of `lint_summary()`.
+A successful measured fit replaces the earlier estimated fit warning.

--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -289,3 +289,9 @@ drop, or missing ink is not hidden by the ownership choice.
 ::: draftwright.sheet._Control
     options:
       filters: public
+
+Imported AP242 nominal-diameter ownership requires absolute agreement within `1e-6`
+with the canonical feature diameter, using the same rule as planning. A larger mismatch
+keeps the original source value and identity in a blocked dimension; it does not replace
+the canonical value or crash planning. Generated Sheet scripts retain the blocker, and
+`authored_dim_source_unresolved` reports the withheld source dimension through lint.

--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -40,6 +40,14 @@ refused at declaration and constraints are never silently relaxed. The immutable
 snapshot is available as `sheet.view_constraints`, while `drawing.view_plan` is the distinct
 resolved result.
 
+Layout advisories are also available as structured findings from `Drawing.lint()` and
+`lint(physical=False)`. `legibility_floor_breached` reports an explicit scale below the
+legibility floor when a legible automatic fit exists; `page_fit_uncertain` reports an
+unsuccessful layout fit; `layout_repack_stalled` reports unresolved measured-repack
+triggers; and `scale_fallback_applied` reports a computed scale or a completeness-driven
+scale fallback. These warnings contribute to the legibility component of `lint_summary()`.
+A successful measured fit replaces the earlier estimated fit warning.
+
 ### Taking over a detected baseline
 
 `Sheet.from_part(part)` retains the detector's feature set and starts with implicit automatic
@@ -289,11 +297,3 @@ drop, or missing ink is not hidden by the ownership choice.
 ::: draftwright.sheet._Control
     options:
       filters: public
-
-Layout advisories are also available as structured findings from `Drawing.lint()` and
-`lint(physical=False)`. `legibility_floor_breached` reports an explicit scale below the
-legibility floor when a legible automatic fit exists; `page_fit_uncertain` reports an
-unsuccessful layout fit; `layout_repack_stalled` reports unresolved measured-repack
-triggers; and `scale_fallback_applied` reports a computed scale or a completeness-driven
-scale fallback. These warnings contribute to the legibility component of `lint_summary()`.
-A successful measured fit replaces the earlier estimated fit warning.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ dev = [
     "pytest-timeout>=2",
     "pytest-xdist>=3",
     # Released provider used by the migration parity tests; production remains on 0.4.14.
-    "quiddity==0.2.0",
+    "quiddity==0.2.1",
     "ruff>=0.4",
     "tomli>=2; python_version < '3.11'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,8 @@ dev = [
     "pytest-split>=0.8",
     "pytest-timeout>=2",
     "pytest-xdist>=3",
+    # Released provider used by the migration parity tests; production remains on 0.4.14.
+    "quiddity==0.2.0",
     "ruff>=0.4",
     "tomli>=2; python_version < '3.11'",
 ]

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -1202,6 +1202,7 @@ class Analysis:
     # Standing ISO 7200 title-block fields (#766) — defaulted, so they sit after the
     # non-default fields above. Defaults preserve the prior output: revision "A", the rest
     # blank (the TitleBlock helper's own defaults).
+    layout_advisories: tuple[tuple[str, str], ...] = ()
     material: str = ""
     date: str = ""
     revision: str = "A"

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -676,6 +676,7 @@ def _validate_explicit_scale(
     layout_required_tables=(),
     margin=_MARGIN,
     warn_advisory: bool = True,
+    advisories: list[tuple[str, str]] | None = None,
     views: tuple[str, ...] | None = None,
     include_iso: bool = True,
     iso_scale_factor: float | None = None,
@@ -701,7 +702,7 @@ def _validate_explicit_scale(
             f"below {_MIN_RENDER_MM:g} mm (OCCT arc construction fails). "
             f"Use scale ≥ {safe:.3g} or omit the scale for automatic selection."
         )
-    if not warn_advisory:
+    if not warn_advisory and advisories is None:
         return
     auto_scale, _, _, _ = choose_scale(
         x_size,
@@ -727,12 +728,16 @@ def _validate_explicit_scale(
         # No stacklevel that reaches user code: this fires deep in _analyse, and the public
         # entry points (make_drawing, Sheet.export, build_drawing) sit at different depths.
         # The message is self-contained (names the scale, the projection, and the fix).
-        warnings.warn(
+        message = (
             f"scale {SCALE!r} projects the smallest part dimension ({min_dim:.0f} mm) to "
             f"{min_view:.1f} mm, below the {_MIN_VIEW_MM:.0f} mm legibility floor — "
             f"annotations may crowd or overlap. Honouring the requested scale; use "
             f"scale ≥ {safe:.3g} or omit the scale for an automatic legible fit."
         )
+        if advisories is not None:
+            advisories.append(("legibility_floor_breached", message))
+        if warn_advisory:
+            warnings.warn(message)
 
 
 def _analyse(
@@ -1126,7 +1131,10 @@ def _analyse(
             bore_callout_width=bore_callout_width,
         )
 
+    layout_advisories: list[tuple[str, str]] = []
+
     def _pick_for_step_count(n_steps_i: int, strips_i: StripDepths) -> _ScalePick:
+        layout_advisories.clear()
         return choose_scale(
             x_size,
             y_size,
@@ -1140,6 +1148,7 @@ def _analyse(
             required_tables=layout_required_tables,
             margin=margin,
             arrangements=_arrangements,
+            advisories=layout_advisories,
             views=_views,
             include_iso=_include_iso,
             iso_scale_factor=planned_iso_scale,
@@ -1171,6 +1180,7 @@ def _analyse(
         layout_required_tables,
         margin=margin,
         warn_advisory=_reuse is None,
+        advisories=layout_advisories,
         views=_views,
         include_iso=_include_iso,
         iso_scale_factor=planned_iso_scale,
@@ -1264,6 +1274,7 @@ def _analyse(
     )
 
     return Analysis(
+        layout_advisories=tuple(layout_advisories),
         arrangement=ARRANGEMENT,
         planned_views=_views,
         planned_iso=_include_iso,

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -491,6 +491,17 @@ def detect_part_model(part, *, pmi="off") -> PartModel:
     return _detect_part_model_analysis(part, pmi=pmi)[0]
 
 
+def _layout_advisory(code: str, message: str) -> LintIssue:
+    """Validate the closed layout-advisory vocabulary at the lint boundary."""
+    if code == "legibility_floor_breached":
+        return LintIssue(severity="warning", code="legibility_floor_breached", message=message)
+    if code == "page_fit_uncertain":
+        return LintIssue(severity="warning", code="page_fit_uncertain", message=message)
+    if code == "scale_fallback_applied":
+        return LintIssue(severity="warning", code="scale_fallback_applied", message=message)
+    raise ValueError(f"unknown layout advisory: {code!r}")
+
+
 def _assemble(
     a,
     out,
@@ -824,6 +835,8 @@ def _assemble(
         # produce a confident "nothing was suppressed" (#996).
         _diagnostics = compile_dimensions(dwg.model()).diagnostics
     dwg._build.omissions = tuple(_diagnostics or ())
+    for code, message in a.layout_advisories:
+        dwg.registry.record_issue(_layout_advisory(code, message))
     return dwg
 
 
@@ -882,6 +895,7 @@ def _repack(
     no view actually moves).
     """
     if not _needs_repack(dwg, a):
+        dwg.registry.drop_issues({"page_fit_uncertain"})
         return None
     blocks = _measure_blocks(dwg, a)
 
@@ -940,6 +954,7 @@ def _repack(
         return g.auto_fits if auto_search else g.fits
 
     fit = next(((c, gg) for c in candidates if _candidate_fits(gg := _geom(c))), None)
+    repack_advisories: list[tuple[str, str]] = []
     if fit is not None:
         chosen, g = fit
     else:
@@ -961,6 +976,12 @@ def _repack(
             if lo > 0.0:
                 chosen = (lo, pw0, ph0, tb0)
                 g = _geom(chosen)
+                repack_advisories.append(
+                    (
+                        "scale_fallback_applied",
+                        f"No standard scale fits the measured layout; using computed {lo:g}",
+                    )
+                )
                 _log.warning(
                     "measure-repack: no standard sheet fits the measured layout; "
                     "using computed %s",
@@ -971,6 +992,9 @@ def _repack(
             # keep the largest candidate and let lint report the overflow (as before).
             chosen = candidates[-1]
             g = _geom(chosen)
+            repack_advisories.append(
+                ("page_fit_uncertain", f"No sheet/scale fits the measured layout; using {chosen}")
+            )
             _log.warning(
                 "measure-repack: no sheet/scale fits the measured layout; using %s", chosen
             )
@@ -983,11 +1007,22 @@ def _repack(
         abs(g.SV_X - a.SV_X),
         abs(g.SV_Y - a.SV_Y),
     )
+    # Seed fit warnings yield to the measured result; retain the explicit legibility
+    # advisory only at the scale for which it was evaluated.
+    advisories = tuple(
+        (code, message)
+        for code, message in a.layout_advisories
+        if code == "legibility_floor_breached" and s == a.SCALE
+    ) + tuple(repack_advisories)
     if s == a.SCALE and pw == a.PAGE_W and ph == a.PAGE_H and moved < _REPACK_TOL:
+        dwg.registry.drop_issues({"page_fit_uncertain", "scale_fallback_applied"})
+        for code, message in repack_advisories:
+            dwg.registry.record_issue(_layout_advisory(code, message))
         return None
     fv_zones, pv_zones, sv_zones = _build_zones(g, a.margin, ph)
     a2 = replace(
         a,
+        layout_advisories=advisories,
         SCALE=s,
         PAGE_W=pw,
         PAGE_H=ph,
@@ -1080,6 +1115,13 @@ def _repack_to_fixed_point(
         )
         if repacked is None:
             if _needs_repack(cur_dwg, cur_a):
+                cur_dwg.registry.record_issue(
+                    LintIssue(
+                        severity="warning",
+                        code="layout_repack_stalled",
+                        message=f"Measured repack stalled after {i} iterations with residual layout triggers",
+                    )
+                )
                 _log.warning(
                     "measure-repack: stalled after %d iteration(s) with residual layout triggers",
                     i,
@@ -1088,6 +1130,13 @@ def _repack_to_fixed_point(
         cur_a, cur_dwg = repacked
 
     if _needs_repack(cur_dwg, cur_a):
+        cur_dwg.registry.record_issue(
+            LintIssue(
+                severity="warning",
+                code="layout_repack_stalled",
+                message=f"Measured repack reached its {_REPACK_MAX_ITER} iteration limit with residual layout triggers",
+            )
+        )
         _log.warning(
             "measure-repack: reached iteration limit (%d) with residual layout triggers",
             _REPACK_MAX_ITER,
@@ -2638,6 +2687,14 @@ def build_drawing(
             blockers=blockers,
             attempted=attempted,
             attempts=attempts,
+        )
+        fallback.registry.record_issue(
+            LintIssue(
+                severity="warning",
+                code="scale_fallback_applied",
+                message=f"Requested scale {requested_scale:g} dropped required annotations; "
+                f"using complete fallback scale {fallback.scale:g}",
+            )
         )
         warnings.warn(
             f"requested scale {requested_scale:g} dropped required annotation outcomes; "

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -689,6 +689,7 @@ def choose_scale(
     views: tuple[str, ...] | None = None,
     include_iso: bool = True,
     iso_scale_factor: float | None = None,
+    advisories: list[tuple[str, str]] | None = None,
 ) -> tuple:
     """Return (SCALE, PAGE_W, PAGE_H, TB_W) for a 4-view layout.
 
@@ -734,6 +735,13 @@ def choose_scale(
             include_iso=include_iso,
             iso_scale_factor=iso_scale_factor,
         ):
+            if advisories is not None:
+                advisories.append(
+                    (
+                        "page_fit_uncertain",
+                        f"Requested scale {scale} on {page} may not fit the requested view layout",
+                    )
+                )
             _log.warning(
                 "Requested scale %s on %s page may not fit the requested view layout",
                 scale,
@@ -867,6 +875,10 @@ def choose_scale(
             iso_scale_factor=iso_scale_factor,
         )
         if s is not None:
+            if advisories is not None:
+                advisories.append(
+                    ("scale_fallback_applied", f"No standard scale fits; using computed {s:g}")
+                )
             _log.warning(
                 "No standard scale fits %.0f × %.0f × %.0f mm; using computed %s",
                 x_size,
@@ -875,6 +887,14 @@ def choose_scale(
                 format_drawing_scale(s),
             )
             return s, _pw, _ph, _tb
+    if advisories is not None:
+        advisories.append(
+            (
+                "page_fit_uncertain",
+                f"No layout fits {x_size:g} × {y_size:g} × {z_size:g} mm; "
+                f"falling back to {candidates[-1]}",
+            )
+        )
     _log.warning(
         "No layout fits %.0f × %.0f × %.0f mm; falling back to %s",
         x_size,

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -53,6 +53,10 @@ _OUTCOME_STATES = (
 # distinguish validation from layout.
 _LEGIBILITY_CODES = frozenset(
     {
+        "legibility_floor_breached",
+        "page_fit_uncertain",
+        "layout_repack_stalled",
+        "scale_fallback_applied",
         "annotation_out_of_bounds",
         "annotation_overlap",
         "annotation_ink_overlap",

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -785,7 +785,7 @@ def _convert_section_recess_pocket(record: Mapping, *, schema_version: int) -> P
     length = world_bounds[span_index][1] - world_bounds[span_index][0]
     if not all(isfinite(n) for n in (*center, width, length, high - low)):
         raise ValueError("projected pocket measurements must be finite")
-    if width <= 0 or length <= 0:
+    if any(hi <= lo for lo, hi in world_bounds.values()):
         raise ValueError("projected pocket extents must remain positive")
     return PocketFeature(
         frame=Frame(origin=(center[0], center[1], center[2]), axis="xyz"[run_index]),

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -15,7 +15,7 @@ for any part.
 from __future__ import annotations
 
 from collections import Counter
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from contextvars import ContextVar
 from dataclasses import dataclass, replace
 from math import isfinite, ulp
@@ -625,6 +625,181 @@ def _member_pocket(pk: Pocket) -> PocketFeature:
 
 def _convert_pocket(pk: Pocket, ctx: ConvContext) -> PocketFeature:
     return _member_pocket(pk)
+
+
+class _UnsupportedSectionRecess(ValueError):
+    """Valid recess geometry outside the first migration adapter's drawing vocabulary."""
+
+
+def _section_object(value: object, keys: set[str], name: str) -> Mapping:
+    if not isinstance(value, Mapping) or set(value) != keys:
+        raise ValueError(f"{name} must contain exactly {sorted(keys)}")
+    return value
+
+
+def _section_numbers(value: object, count: int, name: str) -> tuple[float, ...]:
+    if (
+        not isinstance(value, (tuple, list))
+        or type(value) not in (tuple, list)
+        or len(value) != count
+    ):
+        raise ValueError(f"{name} must contain {count} finite numbers")
+    if any(type(item) not in (int, float) for item in value):
+        raise ValueError(f"{name} requires built-in non-boolean numbers")
+    try:
+        result = tuple(float(item) for item in value)
+    except OverflowError as exc:
+        raise ValueError(f"{name} must be finite") from exc
+    if not all(isfinite(item) for item in result):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _section_axis(vector: tuple[float, ...]) -> tuple[int, int]:
+    index = max(range(3), key=lambda i: abs(vector[i]))
+    sign = 1 if vector[index] > 0 else -1
+    if any(abs(value - (sign if i == index else 0)) > 1e-9 for i, value in enumerate(vector)):
+        raise _UnsupportedSectionRecess("pocket requires principal section and run directions")
+    return index, sign
+
+
+def _convert_section_recess_pocket(record: Mapping, *, schema_version: int) -> PocketFeature:
+    """Lower a schema-2 document's rectangular pocket into the existing drafting IR.
+
+    This private migration adapter consumes JSON primitives from a released SectionRecess.
+    It performs no recognition and returns no provider references. It is not yet wired into
+    production detection: the aggregate, ownership and independent lint cutover must land
+    together before the runtime dependency changes (#1471). The caller remains responsible
+    for validating result-local references and recording ownership from the exact source run.
+
+    Closed rectangles and open rectangular corner/edge cuts share the existing PocketFeature
+    grammar. Open cuts keep ``edge_anchored=True``; no closing edge is manufactured. Curved,
+    general polygonal, sloped-end and free-axis sections are explicitly refused by this slice.
+    """
+
+    if type(schema_version) is not int or schema_version != 2:
+        raise ValueError("unsupported SectionRecess schema version")
+    row = _section_object(
+        record, {"index", "body", "geometry", "classification", "evidence"}, "occurrence"
+    )
+    if any(type(row[key]) is not int or row[key] < 0 for key in ("index", "body")):
+        raise ValueError("occurrence and body indices must be non-negative integers")
+    evidence = _section_object(
+        row["evidence"], {"defining_faces", "constituent_faces"}, "evidence"
+    )
+    for refs in evidence.values():
+        if (
+            type(refs) not in (tuple, list)
+            or any(type(ref) is not int or ref < 0 for ref in refs)
+            or list(refs) != sorted(set(refs))
+        ):
+            raise ValueError("face references must be sorted unique non-negative integers")
+    if not evidence["defining_faces"] or not set(evidence["defining_faces"]) <= set(
+        evidence["constituent_faces"]
+    ):
+        raise ValueError("pocket requires defining faces contained in constituent faces")
+    classification = _section_object(
+        row["classification"], {"feature_kind", "section_shape"}, "classification"
+    )
+    kind, shape = classification["feature_kind"], classification["section_shape"]
+    if (kind, shape) not in (("pocket", "rectangular"), ("edge_open_recess", "polygonal")):
+        raise _UnsupportedSectionRecess("recess is outside the rectangular pocket vocabulary")
+    geometry = _section_object(
+        row["geometry"], {"type", "frame", "run_interval", "profile", "ends"}, "geometry"
+    )
+    if geometry["type"] != "section_recess":
+        raise ValueError("expected section_recess geometry")
+    frame = _section_object(geometry["frame"], {"origin", "run", "u", "v"}, "frame")
+    origin = _section_numbers(frame["origin"], 3, "frame origin")
+    run, u, v = (_section_numbers(frame[key], 3, key) for key in ("run", "u", "v"))
+    run_index, run_sign = _section_axis(run)
+    u_index, u_sign = _section_axis(u)
+    v_index, v_sign = _section_axis(v)
+    if len({run_index, u_index, v_index}) != 3:
+        raise ValueError("section frame directions must be perpendicular")
+    cross = (u[1] * v[2] - u[2] * v[1], u[2] * v[0] - u[0] * v[2], u[0] * v[1] - u[1] * v[0])
+    if any(abs(a - b) > 1e-9 for a, b in zip(cross, run)):
+        raise ValueError("section frame must be right-handed")
+    low, high = _section_numbers(geometry["run_interval"], 2, "run interval")
+    if high <= low:
+        raise ValueError("run interval must increase")
+    ends = _section_object(geometry["ends"], {"low", "high"}, "ends")
+    conditions = []
+    for key in ("low", "high"):
+        end = _section_object(ends[key], {"condition", "gradient"}, "end")
+        conditions.append(end["condition"])
+        if any(_section_numbers(end["gradient"], 2, "end gradient")):
+            raise _UnsupportedSectionRecess("pocket requires perpendicular run ends")
+    if sorted(conditions, key=str) != ["capped", "open"]:
+        raise ValueError("pocket requires exactly one capped and one open end")
+
+    edge_anchored = kind == "edge_open_recess"
+    profile = _section_object(
+        geometry["profile"],
+        {"closure", "boundary", "opening"} if edge_anchored else {"closure", "boundary"},
+        "profile",
+    )
+    if profile["closure"] != ("open" if edge_anchored else "closed"):
+        raise ValueError("profile closure disagrees with pocket classification")
+    boundary = profile["boundary"]
+    if type(boundary) not in (tuple, list) or len(boundary) not in (
+        (3, 4) if edge_anchored else (4,)
+    ):
+        raise _UnsupportedSectionRecess("pocket requires a rectangular boundary or open chain")
+    points = []
+    for item in boundary:
+        vertex = _section_object(item, {"point", "bulge"}, "profile vertex")
+        point = _section_numbers(vertex["point"], 2, "profile point")
+        if _section_numbers([vertex["bulge"]], 1, "bulge")[0] != 0:
+            raise _UnsupportedSectionRecess("curved profiles need their own drafting semantics")
+        points.append(point)
+    if edge_anchored:
+        opening = profile["opening"]
+        if type(opening) not in (tuple, list) or len(opening) != 2:
+            raise ValueError("opening must join the two loose endpoints")
+        endpoints = tuple(_section_numbers(point, 2, "opening point") for point in opening)
+        if endpoints != (points[-1], points[0]):
+            raise ValueError("opening must join the two loose endpoints")
+    bounds = [(min(p[i] for p in points), max(p[i] for p in points)) for i in range(2)]
+    if any(hi <= lo for lo, hi in bounds):
+        raise ValueError("pocket section must have positive extents")
+    if len(set(points)) != len(points) or any(
+        p[0] not in bounds[0] or p[1] not in bounds[1] for p in points
+    ):
+        raise _UnsupportedSectionRecess("profile does not follow rectangular supports")
+    chain = points if edge_anchored else [*points, points[0]]
+    if any(sum(a[i] != b[i] for i in range(2)) != 1 for a, b in zip(chain, chain[1:])):
+        raise _UnsupportedSectionRecess("profile contains a diagonal or crossing support")
+
+    world_bounds = {
+        run_index: sorted(origin[run_index] + run_sign * n for n in (low, high)),
+        u_index: sorted(origin[u_index] + u_sign * n for n in bounds[0]),
+        v_index: sorted(origin[v_index] + v_sign * n for n in bounds[1]),
+    }
+    span_index = max(
+        (u_index, v_index), key=lambda i: (world_bounds[i][1] - world_bounds[i][0], i)
+    )
+    width_index = v_index if span_index == u_index else u_index
+    center = tuple(lo / 2 + hi / 2 for lo, hi in (world_bounds[i] for i in range(3)))
+    width = world_bounds[width_index][1] - world_bounds[width_index][0]
+    length = world_bounds[span_index][1] - world_bounds[span_index][0]
+    if not all(isfinite(n) for n in (*center, width, length, high - low)):
+        raise ValueError("projected pocket measurements must be finite")
+    if width <= 0 or length <= 0:
+        raise ValueError("projected pocket extents must remain positive")
+    return PocketFeature(
+        frame=Frame(origin=(center[0], center[1], center[2]), axis="xyz"[run_index]),
+        width_axis="xyz"[width_index],
+        long_axis="xyz"[span_index],
+        width=width,
+        length=length,
+        depth=high - low,
+        w_center=center[width_index],
+        lo=world_bounds[span_index][0],
+        hi=world_bounds[span_index][1],
+        edge_anchored=edge_anchored,
+        open_sign=run_sign * (1 if conditions[1] == "open" else -1),
+    )
 
 
 def _convert_channel(channel: Channel, ctx: ConvContext) -> ChannelFeature:

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -454,6 +454,10 @@ class NominalRequirement:
     source: str
     source_ids: tuple[str, ...]
 
+    def agrees_with(self, value: float) -> bool:
+        """Whether a canonical value can carry this nominal without changing its meaning."""
+        return abs(float(value) - self.value) <= 1e-6
+
     def __post_init__(self) -> None:
         if isinstance(self.value, bool):
             raise ValueError("nominal requirement value must be finite and positive")

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -521,7 +521,7 @@ def _decorated(model: PartModel, feature: Feature, param: DimParameter) -> DimPa
     from draftwright.model.ir import NominalRequirement, ToleranceDecoration
 
     nominal = model.decorations.get((feature, "nominal_requirement", param.parameter_id))
-    if isinstance(nominal, NominalRequirement) and abs(float(param.value) - nominal.value) > 1e-6:
+    if isinstance(nominal, NominalRequirement) and not nominal.agrees_with(param.value):
         raise ValueError(
             f"{nominal.source} nominal requirement {nominal.value:g} disagrees with "
             f"{param.parameter_id}={param.value:g}"

--- a/src/draftwright/model/pmi_lowering.py
+++ b/src/draftwright/model/pmi_lowering.py
@@ -504,6 +504,7 @@ def lower_ap242_nominal_diameters(model: PartModel) -> PartModel:
         ],
     ] = {}
     blocked: dict[int, str] = {}
+    nominal_conflicts: set[int] = set()
     for dimension_index, dimension in dimensions.items():
         if dimension.lowering_blockers or dimension.rendering_blockers:
             continue
@@ -529,7 +530,19 @@ def lower_ap242_nominal_diameters(model: PartModel) -> PartModel:
             )
             continue
         owner = matches[0]
-        proposals[dimension_index] = (owner, _nominal_owner_key(owner))
+        key = _nominal_owner_key(owner)
+        nominal = NominalRequirement(
+            value=dimension.value, source="ap242_pmi", source_ids=_source_ids(dimension)
+        )
+        parameter = next(p for p in owner.parameters() if p.parameter_id == key[2])
+        if not nominal.agrees_with(parameter.value):
+            nominal_conflicts.add(dimension_index)
+            blocked[dimension_index] = (
+                f"source nominal {dimension.value!r} disagrees with canonical "
+                f"{parameter.parameter_id}={parameter.value!r}"
+            )
+            continue
+        proposals[dimension_index] = (owner, key)
 
     decorations = dict(model.decorations)
     consumed: set[int] = set()
@@ -543,9 +556,7 @@ def lower_ap242_nominal_diameters(model: PartModel) -> PartModel:
             )
             consumed.add(dimension_index)
             continue
-        if isinstance(existing, NominalRequirement) and _same_number(
-            existing.value, dimension.value
-        ):
+        if isinstance(existing, NominalRequirement) and existing.agrees_with(dimension.value):
             decorations[key] = replace(
                 existing,
                 source_ids=tuple(dict.fromkeys((*existing.source_ids, *incoming_ids))),
@@ -562,6 +573,10 @@ def lower_ap242_nominal_diameters(model: PartModel) -> PartModel:
             continue
         if index in blocked and isinstance(feature, AuthoredDimension):
             feature = _block(feature, blocked[index])
+            if index in nominal_conflicts:
+                feature = replace(
+                    feature, rendering_blockers=(*feature.rendering_blockers, blocked[index])
+                )
         rebuilt.append(feature)
     return _apply_standalone_cylinder_blockers(
         replace(model, features=rebuilt, decorations=decorations)

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -105,7 +105,14 @@ from draftwright.model.declare import (
 )
 from draftwright.model.declare import read_bore_step as _read_bore_step
 from draftwright.model.declare import read_countersink as _read_countersink
-from draftwright.model.ir import NominalRequirement, RequestedDimension, ToleranceDecoration
+from draftwright.model.ir import (
+    ControlFrame,
+    DatumRef,
+    NominalRequirement,
+    Note,
+    RequestedDimension,
+    ToleranceDecoration,
+)
 from draftwright.model.planner import LOCATION_ROLE as _LOCATION_ROLE
 from draftwright.model.planner import location_role as _location_role
 from draftwright.view_plan import (
@@ -1175,6 +1182,7 @@ class Sheet:
 
         Adding the exact feature object already in :attr:`features` returns a handle to
         its existing registration. Equal-valued distinct objects remain separate features.
+        Other inputs raise :class:`TypeError` before changing the sheet.
 
         Returns a handle, like every declaration verb (#922). It matters here more than it
         looks: the ENVELOPE is emitted through this escape hatch rather than through
@@ -1184,15 +1192,13 @@ class Sheet:
         in the middle of the file, which is worse than being absent everywhere. A raw
         ``ControlFrame`` or ``DatumRef`` may name a handle as its ``origin``; ``add`` resolves
         and token-binds that provenance exactly like the public GD&T verbs."""
-        if isinstance(feature, Feature):
-            token = self._declared_token(feature, verb="add()")
-            if token is not None:
-                return _Params(self, self._index_of_token(token))
+        if not isinstance(feature, Feature):
+            raise TypeError("add() requires an IR Feature")
+        token = self._declared_token(feature, verb="add()")
+        if token is not None:
+            return _Params(self, self._index_of_token(token))
         src_token = None
-        if (
-            getattr(feature, "kind", None) in ("control_frame", "datum_ref", "note")
-            and feature.origin is not None
-        ):
+        if isinstance(feature, (ControlFrame, DatumRef, Note)) and feature.origin is not None:
             src_token = self._declared_token(feature.origin, verb=f"add() {feature.kind} origin")
             if src_token is not None:
                 feature = replace(

--- a/tests/test_issue_1146_scale_completeness.py
+++ b/tests/test_issue_1146_scale_completeness.py
@@ -123,6 +123,7 @@ def test_default_fallback_returns_largest_complete_standard_scale_and_reports_de
         drawing = build_drawing(_scale_sensitive_plate(), page="A4", scale=1.0, repair=False)
 
     assert drawing.scale == 0.5
+    assert "scale_fallback_applied" in {i.code for i in drawing.lint(physical=False)}
     assert _placement_drops(drawing) == []
     assert drawing.scale_decision == {
         "policy": "fallback",

--- a/tests/test_issue_1325_nominal_agreement.py
+++ b/tests/test_issue_1325_nominal_agreement.py
@@ -1,0 +1,107 @@
+"""PMI lowering must not produce nominal ownership that the planner rejects."""
+
+from dataclasses import replace
+
+import pytest
+from build123d import Box
+
+from draftwright.model import plan_dimensions
+from draftwright.model.ir import (
+    AuthoredDimension,
+    CylindricalReference,
+    Frame,
+    NominalRequirement,
+    PartModel,
+    StepFeature,
+)
+from draftwright.model.pmi_lowering import lower_ap242_nominal_diameters
+
+
+def _model(nominal, diameter):
+    frame = Frame((0, 0, 0), "z")
+    owner = StepFeature(frame=frame, length=10, diameter=diameter, span=((0, 0, -5), (0, 0, 5)))
+    dimension = AuthoredDimension(
+        frame=frame,
+        dimension_kind="diameter",
+        value=nominal,
+        label=f"ø{nominal:g}",
+        dominant_axis="Z",
+        ref_pts=((0, 0, 0),),
+        source_id="dimension:1325",
+        cylindrical_refs=(
+            CylindricalReference(
+                axis_origin=(0, 0, 0),
+                axis_direction=(0, 0, 1),
+                radius=diameter / 2,
+                axial_interval=(-5, 5),
+                sense="external",
+            ),
+        ),
+    )
+    return PartModel(Box(20, 20, 10).bounding_box(), "z", [owner, dimension])
+
+
+@pytest.mark.parametrize(
+    "nominal,diameter", [(4, 4.005), (4, 3.995), (4, 4.000002), (10000, 10000.005)]
+)
+def test_mismatched_nominal_is_blocked_before_planning(nominal, diameter):
+    model = _model(nominal, diameter)
+    # Topology correspondence is exact; only the stated nominal differs.
+    assert model.features[1].cylindrical_refs[0].diameter == diameter
+    assert abs(nominal - diameter) > 1e-6
+    lowered = lower_ap242_nominal_diameters(model)
+    plan_dimensions(lowered)
+    assert not lowered.decorations
+    retained = [f for f in lowered.features if isinstance(f, AuthoredDimension)]
+    assert len(retained) == 1 and retained[0].value == nominal
+    assert any("nominal" in reason for reason in retained[0].lowering_blockers)
+
+
+@pytest.mark.parametrize("delta", [0, 0.0000005, -0.0000005])
+def test_agreeing_nominal_keeps_canonical_owner(delta):
+    lowered = lower_ap242_nominal_diameters(_model(4, 4 + delta))
+    assert len(lowered.features) == 1
+    assert len(lowered.decorations) == 1
+    requirement = next(iter(lowered.decorations.values()))
+    assert requirement.value == 4
+    assert requirement.source_ids == ("dimension:1325",)
+    plan_dimensions(lowered)
+
+
+def test_direct_authored_conflict_still_fails_in_planner():
+    model = _model(4, 4.005)
+    owner = model.features[0]
+    model = replace(
+        model,
+        features=[owner],
+        decorations={
+            (owner, "nominal_requirement", "step.diameter"): NominalRequirement(
+                4, "ap242_pmi", ("dimension:1325",)
+            )
+        },
+    )
+    with pytest.raises(ValueError, match="nominal requirement"):
+        plan_dimensions(model)
+
+
+def test_mismatch_survives_generated_sheet_without_crashing_or_changing_source(tmp_path):
+    from draftwright.sheet_emit import emit_sheet_script
+
+    lowered = lower_ap242_nominal_diameters(_model(4, 4.005))
+    source = emit_sheet_script(
+        lowered,
+        "from build123d import Cylinder\npart = Cylinder(2.0025, 10)",
+        str(tmp_path / "nominal"),
+        title="Nominal mismatch",
+        number="1325",
+        formats=(),
+    )
+    namespace = {}
+    exec(compile(source, "<nominal-1325>", "exec"), namespace)
+    drawing = namespace["drawing"]
+    retained = [f for f in drawing.model().features if isinstance(f, AuthoredDimension)]
+    assert len(retained) == 1
+    assert retained[0].value == 4
+    assert retained[0].source_id == "dimension:1325"
+    assert retained[0].lowering_blockers
+    assert "authored_dim_source_unresolved" in {i.code for i in drawing.lint()}

--- a/tests/test_issue_1390_sheet_registration.py
+++ b/tests/test_issue_1390_sheet_registration.py
@@ -50,3 +50,13 @@ def test_detected_chamfer_keeps_single_rendered_count(repeat):
     annotations = drawing.annotations_of(feature)
     labels = [a.label for a in annotations.values() if hasattr(a, "label")]
     assert labels == ["C0.5"]
+
+
+@pytest.mark.parametrize("invalid", [None, True, 0, "feature", object()])
+def test_add_refuses_non_features_without_mutating_registration(invalid):
+    sheet = Sheet(Box(20, 20, 10)).authored_dimensions()
+    feature = chamfer(leg1=0.5, at=(0, 0, 5), axis="z")
+    sheet.add(feature)
+    with pytest.raises(TypeError, match="requires an IR Feature"):
+        sheet.add(invalid)
+    assert len(sheet.features) == 1 and sheet.features[0] is feature

--- a/tests/test_issue_1396_layout_advisories.py
+++ b/tests/test_issue_1396_layout_advisories.py
@@ -1,5 +1,6 @@
 """Layout degradations are available without parsing Python warnings or logs."""
 
+import warnings
 from dataclasses import replace
 
 import pytest
@@ -95,3 +96,39 @@ def test_computed_scale_reaches_public_declared_lint():
     drawing = Sheet(Box(1e7, 1e7, 1e7)).authored_dimensions().build()
     assert 0 < drawing.scale < 0.0001
     assert "scale_fallback_applied" in _codes(drawing)
+
+
+@pytest.mark.parametrize("warn_advisory", [False, True])
+@pytest.mark.parametrize("collect_advisories", [False, True])
+def test_warning_delivery_and_diagnostic_collection_are_independent(
+    warn_advisory, collect_advisories
+):
+    from draftwright.analysis import _validate_explicit_scale
+
+    # This part has an automatic legible fit, while the requested scale is too small.
+    auto_scale, *_ = choose_scale(680, 860, 80)
+    assert 80 * 0.1 < 15 <= 80 * auto_scale
+    advisories = [] if collect_advisories else None
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        _validate_explicit_scale(
+            0.1,
+            0.1,
+            680,
+            860,
+            80,
+            0,
+            None,
+            None,
+            False,
+            (),
+            warn_advisory=warn_advisory,
+            advisories=advisories,
+        )
+    assert len(caught) == int(warn_advisory)
+    if caught:
+        assert "legibility floor" in str(caught[0].message)
+    if collect_advisories:
+        assert len(advisories) == 1
+        assert advisories[0][0] == "legibility_floor_breached"
+        assert "legibility floor" in advisories[0][1]

--- a/tests/test_issue_1396_layout_advisories.py
+++ b/tests/test_issue_1396_layout_advisories.py
@@ -89,3 +89,9 @@ def test_measured_fit_retracts_seed_uncertainty():
     assert "page_fit_uncertain" in _codes(drawing)
     assert _repack(a, drawing, "", None, None) is None
     assert "page_fit_uncertain" not in _codes(drawing)
+
+
+def test_computed_scale_reaches_public_declared_lint():
+    drawing = Sheet(Box(1e7, 1e7, 1e7)).authored_dimensions().build()
+    assert 0 < drawing.scale < 0.0001
+    assert "scale_fallback_applied" in _codes(drawing)

--- a/tests/test_issue_1396_layout_advisories.py
+++ b/tests/test_issue_1396_layout_advisories.py
@@ -1,0 +1,91 @@
+"""Layout degradations are available without parsing Python warnings or logs."""
+
+from dataclasses import replace
+
+import pytest
+from build123d import Box
+
+from draftwright import Sheet, build_drawing
+from draftwright.analysis import _analyse
+from draftwright.builder import _assemble, _repack_to_fixed_point
+from draftwright.compose import choose_scale
+
+
+def _codes(drawing):
+    return {issue.code for issue in drawing.lint(physical=False)}
+
+
+def test_legibility_warning_reaches_declared_and_detected_lint():
+    part = Box(680, 860, 80)
+    for declared in (False, True):
+        with pytest.warns(UserWarning, match="legibility floor"):
+            if declared:
+                drawing = Sheet(part, scale=0.1).authored_dimensions().build()
+            else:
+                drawing = build_drawing(part, scale=0.1, scale_policy="permissive")
+        assert drawing.scale == 0.1
+        assert (
+            sum(i.code == "legibility_floor_breached" for i in drawing.lint(physical=False)) == 1
+        )
+        assert (
+            "legibility_floor_breached"
+            in drawing.lint_summary()["quality"]["legibility"]["by_code"]
+        )
+
+
+def test_legible_explicit_scale_has_no_legibility_finding():
+    drawing = Sheet(Box(20, 20, 20), scale=1).authored_dimensions().build()
+    assert "legibility_floor_breached" not in _codes(drawing)
+
+
+@pytest.mark.parametrize("scale,page", [(100, "A4"), (None, (1, 1))])
+def test_infeasible_scale_selection_records_the_warning(scale, page, caplog):
+    advisories = []
+    choose_scale(100, 100, 100, scale=scale, page=page, advisories=advisories)
+    assert "fit" in caplog.text
+    assert [code for code, _ in advisories] == ["page_fit_uncertain"]
+
+
+def test_seed_layout_advisory_reaches_assembled_drawing():
+    a = _analyse(Box(20, 20, 20), title="", number="", tolerance="", drawn_by="", out="")
+    a = replace(a, layout_advisories=(("page_fit_uncertain", "fixture seed fit failure"),))
+    drawing = _assemble(a, "", None, None, auto_dims=False)
+    assert "page_fit_uncertain" in _codes(drawing)
+
+
+@pytest.mark.parametrize("limit", [0, 2])
+def test_unresolved_repack_is_machine_visible(monkeypatch, limit):
+    import draftwright.builder as builder
+
+    a = _analyse(Box(20, 20, 20), title="", number="", tolerance="", drawn_by="", out="")
+    drawing = _assemble(a, "", None, None, auto_dims=False)
+    monkeypatch.setattr(builder, "_REPACK_MAX_ITER", limit)
+    monkeypatch.setattr(builder, "_needs_repack", lambda *args: True)
+    monkeypatch.setattr(builder, "_repack", lambda *args, **kwargs: None)
+    _repack_to_fixed_point(a, drawing, "", None, None)
+    assert "layout_repack_stalled" in _codes(drawing)
+
+
+def test_unknown_layout_advisory_is_refused():
+    from draftwright.builder import _layout_advisory
+
+    with pytest.raises(ValueError, match="unknown layout advisory"):
+        _layout_advisory("misspelled_finding", "must not silently evade classification")
+
+
+def test_computed_scale_is_reported_by_scale_selection():
+    advisories = []
+    scale, *_ = choose_scale(1e7, 1e7, 1e7, advisories=advisories)
+    assert 0 < scale < 0.0001
+    assert [code for code, _ in advisories] == ["scale_fallback_applied"]
+
+
+def test_measured_fit_retracts_seed_uncertainty():
+    from draftwright.builder import _repack
+
+    a = _analyse(Box(20, 20, 20), title="", number="", tolerance="", drawn_by="", out="")
+    a = replace(a, layout_advisories=(("page_fit_uncertain", "fixture seed fit failure"),))
+    drawing = _assemble(a, "", None, None, auto_dims=False)
+    assert "page_fit_uncertain" in _codes(drawing)
+    assert _repack(a, drawing, "", None, None) is None
+    assert "page_fit_uncertain" not in _codes(drawing)

--- a/tests/test_issue_1421_rectangular_blind_slot_semantics.py
+++ b/tests/test_issue_1421_rectangular_blind_slot_semantics.py
@@ -191,6 +191,12 @@ def test_every_nonempty_authored_parameter_subset_survives_rendering(
     assert annotation.label == expected_label
     assert {key["parameter_id"] for key in drawing.measurement_keys(name)} == set(parameters)
     issues = drawing.lint()
+    stalled = [issue for issue in issues if issue.code == "layout_repack_stalled"]
+    assert len(stalled) == (
+        parameters
+        == ("rectangular_blind_slot_width.length", "rectangular_blind_slot_length.length")
+    )
+    issues = [issue for issue in issues if issue.code != "layout_repack_stalled"]
     assert len(issues) == 3 - len(parameters)
     assert {issue.code for issue in issues} <= {"rectangular_blind_slot_requirement_suppressed"}
 

--- a/tests/test_issue_1471_section_recess_pockets.py
+++ b/tests/test_issue_1471_section_recess_pockets.py
@@ -1,0 +1,351 @@
+"""First Quiddity migration slice: released geometry against authored pocket facts.
+
+The two providers run separately for comparison. Only primitive JSON enters the new adapter;
+the declared-model drawing still uses the pinned production provider for physical lint. This
+proves the new pocket lowering and existing back end, not completion of provider adoption.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+import quiddity
+from build123d import Box, Pos, import_step
+
+from draftwright import Sheet, build_drawing
+from draftwright.audit import diff_builds
+from draftwright.model.detect import (
+    _convert_section_recess_pocket,
+    _UnsupportedSectionRecess,
+)
+from draftwright.sheet_emit import emit_sheet_script
+
+_CORPUS = Path(__file__).parent / "fixtures/evaluation/corpus-pockets-v1.json"
+_CASES = json.loads(_CORPUS.read_text())["cases"]
+
+
+def _parameters(feature):
+    return {
+        "width": feature.width,
+        "length": feature.length,
+        "depth": feature.depth,
+        "edge_anchored": feature.edge_anchored,
+    }
+
+
+@pytest.fixture(scope="module", params=_CASES, ids=lambda case: case["id"])
+def pocket_case(request):
+    case = request.param
+    path = _CORPUS.parent / case["fixture"]
+    assert hashlib.sha256(path.read_bytes()).hexdigest() == case["sha256"]
+    part = import_step(path)
+    result = quiddity.build_section_recess_document(part).to_dict()
+    converted = []
+    refused = []
+    for source in result["occurrences"]:
+        try:
+            converted.append(
+                _convert_section_recess_pocket(source, schema_version=result["schema_version"])
+            )
+        except _UnsupportedSectionRecess:
+            refused.append(source)
+    assert not result["refusals"]
+    return case, path, part, result, converted, refused
+
+
+def test_released_pockets_match_the_independently_authored_corpus(pocket_case):
+    case, _path, _part, _result, converted, refused = pocket_case
+    assert len(converted) == len(case["facts"])
+    assert len(refused) == (1 if case["id"] == "pocket-prismatic-owner-negative" else 0)
+    remaining = list(converted)
+    for fact in case["facts"]:
+        expected = fact["identity"]
+        matches = [
+            feature
+            for feature in remaining
+            if feature.frame.origin == pytest.approx(expected["location"]["value"], abs=1e-6)
+        ]
+        assert len(matches) == 1
+        feature = matches[0]
+        remaining.remove(feature)
+        assert feature.frame.axis == expected["depth_axis"]["value"]
+        assert feature.long_axis == expected["long_axis"]["value"]
+        assert feature.width_axis == expected["width_axis"]["value"]
+        assert feature.open_sign == expected["open_sign"]["value"]
+        for name, value in _parameters(feature).items():
+            assert value == fact["parameters"][name]["value"]
+    assert remaining == []
+
+
+def test_pocket_lowering_preserves_drawing_and_generated_sheet(pocket_case, tmp_path):
+    case, path, _part, _result, converted, _refused = pocket_case
+    before = build_drawing(path)
+    model = before.model()
+    old_pockets = [feature for feature in model.features if feature.kind == "pocket"]
+    # Equality covers the entire consumer geometry, not merely parameter values. Ordering is
+    # not a cross-provider promise; establish one-to-one equality before replacing each owner.
+    assert len(old_pockets) == len(converted)
+    remaining = list(converted)
+    features = []
+    for feature in model.features:
+        if feature.kind == "pocket":
+            match = next(candidate for candidate in remaining if candidate == feature)
+            remaining.remove(match)
+            features.append(match)
+        else:
+            features.append(feature)
+    assert not remaining
+    candidate = replace(model, features=features)
+    after = build_drawing(path, model=candidate)
+    delta = diff_builds(before, after)
+    assert delta["dimensions_lost"] == {}
+    assert delta["dimensions_gained"] == {}
+    assert delta["dimensions_changed"] == {}
+    assert delta["measurements_substituted"] == {}
+    assert [(i.severity, i.code) for i in after.lint()] == [
+        (i.severity, i.code) for i in before.lint()
+    ]
+
+    source = emit_sheet_script(
+        candidate,
+        f"from build123d import import_step\npart = import_step({str(path)!r})",
+        str(tmp_path / case["id"]),
+        title=case["id"],
+        number="1471",
+        formats=(),
+    )
+    namespace = {"__name__": "__migration_test__"}
+    exec(compile(source, "<generated migration sheet>", "exec"), namespace)
+    rebuilt = namespace["drawing"]
+    generated = [feature for feature in rebuilt.model().features if feature.kind == "pocket"]
+    assert sorted(generated, key=lambda feature: feature.frame.origin) == sorted(
+        converted, key=lambda feature: feature.frame.origin
+    )
+    assert not [issue for issue in rebuilt.lint() if issue.code == "pocket_requirement_missing"]
+
+
+def _record():
+    """Independently specified 30 x 12 x 6 pocket opening toward +Z."""
+    return {
+        "index": 0,
+        "body": 0,
+        "geometry": {
+            "type": "section_recess",
+            "frame": {
+                "origin": [22.0, -11.0, 0.0],
+                "run": [0.0, 0.0, 1.0],
+                "u": [1.0, 0.0, 0.0],
+                "v": [0.0, 1.0, 0.0],
+            },
+            "run_interval": [4.0, 10.0],
+            "profile": {
+                "closure": "closed",
+                "boundary": [
+                    {"point": [-15.0, -6.0], "bulge": 0.0},
+                    {"point": [15.0, -6.0], "bulge": 0.0},
+                    {"point": [15.0, 6.0], "bulge": 0.0},
+                    {"point": [-15.0, 6.0], "bulge": 0.0},
+                ],
+            },
+            "ends": {
+                "low": {"condition": "capped", "gradient": [0.0, 0.0]},
+                "high": {"condition": "open", "gradient": [0.0, 0.0]},
+            },
+        },
+        "classification": {"feature_kind": "pocket", "section_shape": "rectangular"},
+        "evidence": {"defining_faces": [0, 1, 2, 3], "constituent_faces": [0, 1, 2, 3, 4]},
+    }
+
+
+def test_migration_corpus_keeps_its_independent_denominator():
+    assert len(_CASES) == 10
+    assert sum(len(case["facts"]) for case in _CASES) == 13
+
+
+def _change(record, path, value):
+    target = record
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = value
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("index",), True),
+        (("body",), -1),
+        (("evidence", "defining_faces"), []),
+        (("evidence", "defining_faces"), [99]),
+        (("evidence", "constituent_faces"), [1, 0]),
+        (("evidence", "constituent_faces"), [False, 1, 2, 3]),
+        (("geometry", "type"), "pocket"),
+        (("geometry", "frame", "origin"), [0, 0]),
+        (("geometry", "frame", "origin", 0), True),
+        (("geometry", "frame", "origin", 0), float("nan")),
+        (("geometry", "frame", "origin", 0), 10**1000),
+        (("geometry", "frame", "u"), [0, 0, 1]),
+        (("geometry", "frame", "v"), [0, -1, 0]),
+        (("geometry", "run_interval"), [10, 4]),
+        (("geometry", "ends", "high", "condition"), "capped"),
+        (("geometry", "profile", "closure"), "open"),
+        (("geometry", "profile", "boundary", 0), {"point": [0, 0]}),
+        (("geometry", "profile", "boundary", 0, "bulge"), "0"),
+        (("geometry", "profile", "boundary", 0, "point"), [0, float("inf")]),
+    ],
+)
+def test_malformed_geometry_cannot_enter_the_ir(path, value):
+    record = _record()
+    assert _convert_section_recess_pocket(record, schema_version=2).width == 12
+    _change(record, path, value)
+    with pytest.raises(ValueError):
+        _convert_section_recess_pocket(record, schema_version=2)
+
+
+@pytest.mark.parametrize("version", [1, 3, True, 2.0, "2"])
+def test_only_the_released_schema_is_admitted(version):
+    with pytest.raises(ValueError, match="schema"):
+        _convert_section_recess_pocket(_record(), schema_version=version)
+
+
+@pytest.mark.parametrize(
+    ("path", "value"),
+    [
+        (("classification", "section_shape"), "obround"),
+        (("geometry", "frame", "u"), [0.8, 0.6, 0]),
+        (("geometry", "ends", "low", "gradient"), [0.1, 0]),
+        (("geometry", "profile", "boundary", 0, "bulge"), 1.0),
+        (("geometry", "profile", "boundary", 0, "point"), [-10, 0]),
+        (("geometry", "profile", "boundary"), []),
+    ],
+)
+def test_unsupported_sections_are_not_replaced_by_bounding_rectangles(path, value):
+    record = _record()
+    _change(record, path, value)
+    with pytest.raises(_UnsupportedSectionRecess):
+        _convert_section_recess_pocket(record, schema_version=2)
+
+
+def test_negative_run_and_reversed_profile_keep_the_physical_pocket():
+    record = _record()
+    expected = _convert_section_recess_pocket(record, schema_version=2)
+    frame = record["geometry"]["frame"]
+    frame["run"] = [0, 0, -1]
+    frame["v"] = [0, -1, 0]
+    record["geometry"]["run_interval"] = [-10, -4]
+    record["geometry"]["ends"] = {
+        "low": {"condition": "open", "gradient": [0, 0]},
+        "high": {"condition": "capped", "gradient": [0, 0]},
+    }
+    for vertex in record["geometry"]["profile"]["boundary"]:
+        vertex["point"][1] *= -1
+    assert _convert_section_recess_pocket(record, schema_version=2) == expected
+
+
+def test_crossing_vertex_order_is_refused():
+    record = _record()
+    boundary = record["geometry"]["profile"]["boundary"]
+    boundary[1], boundary[2] = boundary[2], boundary[1]
+    with pytest.raises(_UnsupportedSectionRecess, match="diagonal"):
+        _convert_section_recess_pocket(record, schema_version=2)
+
+
+def test_adapter_does_not_mutate_or_retain_provider_json():
+    record = _record()
+    original = copy.deepcopy(record)
+    feature = _convert_section_recess_pocket(record, schema_version=2)
+    assert record == original
+    record["geometry"]["run_interval"][1] = 100
+    assert feature.depth == 6
+    assert feature.frame.origin == (22, -11, 7)
+
+
+def _open_record(*, corner=True):
+    record = _record()
+    record["classification"] = {"feature_kind": "edge_open_recess", "section_shape": "polygonal"}
+    profile = record["geometry"]["profile"]
+    profile["closure"] = "open"
+    if corner:
+        profile["boundary"].pop()
+    profile["opening"] = [profile["boundary"][-1]["point"], profile["boundary"][0]["point"]]
+    return record
+
+
+@pytest.mark.parametrize("corner", [True, False])
+def test_open_corner_and_edge_keep_only_the_existing_pocket_measurements(corner):
+    feature = _convert_section_recess_pocket(_open_record(corner=corner), schema_version=2)
+    assert _parameters(feature) == {"width": 12, "length": 30, "depth": 6, "edge_anchored": True}
+    assert feature.frame.origin == (22, -11, 7)
+    assert feature.open_sign == 1
+
+
+@pytest.mark.parametrize("opening", [[], [[0, 0], [1, 1]]])
+def test_opening_must_reference_the_observed_loose_endpoints(opening):
+    record = _open_record()
+    record["geometry"]["profile"]["opening"] = opening
+    with pytest.raises(ValueError, match="loose endpoints"):
+        _convert_section_recess_pocket(record, schema_version=2)
+
+
+def test_zero_section_and_unrepresentable_world_extents_are_refused():
+    record = _record()
+    for vertex in record["geometry"]["profile"]["boundary"]:
+        vertex["point"][0] = 0
+    with pytest.raises(ValueError, match="positive extents"):
+        _convert_section_recess_pocket(record, schema_version=2)
+    record = _record()
+    record["geometry"]["frame"]["origin"][0] = 1e308
+    with pytest.raises(ValueError, match="remain positive"):
+        _convert_section_recess_pocket(record, schema_version=2)
+    record = _record()
+    record["geometry"]["run_interval"] = [-1e308, 1e308]
+    with pytest.raises(ValueError, match="must be finite"):
+        _convert_section_recess_pocket(record, schema_version=2)
+
+
+def test_lowering_an_existing_document_does_not_recognise_again(monkeypatch):
+    import b123d_recognisers
+
+    import draftwright.model.detect as detect
+
+    def forbidden(*args, **kwargs):
+        pytest.fail("the adapter must only project its supplied document")
+
+    monkeypatch.setattr(quiddity, "build_section_recess_document", forbidden)
+    monkeypatch.setattr(quiddity, "build_raw_recognition_result", forbidden)
+    monkeypatch.setattr(b123d_recognisers, "build_raw_recognition_result", forbidden)
+    monkeypatch.setattr(detect, "build_recognition_evidence", forbidden)
+    assert _convert_section_recess_pocket(_record(), schema_version=2).depth == 6
+
+
+def test_declared_omission_still_withholds_the_whole_pocket_callout():
+    part = Box(100, 60, 20) - Pos(22, -11, 7) * Box(30, 12, 6)
+    feature = _convert_section_recess_pocket(_record(), schema_version=2)
+
+    def callouts(parameters):
+        sheet = Sheet(part)
+        sheet.authored_dimensions()
+        handle = sheet.pocket(
+            **_parameters(feature),
+            long_axis=feature.long_axis,
+            width_axis=feature.width_axis,
+            depth_axis=feature.frame.axis,
+            at=feature.frame.origin,
+            w_center=feature.w_center,
+            lo=feature.lo,
+            hi=feature.hi,
+            open_sign=feature.open_sign,
+        )
+        for parameter in parameters:
+            sheet.dimension(handle, parameter)
+        drawing = sheet.build()
+        return [name for name in drawing.annotations() if name.startswith("m_pocket_")]
+
+    assert (
+        len(callouts(("pocket_width.length", "pocket_length.length", "pocket_depth.length"))) == 1
+    )
+    assert callouts(("pocket_width.length",)) == []

--- a/tests/test_issue_1471_section_recess_pockets.py
+++ b/tests/test_issue_1471_section_recess_pockets.py
@@ -349,3 +349,13 @@ def test_declared_omission_still_withholds_the_whole_pocket_callout():
         len(callouts(("pocket_width.length", "pocket_length.length", "pocket_depth.length"))) == 1
     )
     assert callouts(("pocket_width.length",)) == []
+
+
+@pytest.mark.parametrize("axis", [0, 1, 2])
+def test_translation_must_not_collapse_any_world_extent(axis):
+    record = _record()
+    record["geometry"]["frame"]["origin"][axis] = 1e308
+    # Adding the finite local extent cannot change this floating-point coordinate.
+    assert 1e308 + 30 == 1e308
+    with pytest.raises(ValueError, match="remain positive"):
+        _convert_section_recess_pocket(record, schema_version=2)

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -2904,21 +2904,24 @@ class TestComposeThenPackRepack:
         from types import SimpleNamespace
 
         import draftwright.builder as builder
+        from draftwright.registry import AnnotationRegistry
 
         calls = []
 
         def fake_repack(a, dwg, *args, **kwargs):
             calls.append((a.pass_id, dwg.pass_id))
             pass_id = len(calls)
-            return SimpleNamespace(pass_id=pass_id), SimpleNamespace(pass_id=pass_id)
+            return SimpleNamespace(
+                pass_id=pass_id, registry=AnnotationRegistry()
+            ), SimpleNamespace(pass_id=pass_id, registry=AnnotationRegistry())
 
         monkeypatch.setattr(builder, "_repack", fake_repack)
         monkeypatch.setattr(builder, "_needs_repack", lambda dwg, a: True)
 
         with caplog.at_level(logging.WARNING):
             out_a, out_dwg = builder._repack_to_fixed_point(
-                SimpleNamespace(pass_id=0),
-                SimpleNamespace(pass_id=0),
+                SimpleNamespace(pass_id=0, registry=AnnotationRegistry()),
+                SimpleNamespace(pass_id=0, registry=AnnotationRegistry()),
                 "out",
                 None,
                 False,
@@ -2932,14 +2935,15 @@ class TestComposeThenPackRepack:
         from types import SimpleNamespace
 
         import draftwright.builder as builder
+        from draftwright.registry import AnnotationRegistry
 
         monkeypatch.setattr(builder, "_repack", lambda *args, **kwargs: None)
         monkeypatch.setattr(builder, "_needs_repack", lambda dwg, a: True)
 
         with caplog.at_level(logging.WARNING):
             out = builder._repack_to_fixed_point(
-                SimpleNamespace(pass_id=0),
-                SimpleNamespace(pass_id=0),
+                SimpleNamespace(pass_id=0, registry=AnnotationRegistry()),
+                SimpleNamespace(pass_id=0, registry=AnnotationRegistry()),
                 "out",
                 None,
                 False,

--- a/uv.lock
+++ b/uv.lock
@@ -782,7 +782,7 @@ dev = [
     { name = "pytest-split", specifier = ">=0.8" },
     { name = "pytest-timeout", specifier = ">=2" },
     { name = "pytest-xdist", specifier = ">=3" },
-    { name = "quiddity", specifier = "==0.2.0" },
+    { name = "quiddity", specifier = "==0.2.1" },
     { name = "ruff", specifier = ">=0.4" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2" },
 ]
@@ -2592,15 +2592,15 @@ wheels = [
 
 [[package]]
 name = "quiddity"
-version = "0.2.0"
+version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/73/f2/024b4a77613075b49a001e2d44496b063f82c6aa91c952ff80bd0089b519/quiddity-0.2.0.tar.gz", hash = "sha256:ceb152a7e7009eccdb1ba548ac91a62f85ad298cf4d0e4a30e0a0149245c9d31", size = 13749033, upload-time = "2026-09-05T16:27:33.001Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/fd/cc5f0db511da23d4e99ee41a6f881212e11516779fbb73651cad0e8b0c60/quiddity-0.2.1.tar.gz", hash = "sha256:d30ba4d92eaf7e934e6e012a4d69f290f408e2159fb4fae9cd762ba366835693", size = 13764527, upload-time = "2026-09-06T00:32:08.899Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/d7/c9d2fdbfc0ed1f9d65b713426701e568ea0a558ca5c426ec2b49b8992b98/quiddity-0.2.0-py3-none-any.whl", hash = "sha256:d2fd89d031b8ad955045615b5cdfabb506a6547fcaf89905d7f97e3e82242c57", size = 462108, upload-time = "2026-09-05T16:27:31.25Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/e5/bf380667467987d06b8c10b864cb188b7d149d7f9f8fa54b7150e6507664/quiddity-0.2.1-py3-none-any.whl", hash = "sha256:947867ad028412a1cef272ce29f48b0583d2a8009dea13b2b59be58abdb1df30", size = 466048, upload-time = "2026-09-06T00:32:06.499Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -745,6 +745,7 @@ dev = [
     { name = "pytest-split" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
+    { name = "quiddity" },
     { name = "ruff" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
@@ -781,6 +782,7 @@ dev = [
     { name = "pytest-split", specifier = ">=0.8" },
     { name = "pytest-timeout", specifier = ">=2" },
     { name = "pytest-xdist", specifier = ">=3" },
+    { name = "quiddity", specifier = "==0.2.0" },
     { name = "ruff", specifier = ">=0.4" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2" },
 ]
@@ -2586,6 +2588,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
+]
+
+[[package]]
+name = "quiddity"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
+    { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/73/f2/024b4a77613075b49a001e2d44496b063f82c6aa91c952ff80bd0089b519/quiddity-0.2.0.tar.gz", hash = "sha256:ceb152a7e7009eccdb1ba548ac91a62f85ad298cf4d0e4a30e0a0149245c9d31", size = 13749033, upload-time = "2026-09-05T16:27:33.001Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/d7/c9d2fdbfc0ed1f9d65b713426701e568ea0a558ca5c426ec2b49b8992b98/quiddity-0.2.0-py3-none-any.whl", hash = "sha256:d2fd89d031b8ad955045615b5cdfabb506a6547fcaf89905d7f97e3e82242c57", size = 462108, upload-time = "2026-09-05T16:27:31.25Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This integrates the reviewed patch fixes while preserving each component PR's original commits:

- #1474: block conflicting AP242 nominal ownership before planning, preserving the source value and generated-script diagnostics.
- #1475: expose layout legibility, fit, repack and scale fallback warnings through structured lint. Warning delivery and diagnostic collection remain independent.
- #1472: add the private SectionRecess pocket adapter and comparison corpus against released Quiddity 0.2.1. The Python 3.10/build123d 0.10 crash reproduction now passes. This is preparatory validation; production remains pinned to b123d-recognisers 0.4.14.
- Follow up #1473 by rejecting invalid `Sheet.add()` inputs before registration changes and testing both sides of its input contract. Its non-required Codecov patch failure arrived one second before auto-merge; all remaining merges are manual and require both Codecov statuses.

## Merge and publication gates

Use **Create a merge commit** to preserve the exact component heads and incorporate #1472, #1474 and #1475 through their original commits. Do not squash or rebase this integration PR.

Every component and combined check, including `ci-ok`, `codecov/project` and `codecov/patch`, must be green. The combined branch must satisfy main's up-to-date protection. Auto-merge is disabled.

Quiddity 0.2.1 is published on PyPI and its crash fix has been verified against the supported older kernel. Draftwright 0.4.19 publication still waits for successful integration and release validation; no release has been published.

## Validation at f8c8eeea

- Full local gate exits 0: **6,844 passed, 5 skipped, 2 xfailed**, 95.97% overall coverage and **99% changed-line coverage** (163 of 164 changed lines). All static gates pass.
- Final component gates exit 0: #1475 has 6,762 passing tests and 97% changed-line coverage; #1472 has 6,811 passing tests and 100% changed-line coverage. #1474's full gate and hosted checks pass as recorded in that PR.
- The public Quiddity crash reproduction and all 64 migration tests pass on Python 3.10/build123d 0.10.0 and Python 3.14/build123d 0.11.1. All 15 layout diagnostic tests also pass on Python 3.10/build123d 0.10.
- All five pocket-adapter mutations are caught against 0.2.1. The warning-delivery regression catches suppression of structured diagnostics. Previously recorded registration and four-code diagnostic mutations remain valid because those source guards are unchanged.
- Wheel and source distribution build successfully. Wheel metadata retains the production recogniser pin and excludes development-only Quiddity.
- All three exact component heads are ancestors of this integration head. Hosted checks for the final commits are pending.

## Google and ADR review

Final local review covers design, behavior, complexity, tests, naming, comments, style and documentation, including each changed line and component interactions. No substantive findings remain. This is a local review, not an independent maintainer approval.

ADR 1: conversion remains at the IR boundary and diagnostics use existing typed state. ADR 2: shared placement and bounded repack remain intact. ADR 3: the exact development pin is verified, production recognition is unchanged, and the adapter performs no recognition; same-run ownership and the production cutover remain explicit future work. ADR 4: declaration identity, source ownership, generated-script execution and omission behavior are preserved. ADR 5: degraded layout and blocked PMI remain visible, malformed geometry is refused, and mutation tests prove the guards. No ADR text or branch-protection settings change.
