### PR TITLE
Separate hole callouts and overall height with semantic sides

### DIFF
--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -37,6 +37,26 @@ or side override. Invalid references, unsupported controls and unsupported place
 separate structured refusal codes in `validate_dimension()`; `dimension_options()` raises on an
 invalid reference.
 
+Hole-size callouts in the plan and side views accept `left` or `right`. The overall
+envelope height accepts `left` or `right` in the front view. These hints can separate
+hole sizes from vertical location dimensions without moving annotation coordinates:
+
+```python
+sheet.dimension(lower_hole, "bore.diameter", side="left")
+sheet.dimension(upper_hole, "bore.diameter", side="left")
+sheet.dimension(envelope, "height.length", side="left")
+sheet.dimension(lower_hole, "location")
+sheet.dimension(upper_hole, "location")
+```
+
+Each side belongs to its named view: the front-view height and side-view hole sizes
+occupy different boundaries. The layout reserves space for the left height and short
+step rises together before choosing scale and page. The shared solver places the
+annotations within those boundaries; generated scripts retain the authored sides.
+An explicit side is a constraint: an infeasible placement reports the affected
+measurement instead of silently choosing the opposite boundary. Repair preserves an
+authored overall-height side, including after a label adjustment.
+
 The explicit `single_dimension_placement_rules` scope means `supported` reports acceptance by
 the current planner placement rules. Both documents set `requires_build_validation: true`:
 whole-part classification can select a different renderer, so this query does not prove actual

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -5830,9 +5830,9 @@ def ladder_plan_for(plan, *, step_height: bool, overall: bool):
 
 
 def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) -> int:
-    """Front-view right ladder: prismatic step heights stacked inner→outer, then the overall
-    height outermost — registered as :class:`CorridorCandidate`s in the shared
-    ``(front, right)`` corridor (#636). The leapfrog witness cursor (#237) survives as a
+    """Front-view ladder: prismatic step heights stacked inner→outer, then the overall
+    height outermost. The overall height can be authored on the left; candidates enter
+    the shared corridor for their side. The leapfrog witness cursor (#237) survives as a
     *build-time chain*: candidates share a ``solved`` position map, and each dim's witness
     anchors on its nearest already-built predecessor's line (the view edge for the first).
 
@@ -5868,8 +5868,6 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
             frame.project("front", entry.span[0])[1],
             frame.project("front", entry.span[1])[1],
         )
-
-    strip = frame.fv_zones.right
 
     rung_set = plan.ladder("step_height")
     rungs = list(rung_set.rungs) if rung_set is not None else []
@@ -6022,6 +6020,12 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
     _tolerances = {c[0]: c[8] for c in chain}
 
     names = [c[0] for c in chain]
+    sides = {
+        name: (overall.rungs[0].side or "right")
+        if name == "dim_height" and overall is not None
+        else "right"
+        for name in names
+    }
     solved: dict[str, float] = {}
     for k, (
         name,
@@ -6035,6 +6039,21 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
         _rt,
         measurement_span,
     ) in enumerate(chain):
+        side = sides[name]
+        direction = 1 if side == "right" else -1
+        edge = edge2 if side == "right" else _left - 2
+        strip = frame.fv_zones.right if side == "right" else frame.fv_zones.left
+        predecessors = [pn for pn in names[:k] if sides[pn] == side]
+
+        def _witness_base(pos, predecessors=predecessors, direction=direction, edge=edge):
+            base = edge
+            for pn in reversed(predecessors):
+                if pn in solved:
+                    base = solved[pn]
+                    break
+            # A retry can revisit the inner position after a predecessor was built.
+            # Prediction and rendering must use the same non-degenerate witness.
+            return edge if direction * (pos - base) < 0.5 else base
 
         def _build(
             pos,
@@ -6042,22 +6061,23 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
             zbase=zbase,
             ztop=ztop,
             label=label,
-            k=k,
+            witness_base=_witness_base,
+            side=side,
+            direction=direction,
+            authored_side=overall.rungs[0].side
+            if name == "dim_height" and overall is not None
+            else None,
             per_unit=per_unit,
             _tol=_tolerances.get(name),
             measurement_span=measurement_span,
         ):
-            base = edge2
-            for pn in reversed(names[:k]):  # nearest already-built predecessor's line
-                if pn in solved:
-                    base = solved[pn]
-                    break
+            base = witness_base(pos)
             solved[name] = pos
             dim = _dim(
                 (base, zbase, 0),
                 (base, ztop, 0),
-                "right",
-                pos - base,
+                side,
+                direction * (pos - base),
                 draft,
                 label=label + _tol_suffix(_tol, draft),
             )
@@ -6068,6 +6088,8 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
                 # step, while a hole pitch spans the whole run. Same seam as `_dw_scale`.
                 dim._dw_label_value = per_unit
             dim._dw_measurement_span = measurement_span
+            if authored_side is not None:
+                dim._dw_authored_side = authored_side
             return dim
 
         # The footprint measures the RENDERED string, so it carries the same suffix the
@@ -6078,25 +6100,22 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
             zbase=zbase,
             ztop=ztop,
             label=label + _tol_suffix(_tolerances.get(name), draft),
-            k=k,
+            witness_base=_witness_base,
+            side=side,
+            direction=direction,
         ):
             # Predecessor-aware prediction (#689 review): the conservative edge-anchored
             # witness can falsely exhaust the strip when an inner obstacle sits in the
-            # already-traversed region. Use the same solved map the build chain uses.
-            base = edge2
-            for pn in reversed(names[:k]):
-                if pn in solved:
-                    base = solved[pn]
-                    break
-            if pos - base < 0.5:  # degenerate guard: never model a zero-length offset
-                base = edge2
+            # already-traversed region. Use the build chain's witness calculation.
+            base = witness_base(pos)
             return dim_footprint(
-                (base, zbase, 0), (base, ztop, 0), "right", pos - base, draft, label
+                (base, zbase, 0), (base, ztop, 0), side, direction * (pos - base), draft, label
             )
 
         def _drop(
             nm,
-            drop_msg=drop_msg,
+            drop_msg=drop_msg.replace("right strip", f"{side} strip"),
+            strip=strip,
             name=name,
             measurement=mid,
             measurement_span=measurement_span,
@@ -6116,7 +6135,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
 
         register_corridor(
             ctx,
-            ("front", "right"),
+            ("front", side),
             strip,
             "front",
             "x",

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -2996,6 +2996,10 @@ def _place_planside_callouts(
     over-capacity drop per edge, right then left with index continuity (``next_i``)."""
     edge_right = plan_right if view == "plan" else side_right
     edge_left = plan_left if view == "plan" else None
+    if view == "side" and any(
+        side_of_callout.get(id(callout)) == "left" for _, _, callout, _ in specs
+    ):
+        edge_left = a.proj.side_x(a.bb.min.Y)
 
     right_strip = a.pv_zones.right if view == "plan" else a.sv_zones.right
     # Elbow offset past the view boundary: only needed in the plan view when a section line will
@@ -3075,9 +3079,13 @@ def _place_planside_callouts(
 
         if not can_right and not can_left:
             _log.info("Hole callout ø%s skipped (no room)", _fmt(dia))
-            _record_callout_drop(
-                ctx, dwg, view, dia, "no room beside the view", feat, callout=callout
+            reason = (
+                f"requested {requested_side} side has insufficient label space "
+                f"at the {'page margin' if requested_side == 'left' else 'right boundary'}"
+                if requested_side is not None
+                else "no room beside the view"
             )
+            _record_callout_drop(ctx, dwg, view, dia, reason, feat, callout=callout)
             continue
 
         # Natural Y is the bore's own row; keep-out-band avoidance is `_place_queue`'s carve.
@@ -3160,9 +3168,8 @@ def _annotate_holes(
     wall thickness. The leader tip lands on the hole's profile boundary, on the
     group's hole nearest the callout.
 
-    Placement: plan- and side-view callouts go to the right of their view
-    (the strip before the iso view / page margin; plan falls back to its
-    left, the side view has no usable left strip), front-view callouts go
+    Placement: plan- and side-view callouts use the shared boundary assignment;
+    explicit left/right hints constrain its candidates. Front-view callouts go
     below the front view through the strip solver. Each callout is width-checked;
     anything that fits nowhere is logged and skipped — never force-placed — and
     then surfaces through the coverage lint as ``feature_not_dimensioned``.

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -422,6 +422,20 @@ def _compose_anno_boxes(
     n_boss_h = _n_right_strip_boss_heights(model)
     # FV right dim ladder + the boss heights that share the strip with it
     boxes = [AnnoBox("right", _est_right_strip_depth(n_steps, n_boss_h))]
+    requests = (
+        model.authored_dimensions
+        if model.authored_dimensions is not None
+        else model.requested_dimensions
+    )
+    if any(
+        request.feature.kind == "envelope"
+        and request.role in {"height", "height.length"}
+        and request.side == "left"
+        for request in requests
+    ):
+        # Short step rises can also use the left corridor. Reserve their ladder with
+        # the authored overall height before choosing the page and scale.
+        boxes.append(AnnoBox("left", _est_right_strip_depth(n_steps)))
     bore_depth = bore_callout_width
     if bore_depth > 0:
         # elbow clearance + leader-to-label gap, as in _measure_strips

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -1021,10 +1021,10 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
 
 
 def _compile_overall_height(
-    model: PartModel, marked, *, include_overall: bool, step_chain_approved: bool
+    model: PartModel, marked, *, planned, include_overall: bool, step_chain_approved: bool
 ) -> tuple[ApprovedLadder | None, ApprovedContingency | None, list[Omission]]:
-    """The part's overall height — the envelope's ``height`` parameter, drawn in the
-    front-view right strip rather than below a view, which is why it rides the ladder.
+    """The part's overall height — the envelope's ``height`` parameter, drawn in a
+    front-view vertical strip rather than below a view, which is why it rides the ladder.
 
     Every reason it might not be drawn is settled here — as conditions named in `planner`
     (`polygonal_stock_conveys_height`, `rotational_od_conveys_height`) and applied here, so
@@ -1141,9 +1141,20 @@ def _compile_overall_height(
     # would silently drop an authored tolerance if the contract ever changed. Raising is the
     # honest failure.
     height_tol = None
+    height_side = None
     if env is not None:
         height_param = next(pm for pm in env.parameters() if pm.role == "height")
         height_tol = _decorated(model, env, height_param).tolerance
+        height_side = next(
+            (
+                pd.side
+                for group in planned
+                if group.feature is env
+                for pd in group.dims
+                if pd.param.parameter_id == "height.length"
+            ),
+            None,
+        )
     ladder = ApprovedLadder(
         "overall_height",
         (
@@ -1154,6 +1165,7 @@ def _compile_overall_height(
                 span=((x, y, float(bb.min.Z)), (x, y, float(bb.max.Z))),
                 ref=env_ref,
                 tolerance=height_tol,
+                side=height_side,
                 # `rendered_label` is the BARE value while `tolerance` is set beside it, so for
                 # a toleranced rung this field is not the "complete compiler-owned label" its
                 # own docstring promises — the renderer composes the suffix. It has to:
@@ -1636,6 +1648,7 @@ def compile_dimensions(
     overall, contingency, height_omissions = _compile_overall_height(
         model,
         marked,
+        planned=planned,
         include_overall=include_overall,
         step_chain_approved=step_chain_approved,
     )

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -1064,10 +1064,11 @@ def _group_placement(feature: Feature, dims: list[PlannedDimension], planned_vie
     # reject a perfectly valid width/front + depth/side pair.
     if feature.kind == "envelope":
         for pd in approved:
-            if pd.side is not None:
+            supported_sides = {"left", "right"} if pd.param.role == "height" else set()
+            if pd.side is not None and pd.side not in supported_sides:
                 raise ValueError(
                     f"envelope dimensions cannot render at {pd.view!r}/{pd.side!r}; "
-                    "supported sides for this renderer: none"
+                    f"supported sides for this renderer: {sorted(supported_sides) or 'none'}"
                 )
             if pd.view is None:
                 continue
@@ -1118,7 +1119,7 @@ def _group_placement(feature: Feature, dims: list[PlannedDimension], planned_vie
     if requested_side is not None:
         supported = {
             "plan": {"left", "right"},
-            "side": {"right"},
+            "side": {"left", "right"},
             "front": {"below"},
         }.get(selected_view or "", set())
         if (

--- a/src/draftwright/repair.py
+++ b/src/draftwright/repair.py
@@ -50,6 +50,8 @@ def _replace_dim(dwg, old, new):
         new._dw_label_value = old._dw_label_value
     if getattr(old, "_dw_measurement_span", None) is not None:
         new._dw_measurement_span = old._dw_measurement_span
+    if getattr(old, "_dw_authored_side", None) is not None:
+        new._dw_authored_side = old._dw_authored_side
     dwg.items[dwg.items.index(old)] = new
     dwg.registry.replace_object(old, new)
 
@@ -59,6 +61,10 @@ def _repair_dim_inside_part(dwg, issue) -> bool:
     labels = _QUOTED_RE.findall(issue.message)
     dim = _find_dim(dwg, labels[0]) if labels else None
     if dim is None:
+        return False
+    # A side override is an authored constraint, including after a same-side label
+    # reconciliation rebuild. Leave the diagnosis visible instead of flipping it.
+    if getattr(dim, "_dw_authored_side", None) is not None:
         return False
     s = dim._dw_spec
     new_side = _OPPOSITE_SIDE.get(s.side)

--- a/tests/test_issue_1466_dimension_options.py
+++ b/tests/test_issue_1466_dimension_options.py
@@ -71,9 +71,13 @@ def test_location_and_envelope_constraints_are_discoverable():
     envelope = sheet.envelope()
     assert sheet.dimension_options(envelope, "height.length")["placements"] == [
         {"view": None, "side": None},
+        {"view": None, "side": "left"},
+        {"view": None, "side": "right"},
         {"view": "front", "side": None},
+        {"view": "front", "side": "left"},
+        {"view": "front", "side": "right"},
     ]
-    assert not sheet.validate_dimension(envelope, "height.length", side="left")["supported"]
+    assert not sheet.validate_dimension(envelope, "height.length", side="above")["supported"]
     result = sheet.validate_dimension(hole_handle, "location", axis="y", side="below")
     assert result["issues"][0]["code"] == "invalid_measurement"
 
@@ -245,7 +249,7 @@ def test_grm04_discovers_supported_edits_without_exploratory_renders(monkeypatch
 
     monkeypatch.setattr(Sheet, "build", forbidden)
     assert not sheet.validate_dimension(holes[0], "location", side="below")["supported"]
-    assert not sheet.validate_dimension(envelopes[0], "height.length", side="left")["supported"]
+    assert sheet.validate_dimension(envelopes[0], "height.length", side="left")["supported"]
     options = sheet.dimension_options(holes[0], "bore.diameter")
     assert options["placements"]
     assert not sheet.validate_dimension(holes[0], "bore.diameter", side="bottom")["supported"]

--- a/tests/test_issue_1466_semantic_sides.py
+++ b/tests/test_issue_1466_semantic_sides.py
@@ -1,0 +1,287 @@
+"""Separate GRM04 hole sizes and location dimensions through authored side hints."""
+
+from collections import Counter
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+from build123d import Box, Cylinder, Pos
+
+from draftwright import Sheet, build_drawing
+from draftwright.linting.issues import LintIssue
+from draftwright.model import hole
+from draftwright.sheet_emit import emit_sheet_script, generate_sheet_script
+
+
+def _execute(source):
+    namespace = {}
+    exec(compile(source, "<semantic-sides>", "exec"), namespace)
+    return namespace
+
+
+@pytest.fixture(scope="module")
+def grm04_scripts(tmp_path_factory):
+    out = tmp_path_factory.mktemp("semantic-sides")
+    path = generate_sheet_script(
+        str(Path(__file__).parent / "fixtures" / "grm04_drive_plate.step"),
+        out=str(out / "grm04"),
+        title="GRM04",
+        number="1466",
+        scale=4,
+        formats=(),
+    )
+    source = Path(path).read_text(encoding="utf-8")
+    assert source.count('"bore.diameter")') == 2
+    assert source.count('"height.length")') == 1
+    edited = source.replace('"bore.diameter")', '"bore.diameter", side="left")')
+    edited = edited.replace('"height.length")', '"height.length", side="left")')
+    return _execute(source), _execute(edited), out
+
+
+def _measurements(drawing):
+    return Counter(
+        (key["feature"], key["parameter_id"])
+        for name in drawing.annotations()
+        for key in drawing.measurement_keys(name)
+    )
+
+
+def test_side_edit_clears_demonstrated_crossing_without_losing_measurements(grm04_scripts):
+    original, edited, _ = grm04_scripts
+    before, after = original["drawing"], edited["drawing"]
+    before_issues = before.lint()
+    assert any(
+        issue.code == "annotation_ink_overlap" and "⌀2.4 THRU" in issue.message
+        for issue in before_issues
+    ), "The fixture must exhibit the hole/location collision before editing"
+    assert before.scale == after.scale == 4
+    assert not any(
+        issue.code in {"annotation_overlap", "annotation_ink_overlap", "placement_unsatisfiable"}
+        for issue in after.lint()
+    )
+    assert _measurements(after) == _measurements(before)
+    assert {"dim_step_0", "dim_step_1", "dim_height"} <= after.annotations().keys()
+    assert len(after.lint()) < len(before_issues)
+
+
+def test_discovery_and_emission_preserve_the_supported_sides(grm04_scripts):
+    _, edited, out = grm04_scripts
+    sheet = edited["sheet"]
+    model = sheet.model()
+    requested = [request for request in model.authored_dimensions if request.side == "left"]
+    assert len(requested) == 3
+    for request in requested:
+        options = sheet.dimension_options(request.feature, request.role)
+        assert {"view": None, "side": "left"} in options["placements"]
+        assert sheet.validate_dimension(request.feature, request.role, side="left")["supported"]
+    source = emit_sheet_script(
+        model,
+        "part",
+        str(out / "roundtrip"),
+        title="GRM04",
+        number="1466",
+        scale=4,
+        formats=(),
+    )
+    namespace = {"part": edited["part"]}
+    exec(compile(source, "<side-roundtrip>", "exec"), namespace)
+    repeated = namespace["sheet"].model().authored_dimensions
+    assert [(r.role, r.view, r.side) for r in repeated] == [
+        (r.role, r.view, r.side) for r in model.authored_dimensions
+    ]
+    assert _measurements(namespace["drawing"]) == _measurements(edited["drawing"])
+
+
+def _side_sheet(kind, side, **options):
+    stock = Box(20, 40, 50)
+    cutter = Cylinder(2, 20, rotation=(0, 90, 0))
+    if kind == "pattern":
+        part = stock - Pos(0, 0, -10) * cutter - Pos(0, 0, 10) * cutter
+    elif kind == "profile":
+        cutter = Cylinder(4, 20, rotation=(0, 90, 0)) & Box(20, 5, 20)
+        part = stock - cutter
+    else:
+        part = stock - cutter
+    sheet = Sheet(part, scale=2, **options).authored_dimensions()
+    if kind == "pattern":
+        target = sheet.pattern(
+            hole(diameter=4, depth=20, at=(0, 0, 0), axis="x"),
+            kind="linear",
+            count=2,
+            pitch=20,
+            direction=(0, 0, 1),
+        )
+    elif kind == "profile":
+        target = sheet.double_d_bore(
+            major_diameter=8,
+            depth=20,
+            at=(0, 0, 0),
+            axis="x",
+            across_flats=5,
+            profile_direction=(0, 1, 0),
+        )
+    else:
+        target = sheet.hole(diameter=4, depth=20, at=(0, 0, 0), axis="x")
+    for parameter_id in target.dimension_ids():
+        sheet.dimension(
+            target, parameter_id, side=side if parameter_id == "bore.diameter" else None
+        )
+    envelope = sheet.envelope()
+    for parameter_id in envelope.dimension_ids():
+        sheet.dimension(
+            envelope, parameter_id, side=side if parameter_id == "height.length" else None
+        )
+    return sheet
+
+
+@pytest.mark.parametrize("kind", ["single", "pattern", "profile"])
+@pytest.mark.parametrize("side", ["left", "right"])
+def test_native_hole_routes_and_height_honour_the_requested_side(kind, side):
+    drawing = _side_sheet(kind, side).build()
+    leaders = [
+        annotation
+        for name, annotation in drawing.iter_annotations()
+        if any(key["parameter_id"] == "bore.diameter" for key in drawing.measurement_keys(name))
+    ]
+    assert len(leaders) == 1
+    left, _, right, _ = drawing.view_bounds("side")
+    box = leaders[0].bounding_box()
+    if side == "left":
+        assert box.max.X < (left + right) / 2
+    else:
+        assert box.min.X > (left + right) / 2
+    height = drawing.get_annotation("dim_height").bounding_box()
+    left, _, right, _ = drawing.view_bounds("front")
+    assert height.max.X < left if side == "left" else height.min.X > right
+    assert not any(issue.code.endswith("_dropped") for issue in drawing.lint())
+
+
+def test_a_full_authored_side_is_reported_instead_of_using_the_other_side(monkeypatch):
+    import draftwright.annotations.holes as holes
+
+    annotate = holes._annotate_holes
+    attempts = []
+
+    def narrow_left(drawing, analysis, *args, **kwargs):
+        edge_left = analysis.proj.side_x(analysis.bb.min.Y)
+        bounded = replace(analysis, margin=edge_left + 1)
+        assert bounded.margin > edge_left
+        attempts.append(bounded)
+        return annotate(drawing, bounded, *args, **kwargs)
+
+    monkeypatch.setattr("draftwright.annotations.orchestrator._annotate_holes", narrow_left)
+    control = _side_sheet("single", "right", scale_policy="permissive").build()
+    assert any(
+        key["parameter_id"] == "bore.diameter"
+        for name in control.annotations()
+        for key in control.measurement_keys(name)
+    ), "The opposite side must still fit, so the authored restriction decides the refusal"
+    drawing = _side_sheet("single", "left", scale_policy="permissive").build()
+    assert attempts
+    assert not any(
+        key["parameter_id"] == "bore.diameter"
+        for name in drawing.annotations()
+        for key in drawing.measurement_keys(name)
+    )
+    refusals = [issue for issue in drawing.lint() if issue.code == "callout_dropped"]
+    assert len(refusals) == 1
+    assert "requested left side" in refusals[0].message and "page margin" in refusals[0].message
+    assert any(mid.parameter == "bore.diameter" for mid in refusals[0].measurement_ids)
+
+
+def _inject_repair_attempt(monkeypatch, drawing, name):
+    original = drawing.get_annotation(name)
+
+    def diagnosis(**kwargs):
+        if drawing.get_annotation(name) is original:
+            return [
+                LintIssue(
+                    "warning",
+                    f"dimension '{original.label}' is inside the part",
+                    code="dim_inside_part",
+                )
+            ]
+        return []
+
+    monkeypatch.setattr(drawing, "lint", diagnosis)
+    assert drawing.lint()[0].code == "dim_inside_part"
+    return original
+
+
+def test_pin_blocks_a_repair_attempt_beside_the_authored_left_height(monkeypatch):
+    drawing = _side_sheet("single", "left").build()
+
+    # Inject a repairable diagnosis to exercise the pin, rather than letting clean lint
+    # make both pinned and unpinned calls pass without attempting a change.
+    original = _inject_repair_attempt(monkeypatch, drawing, "m_env_depth")
+    drawing.pin("m_env_depth").repair()
+    assert drawing.get_annotation("m_env_depth") is original
+    drawing.unpin("m_env_depth").repair()
+    assert drawing.get_annotation("m_env_depth") is not original
+
+
+@pytest.mark.parametrize("side", ["left", "right"])
+def test_repair_does_not_relax_an_authored_side(monkeypatch, side):
+    automatic = _side_sheet("single", None).build()
+    auto_height = _inject_repair_attempt(monkeypatch, automatic, "dim_height")
+    automatic.repair()
+    assert automatic.get_annotation("dim_height") is not auto_height
+
+    drawing = _side_sheet("single", side).build()
+    original = _inject_repair_attempt(monkeypatch, drawing, "dim_height")
+    assert not drawing.registry.is_pinned("dim_height")
+    drawing.repair()
+    assert drawing.get_annotation("dim_height") is original
+
+
+def test_same_side_label_rebuild_preserves_the_authored_constraint(monkeypatch):
+    from draftwright._core import _dim
+    from draftwright.repair import _replace_dim
+
+    drawing = _side_sheet("single", "left").build()
+    before = _measurements(drawing)
+    original = drawing.get_annotation("dim_height")
+    spec = original._dw_spec
+    rebuilt = _dim(
+        spec.p1,
+        spec.p2,
+        spec.side,
+        spec.distance,
+        spec.draft,
+        **{**spec.kwargs, "label_offset_x": 1},
+    )
+    # This is the replacement seam used by witness-label reconciliation. Exercise
+    # subsequent repair too: merely retaining the original side string is insufficient.
+    _replace_dim(drawing, original, rebuilt)
+    assert drawing.get_annotation("dim_height") is rebuilt
+    _inject_repair_attempt(monkeypatch, drawing, "dim_height")
+    drawing.repair()
+    assert drawing.get_annotation("dim_height") is rebuilt
+    assert _measurements(drawing) == before
+
+
+def test_height_retry_predicts_the_geometry_it_builds_after_a_predecessor_is_placed(monkeypatch):
+    import draftwright.annotations.from_model as renderer
+
+    captured = {}
+    register = renderer.register_corridor
+
+    def observe(ctx, key, strip, view, axis, tier, candidate):
+        if candidate.name == "dim_height":
+            captured.update(strip=strip, candidate=candidate)
+        return register(ctx, key, strip, view, axis, tier, candidate)
+
+    monkeypatch.setattr(renderer, "register_corridor", observe)
+    part = Pos(0, 0, -5) * Box(40, 30, 10) + Pos(10, 0, 5) * Box(20, 30, 10)
+    drawing = build_drawing(part, scale=2)
+    strip, candidate = captured["strip"], captured["candidate"]
+    inner = strip.anchor + strip.direction * strip.gap
+    predecessor = drawing.get_annotation("dim_step_0")._dw_spec
+    assert predecessor.p1[0] + predecessor.distance == pytest.approx(inner)
+    # The force pass probes the strip's inner position again after earlier candidates
+    # have been built. A valid predicted footprint must not become a zero-offset build.
+    predicted = candidate.footprint(inner)
+    actual = candidate.build(inner).bounding_box()
+    assert predicted == pytest.approx(
+        (actual.min.X, actual.min.Y, actual.max.X, actual.max.Y), abs=0.06
+    )


### PR DESCRIPTION
## Symptom and evidence

A generated GRM04 declaration at scale 4 puts the lower `Ø2.4 THRU` callout across a location dimension. The existing discovery API rejected left-side hole callouts in the side view and left-side overall height in the front view, so it could not describe the edit needed to separate them.

Allow those two existing annotation families to use either left or right. Authored sides reach the shared boundary/corridor solve, and compose reserves the left height together with short step rises before choosing scale and page. On GRM04, moving both hole sizes and the overall height left clears the demonstrated annotation overlaps while retaining scale 4, the short step dimensions and the same feature/parameter key multiset. Two pre-existing informational crossings remain; this is not a claim of universally clean lint.

Height prediction and rendering now share the witness-origin calculation: a captured native height candidate previously predicted a valid inner-strip retry footprint but raised a zero-offset error when built after its predecessor. The regression failed before the fix and now compares predicted and rendered bounds.

An explicit height side also survives repair and label reconciliation. A callout that cannot fit its authored side reports the measurement and the limiting boundary rather than using the opposite side. Discovery and generated declarations retain the supported side choices.

## Contract and scope

This delivers the bounded side-control slice of #1466 through the existing vocabulary. The GRM04 regression proves preservation for this unchanged-geometry declaration; #883/#1006 still own exact member/axis identity and independently trustworthy comparison across edits. General route/anchor controls remain with their scoped follow-ups. Refs #1466, #1277.

ADR 1: per-dimension placement intent reaches the existing overall-height compiler and renderer; no new engine or recognition run. ADR 2: the existing composition reservation, boundary assignment and shared corridor solve own placement. ADR 3: provider contracts and occurrence ownership are unchanged. ADR 4: authored sides survive discovery and executable declaration round-trip. ADR 5: infeasible placement remains diagnosed, pins survive repair, and repair's allowlist is unchanged. No ADR text or invariant changes.

## Validation

- `scripts/pr-check --quick`: N/A; full preflight used.
- [x] Full `scripts/pr-check` exited 0 against the reviewed Quiddity 0.2.4 prerequisite (`BASE_REF=745fc4f8`): **7,242 passed, 5 skipped, 14 expected failures; 95.9% total coverage and 100% changed-line coverage (32 lines).** All 32 changed executable lines also have full branch coverage locally.
- [x] Native single-hole, pattern and double-D cases exercise left and right callouts and overall height.
- [x] The GRM04 fixture asserts the crossing before the edit and retains the exact measurement-key multiset afterward; generated declarations preserve authored side choices.
- [x] A forced left-boundary obstruction refuses the selected callout while an opposite-side control still fits.
- [x] Fault-injected repair exercises pins and authored sides rather than relying on a clean drawing to do nothing. Removing the height constraint tag, repair guard, replacement preservation, or witness fallback each failed its named test; source was restored before preflight.
- [x] Automatic, declared and generated-script paths exercised where affected. Recognition/lint lifecycle is unchanged; its existing regression gates remain part of the full preflight.

## Stop check

- [x] No two consecutive review rounds invalidated the same core association strategy. Placement remains in the shared solve.
- [x] Member identity, independent before/after comparison, bounded repair and broader physical-target assurance retain their existing scoped issues under #1277.

## Contributor License Agreement

N/A: maintainer-owned repository changes; no new external-contributor CLA attestation is made by this PR.
