### PR TITLE
Fix radius leaders targeting profile centres instead of arcs

### DIFF
--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -191,6 +191,13 @@ explicit declaration has the same exact occurrence identity and view routing as 
 record.
 Generated Sheet code preserves every field.
 
+Straight-path radius leaders target curved boundaries of the physical cylindrical patch.
+Their `at` value locates the analytic axis, not the arrow tip. If a declared support is missing
+or ambiguous, the engine reports `blend_dropped`. Physical lint reports
+`radius_leader_target_mismatch` when a placed tip misses its trimmed boundary, or
+`radius_leader_target_unverifiable` when that boundary cannot be established; these findings
+lower fidelity. Circular-path toroidal blends retain their separate tangency selection.
+
 These are part-space feature coordinates, never page positions. The annotation placement solve
 owns the final leader and label coordinates. The word is explicit-only because detached surface
 geometry cannot prove a complete chain or the provider aggregate's Fillet precedence.

--- a/src/draftwright/_geometry.py
+++ b/src/draftwright/_geometry.py
@@ -19,7 +19,7 @@ from decimal import Decimal
 from inspect import signature
 
 from b123d_recognisers import full_cylinders
-from build123d import Compound, Shape
+from build123d import Compound, GeomType, Shape
 
 _log = logging.getLogger(__name__)
 
@@ -1181,3 +1181,51 @@ def _segments_cross_or_overlap(a1, a2, b1, b2) -> bool:
         if on_segment(point, first, second) and not (same(point, first) or same(point, second)):
             return True
     return False
+
+
+def _straight_blend_faces(blend, cylinders, radius, *, defining_faces=None):
+    """Use exact occurrence faces, or one unambiguous declared cylinder support."""
+    if defining_faces is not None:
+        return tuple(defining_faces)
+    origin = blend.frame.origin
+    direction = blend.axis_direction
+    length = math.hypot(*direction)
+    normal = tuple(value / length for value in direction)
+    matches = []
+    for family in cylinders:
+        for cylinder in family:
+            if abs(cylinder["diameter"] / 2 - radius) > 2e-3:
+                continue
+            if cylinder["external"] != (blend.side == "convex"):
+                continue
+            axis = cylinder["dir_xyz"]
+            alignment = abs(sum(normal[i] * axis[i] for i in range(3)))
+            delta = tuple(origin[i] - cylinder["axis_xyz"][i] for i in range(3))
+            along = sum(delta[i] * axis[i] for i in range(3))
+            radial = math.hypot(*(delta[i] - along * axis[i] for i in range(3)))
+            station = sum(origin[i] * axis[i] for i in range(3))
+            if (
+                abs(alignment - 1) <= 2e-6
+                and radial <= 2e-3
+                and cylinder["s_lo"] - 2e-3 <= station <= cylinder["s_hi"] + 2e-3
+            ):
+                matches.append(cylinder["face"])
+    return tuple(matches) if len(matches) == 1 else ()
+
+
+def _blend_profile_arcs(faces, radius):
+    """Curved boundaries of the physical cylindrical patch carrying this radius.
+
+    An oblique end trim can be a spline in 3-D while its end-on profile is still a radius
+    arc. Validate the cylinder's radius and retain the actual boundary curve, never rebuild
+    an untrimmed mathematical circle. Straight generatrices are not radius targets.
+    """
+    return tuple(
+        edge
+        for face in faces
+        if face.geom_type == GeomType.CYLINDER
+        and face.radius is not None
+        and abs(face.radius - radius) <= 2e-3
+        for edge in face.edges()
+        if edge.geom_type != GeomType.LINE
+    )

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -63,7 +63,12 @@ from draftwright._core import (
     _title_block_box,
     _tol_suffix,
 )
-from draftwright._geometry import _segment_clips_box, _turned_profile_site
+from draftwright._geometry import (
+    _blend_profile_arcs,
+    _segment_clips_box,
+    _straight_blend_faces,
+    _turned_profile_site,
+)
 from draftwright.annotations._common import (
     CROSSABLE_TYPES,
     PRIORITY,
@@ -2065,14 +2070,14 @@ def _blend_faces_by_ref(analysis):
     return indexed
 
 
-def _blend_surface_site(
+def _blend_surface_sites(
     blend,
     cylinders,
     rolling_radius: float,
     *,
     defining_faces=None,
-) -> tuple[float, float, float] | None:
-    """Return a deterministic natural leader site on a circular Blend surface.
+) -> tuple[tuple[float, float, float], ...]:
+    """Return natural sites on a straight profile arc or circular Blend surface.
 
     A circular path stores the rolling-ball centre trajectory, not a surface point. Its proved
     supports include one coaxial finite cylinder whose radius differs from the path radius by
@@ -2085,8 +2090,14 @@ def _blend_surface_site(
     solve still owns placement.
     """
     if blend.path_kind != "circular":
-        origin: tuple[float, float, float] = blend.frame.origin
-        return origin
+        faces = _straight_blend_faces(
+            blend, cylinders, rolling_radius, defining_faces=defining_faces
+        )
+        arcs = _blend_profile_arcs(faces, rolling_radius)
+        if not arcs:
+            return ()
+        arc = min(arcs, key=lambda edge: (-edge.length, tuple(edge.position_at(0.5))))
+        return tuple(tuple(arc.position_at(fraction)) for fraction in (0.5, 0.25, 0.75))
     origin = blend.frame.origin
     normal: tuple[float, float, float] = blend.axis_direction
     seed_index = min(range(3), key=lambda index: (abs(normal[index]), index))
@@ -2139,7 +2150,7 @@ def _blend_surface_site(
         # Automatic recognition has an exact face authority. If its ownership or surface is
         # absent, fail closed; scalar cylinders must not silently replace missing evidence.
         if not defining_faces:
-            return None
+            return ()
         radii = sorted(
             {
                 *(candidate[2] for candidate in matches),
@@ -2151,14 +2162,14 @@ def _blend_surface_site(
             for radius in radii
         ]
         distance, surface_radius = min(candidates)
-        return site(surface_radius) if distance <= _BLEND_POINT_TOL else None
+        return (site(surface_radius),) if distance <= _BLEND_POINT_TOL else ()
 
     if matches:
         support_radii = sorted(candidate[2] for candidate in matches)
         if support_radii[-1] - support_radii[0] > _BLEND_POINT_TOL:
-            return None
-        return site(min(matches)[2])
-    return site(outer_radius)
+            return ()
+        return (site(min(matches)[2]),)
+    return (site(outer_radius),)
 
 
 def _flat_candidates(dwg, view, vb, members, reach, *, provenances):
@@ -2597,13 +2608,13 @@ def _render_radius_callouts(
             site = None
             if kind == "blend":
                 defining_faces = None if blend_faces is None else blend_faces.values_for(group.ref)
-                site = _blend_surface_site(
+                site = _blend_surface_sites(
                     group.facts,
                     a.cyls,
                     dimension.value,
                     defining_faces=defining_faces,
                 )
-                if site is None:
+                if not site:
                     continue
             key = (group.facts.axis, group.view)
             by_presentation.setdefault(key, []).append((group, dimension, site))
@@ -2621,6 +2632,12 @@ def _render_radius_callouts(
             by_presentation.items(), key=lambda item: (-len(item[1]), item[0])
         )
         visible.sort(key=lambda item: item[0].facts.frame.origin)
+        if kind == "blend":
+            visible = [
+                (group, dimension, point)
+                for group, dimension, points in visible
+                for point in points
+            ]
         ordered = [(group, dimension) for group, dimension, _site in visible]
         sites = [site for _group, _dimension, site in visible] if kind == "blend" else None
         view = ordered[0][0].view

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -99,6 +99,7 @@ from draftwright.linting import (
     lint_angled_step_coverage,
     lint_axial_coverage,
     lint_blend_coverage,
+    lint_blend_leader_targets,
     lint_boss_height_coverage,
     lint_chamfer_coverage,
     lint_channel_coverage,
@@ -3865,6 +3866,13 @@ class Drawing:
                 registry=self._registry,
                 omissions=self._build.omissions,
                 assembly=self.assembly,
+            )
+            issues += lint_blend_leader_targets(
+                registry=self._registry,
+                cylinders=cyls,
+                project=self.at,
+                evidence=self._build.recognition_evidence,
+                ownership=self._build.recognition_ownership,
             )
             issues += lint_blend_coverage(
                 working_part,

--- a/src/draftwright/linting/__init__.py
+++ b/src/draftwright/linting/__init__.py
@@ -17,7 +17,7 @@ Import the public surface from here, not the submodules.
 from __future__ import annotations
 
 from draftwright.linting.angled_step_coverage import lint_angled_step_coverage
-from draftwright.linting.blend_coverage import lint_blend_coverage
+from draftwright.linting.blend_coverage import lint_blend_coverage, lint_blend_leader_targets
 from draftwright.linting.chamfer_coverage import lint_chamfer_coverage
 from draftwright.linting.channel_coverage import lint_channel_coverage
 from draftwright.linting.circular_blind_step_coverage import lint_circular_blind_step_coverage
@@ -91,6 +91,7 @@ __all__ = [
     "lint_axial_coverage",
     "lint_boss_height_coverage",
     "lint_blend_coverage",
+    "lint_blend_leader_targets",
     "lint_channel_coverage",
     "lint_circular_blind_step_coverage",
     "lint_chamfer_coverage",

--- a/src/draftwright/linting/blend_coverage.py
+++ b/src/draftwright/linting/blend_coverage.py
@@ -7,7 +7,9 @@ from dataclasses import dataclass, field
 from typing import Literal
 
 from b123d_recognisers import RecognitionResult
+from build123d import Edge, Vector
 
+from draftwright._geometry import _blend_profile_arcs, _straight_blend_faces
 from draftwright.blend_contract import (
     blend_provider_key,
     is_exact_blend_feature,
@@ -216,4 +218,97 @@ def lint_blend_coverage(
                 message=f"blend at {outcome.source_at} {messages[outcome.state]}",
             )
         )
+    return issues
+
+
+def _projected_arc_distance(edge, tip, project):
+    """Distance from a page point's projection line to the actual trimmed OCC edge."""
+    origin = project(0, 0, 0)
+    basis = [project(*(1 if i == j else 0 for i in range(3))) for j in range(3)]
+    u = Vector(*(point[0] - origin[0] for point in basis))
+    v = Vector(*(point[1] - origin[1] for point in basis))
+    normal = u.cross(v).normalized()
+    centre = edge.center()
+    projected = project(*centre)
+    point = (
+        centre
+        + u * ((tip[0] - projected[0]) / u.dot(u))
+        + v * ((tip[1] - projected[1]) / v.dot(v))
+    )
+    reach = edge.bounding_box().size.length + 1
+    line = Edge.make_line(point - normal * reach, point + normal * reach)
+    return edge.distance_to(line)
+
+
+def lint_blend_leader_targets(*, registry, cylinders, project, evidence=None, ownership=None):
+    """Judge placed straight-Blend radius tips against their physical trimmed arcs.
+
+    The renderer's candidate site is not evidence here: lint measures the finished tip against
+    the complete trimmed edge. Circular-path toroidal blends have a different target contract.
+    """
+    issues = []
+    for name in sorted(registry.names()):
+        measurements = registry.measurement_of(name)
+        if not any(measurement.parameter == "blend.radius" for measurement in measurements):
+            continue
+        feature = registry.feature_of(name)
+        annotation = registry.named(name)
+        view = registry.view_of(name)
+        tip = getattr(annotation, "tip", None)
+        if tip is None:
+            continue
+        arcs = ()
+        try:
+            key = blend_feature_key(feature)
+        except (AttributeError, OverflowError, TypeError, ValueError):
+            key = None
+        if key is not None and not any(
+            measurement.feature is feature and measurement.parameter == "blend.radius"
+            for measurement in measurements
+        ):
+            key = None
+        if key is not None and feature.path_kind == "circular":
+            continue
+        if key is not None and view is not None:
+            defining_faces = None
+            if ownership is not None:
+                defining_faces = ()
+                if evidence is not None and ownership.evidence is evidence:
+                    defining_faces = tuple(
+                        evidence.face(ref)
+                        for binding in ownership.bindings
+                        if evidence.family(binding.occurrence) == "blends"
+                        and any(owner is feature for owner in binding.features)
+                        for ref in evidence.defining_faces(binding.occurrence)
+                    )
+            faces = _straight_blend_faces(
+                feature, cylinders, feature.radius, defining_faces=defining_faces
+            )
+            arcs = _blend_profile_arcs(faces, feature.radius)
+        if not arcs:
+            issues.append(
+                LintIssue(
+                    severity="warning",
+                    code="radius_leader_target_unverifiable",
+                    message=f"{name}: the radius leader's physical profile arc cannot be verified",
+                    location=tip,
+                    measurement_ids=measurements,
+                )
+            )
+        elif (
+            min(
+                _projected_arc_distance(edge, tip, lambda x, y, z: project(view, x, y, z))
+                for edge in arcs
+            )
+            > 2e-3
+        ):
+            issues.append(
+                LintIssue(
+                    severity="warning",
+                    code="radius_leader_target_mismatch",
+                    message=f"{name}: the radius leader tip does not touch its trimmed profile arc",
+                    location=tip,
+                    measurement_ids=measurements,
+                )
+            )
     return issues

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -249,6 +249,8 @@ _UNRECOGNISED_GEOMETRY_CODE = "unrecognised_defining_geometry"
 _FIDELITY_CODES = frozenset(
     {
         "label_vs_measured",
+        "radius_leader_target_mismatch",
+        "radius_leader_target_unverifiable",
         "declared_feature_absent",
         "gear_repeat_count_mismatch",
         "gear_axis_mismatch",

--- a/tests/test_issue_1308_machined_leader_analytics.py
+++ b/tests/test_issue_1308_machined_leader_analytics.py
@@ -16,7 +16,8 @@ FIXTURES = Path(__file__).parent / "fixtures"
 
 # Recorded from the OCC-measured path immediately before #1308.  This is intentionally
 # semantic rather than SVG-byte exact: every annotation, its rendered type, its 3-decimal
-# ink box, and the lint-code inventory must remain identical.
+# ink box, and lint-code inventory. #1479 updates the three Blend boxes after correcting
+# their radius targets; the spline-boundary assertion below verifies that change physically.
 EXPECTED = {
     "grm03_thumbwheel_drive_screw.step": (
         {
@@ -98,9 +99,9 @@ EXPECTED = {
             "m_chamfer_y0": ("Leader", (89.433, 169.491, 108.266, 183.115)),
             "m_chamfer_z1": ("Leader", (192.775, 275.0, 213.032, 283.142)),
             "m_fillet_z0": ("Leader", (15.101, 184.659, 40.704, 192.929)),
-            "m_blend_x0": ("Leader", (225.168, 159.935, 286.249, 162.065)),
-            "m_blend_z1": ("Leader", (93.375, 257.0, 108.548, 296.083)),
-            "m_blend_z2": ("Leader", (10.278, 203.917, 72.775, 206.083)),
+            "m_blend_x0": ("Leader", (225.168, 159.203, 289.818, 161.333)),
+            "m_blend_z1": ("Leader", (94.789, 255.586, 109.962, 296.083)),
+            "m_blend_z2": ("Leader", (10.278, 207.453, 69.239, 209.619)),
             "title_block": ("TitleBlock", (432.925, 10.925, 583.075, 27.075)),
             "note_iso_nts": ("Note", (460.221, 103.057, 484.554, 105.751)),
         },
@@ -237,6 +238,35 @@ def test_analytical_machined_leaders_preserve_the_occ_measured_drawing(fixture, 
     assert actual == expected_annotations
     assert drawing.lint_summary()["by_code"] == expected_lint
     if fixture == "nist_ctc_01_asme1_ap242.stp":
+        from build123d import Edge, GeomType
+
+        # #1479 moved all three Blend tips from analytic axes to physical boundaries.
+        # R5's oblique end trims are splines: preserve this radius and check its own
+        # occurrence's trimmed edge, independently of the renderer's candidate selection.
+        feature = drawing.registry.feature_of("m_blend_x0")
+        assert feature.radius == 5
+        assert drawing.view_of("m_blend_x0") == "side"
+        evidence = drawing.recognition_evidence()
+        ownership = drawing.recognition_ownership()
+        (binding,) = [
+            item
+            for item in ownership.bindings
+            if evidence.family(item.occurrence) == "blends" and item.feature is feature
+        ]
+        curves = [
+            edge
+            for ref in evidence.defining_faces(binding.occurrence)
+            for edge in evidence.face(ref).edges()
+            if edge.geom_type != GeomType.LINE
+        ]
+        assert curves and all(edge.geom_type == GeomType.BSPLINE for edge in curves)
+        tip = drawing.get_annotation("m_blend_x0").tip
+        origin = drawing.at("side", 0, 0, 0)
+        y = (tip[0] - origin[0]) / (drawing.at("side", 0, 1, 0)[0] - origin[0])
+        z = (tip[1] - origin[1]) / (drawing.at("side", 0, 0, 1)[1] - origin[1])
+        bounds = drawing.working_part.bounding_box()
+        ray = Edge.make_line((bounds.min.X - 1, y, z), (bounds.max.X + 1, y, z))
+        assert min(edge.distance_to(ray) for edge in curves) < 1e-6
         polygonal_jobs = [job for job in immediate_jobs if job.name == "m_polygonal_boss_z0"]
         assert polygonal_jobs
         assert all(job.analytical_geometry is not None for job in polygonal_jobs)

--- a/tests/test_issue_1433_blend_semantics.py
+++ b/tests/test_issue_1433_blend_semantics.py
@@ -683,9 +683,19 @@ def test_detected_drawing_places_one_grouped_callout_with_four_exact_credits() -
 
 
 def test_authored_distinct_display_radii_never_share_false_group_credit() -> None:
-    sheet = Sheet(_single_blend()).authored_dimensions()
-    first = sheet.blend(axis="z", radius=0.2001, at=(-2.0, 0.0, 0.0))
-    second = sheet.blend(axis="z", radius=0.2002, at=(2.0, 0.0, 0.0))
+    part = Compound(children=[_single_blend(0.2001), Pos(40, 0, 0) * _single_blend(0.2002)])
+    sheet = Sheet(part).authored_dimensions()
+    handles = []
+    for radius in (0.2001, 0.2002):
+        arcs = [
+            edge
+            for edge in part.edges()
+            if edge.geom_type == GeomType.CIRCLE and abs(edge.radius - radius) < 1e-8
+        ]
+        assert len(arcs) == 2
+        centre = arcs[0].arc_center
+        handles.append(sheet.blend(axis="z", radius=radius, at=(centre.X, centre.Y, 0.0)))
+    first, second = handles
     sheet.dimension(first, "blend.radius").format(decimals=4)
     sheet.dimension(second, "blend.radius").format(decimals=4)
     drawing = sheet.build()

--- a/tests/test_issue_1479_radius_leader_targets.py
+++ b/tests/test_issue_1479_radius_leader_targets.py
@@ -1,0 +1,262 @@
+"""GRM04 radius leaders must land on the named trimmed profile arcs."""
+
+from copy import deepcopy
+from pathlib import Path
+from runpy import run_path
+
+import pytest
+from build123d import GeomType, Pos, Vertex
+
+from draftwright import build_drawing
+from draftwright.sheet_emit import generate_sheet_script
+
+FIXTURE = Path(__file__).parent / "fixtures" / "grm04_drive_plate.step"
+
+
+@pytest.fixture(scope="module")
+def automatic():
+    return build_drawing(FIXTURE, title="GRM-04")
+
+
+def _radius_leaders(drawing):
+    features = [f for f in drawing.model().features if f.kind == "blend"]
+    assert sorted(f.radius for f in features) == [3.0, 4.0]
+    result = []
+    for feature in features:
+        names = drawing.annotations_of(feature)
+        assert len(names) == 1
+        name = next(iter(names))
+        assert drawing.view_of(name) == "side"
+        result.append((feature, name, drawing.get_annotation(name)))
+    return result
+
+
+def _assert_on_profile_arcs(drawing):
+    for feature, name, leader in _radius_leaders(drawing):
+        # Independently lift the page tip onto each physical circle plane. Testing the
+        # trimmed OCC edge rejects both the bore rim and the missing half of the R3 circle.
+        origin = drawing.at("side", 0, 0, 0)
+        unit_y = drawing.at("side", 0, 1, 0)[0] - origin[0]
+        unit_z = drawing.at("side", 0, 0, 1)[1] - origin[1]
+        y = (leader.tip[0] - origin[0]) / unit_y
+        z = (leader.tip[1] - origin[1]) / unit_z
+        arcs = [
+            edge
+            for edge in drawing.working_part.edges()
+            if edge.geom_type == GeomType.CIRCLE
+            and abs(edge.radius - feature.radius) < 1e-6
+            and abs(edge.arc_center.Z - feature.frame.origin[2]) < 1e-6
+        ]
+        assert arcs
+        distance = min(edge.distance_to(Vertex(edge.arc_center.X, y, z)) for edge in arcs)
+        assert distance < 1e-6, (name, leader.tip, distance)
+
+
+def test_automatic_radius_tips_land_on_trimmed_profile_arcs(automatic):
+    _assert_on_profile_arcs(automatic)
+
+
+def test_generated_authored_radius_tips_land_on_trimmed_profile_arcs(tmp_path):
+    script = generate_sheet_script(str(FIXTURE), out=str(tmp_path / "grm04"))
+    drawing = run_path(str(script))["drawing"]
+    _assert_on_profile_arcs(drawing)
+
+
+@pytest.mark.parametrize("wrong_site", [(0, 0, 9.5), (0, 2.1, 9.5), (0, 0, 6.5)])
+def test_lint_rejects_centre_bore_and_untrimmed_circle_extension(
+    automatic, monkeypatch, wrong_site
+):
+    feature, name, leader = next(row for row in _radius_leaders(automatic) if row[0].radius == 3)
+    tip = automatic.at("side", *wrong_site)[:2]
+    monkeypatch.setattr(
+        leader,
+        "location",
+        Pos(tip[0] - leader.tip[0], tip[1] - leader.tip[1], 0) * leader.location,
+    )
+    issues = [issue for issue in automatic.lint() if issue.code == "radius_leader_target_mismatch"]
+    assert len(issues) == 1
+    assert name in issues[0].message
+    assert issues[0].location == tip
+    assert issues[0].measurement_ids == automatic.registry.measurement_of(name)
+
+
+@pytest.mark.parametrize("mode", ["live", "deferred", "retained"])
+def test_editing_keeps_radius_tips_on_the_profile(mode):
+    drawing = build_drawing(FIXTURE)
+    features = [feature for feature, _, _ in _radius_leaders(drawing)]
+    if mode == "retained":
+        for _, name, _ in _radius_leaders(drawing):
+            drawing.pin(name)
+        with drawing.deferred():
+            drawing.locate(next(f for f in drawing.model().features if f.kind == "hole"))
+    else:
+        for feature in features:
+            drawing.drop(feature)
+        if mode == "live":
+            for feature in features:
+                drawing.callout(feature)
+        else:
+            with drawing.deferred():
+                for feature in features:
+                    drawing.callout(feature)
+    _assert_on_profile_arcs(drawing)
+    assert not [
+        issue for issue in drawing.lint() if issue.code.startswith("radius_leader_target_")
+    ]
+
+
+def _arc_gap(drawing, view, tip, arc):
+    centre = arc.arc_center
+    u = arc.position_at(0) - centre
+    v = arc.tangent_at(0) * arc.radius
+    c = drawing.at(view, *centre)
+    pu = drawing.at(view, *(centre + u))
+    pv = drawing.at(view, *(centre + v))
+    ux, uy = pu[0] - c[0], pu[1] - c[1]
+    vx, vy = pv[0] - c[0], pv[1] - c[1]
+    dx, dy = tip[0] - c[0], tip[1] - c[1]
+    determinant = ux * vy - uy * vx
+    assert abs(determinant) > 1e-6
+    point = (
+        centre + u * ((dx * vy - dy * vx) / determinant) + v * ((ux * dy - uy * dx) / determinant)
+    )
+    return arc.distance_to(Vertex(point))
+
+
+@pytest.mark.parametrize("rotation", [(0, 0, 0), (0, 90, 0), (90, 0, 0), (17, 31, 43)])
+@pytest.mark.parametrize("projection", ["first", "third"])
+def test_radius_targets_follow_rotated_translated_geometry(rotation, projection):
+    from build123d import Axis, Box, Rot, fillet
+
+    stock = Box(27, 19, 13)
+    part = Pos(30, -20, 40) * Rot(*rotation) * fillet([stock.edges().filter_by(Axis.Z)[0]], 0.4)
+    drawing = build_drawing(part, projection=projection)
+    (feature,) = [f for f in drawing.model().features if f.kind == "blend"]
+    (name,) = drawing.annotations_of(feature)
+    annotation = drawing.get_annotation(name)
+    view = drawing.view_of(name)
+    arcs = [edge for edge in part.edges() if edge.geom_type == GeomType.CIRCLE]
+    assert len(arcs) == 2
+    assert min(_arc_gap(drawing, view, annotation.tip, arc) for arc in arcs) < 1e-6
+    assert not [
+        issue for issue in drawing.lint() if issue.code.startswith("radius_leader_target_")
+    ]
+
+
+@pytest.mark.parametrize(
+    "withdraw", ["faces", "ownership", "foreign_evidence", "owner", "wrong_owner", "view"]
+)
+def test_lint_reports_unverifiable_target_authority(automatic, monkeypatch, withdraw):
+    from draftwright.linting.blend_coverage import lint_blend_leader_targets
+
+    evidence = automatic.recognition_evidence()
+    ownership = automatic.recognition_ownership()
+    registry = automatic.registry
+    kwargs = dict(
+        registry=registry,
+        cylinders=automatic.recognition().cylinders,
+        project=automatic.at,
+        evidence=evidence,
+        ownership=ownership,
+    )
+    assert lint_blend_leader_targets(**kwargs) == []
+    if withdraw == "faces":
+        monkeypatch.setattr(type(evidence), "defining_faces", lambda *_: ())
+    elif withdraw == "ownership":
+        from types import SimpleNamespace
+
+        kwargs["ownership"] = SimpleNamespace(evidence=evidence, bindings=())
+    elif withdraw == "foreign_evidence":
+        kwargs["evidence"] = object()
+    elif withdraw == "owner":
+        monkeypatch.setattr(registry, "feature_of", lambda *_: None)
+    elif withdraw == "wrong_owner":
+        from dataclasses import replace
+
+        kwargs["ownership"] = None
+        kwargs["evidence"] = None
+        original = registry.feature_of
+        owners = {name: replace(original(name)) for _, name, _ in _radius_leaders(automatic)}
+        monkeypatch.setattr(registry, "feature_of", lambda name: owners.get(name, original(name)))
+    else:
+        monkeypatch.setattr(registry, "view_of", lambda *_: None)
+    issues = lint_blend_leader_targets(**kwargs)
+    assert len(issues) == 2
+    assert all(issue.code == "radius_leader_target_unverifiable" for issue in issues)
+    assert all(issue.measurement_ids for issue in issues)
+
+
+@pytest.mark.parametrize("defect", ["radius", "side", "direction", "axis", "station", "ambiguous"])
+def test_declared_target_requires_one_matching_physical_support(automatic, defect):
+    from draftwright._geometry import _straight_blend_faces
+
+    feature = next(f for f, _, _ in _radius_leaders(automatic) if f.radius == 3)
+    cylinders = automatic.recognition().cylinders
+    (face,) = _straight_blend_faces(feature, cylinders, feature.radius)
+    (support,) = [dict(c) for family in cylinders for c in family if c["face"] is face]
+    if defect == "radius":
+        support["diameter"] = 4.2
+    elif defect == "side":
+        support["external"] = False
+    elif defect == "direction":
+        support["dir_xyz"] = (0, 1, 0)
+        support["axis_xyz"] = feature.frame.origin
+    elif defect == "axis":
+        support["axis_xyz"] = (0, 10, 9.5)
+    elif defect == "station":
+        support["s_lo"], support["s_hi"] = (10, 20)
+    inventory = ((support, support) if defect == "ambiguous" else (support,), ())
+    assert _straight_blend_faces(feature, inventory, feature.radius) == ()
+    # Exact automatic occurrence authority still resolves its own face in an ambiguous inventory.
+    assert _straight_blend_faces(feature, inventory, feature.radius, defining_faces=(face,)) == (
+        face,
+    )
+    assert _straight_blend_faces(feature, cylinders, feature.radius, defining_faces=()) == ()
+
+
+@pytest.mark.parametrize("defect", ["missing", "ambiguous"])
+def test_unverifiable_declared_support_is_an_explicit_placement_drop(automatic, defect):
+    from build123d import Compound
+
+    from draftwright import Sheet
+
+    part = automatic.working_part
+    if defect == "ambiguous":
+        part = Compound(children=[deepcopy(part), deepcopy(part)])
+    sheet = Sheet(part).authored_dimensions()
+    handle = sheet.blend(axis="x", radius=3, at=(0.0, 0.0, 9.5 if defect == "ambiguous" else 90.0))
+    sheet.dimension(handle, "blend.radius")
+    with pytest.warns(UserWarning, match="blend_dropped"):
+        drawing = sheet.build()
+    (feature,) = drawing.model().features
+    assert drawing.recognition_evidence() is None
+    assert not drawing.annotations_of(feature)
+    issue = next(issue for issue in drawing.lint(physical=False) if issue.code == "blend_dropped")
+    assert issue.outcome_stage == "placement"
+    assert issue.measurement_ids[0].feature is feature
+    assert issue.measurement_ids[0].parameter == "blend.radius"
+
+
+def test_wrong_radius_tip_lowers_fidelity(automatic, monkeypatch):
+    _, _, leader = next(row for row in _radius_leaders(automatic) if row[0].radius == 3)
+    before = automatic.lint_summary()["quality"]["fidelity"]
+    tip = automatic.at("side", 0, 0, 9.5)
+    monkeypatch.setattr(
+        leader,
+        "location",
+        Pos(tip[0] - leader.tip[0], tip[1] - leader.tip[1], 0) * leader.location,
+    )
+    after = automatic.lint_summary()["quality"]["fidelity"]
+    assert before["score"] == 1.0
+    assert after["score"] < before["score"]
+    assert after["by_code"]["radius_leader_target_mismatch"] == 1
+
+
+def test_profile_edges_require_the_matching_cylindrical_surface(automatic):
+    from draftwright._geometry import _blend_profile_arcs
+
+    faces = automatic.working_part.faces()
+    arcs = _blend_profile_arcs(faces, 3)
+    assert len(arcs) == 2
+    assert all(edge.geom_type == GeomType.CIRCLE and edge.radius == 3 for edge in arcs)
+    assert _blend_profile_arcs(faces, 30) == ()

--- a/tests/test_issue_915_dense_case.py
+++ b/tests/test_issue_915_dense_case.py
@@ -28,8 +28,11 @@ _KNOWN_CROSSINGS = (
     ("170", "75"),
     ("170", "44 × 93.4 × 10 DEEP"),
 )
-_KNOWN_FEATURE_CROSSING = (
-    "pocket callout 50 × 120 × 5 DEEP retained under Policy B across: hc_front0:label"
+# With #1479's tips on the actual trimmed arcs, R5 crosses a dimension line under Policy B.
+# Quarter-arc alternatives keep R4 clear; R5 retains this explicit soft crossing on both pages.
+_KNOWN_FEATURE_CROSSINGS = (
+    "pocket callout 50 × 120 × 5 DEEP retained under Policy B across: hc_front0:label",
+    "blend callout 4× R5 retained under Policy B across: m_pocket0_pos_long:segment:2",
 )
 
 
@@ -41,11 +44,11 @@ def _is_known(issue):
             and f"through the label '{crossed}'" in issue.message
             for crosser, crossed in _KNOWN_CROSSINGS
         )
-    ) or (issue.code == "feature_leader_crossing" and issue.message == _KNOWN_FEATURE_CROSSING)
+    ) or (issue.code == "feature_leader_crossing" and issue.message in _KNOWN_FEATURE_CROSSINGS)
 
 
 def _lint_apart_from_the_known_crossings(dwg):
-    """Every issue except the four explicitly rendered crossings this fixture carries."""
+    """Every issue except the explicitly rendered crossings this fixture carries."""
     return [issue for issue in dwg.lint() if not _is_known(issue)]
 
 
@@ -115,7 +118,7 @@ def test_issue_915_actually_carries_the_known_crossings(detail_dwg):
     """
     page, dwg = detail_dwg
     matched = [issue for issue in dwg.lint() if _is_known(issue)]
-    assert len(matched) == len(_KNOWN_CROSSINGS) + 1, (
+    assert len(matched) == len(_KNOWN_CROSSINGS) + len(_KNOWN_FEATURE_CROSSINGS), (
         f"the {page} sheet no longer carries every known crossing — the filter in "
         f"this module is now over-broad; matched {[i.message for i in matched]}"
     )


### PR DESCRIPTION
GRM04's R3 and R4 leaders pointed at the profile-arc centres, coinciding with the bore crosshairs. Straight-path Blend leaders now use real curved boundaries of their owning cylindrical patches, including spline end trims, with midpoint/quarter-arc candidates routed through the shared placement solve.

Physical lint independently checks the finished tip against the trimmed boundary. It reports `radius_leader_target_mismatch` or `radius_leader_target_unverifiable`, with measurement provenance and a fidelity penalty. Automatic builds retain exact same-run face authority; declared builds require one unambiguous finite cylinder support. Missing support produces an explicit `blend_dropped` outcome.

Fixes #1479.

### Review and architecture

Three local iterations followed [Google's review guidance](https://google.github.io/eng-practices/review/reviewer/looking-for.html), including all five live ADRs. Review fixed missing spline-boundary support and exact measurement-owner validation, and replaced a fictitious-geometry precision test with real radii. No substantive findings remain; this is not an independent human approval.

- ADR 1: existing compiler, geometry leaf, render pass and lint modules; no second engine or state owner.
- ADR 2: part-space boundary candidates enter the existing solve; no raw-coordinate feature API or fixture-specific routing.
- ADR 3: reuse the current inventory and exact automatic occurrence ownership; no second recognition run or private provider imports.
- ADR 4: compiler-approved radius/text, authored/generated scripts, live/deferred edits and retained pins share the same path.
- ADR 5: finished-tip geometry is judged independently of candidate selection; mismatches, unverifiable targets and drops stay explicit.

The dense #915 fixture retains one additional soft dimension-line crossing under existing Policy B. Quarter-arc alternatives removed the other new crossing; eighth-arc alternatives did not remove this one. Its exact diagnostic is tested on both page sizes. GRM04 itself has no lint findings after the fix. Circular-path toroidal Blend tangencies retain their established contract; this does not close the general diameter-targeting work in #1378.

### Validation

- Full local gate: 6,904 passed, 5 skipped, 2 xfailed; 96.00% total and 96% changed-line coverage. A further geometry guard passed independently after that run, with production code unchanged.
- Python 3.10/build123d 0.10: 87 focused tests passed; the full gate ran on Python 3.14/build123d 0.11.
- 15 named mutation guards caught deliberate violations.
- Automatic/generated GRM04, live/deferred/retained edits, rotated/translated geometry, both projection conventions, invalid/ambiguous support, and NIST spline-boundary targets exercised. Before/after PNGs inspected.

Merge only after CI and both Codecov checks pass for the reviewed head. The patch release remains gated on production Quiddity 0.2.2 adoption in #1471.
