### PR TITLE
Align NIST regressions with accepted Quiddity 0.2.2 limits

### DIFF
--- a/tests/test_e2e_standards.py
+++ b/tests/test_e2e_standards.py
@@ -148,7 +148,11 @@ def test_ctc_ap203_exports_honest_diagnostic_no_degenerate_arcs(tmp_path, n):
     _p = dwg.export(stem, formats=("svg", "dxf"))
     svg = _p["svg"]
     dxf = _p["dxf"]
-    _assert_ctc_diagnostic_contract(dwg, svg, dxf, expect_incomplete=True)
+    _assert_ctc_diagnostic_contract(dwg, svg, dxf, expect_incomplete=n != "01")
+    if n == "01":
+        # Quiddity 0.2.2 reclassifies/refuses the former pockets. The smaller plan
+        # fits, but recognition gaps must remain visible; this is not completeness.
+        assert "section_recess_recognition_refused" in {issue.code for issue in dwg.lint()}
     # The #19 fix: no circle-edge-on degenerate arcs leak into the SVG.
     data = Path(svg).read_text(encoding="utf-8")
     degenerate = [

--- a/tests/test_issue_1204_multiscale_view_issues.py
+++ b/tests/test_issue_1204_multiscale_view_issues.py
@@ -202,8 +202,8 @@ class TestTheCountsDoNotMoveWithTheGrouping:
     @pytest.mark.slow  # >=30 s inherent dense build; post-merge tier (#656)
     def test_a_real_multi_group_part_keeps_its_leader_findings(self):
         # `leader_crosses_silhouette` is annotation-dependent, and the synthetic fixture
-        # produces none, so only a real part covers it. CTC-05 has two genuine scale groups
-        # (0.2 and 1.0).
+        # produces none, so a real part covers it. CTC-04 retains a real crossing
+        # with Quiddity 0.2.2; CTC-05's changed recess inventory no longer supplies one.
         #
         # An earlier version stopped there and constrained NOTHING: the leader findings
         # sit at scale 0.2, which was group index 0 and always got the flag. Moving the
@@ -213,7 +213,7 @@ class TestTheCountsDoNotMoveWithTheGrouping:
         # what any reintroduced grouping would have to survive. With #1216's single call
         # there is no index at all, so this now asserts the property directly: the tag
         # changes nothing.
-        drawing = build_drawing(step_file="tests/fixtures/nist_ctc_05_asme1_ap242.stp")
+        drawing = build_drawing(step_file="tests/fixtures/nist_ctc_04_asme1_ap203.stp")
         before = _counts(drawing)["leader_crosses_silhouette"]
         assert before > 0, "fixture no longer supplies a real leader finding"
 

--- a/tests/test_issue_798_silhouette_lint.py
+++ b/tests/test_issue_798_silhouette_lint.py
@@ -224,6 +224,10 @@ class TestGreedyFloorPrefersClearRoutes:
         assert _MATERIAL_PENALTY_UNIT > 0
 
 
+class _HistoricalCalloutFloorNotMet(AssertionError):
+    """Only the accepted historical-count gap may be expected to fail."""
+
+
 class TestCardinalityIsNotTradedForCleanliness:
     """#798 — a crossing is cosmetic; a missing dimension is not.
 
@@ -245,9 +249,26 @@ class TestCardinalityIsNotTradedForCleanliness:
     """
 
     # (fixture stem, feature-leader callouts the floor must keep placing)
-    CASES = (
-        ("nist_ctc_04_asme1_ap203", 11),
-        ("nist_ctc_05_asme1_ap242", 18),
+    # Preserve the historical floors while the release-accepted Quiddity migration
+    # reclassifies/refuses the old pocket inventory. Do not lower these counts to
+    # the smaller drawings or treat their disappearance as a routing improvement.
+    CASES = tuple(
+        pytest.param(
+            stem,
+            floor,
+            marks=pytest.mark.xfail(
+                strict=True,
+                raises=_HistoricalCalloutFloorNotMet,
+                reason=(
+                    "Quiddity 0.2.2 accepted recess-inventory limitation: "
+                    "https://github.com/pzfreo/draftwright/issues/1471"
+                ),
+            ),
+        )
+        for stem, floor in (
+            ("nist_ctc_04_asme1_ap203", 11),
+            ("nist_ctc_05_asme1_ap242", 18),
+        )
     )
 
     # Parametrized per fixture (#656): each dense build is ~60 s, and one test running
@@ -265,11 +286,12 @@ class TestCardinalityIsNotTradedForCleanliness:
         build_drawing(step_file=str(Path("tests/fixtures") / f"{stem}.stp"))
         events = json.loads(trace.read_text())["pass_events"]
         event = next(e for e in events if e.get("label") == "feature_leader_inventory")
-        assert event["objective"]["placed"] >= floor, (
-            f"{stem}: the leader floor placed {event['objective']['placed']} callouts, "
-            f"below the historical floor of {floor} — a route preference must never "
-            "cost a dimension"
-        )
+        if event["objective"]["placed"] < floor:
+            raise _HistoricalCalloutFloorNotMet(
+                f"{stem}: the leader floor placed {event['objective']['placed']} callouts, "
+                f"below the historical floor of {floor} — a route preference must never "
+                "cost a dimension"
+            )
 
     def test_material_is_never_an_acceptance_test(self):
         # The direct guarantee, read off the code rather than a fixture: the floor's


### PR DESCRIPTION
Main's first Quiddity 0.2.2 slow run failed four NIST regressions after the accepted migration changed their recess inventories. Side-by-side builds through `build_drawing(step_file=...)` confirmed that CTC-01 AP203, CTC-04 AP203 and CTC-05 AP242 lose the former pocket IR while retaining the other feature-kind counts: the provider now returns side channels outside the current drafting support plus explicit support-geometry refusals. This follow-up carries the maintainer's accepted release limitations into the slow tier.

- CTC-01's smaller supported plan now fits. Keep the structural SVG/DXF and degenerate-arc checks, and explicitly require visible recognition refusal so fitting is not presented as source completeness.
- Move the multi-scale silhouette-lint regression to CTC-04, which still has a real crossing. Preserve its positive crossing, group-order and exact before/after count assertions.
- Retain the historical 11/18 callout floors as strict expected failures, rather than lowering them. Only a dedicated exception from that final count comparison is waived; an unrelated build assertion fails, and recovered counts produce a failing strict XPASS.

Local iterative review used Google's design/functionality/complexity/tests/naming/comments/style/documentation checklist. The review narrowed the expected exception to avoid absorbing unrelated assertions; no substantive findings remain. This is local AI review, not independent human approval.

ADR assessment: **1** no runtime, IR, state-owner or DAG changes; **2** the existing solve and historical cardinality floors remain intact, with real solver-placed ink in the replacement fixture; **3** provider records and consumer policy are unchanged; **4** declaration, generated-script and suppression semantics are unchanged; **5** recognition refusals remain visible and annotation losses remain explicit regressions. No live ADR text or invariant changes.

Validation: static gate passed; full slow suite **45 passed, two xfailed** (179.76 seconds); Python 3.10/build123d 0.10 affected-case check **two passed, two xfailed**. The final narrowed waiver separately produced two real strict xfails. Deliberately dropping later scale groups fails the named post-tag assertion (`0 == 1`), after its real-build precondition passes. Injected unrelated build assertions and simulated restored callout floors each fail both named cases (pytest exit 1; harness exit 0). All commands completed with observed exit codes. The fast tier has no runtime changes in this PR; hosted CI remains required.

Follow-up to #1471 and #1482 for the authorized 0.4.20 release. The release notes document the NIST callout limitation alongside the already accepted Quiddity gaps.
