### PR TITLE
Expose planner placement-rule discovery and bounded preflight validation

### DIFF
--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -4,6 +4,37 @@
 are documented here because they are part of normal use even though their Python names begin
 with an underscore.
 
+## Discovering supported dimension edits
+
+Call `handle.dimension_ids()` to find the measurements a declared feature exposes, then
+query a measurement before choosing its placement controls:
+
+```python
+options = s.dimension_options(hole, "bore.diameter")
+# options["placements"] contains valid {"view": ..., "side": ...} pairs.
+# None means leave that override unspecified.
+
+check = s.validate_dimension(hole, "bore.diameter", view="plan", side="left")
+if check["supported"]:
+    s.dimension(hole, "bore.diameter", view="plan", side="left")
+else:
+    print(check["issues"], check["options"])
+```
+
+Both queries return versioned JSON-ready dictionaries without recording intent, preparing the
+Sheet, recognising geometry or rendering. Use complete view/side pairs: a side supported in one
+view may be unavailable in another. The `axis` argument follows `dimension()`'s parameter-variant
+rules; full parameter ids already name their variant. Location intent currently admits no view
+or side override. Invalid references, unsupported controls and unsupported placement pairs have
+separate structured refusal codes in `validate_dimension()`; `dimension_options()` raises on an
+invalid reference.
+
+The explicit `single_dimension` scope checks renderer support in isolation. It does not certify
+agreement with other authored dimensions, visibility in an authored view set, available space,
+completeness or a collision-free drawing. Build and lint still assess the resulting Sheet. A
+query never replaces an existing dimension request. Keep the original feature handle for edits;
+these reports do not introduce persistent feature identities or new lane, route or pin controls.
+
 ## Sheet
 
 ::: draftwright.sheet.Sheet

--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -4,14 +4,14 @@
 are documented here because they are part of normal use even though their Python names begin
 with an underscore.
 
-## Discovering supported dimension edits
+## Checking dimension placement rules
 
 Call `handle.dimension_ids()` to find the measurements a declared feature exposes, then
 query a measurement before choosing its placement controls:
 
 ```python
 options = s.dimension_options(hole, "bore.diameter")
-# options["placements"] contains valid {"view": ..., "side": ...} pairs.
+# options["placements"] contains pairs accepted by the planner's placement rules.
 # None means leave that override unspecified.
 
 check = s.validate_dimension(hole, "bore.diameter", view="plan", side="left")
@@ -29,9 +29,13 @@ or side override. Invalid references, unsupported controls and unsupported place
 separate structured refusal codes in `validate_dimension()`; `dimension_options()` raises on an
 invalid reference.
 
-The explicit `single_dimension` scope checks renderer support in isolation. It does not certify
-agreement with other authored dimensions, visibility in an authored view set, available space,
-completeness or a collision-free drawing. Build and lint still assess the resulting Sheet. A
+The explicit `single_dimension_placement_rules` scope means `supported` reports acceptance by
+the current planner placement rules. Both documents set `requires_build_validation: true`:
+whole-part classification can select a different renderer, so this query does not prove actual
+rendered support. For example, a boss on a turned part can use a different diameter renderer
+from a boss on a prismatic part. Agreement with other authored dimensions, visibility in an
+authored view set, available space, completeness and collision-free placement also require a
+build. Build and lint still assess the resulting Sheet. A
 query never replaces an existing dimension request. Keep the original feature handle for edits;
 these reports do not introduce persistent feature identities or new lane, route or pin controls.
 

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -365,8 +365,8 @@ def _preferred_group_view(feature: Feature) -> str:
     `render_step_lengths` draws the chain on the front view (X → horizontal
     above, Z → vertical right) and `render_diameters` hangs its ø row/column off
     the front view (X → row below, Z → column left). A Y-axis step derives to
-    its geometric profile ("side"); no step render pipeline consumes Y today
-    (`render_diameters` buckets x/z only).
+    its geometric profile ("side") for lengths; its diameter leaders use the
+    end-on front view. `_parameter_view_preferences` records that distinction.
     """
     if isinstance(feature, ChamferFeature | FilletFeature) and feature.turned:
         return _PROFILE.get(feature.frame.axis, "front")
@@ -1131,11 +1131,11 @@ def _group_placement(feature: Feature, dims: list[PlannedDimension], planned_vie
 
 
 def validate_dimension_placement(request: RequestedDimension) -> None:
-    """Check one request's renderer support, independently of other authored intent.
+    """Apply the planner's placement rules to one request, without whole-build context.
 
-    This is the same group-placement validator planning uses. It proves supported
-    controls, not visibility in a chosen view set, compound-intent agreement, placement
-    capacity, or preservation of a complete authored requirement set.
+    This is the same group-placement validator planning uses. Acceptance does not prove
+    actual renderer support: whole-part classification can select another renderer.
+    Chosen views, compound intent, placement capacity and completeness also need a build.
     """
     if request.role == LOCATION_ROLE:
         if location_role(request.feature) is None:
@@ -1291,6 +1291,8 @@ def _parameter_view_preferences(feature: Feature, pd: PlannedDimension) -> tuple
     if role in {"boss_height", "stock_length"}:
         return (_PROFILE.get(axis, "front"),)
     if kind == "step_level" and role == "step_height":
+        return ("front",)
+    if kind == "step" and axis == "y" and pd.param.kind == "diameter":
         return ("front",)
     if kind in {"step", "groove", "rotational", "plate"}:
         return (_PROFILE.get(axis, "front"),)

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -30,6 +30,8 @@ from dataclasses import dataclass, replace
 
 from draftwright._geometry import _EDGE_ON, _END_ON, HoleRef
 from draftwright.model.ir import (
+    PLACEMENT_SIDES,
+    PLACEMENT_VIEWS,
     BlendFeature,
     ChamferFeature,
     ChannelFeature,
@@ -48,6 +50,7 @@ from draftwright.model.ir import (
     PocketPatternFeature,
     Point,
     RectangularBlindSlotFeature,
+    RequestedDimension,
     RoundBottomBlindSlotFeature,
     SlotFeature,
     SlotPatternFeature,
@@ -1125,6 +1128,51 @@ def _group_placement(feature: Feature, dims: list[PlannedDimension], planned_vie
                 f"{choices or 'none'}"
             )
     return selected_view, requested_side
+
+
+def validate_dimension_placement(request: RequestedDimension) -> None:
+    """Check one request's renderer support, independently of other authored intent.
+
+    This is the same group-placement validator planning uses. It proves supported
+    controls, not visibility in a chosen view set, compound-intent agreement, placement
+    capacity, or preservation of a complete authored requirement set.
+    """
+    if request.role == LOCATION_ROLE:
+        if location_role(request.feature) is None:
+            raise ValueError("feature has no location measurement")
+        return  # RequestedDimension already refuses location view/side overrides.
+    parameters = [
+        parameter
+        for parameter in request.feature.parameters()
+        if _authored_addresses(request, request.feature, parameter)
+    ]
+    if not parameters:
+        raise ValueError(f"no parameter matches {request.role!r}")
+    _group_placement(
+        request.feature,
+        [
+            PlannedDimension(
+                param=parameter,
+                convention=_CONVENTION.get((parameter.role, parameter.kind), "linear"),
+                view=request.view,
+                side=request.side,
+            )
+            for parameter in parameters
+        ],
+    )
+
+
+def dimension_placement_options(request: RequestedDimension) -> list[dict[str, str | None]]:
+    """Enumerate valid view/side pairs using the planner's existing support checks."""
+    options = []
+    for view in (None, *sorted(PLACEMENT_VIEWS)):
+        for side in (None, *sorted(PLACEMENT_SIDES)):
+            try:
+                validate_dimension_placement(replace(request, view=view, side=side))
+            except ValueError:
+                continue
+            options.append({"view": view, "side": side})
+    return options
 
 
 def authored_location_omitted(model, feature) -> bool:

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -107,6 +107,7 @@ from draftwright.model.declare import read_bore_step as _read_bore_step
 from draftwright.model.declare import read_countersink as _read_countersink
 from draftwright.model.ir import NominalRequirement, RequestedDimension, ToleranceDecoration
 from draftwright.model.planner import LOCATION_ROLE as _LOCATION_ROLE
+from draftwright.model.planner import dimension_placement_options, validate_dimension_placement
 from draftwright.model.planner import location_role as _location_role
 from draftwright.view_plan import (
     ConstraintSource,
@@ -1269,6 +1270,99 @@ class Sheet:
         if feature is _UNSET or role is _UNSET:
             raise TypeError("dimension() requires a feature and a parameter id")
         return self._authored_dimension(feature, role, axis=axis, view=view, side=side)
+
+    def dimension_options(
+        self, feature, role: DimensionParameterId, *, axis: str | None = None
+    ) -> dict:
+        """Discover supported view/side pairs for one declared measurement, without building.
+
+        Uses the same handle/id resolver as :meth:`dimension` and the planner's renderer
+        support checks. ``None`` means omit that override. Pairs are intentional: a side
+        supported in one view need not be supported in another. The result is JSON-ready.
+
+        Scope is **one dimension in isolation**. It does not validate the full authored set,
+        chosen views, compound-callout agreement, or collision-free placement. Keep the supplied
+        feature handle to address subsequent edits; the result creates no persistent feature
+        identity. Invalid feature/measurement references raise as they do in ``dimension``.
+        The query neither records an intent nor prepares, recognises, or renders the part.
+        """
+        _token, target, discriminator, canonical = self._resolve_measurement(
+            feature, role, axis, "dimension_options"
+        )
+        request = RequestedDimension(target, canonical, discriminator=discriminator)
+        parameter_id = next(
+            (
+                parameter.parameter_id
+                for parameter in target.parameters()
+                if canonical in (parameter.role, parameter.parameter_id)
+                and parameter.discriminator == discriminator
+            ),
+            canonical,
+        )
+        return {
+            "schema": "draftwright.dimension-options",
+            "schema_version": 1,
+            "scope": "single_dimension",
+            "feature_kind": target.kind,
+            "parameter_id": parameter_id,
+            "axis": discriminator,
+            "placements": dimension_placement_options(request),
+        }
+
+    def validate_dimension(
+        self,
+        feature,
+        role: DimensionParameterId,
+        *,
+        axis: str | None = None,
+        view: str | None = None,
+        side: str | None = None,
+        **unsupported,
+    ) -> dict:
+        """Preflight a proposed ``dimension`` call without recording or rendering it.
+
+        Returns ``supported``, structured ``issues`` and the valid ``options`` for this
+        target. This checks the single-dimension support scope of :meth:`dimension_options`,
+        not whole-sheet feasibility. Existing authored intent is never replaced or modified.
+        Unknown controls are refused rather than ignored or passed on to a renderer.
+        """
+        result = {
+            "schema": "draftwright.dimension-validation",
+            "schema_version": 1,
+            "scope": "single_dimension",
+            "supported": False,
+            "issues": [],
+            "options": None,
+        }
+        try:
+            options = self.dimension_options(feature, role, axis=axis)
+        except (TypeError, ValueError) as exc:
+            result["issues"] = [{"code": "invalid_measurement", "message": str(exc)}]
+            return result
+        result["options"] = options
+        if unsupported:
+            result["issues"] = [
+                {
+                    "code": "unsupported_control",
+                    "message": "dimension accepts only axis, view and side placement controls",
+                    "controls": sorted(unsupported),
+                }
+            ]
+            return result
+        _token, target, discriminator, canonical = self._resolve_measurement(
+            feature, role, axis, "validate_dimension"
+        )
+        try:
+            validate_dimension_placement(
+                RequestedDimension(
+                    target, canonical, discriminator=discriminator, view=view, side=side
+                )
+            )
+        except (TypeError, ValueError) as exc:
+            result["issues"] = [{"code": "unsupported_placement", "message": str(exc)}]
+            return result
+        result["supported"] = True
+        return result
 
     def _authored_dimension(
         self,

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -1280,14 +1280,16 @@ class Sheet:
     def dimension_options(
         self, feature, role: DimensionParameterId, *, axis: str | None = None
     ) -> dict:
-        """Discover supported view/side pairs for one declared measurement, without building.
+        """Discover view/side pairs accepted by planner placement rules, without building.
 
-        Uses the same handle/id resolver as :meth:`dimension` and the planner's renderer
-        support checks. ``None`` means omit that override. Pairs are intentional: a side
+        Uses the same handle/id resolver as :meth:`dimension` and the planner's placement
+        rules. ``None`` means omit that override. Pairs are intentional: a side
         supported in one view need not be supported in another. The result is JSON-ready.
 
-        Scope is **one dimension in isolation**. It does not validate the full authored set,
-        chosen views, compound-callout agreement, or collision-free placement. Keep the supplied
+        Scope is **one dimension's planner placement rules**. Whole-part classification can
+        select a different renderer, so acceptance does not prove actual rendered support.
+        The full authored set, chosen views, compound-callout agreement and collision-free
+        placement also require build validation. Keep the supplied
         feature handle to address subsequent edits; the result creates no persistent feature
         identity. Invalid feature/measurement references raise as they do in ``dimension``.
         The query neither records an intent nor prepares, recognises, or renders the part.
@@ -1308,7 +1310,8 @@ class Sheet:
         return {
             "schema": "draftwright.dimension-options",
             "schema_version": 1,
-            "scope": "single_dimension",
+            "scope": "single_dimension_placement_rules",
+            "requires_build_validation": True,
             "feature_kind": target.kind,
             "parameter_id": parameter_id,
             "axis": discriminator,
@@ -1328,21 +1331,23 @@ class Sheet:
         """Preflight a proposed ``dimension`` call without recording or rendering it.
 
         Returns ``supported``, structured ``issues`` and the valid ``options`` for this
-        target. This checks the single-dimension support scope of :meth:`dimension_options`,
-        not whole-sheet feasibility. Existing authored intent is never replaced or modified.
+        target. ``supported`` means accepted by the current planner placement rules;
+        actual renderer support and whole-sheet feasibility still require build validation.
+        Existing authored intent is never replaced or modified.
         Unknown controls are refused rather than ignored or passed on to a renderer.
         """
         result = {
             "schema": "draftwright.dimension-validation",
             "schema_version": 1,
-            "scope": "single_dimension",
+            "scope": "single_dimension_placement_rules",
+            "requires_build_validation": True,
             "supported": False,
             "issues": [],
             "options": None,
         }
         try:
             options = self.dimension_options(feature, role, axis=axis)
-        except (TypeError, ValueError) as exc:
+        except (TypeError, ValueError, IndexError) as exc:
             result["issues"] = [{"code": "invalid_measurement", "message": str(exc)}]
             return result
         result["options"] = options

--- a/tests/test_issue_1466_dimension_options.py
+++ b/tests/test_issue_1466_dimension_options.py
@@ -5,7 +5,7 @@ from dataclasses import replace
 from pathlib import Path
 
 import pytest
-from build123d import Box, Cylinder
+from build123d import Box, Cylinder, Pos
 
 from draftwright import Sheet
 from draftwright.model import hole
@@ -24,7 +24,8 @@ def test_hole_options_are_pairs_with_omission_distinct_from_an_override():
     sheet, handle = _sheet()
     options = sheet.dimension_options(handle, "bore.diameter")
     assert options["parameter_id"] == "bore.diameter"
-    assert options["scope"] == "single_dimension"
+    assert options["scope"] == "single_dimension_placement_rules"
+    assert options["requires_build_validation"] is True
     assert options["placements"] == [
         {"view": None, "side": None},
         {"view": None, "side": "left"},
@@ -133,7 +134,8 @@ def test_queries_preserve_existing_intent_and_require_no_build_or_preparation(mo
     monkeypatch.setattr(Sheet, "build", forbidden)
     monkeypatch.setattr(b123d_recognisers, "build_raw_recognition_result", forbidden)
     result = sheet.validate_dimension(handle, "bore.diameter", view="plan", side="right")
-    assert result["supported"] and result["scope"] == "single_dimension"
+    assert result["supported"] and result["scope"] == "single_dimension_placement_rules"
+    assert result["requires_build_validation"] is True
     assert all(a is b for a, b in zip(features, sheet.features, strict=True))
     monkeypatch.undo()
     after = sheet.model()
@@ -156,6 +158,23 @@ def test_handles_survive_reorder_but_foreign_removed_and_unknown_targets_are_ref
     assert not sheet.validate_dimension(handle, "bore.diameter")["supported"]
     with pytest.raises(ValueError):
         sheet.dimension_options(handle, "bore.diameter")
+
+
+@pytest.mark.parametrize("populated,index", [(True, 1), (True, -2), (False, 0), (False, -1)])
+def test_out_of_range_indices_return_structured_refusals(populated, index):
+    sheet = Sheet(Box(20, 20, 10))
+    if populated:
+        sheet.envelope()
+        assert sheet.validate_dimension(0, "height.length")["supported"]
+        assert sheet.validate_dimension(-1, "height.length")["supported"]
+    with pytest.raises(IndexError, match="out of range"):
+        sheet.dimension_options(index, "height.length")
+    result = sheet.validate_dimension(index, "height.length")
+    assert not result["supported"]
+    assert result["options"] is None
+    assert result["issues"][0]["code"] == "invalid_measurement"
+    assert "out of range" in result["issues"][0]["message"]
+    assert json.loads(json.dumps(result)) == result
 
 
 def test_supported_placement_survives_generated_script_and_real_build(tmp_path):
@@ -182,6 +201,35 @@ def test_supported_placement_survives_generated_script_and_real_build(tmp_path):
     )
     request = namespace["sheet"].model().authored_dimensions[0]
     assert (request.view, request.side) == ("plan", "left")
+
+
+@pytest.mark.parametrize("axis,rotation", [("x", (0, 90, 0)), ("y", (90, 0, 0)), ("z", (0, 0, 0))])
+@pytest.mark.parametrize("parameter_id", ["step.diameter", "step.length"])
+def test_step_options_match_the_view_that_actually_renders(axis, rotation, parameter_id):
+    part = Cylinder(5, 20, rotation=rotation)
+    sheet = Sheet(part)
+    handle = sheet.step(part)
+    assert sheet.features[0].frame.axis == axis
+    expected_view = "side" if axis == "y" and parameter_id == "step.length" else "front"
+    options = sheet.dimension_options(handle, parameter_id)
+    assert options["placements"] == [
+        {"view": None, "side": None},
+        {"view": expected_view, "side": None},
+    ]
+    for view in PLACEMENT_VIEWS:
+        assert sheet.validate_dimension(handle, parameter_id, view=view)["supported"] == (
+            view == expected_view
+        )
+    sheet.dimension(handle, parameter_id, view=expected_view)
+    plan_dimensions(sheet.model(), planned_views=(expected_view,))
+    drawing = sheet.build()
+    names = [
+        name
+        for name in drawing.annotations()
+        if any(key["parameter_id"] == parameter_id for key in drawing.measurement_keys(name))
+    ]
+    assert names, "the requested measurement must reach a rendered annotation"
+    assert {drawing.view_of(name) for name in names} == {expected_view}
 
 
 def test_grm04_discovers_supported_edits_without_exploratory_renders(monkeypatch):
@@ -224,3 +272,33 @@ def test_single_dimension_support_does_not_claim_authored_view_feasibility():
     sheet.dimension(handle, "bore.diameter", view="plan")
     with pytest.raises(ViewPlanIncomplete):
         plan_dimensions(sheet.model(), planned_views=("front",))
+
+
+def test_boss_rule_acceptance_requires_whole_part_renderer_validation():
+    sheets = [
+        Sheet(Cylinder(5, 20)),
+        Sheet(Box(20, 20, 20) + Pos(0, 0, 15) * Cylinder(5, 10)),
+    ]
+    options = []
+    rendered_views = []
+    for sheet, height, at in zip(sheets, (20, 10), ((0, 0, 0), (0, 0, 15)), strict=True):
+        handle = sheet.boss(diameter=10, height=height, at=at, axis="z")
+        result = sheet.validate_dimension(handle, "boss.diameter", view="plan")
+        assert result["supported"]
+        assert result["scope"] == "single_dimension_placement_rules"
+        assert result["requires_build_validation"] is True
+        assert result["options"]["requires_build_validation"] is True
+        options.append(result["options"])
+        sheet.dimension(handle, "boss.diameter", view="plan")
+        drawing = sheet.build()
+        names = [
+            name
+            for name in drawing.annotations()
+            if any(
+                key["parameter_id"] == "boss.diameter" for key in drawing.measurement_keys(name)
+            )
+        ]
+        assert names
+        rendered_views.append({drawing.view_of(name) for name in names})
+    assert options[0] == options[1]
+    assert rendered_views == [{"front"}, {"plan"}], "whole-part context changes the renderer"

--- a/tests/test_issue_1466_dimension_options.py
+++ b/tests/test_issue_1466_dimension_options.py
@@ -1,0 +1,226 @@
+"""An agent can discover supported Sheet edits without trial rendering."""
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+from build123d import Box, Cylinder
+
+from draftwright import Sheet
+from draftwright.model import hole
+from draftwright.model.ir import PLACEMENT_SIDES, PLACEMENT_VIEWS, RequestedDimension
+from draftwright.model.planner import plan_dimensions
+from draftwright.sheet_emit import emit_sheet_script
+
+
+def _sheet(axis="z"):
+    sheet = Sheet(Box(40, 30, 10)).authored_dimensions()
+    handle = sheet.hole(diameter=4, depth=3, at=(0, 0, 0), axis=axis)
+    return sheet, handle
+
+
+def test_hole_options_are_pairs_with_omission_distinct_from_an_override():
+    sheet, handle = _sheet()
+    options = sheet.dimension_options(handle, "bore.diameter")
+    assert options["parameter_id"] == "bore.diameter"
+    assert options["scope"] == "single_dimension"
+    assert options["placements"] == [
+        {"view": None, "side": None},
+        {"view": None, "side": "left"},
+        {"view": None, "side": "right"},
+        {"view": "plan", "side": None},
+        {"view": "plan", "side": "left"},
+        {"view": "plan", "side": "right"},
+    ]
+    assert json.loads(json.dumps(options)) == options
+
+
+@pytest.mark.parametrize("axis", ["x", "y", "z"])
+def test_every_reported_pair_and_refusal_agrees_with_actual_planning(axis):
+    sheet, handle = _sheet(axis)
+    model = sheet.model()
+    target = model.features[0]
+    options = sheet.dimension_options(handle, "bore.diameter")["placements"]
+    for view in (None, *sorted(PLACEMENT_VIEWS)):
+        for side in (None, *sorted(PLACEMENT_SIDES)):
+            candidate = replace(
+                model,
+                authored_dimensions=(
+                    RequestedDimension(target, "bore.diameter", view=view, side=side),
+                ),
+            )
+            advertised = {"view": view, "side": side} in options
+            result = sheet.validate_dimension(handle, "bore.diameter", view=view, side=side)
+            assert result["supported"] == advertised
+            if advertised:
+                plan_dimensions(candidate)
+                assert result["issues"] == []
+            else:
+                with pytest.raises(ValueError):
+                    plan_dimensions(candidate)
+                assert result["issues"][0]["code"] == "unsupported_placement"
+
+
+def test_location_and_envelope_constraints_are_discoverable():
+    sheet, hole_handle = _sheet()
+    assert sheet.dimension_options(hole_handle, "location")["placements"] == [
+        {"view": None, "side": None}
+    ]
+    envelope = sheet.envelope()
+    assert sheet.dimension_options(envelope, "height.length")["placements"] == [
+        {"view": None, "side": None},
+        {"view": "front", "side": None},
+    ]
+    assert not sheet.validate_dimension(envelope, "height.length", side="left")["supported"]
+    result = sheet.validate_dimension(hole_handle, "location", axis="y", side="below")
+    assert result["issues"][0]["code"] == "invalid_measurement"
+
+
+def test_pattern_pitch_has_no_override_and_its_full_id_names_the_axis():
+    sheet = Sheet(Box(40, 30, 10))
+    handle = sheet.pattern(
+        hole(diameter=4, at=(0, 0, 0), axis="z"),
+        kind="grid",
+        count=6,
+        rows=2,
+        cols=3,
+        grid=(10, 12),
+        at=(0, 0, 0),
+    )
+    ids = handle.dimension_ids()
+    assert "grid_pitch.length.row" in ids and "grid_pitch.length.col" in ids
+    options = sheet.dimension_options(handle, "grid_pitch", axis="row")
+    assert options["parameter_id"] == "grid_pitch.length.row"
+    assert options["axis"] == "row"
+    assert options["placements"] == [{"view": None, "side": None}]
+    assert sheet.dimension_options(handle, "grid_pitch.length.row") == options
+    assert not sheet.validate_dimension(handle, "grid_pitch.length.row", axis="col")["supported"]
+    assert not sheet.validate_dimension(handle, "grid_pitch")["supported"]
+
+
+@pytest.mark.parametrize(
+    "kwargs,code",
+    [
+        ({"side": "bottom"}, "unsupported_placement"),
+        ({"view": "iso"}, "unsupported_placement"),
+        ({"side": []}, "unsupported_placement"),
+        ({"lane": "outer"}, "unsupported_control"),
+        ({"pin": True, "priority": 2}, "unsupported_control"),
+    ],
+)
+def test_bad_controls_return_json_refusals_and_valid_alternatives(kwargs, code):
+    sheet, handle = _sheet()
+    result = sheet.validate_dimension(handle, "bore.diameter", **kwargs)
+    assert not result["supported"]
+    assert result["issues"][0]["code"] == code
+    assert {"view": "plan", "side": "right"} in result["options"]["placements"]
+    assert json.loads(json.dumps(result)) == result
+
+
+def test_queries_preserve_existing_intent_and_require_no_build_or_preparation(monkeypatch):
+    sheet, handle = _sheet()
+    sheet.dimension(handle, "bore.diameter", view="plan", side="left")
+    before = sheet.model()
+    features = tuple(sheet.features)
+
+    def forbidden(*args, **kwargs):
+        pytest.fail("discovery must not prepare, build, or recognise")
+
+    import b123d_recognisers
+
+    monkeypatch.setattr(Sheet, "_prepare", forbidden)
+    monkeypatch.setattr(Sheet, "build", forbidden)
+    monkeypatch.setattr(b123d_recognisers, "build_raw_recognition_result", forbidden)
+    result = sheet.validate_dimension(handle, "bore.diameter", view="plan", side="right")
+    assert result["supported"] and result["scope"] == "single_dimension"
+    assert all(a is b for a, b in zip(features, sheet.features, strict=True))
+    monkeypatch.undo()
+    after = sheet.model()
+    assert after.authored_dimensions == before.authored_dimensions
+    assert len(after.authored_dimensions) == 1
+    assert after.authored_dimensions[0].side == "left"
+
+
+def test_handles_survive_reorder_but_foreign_removed_and_unknown_targets_are_refused():
+    sheet, handle = _sheet()
+    other = sheet.hole(diameter=8, at=(5, 0, 0), axis="x")
+    before = sheet.dimension_options(handle, "bore.diameter")
+    sheet.features.reverse()
+    assert sheet.dimension_options(handle, "bore.diameter") == before
+    assert sheet.dimension_options(other, "bore.diameter")["placements"] != before["placements"]
+    foreign, foreign_handle = _sheet()
+    assert not sheet.validate_dimension(foreign_handle, "bore.diameter")["supported"]
+    assert not sheet.validate_dimension(handle, "not.a.measurement")["supported"]
+    sheet.features.pop()
+    assert not sheet.validate_dimension(handle, "bore.diameter")["supported"]
+    with pytest.raises(ValueError):
+        sheet.dimension_options(handle, "bore.diameter")
+
+
+def test_supported_placement_survives_generated_script_and_real_build(tmp_path):
+    part = Box(40, 30, 10) - Cylinder(2, 10)
+    sheet = Sheet(part).authored_dimensions()
+    handle = sheet.hole(diameter=4, depth=10, at=(0, 0, 0), axis="z")
+    assert sheet.validate_dimension(handle, "bore.diameter", view="plan", side="left")["supported"]
+    sheet.dimension(handle, "bore.diameter", view="plan", side="left")
+    source = emit_sheet_script(
+        sheet.model(),
+        "part",
+        str(tmp_path / "options"),
+        title="Options",
+        number="1466",
+        formats=(),
+    )
+    namespace = {"part": part}
+    exec(compile(source, "<options-roundtrip>", "exec"), namespace)
+    drawing = namespace["drawing"]
+    assert any(
+        key["parameter_id"] == "bore.diameter"
+        for name in drawing.annotations()
+        for key in drawing.measurement_keys(name)
+    )
+    request = namespace["sheet"].model().authored_dimensions[0]
+    assert (request.view, request.side) == ("plan", "left")
+
+
+def test_grm04_discovers_supported_edits_without_exploratory_renders(monkeypatch):
+    path = Path(__file__).parent / "fixtures/grm04_drive_plate.step"
+    sheet = Sheet.from_part(path)
+    holes = [f for f in sheet.features if f.kind == "hole" and abs(f.diameter - 2.4) < 1e-6]
+    assert holes, "the reported small hole must be present"
+    envelopes = [f for f in sheet.features if f.kind == "envelope"]
+    assert len(envelopes) == 1
+
+    def forbidden(*args, **kwargs):
+        pytest.fail("an agent must discover these restrictions without rendering")
+
+    monkeypatch.setattr(Sheet, "build", forbidden)
+    assert not sheet.validate_dimension(holes[0], "location", side="below")["supported"]
+    assert not sheet.validate_dimension(envelopes[0], "height.length", side="left")["supported"]
+    options = sheet.dimension_options(holes[0], "bore.diameter")
+    assert options["placements"]
+    assert not sheet.validate_dimension(holes[0], "bore.diameter", side="bottom")["supported"]
+    for pair in options["placements"]:
+        assert sheet.validate_dimension(holes[0], "bore.diameter", **pair)["supported"]
+
+
+@pytest.mark.parametrize("role", ["location", "missing.length"])
+def test_planner_support_query_refuses_an_absent_ir_measurement(role):
+    from draftwright.model.planner import validate_dimension_placement
+
+    sheet = Sheet(Box(20, 20, 10))
+    sheet.envelope()
+    with pytest.raises(ValueError, match="no location|no parameter"):
+        validate_dimension_placement(RequestedDimension(sheet.features[0], role))
+
+
+def test_single_dimension_support_does_not_claim_authored_view_feasibility():
+    from draftwright import ViewPlanIncomplete
+
+    sheet, handle = _sheet()
+    sheet.authored_views().view("front")
+    assert sheet.validate_dimension(handle, "bore.diameter", view="plan")["supported"]
+    sheet.dimension(handle, "bore.diameter", view="plan")
+    with pytest.raises(ViewPlanIncomplete):
+        plan_dimensions(sheet.model(), planned_views=("front",))


### PR DESCRIPTION
Agents currently discover unsupported annotation controls by attempting renders and reading exceptions. `Sheet.dimension_options(feature, parameter_id)` now lists view/side pairs accepted by the existing planner placement rules, and `Sheet.validate_dimension(...)` returns structured refusals and alternatives without changing the Sheet or rendering.

Part of #1466. This is the first discovery/validation slice; the broader semantic constraints and repair issue remains open.

The queries reuse the feature-token resolver, parameter vocabulary, RequestedDimension checks and planner group-placement validation. Both JSON-ready documents declare `scope: single_dimension_placement_rules` and `requires_build_validation: true`. `supported` means planner-rule acceptance. Whole-part classification can choose a different renderer; actual rendered support, authored-view feasibility, compound-intent agreement, collision-free placement and completeness still require build validation. The API introduces no lane/route/pin controls or persistent feature identities.

Independent Google review found and corrected three substantive issues:

- Invalid feature indices leaked IndexError instead of structured invalid_measurement refusals. Four positive/negative out-of-range cases fail before the fix and pass afterward, including an empty Sheet.
- The shared planner advertised side instead of front for Y-axis step diameters. The preference now matches the existing front renderer, while Y-axis lengths remain in side. Six axis/measurement cases verify actual rendered measurement provenance; the Y-diameter case fails before the fix.
- Renderer-support claims exceeded the evidence available without whole-part classification. The explicit machine-readable scope and required-build marker now state the bound, with real prismatic/rotational boss builds demonstrating why that distinction matters.

Validation at `dce9d441`:

- All 29 focused PR tests pass, including GRM-04 discovery, generated-script execution, handle identity and actual rendered-view checks.
- The full local gate exits 0: 6,873 passed, 5 skipped, 2 xfailed; 95.98% overall coverage and 100% changed-line coverage (46 lines). All static gates pass. Python 3.10/build123d 0.10 passes all 84 selected capability and existing placement tests. All eight deliberate mutations are caught, including the four refreshed original guards, index refusal, Y-step view choice and both required-build markers. Hosted CI and both Codecov checks remain required before merge.
- Independent first-round probes covered 1,500 parameter/view/side cases across 27 measurement-bearing feature kinds and checked recursive Sheet-state preservation for successful and malformed queries. These establish planner parity, not full render coverage.

Review uses [Google's review standard](https://google.github.io/eng-practices/review/reviewer/standard.html) and [review checklist](https://google.github.io/eng-practices/review/reviewer/looking-for.html). A separate AI reviewer identified the routing and scope findings; the author found the index error. The second independent review of `dce9d441` found no substantive findings or nits, reran all 29 PR tests and 1,420 planner-parity probes, and verified the corrected rendered view and structured refusals. This is independent AI review, not human maintainer approval.

ADR assessment: ADR 1 reuses the planner and facade; ADR 2 keeps the existing solver and corrects a shared view rule to match rendering; ADR 3 adds no recognition or reconstructed identity; ADR 4 preserves feature/parameter intent and generated-script execution; ADR 5 requires explicit support bounds and mutation-verified refusals. No ADR text or repair allowlist change is needed.
