### PR TITLE
Select hole location dimensions by member and axis

### DIFF
--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -67,6 +67,34 @@ build. Build and lint still assess the resulting Sheet. A
 query never replaces an existing dimension request. Keep the original feature handle for edits;
 these reports do not introduce persistent feature identities or new lane, route or pin controls.
 
+## Selecting a hole location component
+
+Use `location` alone to request the usual location set. To select one component of a hole
+group or pattern, pair its declared member index with the measured world axis:
+
+```python
+options = sheet.dimension_options(holes, "location")
+print(options["location_components"])  # valid member/axis pairs and their parameter ids
+sheet.dimension(holes, "location", member=1, axis="y")
+```
+
+Member indices start at zero and refer to the declared `members` tuple. A singleton hole
+has member 0. The axis is transverse to the hole's own axis: an X-directed hole can have
+Y and Z location dimensions. A bolt-circle pattern also accepts `member="centre"`.
+Both selectors are required for a fine request; invalid members or axes are refused.
+The existing `validate_dimension()` query accepts the same selectors.
+
+The coarse pattern request keeps its automatic anchor policy: the member nearest the
+datum, or the centre of a bolt circle. Adding a fine request selects that extra component
+without selecting its sibling axis. Repeating a request does not duplicate a measurement.
+Generated scripts carry the member and axis so removing one location declaration omits
+that component. Coincident dimensions can share one mark while recording every approved
+owner.
+
+These indices address one declaration and its generated script. They do not establish
+correspondence across unrelated recognition runs. The shared solver still chooses where
+to place the dimension; location selection supplies no page coordinates.
+
 ## Sheet
 
 ::: draftwright.sheet.Sheet

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -46,6 +46,8 @@ from draftwright.linting.structural import (
     _centerline_extent,
 )
 from draftwright.model.compiled import resolve_feature
+from draftwright.model.ir import HoleFeature, PatternFeature
+from draftwright.model.planner import hole_location_parameter_id
 
 _log = logging.getLogger(__name__)
 
@@ -67,14 +69,21 @@ def _with_hole_location_coverage(annotation, coverage):
 def _hole_location_coverage_fact(location):
     """The directional physical fact rendered by one compiled hole location member.
 
-    ``location.id`` remains ADR 4 (was 0016)'s feature-level addressable ``DimensionId``. The
-    requirement parameter is deliberately separate: critique can distinguish X from Y
-    without resolving #883's open public naming decision or minting a general identity.
+    The physical requirement vocabulary is independent of the public member address.
+    Its point identifies the physical member; the compiler's declaration-local index
+    must not replace that independent evidence.
     """
     feature = resolve_feature(location.ref)
     if feature is None and location.id is not None:
         feature = location.id.feature
     assert feature is not None and location.span is not None
+    if isinstance(feature, HoleFeature | PatternFeature):
+        parameter = (
+            f"{location.role}.{location.discriminator}"
+            if isinstance(feature, HoleFeature) and location.axis != "z"
+            else f"{location.role}.location.{location.discriminator}"
+        )
+        return (feature, parameter, tuple(location.span[1]))
     parameter = location.id.parameter if location.id is not None else location.parameter_id
     if (
         parameter
@@ -189,6 +198,16 @@ def _annotation_hole_features(registry, name, annotation) -> frozenset:
     return frozenset(features)
 
 
+def _table_location_parameters(feature) -> set[str]:
+    if not isinstance(feature, HoleFeature) or feature.frame.axis != "z":
+        return set()
+    return {
+        hole_location_parameter_id(feature, member, axis)
+        for member in range(len(feature.members or (feature.frame.origin,)))
+        for axis in ("x", "y")
+    }
+
+
 def _hole_table_replaceable_annotation(registry, name, annotation) -> bool:
     """Whether a table can replace *all* semantic facts carried by an annotation.
 
@@ -214,6 +233,8 @@ def _hole_table_replaceable_annotation(registry, name, annotation) -> bool:
         "location.location",
         "location_pattern.location",
     }
+    for feature in features:
+        table_parameters.update(_table_location_parameters(feature))
     return all(
         getattr(measurement, "parameter", None) in table_parameters
         for measurement in registry.measurement_of(name)
@@ -233,6 +254,8 @@ def _hole_table_replaceable_location_annotation(registry, name, annotation) -> b
     measurements = tuple(registry.measurement_of(name))
     return bool(measurements) and all(
         getattr(measurement, "parameter", None) == "location.location"
+        or getattr(measurement, "parameter", None)
+        in _table_location_parameters(getattr(measurement, "feature", None))
         for measurement in measurements
     )
 

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -875,6 +875,8 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
     PX, PY = a.proj.plan_x, a.proj.plan_y
     x_refs: list = []
     for r in refs:
+        if r[4] not in (None, "x"):
+            continue
         for u in x_refs:
             if _same_location_ordinate(r[0], u[0]):
                 u[3] = u[3] or r[2] in pinned_set
@@ -932,7 +934,10 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
         # A single X-location dim shared by two *distinct* features at this X belongs to
         # neither exclusively — leave it unowned so drop() cannot over-strip a sibling's
         # dimension and annotations_of never over-claims it (review #406, ADR 5 (was 0010)).
-        _shared_x = any(_same_location_ordinate(o[0], rx) and o[2] != feat for o in refs)
+        _shared_x = any(
+            o[4] in (None, "x") and _same_location_ordinate(o[0], rx) and o[2] != feat
+            for o in refs
+        )
         _xfeat = None if _shared_x else feat
         # The measurement does NOT follow the feature (#1002 r4). Feature-unowned is an
         # ADR 5 (was 0010) *ownership* rule — it stops drop(feature) stripping a sibling's dim. It
@@ -995,6 +1000,8 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
     iso_x0, iso_y0, _, _ = _iso_bbox(dwg)
     y_refs: list = []
     for r in refs:
+        if r[4] not in (None, "y"):
+            continue
         for u in y_refs:
             if _same_location_ordinate(r[1], u[1]):
                 u[3] = u[3] or r[2] in pinned_set
@@ -1053,7 +1060,10 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
             continue
         n += 1
         # Shared-Y location dim → unowned (see the X loop; review #406).
-        _shared_y = any(_same_location_ordinate(o[1], ry) and o[2] != feat for o in refs)
+        _shared_y = any(
+            o[4] in (None, "y") and _same_location_ordinate(o[1], ry) and o[2] != feat
+            for o in refs
+        )
         _yfeat = None if _shared_y else feat
         # Every collapsed feature-level location; the structured facts carry Y (see X above).
         _ymid = tuple(mids)

--- a/src/draftwright/audit.py
+++ b/src/draftwright/audit.py
@@ -35,12 +35,9 @@ coordinates. Two features of one kind are therefore not separated: a same-count 
 slot's width for another's is invisible (**#1006**). Multiplicity IS compared — as a multiset,
 so a grouped callout dropping a member is caught — but a like-for-like exchange is not.
 
-- **A replaced measurement hides where identity is unrecorded.** Move a hole and `m_locx0`
-  goes from `70` to `90`: a different measurement reused the slot. With identity recorded
-  that is caught and reported as ``measurements_substituted``. Without it the old hole
-  remains — and if the replacement renders the same label, **every result map is empty**. So
-  a clean diff still does not establish that the measurements were preserved; it establishes
-  that nothing observable at this resolution moved (Codex #1001).
+- **A replaced measurement can reuse an annotation name.** Recorded parameter and member
+  identities allow ``measurements_substituted`` to report changes even when the displayed
+  value agrees. The same-kind, same-parameter feature swap described above remains a gap.
 - **A loss is attributed only where identity exists, and only by kind.** Where identity is
   recorded the join is on ``(feature kind, parameter_id)`` — precise enough to separate an
   envelope's width from a slot's, not precise enough to separate two slots. Where it is not
@@ -186,10 +183,9 @@ def diff_builds(before, after) -> dict:
     # every envelope dim of every perturbed build as "reattributed" — three noise lines on a
     # three-dimension drawing, in the one experiment this module exists to run.
     #
-    # Hole location DimensionIds remain one feature-level `location.location` unit (ADR 4 (was 0016)).
-    # Physical completeness carries directional X/Y evidence separately, but this differential
-    # audit intentionally compares the public addressable identity, so X↔Y substitution remains
-    # part of #883's open naming decision.
+    # Hole location IDs carry the declared member and measured axis. This detects component
+    # substitutions even when the rendered name and value agree. The feature-kind join still
+    # cannot distinguish unrelated same-kind owners; that remaining gap is tracked in #1006.
     substituted: dict[str, tuple] = {}
     for name in set(before_dims) & set(after_dims):
         b_ids, a_ids = _identities(before, name), _identities(after, name)

--- a/src/draftwright/linting/evidence.py
+++ b/src/draftwright/linting/evidence.py
@@ -156,12 +156,8 @@ class ClaimOutcome:
 def compiled_values(plan) -> dict:
     """``{measurement id: (ApprovedDimension, ...)}`` for everything the compiler approved.
 
-    A **multimap**, deliberately. A ``DimensionId`` is not unique per rendered dimension: one
-    hole's ``location.location`` yields both the X and the Y offset, and the overall height
-    appears in a group and in the ladder. Keyed as a single value it silently drops one of each
-    pair, and the verifier then reports a true dimension as a mismatch — measured while building
-    this, on a two-hole plate where the Y locations read 15 and 45 against a lookup insisting on
-    20 and 60.
+    A **multimap**, deliberately: the overall height appears in a group and in the ladder.
+    Multiple compiled representations of one identity must remain available to the verifier.
     """
     values: dict = defaultdict(list)
     for group in getattr(plan, "groups", ()):

--- a/src/draftwright/linting/hole_coverage.py
+++ b/src/draftwright/linting/hole_coverage.py
@@ -494,8 +494,7 @@ def _parameter_ids(
             ids.extend((f"{stem}.{in_plane}", f"{stem}.z"))
     else:
         # Pitch/direction/count define only relative arrangement. Retain both absolute
-        # in-plane physical requirements independently; the compiler's one feature-level
-        # location unit can prove both without changing this physical ledger schema.
+        # in-plane physical requirements independently of authoring granularity.
         stem = getattr(feature, "LOCATION_STEM", None)
         if stem is None:
             return None
@@ -514,8 +513,8 @@ def _evidence_parameter(parameter: str) -> str:
         # those compiler-owned ids instead of inventing a second suppression vocabulary.
         return parameter.replace(".centerline.", ".")
     if parameter.startswith(("location.location.", "location_pattern.location.")):
-        # X/Y are independent physical critique requirements, while ADR 4 (was 0016) / #883 keeps
-        # their authored addressability as one feature-level location unit.
+        # A whole-feature authored omission retains the coarse location parameter.
+        # Independent X/Y requirements consult that omission without merging their evidence.
         return parameter.rsplit(".", 1)[0]
     return parameter
 
@@ -558,6 +557,29 @@ def _normalised_location(feature, point) -> tuple[float, float, float]:
     if hole.through:
         normalized["xyz".index(feature.frame.axis)] = 0.0
     return (normalized[0], normalized[1], normalized[2])
+
+
+def _member_location_drop_parameter(parameter: str) -> str | None:
+    """Project a component's public address to its aggregate drop category.
+
+    This classifies a recorded failure; it supplies neither an owner nor evidence that
+    a location was placed. Physical placement still requires the recorded member point.
+    """
+    parts = parameter.split(".")
+    if len(parts) == 5 and parts[2] == "member":
+        if not parts[3].isascii() or not parts[3].isdecimal() or str(int(parts[3])) != parts[3]:
+            return None
+    elif len(parts) == 4 and parts[2] == "centre" and parts[0] == "location_pattern":
+        pass
+    else:
+        return None
+    if parts[1] != "location" or parts[-1] not in {"x", "y", "z"}:
+        return None
+    if parts[0] == "location_off_axis":
+        return f"{parts[0]}.{parts[-1]}"
+    if parts[0] in {"location", "location_pattern"}:
+        return f"{parts[0]}.location.{parts[-1]}"
+    return None
 
 
 def _index_hole_evidence(registry) -> _HoleEvidence:
@@ -654,6 +676,12 @@ def _index_hole_evidence(registry) -> _HoleEvidence:
         if is_placement_drop(issue)
         for feature, parameter in getattr(issue, "hole_requirement_ids", ())
     )
+    dropped.update(
+        (feature, physical_parameter)
+        for feature, parameter in tuple(dropped)
+        if isinstance(parameter, str)
+        and (physical_parameter := _member_location_drop_parameter(parameter)) is not None
+    )
     return _HoleEvidence(
         placed,
         satisfied,
@@ -690,8 +718,8 @@ def _structured_locations_placed(evidence, features, parameter: str, turned_axis
             else:
                 # Linear/grid absolute location is compiled from one member nearest the
                 # datum. Any member is a truthful anchor because pitch/lattice facts locate
-                # the rest; requiring every member would mistake one pattern-location
-                # dimension for N independently addressable locations (#883).
+                # the rest. Fine member addressing does not make every member's absolute
+                # position a separate physical requirement for a pattern.
                 valid = {_normalised_location(feature, point) for point in _members(feature)}
             if not valid.intersection(evidence.locations.get((feature, parameter), ())):
                 return False
@@ -752,7 +780,10 @@ def _state(features, parameter, *, member_count, evidence_index, suppressed, tur
         ]
         if all(satisfied) if "location" in parameter else any(satisfied):
             return "satisfied_by_structured_note"
-    if all((feature, evidence_parameter) in suppressed for feature in features):
+    if all(
+        (feature, evidence_parameter) in suppressed or (feature, parameter) in suppressed
+        for feature in features
+    ):
         return "suppressed"
     drop_parameter = (
         parameter

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -50,7 +50,7 @@ completeness:
 from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
-from typing import Any
+from typing import Any, Literal
 
 from draftwright._geometry import _fmt
 from draftwright.model.ir import (
@@ -74,7 +74,10 @@ from draftwright.model.planner import (
     DimensionId,
     _decorated,
     _is_zero_step_position,
+    authored_location_axis_omitted,
     authored_location_omitted,
+    hole_location_parameter_id,
+    hole_location_references,
     location_datum,
     plan_dimensions,
     plan_locations,
@@ -248,6 +251,9 @@ class ApprovedDimension:
     #: fields because one feature's dimensions legitimately scatter across views.
     view: str | None = None
     side: str | None = None
+    #: The declaration-local selector retained for location script emission. Other
+    #: dimensional families keep their established parameter-id addressing.
+    location_member: int | Literal["centre"] | None = None
 
     @property
     def parameter_id(self) -> str:
@@ -583,11 +589,16 @@ _LADDER_ROLE = {"overall_height": "height.length"}
 
 
 def _deduplicated(intents: list) -> list:
-    """*intents* with repeated ``(feature, role)`` targets removed, first occurrence kept."""
+    """Repeated feature/parameter/member/axis selectors removed, first occurrence kept."""
     seen: set = set()
     out = []
     for i in intents:
-        key = (id(resolve_feature(i.ref)) if i.ref is not None else None, i.role)
+        key = (
+            id(resolve_feature(i.ref)) if i.ref is not None else None,
+            i.role,
+            i.discriminator,
+            i.member,
+        )
         if key in seen:
             continue
         seen.add(key)
@@ -638,6 +649,8 @@ class AddressableIntent:
 
     ref: FeatureRef | None
     role: str
+    discriminator: str | None = None
+    member: int | Literal["centre"] | None = None
 
 
 @dataclass(frozen=True)
@@ -760,17 +773,19 @@ class RenderableDimensionPlan:
 
     def _addressable_locations(self) -> list[AddressableIntent]:
         out: list[AddressableIntent] = []
-        named: set[int] = set()
         for approved in self.locations:
-            # One intent per FEATURE, not per ref. The compiler preserves coincident
-            # feature-owned identities; rendering may share one visible ordinate while
-            # accumulating every owner. `dimension(f, "location")` remains a per-feature
-            # unit (#883 is the per-member question, deliberately not answered here).
-            feature = resolve_feature(approved.ref)
-            if feature is None or id(feature) in named:
+            if approved.ref is None:
                 continue
-            named.add(id(feature))
-            out.append(AddressableIntent(approved.ref, "location"))
+            out.append(
+                AddressableIntent(
+                    approved.ref,
+                    "location",
+                    discriminator=approved.discriminator
+                    if approved.location_member is not None
+                    else None,
+                    member=approved.location_member,
+                )
+            )
         return out
 
     def _addressable_contingencies(self) -> list[AddressableIntent]:
@@ -1226,6 +1241,7 @@ def _compile_locations(model: PartModel) -> tuple[list[ApprovedDimension], list[
     """
     approved: list[ApprovedDimension] = []
     omissions: list[Omission] = []
+    omitted_axes: set[tuple[int, str]] = set()
     for pd in plan_locations(model):
         feature = pd.feature
         span = pd.param.span
@@ -1254,6 +1270,11 @@ def _compile_locations(model: PartModel) -> tuple[list[ApprovedDimension], list[
                 if directional_slot_pattern
                 else (pd.param.parameter_id,)
             )
+            if isinstance(feature, HoleFeature | PatternFeature) and pd.location_axes:
+                parameter_ids = tuple(
+                    hole_location_parameter_id(feature, pd.location_member, axis)
+                    for axis in pd.location_axes
+                )
             omissions.extend(
                 Omission(feature, parameter_id, None, pd.reason or "suppressed")
                 for parameter_id in parameter_ids
@@ -1263,19 +1284,40 @@ def _compile_locations(model: PartModel) -> tuple[list[ApprovedDimension], list[
         axis = feature.frame.axis if feature is not None else None
         if directional_location:
             assert feature is not None
-            # One authored `location` intent, two independently observable page dimensions.
-            # Hole/pattern X/Y facts remain rendering members of the ONE feature-level
-            # addressable DimensionId (ADR 4 (was 0016) / #883); critique carries their directional
-            # physical evidence separately. Slot patterns retain their existing directional
-            # identity contract.
+            # A coarse location request expands to independently identified components.
+            # The member index comes from the declared reference, before layout grouping;
+            # it is not a correspondence claim across unrelated recognition runs.
             for measured_axis in ("x", "y"):
                 index = "xyz".index(measured_axis)
                 value = abs(span[1][index] - span[0][index])
-                parameter_id = (
-                    f"{pd.param.parameter_id}.{measured_axis}"
-                    if directional_slot_pattern
-                    else pd.param.parameter_id
-                )
+                if isinstance(feature, HoleFeature | PatternFeature):
+                    parameter_id = hole_location_parameter_id(
+                        feature, pd.location_member, measured_axis
+                    )
+                else:
+                    parameter_id = (
+                        f"{pd.param.parameter_id}.{measured_axis}"
+                        if directional_slot_pattern
+                        else pd.param.parameter_id
+                    )
+                if pd.location_axes is not None and measured_axis not in pd.location_axes:
+                    omissions.append(Omission(feature, parameter_id, value, _AUTHORED_OMISSION))
+                    axis_key = (id(feature), measured_axis)
+                    if axis_key not in omitted_axes and authored_location_axis_omitted(
+                        model, feature, measured_axis
+                    ):
+                        # This whole-axis omission follows explicit intent, not a missing
+                        # rendered mark. Keep the finer component diagnostic as well.
+                        omissions.append(
+                            Omission(
+                                feature,
+                                f"{pd.param.role}.location.{measured_axis}",
+                                None,
+                                _AUTHORED_OMISSION,
+                            )
+                        )
+                        omitted_axes.add(axis_key)
+                    continue
                 approved.append(
                     ApprovedDimension(
                         id=_dim_id(feature, parameter_id),
@@ -1290,6 +1332,11 @@ def _compile_locations(model: PartModel) -> tuple[list[ApprovedDimension], list[
                         role=pd.param.role,
                         discriminator=measured_axis,
                         axis=axis,
+                        location_member=(
+                            "centre" if pd.location_member is None else pd.location_member
+                        )
+                        if isinstance(feature, HoleFeature | PatternFeature)
+                        else None,
                     )
                 )
             continue
@@ -1402,38 +1449,39 @@ def _compile_off_axis_hole_locations(
         # carry a height. Patterns compile one absolute address below, independently of
         # their relative pitch/count requirements.
         measured = ("y" if f.frame.axis == "x" else "x", "z")
-        omitted = authored_location_omitted(model, f)
-        references: tuple[Point, ...]
-        if isinstance(f, PatternFeature):
-            # One absolute address owns a pattern. A grid uses the member nearest the bbox
-            # datum so the two emitted offsets identify its near corner; a bolt circle uses
-            # its centre. Relative pitch/count remain separate requirements.
-            if f.pattern == "bolt_circle" or not f.members:
-                references = (f.frame.origin,)
-            else:
-                transverse = tuple(axis for axis in "xyz" if axis != f.frame.axis)
-                references = (
-                    min(
-                        f.members,
-                        key=lambda member: sum(
-                            (member["xyz".index(axis)] - float(getattr(bb.min, axis.upper()))) ** 2
-                            for axis in transverse
-                        ),
-                    ),
-                )
-            role = f.LOCATION_STEM
-        else:
-            references = f.members or (f.frame.origin,)
-            role = f.LOCATION_OFF_AXIS_STEM
-        for member in references:
+        datum_point = (float(bb.min.X), float(bb.min.Y), float(bb.min.Z))
+        role = f.LOCATION_STEM if isinstance(f, PatternFeature) else f.LOCATION_OFF_AXIS_STEM
+        if isinstance(f, PatternFeature) and f.pattern != "bolt_circle" and not f.members:
+            omissions.append(
+                Omission(f, f"{role}.location", None, "pattern has no members to locate from")
+            )
+            continue
+        omitted_axes_for_feature: set[str] = set()
+        for member_index, member, axes in hole_location_references(model, f, datum_point):
             for meas in measured:
                 index = "xyz".index(meas)
                 datum = float(getattr(bb.min, meas.upper()))
                 value = abs(member[index] - datum)
-                parameter = (
-                    f"{role}.location" if isinstance(f, PatternFeature) else f"{role}.{meas}"
-                )
-                if omitted:
+                parameter = hole_location_parameter_id(f, member_index, meas)
+                if meas not in axes:
+                    if meas not in omitted_axes_for_feature and authored_location_axis_omitted(
+                        model, f, meas
+                    ):
+                        physical_parameter = (
+                            f"{role}.location.{meas}"
+                            if isinstance(f, PatternFeature)
+                            else f"{role}.{meas}"
+                        )
+                        omissions.append(Omission(f, physical_parameter, None, _AUTHORED_OMISSION))
+                        omitted_axes_for_feature.add(meas)
+                    if authored_location_omitted(model, f):
+                        # The whole-feature omission remains the physical ledger's
+                        # coarse authored suppression, distinct from a selected component.
+                        parameter = (
+                            f"{role}.location"
+                            if isinstance(f, PatternFeature)
+                            else f"{role}.{meas}"
+                        )
                     omissions.append(Omission(f, parameter, value, _AUTHORED_OMISSION))
                     continue
                 start = list(member)
@@ -1449,6 +1497,7 @@ def _compile_off_axis_hole_locations(
                         role=role,
                         discriminator=meas,
                         axis=f.frame.axis,
+                        location_member="centre" if member_index is None else member_index,
                     )
                 )
     return approved, omissions

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -302,6 +302,8 @@ def double_d_bore(
     depth=None,
     through=True,
     profile_direction=None,
+    count=1,
+    members=(),
 ) -> HoleFeature:
     """A through double-D bore, from its cutter or explicit geometric values.
 
@@ -327,6 +329,7 @@ def double_d_bore(
     axis = _norm_axis(axis)
     _require_positive(major_diameter=major_diameter, across_flats=across_flats, depth=depth)
     _require_point("at", at)
+    _require_count("double_d_bore()", count)
     if profile_direction is None:
         direction_axis = next(candidate for candidate in "xyz" if candidate != axis)
         profile_direction = (
@@ -342,6 +345,8 @@ def double_d_bore(
         profile="double_d",
         across_flats=across_flats,
         profile_direction=profile_direction,
+        count=count,
+        members=tuple(members),
     )
 
 

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -3151,9 +3151,39 @@ class RequestedDimension:
     #: compatibility; the placement engine still owns coordinates.
     view: str | None = None
     side: str | None = None
+    #: Declaration-local hole member, or the centre of a bolt-circle pattern.
+    #: Paired with the measured-axis discriminator to select one location component.
+    member: int | Literal["centre"] | None = None
 
     def __post_init__(self) -> None:
         validate_placement_intent(self.view, self.side, owner="requested dimension")
+        if self.member is not None and self.role != "location":
+            raise ValueError("member selects only a location measurement")
+        if self.role == "location" and (self.member is not None or self.discriminator is not None):
+            feature = self.feature
+            if not isinstance(feature, HoleFeature | PatternFeature):
+                raise ValueError("member/axis location selection requires a hole or hole pattern")
+            if self.member is None or self.discriminator is None:
+                raise ValueError("select a location component with both member and axis")
+            if self.discriminator not in tuple(
+                axis for axis in "xyz" if axis != feature.frame.axis
+            ):
+                raise ValueError("location axis must be transverse to the hole axis")
+            if self.member == "centre":
+                if not isinstance(feature, PatternFeature) or feature.pattern != "bolt_circle":
+                    raise ValueError("only a bolt-circle pattern has a centre location")
+            elif (
+                isinstance(self.member, bool)
+                or not isinstance(self.member, int)
+                or not 0
+                <= self.member
+                < len(
+                    feature.members
+                    if isinstance(feature, PatternFeature)
+                    else feature.members or (feature.frame.origin,)
+                )
+            ):
+                raise ValueError("location member must index the declared member tuple")
         if self.role == "location" and (self.view is not None or self.side is not None):
             raise ValueError(
                 "placement intent is unavailable for location dimensions: one location "

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -27,6 +27,7 @@ ISO/ASME rule set grows here as real features demand it.
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
+from typing import Any, Literal
 
 from draftwright._geometry import _EDGE_ON, _END_ON, HoleRef
 from draftwright.model.ir import (
@@ -180,6 +181,10 @@ class PlannedDimension:
     # happens once per compound group below; renderers never receive raw coordinates.
     view: str | None = None
     side: str | None = None
+    # Index in the declared hole/group member tuple, carried from reference selection.
+    # None identifies a pattern centre (or a location family without member addressing).
+    location_member: int | None = None
+    location_axes: tuple[str, ...] | None = None
 
 
 # Correlated sets (ADR 4 (was 0016) identity, tier 3): exact ``(feature kind, role)`` pairs
@@ -229,12 +234,9 @@ class AddressableDimension:
     renderer may collapse truly coincident ordinates into one visible mark, while retaining
     every semantic owner on that mark.
 
-    That no longer means a location is unaddressable. each feature's own `LOCATION_STEM` gives
-    locatable kind a role, which is what `sheet.dimension(bore, "location")` names and what
-    an authored set omits (#925) — one unit per feature. The finer question **#883** asks
-    (one unit or one per member; how X/Y components are named; who owns a shared mark) is
-    about NAMING, and omission is well-formed either way, so
-    it no longer blocks the `"location"` role."""
+    Locations have a coarse authored `location` role and hole locations additionally carry
+    member/axis selectors. Their identities are derived during location compilation rather
+    than from a feature's static parameter list; coincident marks retain each approved id."""
 
     id: ParameterId
     members: tuple[PlannedDimension, ...]
@@ -794,12 +796,8 @@ def location_datum(feature) -> str | None:
 
 #: The role every authored entry uses to name a location, whatever the per-kind role above.
 #:
-#: One coarse unit per feature, deliberately: #883 asks whether a patterned hole's location
-#: is one addressable thing or one per member and how its X/Y components are named. Those are
-#: questions about NAMING. Omission does not need the answer — "this feature's position is not
-#: in the set" is well-formed at either granularity, and a finer id
-#: (`location.member.3`, for example) refines this one later without contradicting it. So the
-#: completeness contract does not wait on #883.
+#: Omitting this role suppresses the feature's whole location set. A member/axis selector
+#: refines it without changing the meaning of the coarse request.
 LOCATION_ROLE = "location"
 
 
@@ -813,15 +811,133 @@ def location_role(feature) -> str | None:
     return getattr(type(feature), "LOCATION_STEM", None)  # live read, never a snapshot
 
 
+def hole_location_parameter_id(feature, member: int | None, axis: str) -> str:
+    role = (
+        feature.LOCATION_OFF_AXIS_STEM
+        if isinstance(feature, HoleFeature) and feature.frame.axis != "z"
+        else feature.LOCATION_STEM
+    )
+    address = "centre" if member is None else f"member.{member}"
+    return f"{role}.location.{address}.{axis}"
+
+
+def location_components(feature) -> list[dict]:
+    """Discover hole location selectors without building or consulting placement."""
+    if not isinstance(feature, HoleFeature | PatternFeature):
+        return []
+    points = (
+        feature.members
+        if isinstance(feature, PatternFeature)
+        else feature.members or (feature.frame.origin,)
+    )
+    members: list[int | Literal["centre"]] = list(range(len(points)))
+    if isinstance(feature, PatternFeature) and feature.pattern == "bolt_circle":
+        members.append("centre")
+    return [
+        {
+            "member": member,
+            "axis": axis,
+            "parameter_id": hole_location_parameter_id(
+                feature, None if member == "centre" else member, axis
+            ),
+        }
+        for member in members
+        for axis in "xyz"
+        if axis != feature.frame.axis
+    ]
+
+
+def _location_requests(model: PartModel, feature):
+    return tuple(
+        request
+        for request in (
+            model.authored_dimensions
+            if model.authored_dimensions is not None
+            else model.requested_dimensions
+        )
+        if request.feature is feature and request.role == LOCATION_ROLE
+    )
+
+
+def authored_location_axis_omitted(model: PartModel, feature, axis: str) -> bool:
+    """An authored location set deliberately selects no component on this axis."""
+    requests = _location_requests(model, feature)
+    return (
+        model.authored_dimensions is not None
+        and bool(requests)
+        and all(
+            request.member is not None and request.discriminator != axis for request in requests
+        )
+    )
+
+
+def hole_location_references(model: PartModel, feature, datum: Point):
+    """Select declaration-local members and their approved transverse components.
+
+    Coarse intent keeps the automatic anchor policy. Fine intent can name another member
+    without approving its sibling axis. Member indices are carried from the IR tuple.
+    """
+    axes = tuple(axis for axis in "xyz" if axis != feature.frame.axis)
+    points = (
+        feature.members
+        if isinstance(feature, PatternFeature)
+        else feature.members or (feature.frame.origin,)
+    )
+    members: dict[int | None, Point] = dict(enumerate(points))
+    defaults: set[int | None]
+    if isinstance(feature, PatternFeature):
+        if feature.pattern == "bolt_circle":
+            members[None] = feature.frame.origin
+            defaults = {None}
+        else:
+            if not members:
+                return
+            defaults = {
+                min(
+                    members,
+                    key=lambda index: sum(
+                        (members[index]["xyz".index(axis)] - datum["xyz".index(axis)]) ** 2
+                        for axis in axes
+                    ),
+                )
+            }
+    else:
+        defaults = set(members)
+    requests = _location_requests(model, feature)
+    selected = defaults | {
+        None if request.member == "centre" else request.member
+        for request in requests
+        if request.member is not None
+    }
+    for member, point in members.items():
+        if member not in selected:
+            continue
+        allowed = tuple(
+            axis
+            for axis in axes
+            if (model.authored_dimensions is None and member in defaults)
+            or any(
+                (request.member is None and member in defaults)
+                or (
+                    (None if request.member == "centre" else request.member) == member
+                    and request.discriminator == axis
+                )
+                for request in requests
+            )
+        )
+        yield member, point, allowed
+
+
 def plan_locations(model: PartModel) -> list[PlannedDimension]:
     """Plan hole **location** dimensions — the *intent*: which features get located
     and from which datum. The renderer owns the tier/legibility/zone layout
-    (Amendment 4). One ref per un-patterned Z-hole + one per Z-pattern (bolt-circle
+    (Amendment 4). By default, one ref per un-patterned Z-hole + one per Z-pattern (bolt-circle
     centre, else the array member nearest the datum). Coincident refs remain distinct here
     so the renderer can collapse them into one mark while retaining every measurement id.
     Each
     returned `PlannedDimension` carries the datum and a `span` of datum → ref; the
-    renderer derives the X (plan) and Y (side) distances from it (#238).
+    compiler derives the directional values from it. Fine pattern requests may add references
+    beyond the default absolute anchor.
 
     Under an AUTHORED set (#876) a feature whose position the script did not name is
     marked suppressed here, exactly as `plan_dimensions` marks an unnamed parameter — a
@@ -847,26 +963,37 @@ def plan_locations(model: PartModel) -> list[PlannedDimension]:
         #
         # Deliberately NOT fixed by defaulting a datum into model coercion: that would hide
         # malformed compiler input behind a plausible drawing instead of reporting it.
-        return [
-            PlannedDimension(
-                param=DimParameter(kind="location", role=role, value=0.0, span=None, refs=()),
-                convention="location",
-                suppressed=True,
-                reason="no datum_xy in the model to measure the position from",
-                datum=None,
-                feature=f,
-            )
-            for f in model.features
-            for role in (location_role(f),)
-            if role is not None and location_datum(f) == "datum_xy"
-        ]
+        unavailable = []
+        for feature in model.features:
+            role = location_role(feature)
+            if role is None or location_datum(feature) != "datum_xy":
+                continue
+            requests = _location_requests(model, feature)
+            selectors = [(request.member, request.discriminator) for request in requests]
+            if model.authored_dimensions is None or not selectors:
+                selectors.append((None, None))
+            for member, axis in dict.fromkeys(selectors):
+                unavailable.append(
+                    PlannedDimension(
+                        param=DimParameter(
+                            kind="location", role=role, value=0.0, span=None, refs=()
+                        ),
+                        convention="location",
+                        suppressed=True,
+                        reason="no datum_xy in the model to measure the position from",
+                        feature=feature,
+                        location_member=None if member == "centre" else member,
+                        location_axes=(axis,) if axis is not None else None,
+                    )
+                )
+        return unavailable
     dx, dy, dz = datum.at
     # (ref_point, role): role distinguishes a hole ref from a pattern ref — the
     # renderer's concentric-bore exclusion applies to holes only (a bolt circle on
     # the axis is still located by its centre), matching the engine.
     # (ref_point, role, source feature): the feature is carried so the renderer can
     # record provenance on the placed location dim (ADR 5 (was 0010)).
-    refs: list[tuple[Point, str, Feature]] = []
+    refs: list[tuple[Point, str, Feature, int | None, tuple[str, ...] | None]] = []
     # Features whose location a RULE declined before a reference point existed. They have no
     # ref to plan from, so they cannot go through `refs`, but they were considered — and an
     # audit that cannot see them reads their absence as "nothing was suppressed" (#996).
@@ -880,21 +1007,12 @@ def plan_locations(model: PartModel) -> list[PlannedDimension]:
         role = location_role(f)
         if role is None or location_datum(f) != "datum_xy":
             continue
-        if isinstance(f, HoleFeature):
-            # un-patterned holes — a HoleFeature may group identical holes
-            for m in f.members or (f.frame.origin,):
-                refs.append((m, role, f))
-        elif isinstance(f, PatternFeature):
-            if f.pattern == "bolt_circle":
-                refs.append((f.frame.origin, role, f))
-            elif f.members:
-                near = min(f.members, key=lambda m: (m[0] - dx) ** 2 + (m[1] - dy) ** 2)
-                refs.append((near, role, f))
-            else:
-                # A non-bolt-circle pattern with no members has no point to locate FROM.
-                # Recorded rather than skipped (#996): this feature passed the eligibility
-                # check two lines up, so its location was considered and then dropped.
+        if isinstance(f, HoleFeature | PatternFeature):
+            if isinstance(f, PatternFeature) and f.pattern != "bolt_circle" and not f.members:
                 dropped.append((f, role, "pattern has no members to locate from"))
+                continue
+            for member, point, axes in hole_location_references(model, f, datum.at):
+                refs.append((point, role, f, member, axes))
         elif isinstance(f, PocketFeature):
             if f.edge_anchored:
                 # The pocket's position is conveyed by the edge it is anchored to, so no
@@ -915,11 +1033,13 @@ def plan_locations(model: PartModel) -> list[PlannedDimension]:
             ref_point[long_index] = f.lo if abs(f.lo - datum_coord) <= 1e-6 else (f.lo + f.hi) / 2
             ref_point["xyz".index(f.width_axis)] = f.w_center
             ref = (ref_point[0], ref_point[1], ref_point[2])
-            refs.append((ref, role, f))
+            refs.append((ref, role, f, None, None))
         else:
-            refs.append((f.frame.origin, role, f))
+            refs.append((f.frame.origin, role, f, None, None))
 
-    def _plan(r, role, feat, *, suppressed=False, reason=None) -> PlannedDimension:
+    def _plan(
+        r, role, feat, member=None, axes=None, *, suppressed=False, reason=None
+    ) -> PlannedDimension:
         return PlannedDimension(
             param=DimParameter(
                 kind="location",
@@ -933,16 +1053,20 @@ def plan_locations(model: PartModel) -> list[PlannedDimension]:
             reason=reason,
             datum=datum,
             feature=feat,
+            location_member=member,
+            location_axes=axes,
         )
 
     omitted: list[PlannedDimension] = []
     if model.authored_dimensions is not None:
-        kept: list[tuple[Point, str, Feature]] = []
-        for r, role, feat in refs:
+        kept: list[tuple[Point, str, Feature, int | None, tuple[str, ...] | None]] = []
+        for r, role, feat, member, axes in refs:
             if _authored_location_for(model, feat) is None:
-                omitted.append(_plan(r, role, feat, suppressed=True, reason=_AUTHORED_OMISSION))
+                omitted.append(
+                    _plan(r, role, feat, member, axes, suppressed=True, reason=_AUTHORED_OMISSION)
+                )
             else:
-                kept.append((r, role, feat))
+                kept.append((r, role, feat, member, axes))
         refs = kept
     omitted += [
         _plan(feat.frame.origin, role, feat, suppressed=True, reason=why)
@@ -952,7 +1076,7 @@ def plan_locations(model: PartModel) -> list[PlannedDimension]:
     # per-axis grouping and records every collapsed id on its one shared mark (ADR 5 (was 0010) /
     # 0016). Compiler-time dedup used to make a central bore sharing a bolt-circle centre
     # look unlocated even though the visible X/Y dimensions constrained both features.
-    return [_plan(r, role, feat) for r, role, feat in refs] + omitted
+    return [_plan(r, role, feat, member, axes) for r, role, feat, member, axes in refs] + omitted
 
 
 def _request_for(model, feature, param):
@@ -1393,12 +1517,7 @@ def _uncovered_group_requirements(
 def _uncovered_location_requirements(
     model: PartModel, planned_views
 ) -> list[UncoveredViewRequirement]:
-    """Approved datum locations whose current semantic renderer has no selected view.
-
-    Location identity is feature-level today (ADR 4 (was 0016) / #883), while X and Y are distinct
-    observable members.  The two records therefore retain the same ``DimensionId`` and use
-    an ``.x``/``.y`` diagnostic suffix; correspondence never depends on that suffix.
-    """
+    """Approved datum locations whose current semantic renderer has no selected view."""
     planned = set(planned_views)
     labels = _feature_labels(model)
     uncovered: list[UncoveredViewRequirement] = []
@@ -1408,6 +1527,28 @@ def _uncovered_location_requirements(
         if pd.suppressed or feature is None or pd.param.span is None:
             continue
         start, end = pd.param.span
+        if isinstance(feature, HoleFeature | PatternFeature):
+            for axis in pd.location_axes or ():
+                index = "xyz".index(axis)
+                parameter = hole_location_parameter_id(feature, pd.location_member, axis)
+                key = (id(feature), parameter, "plan")
+                if (
+                    "plan" in planned
+                    or key in seen
+                    or abs(end[index] - start[index]) <= _PLANE_TOL
+                ):
+                    continue
+                seen.add(key)
+                uncovered.append(
+                    UncoveredViewRequirement(
+                        identity=DimensionId(feature, parameter),
+                        label=f"{labels[id(feature)]}.{parameter}",
+                        preferred_view="plan",
+                        eligible_views=("plan",),
+                        reason="reads only in `plan`",
+                    )
+                )
+            continue
         requirements: list[tuple[str, str]] = []
         if isinstance(feature, PocketFeature) and feature.frame.axis != "z":
             requirements.append(("position", _END_ON[feature.depth_axis]))
@@ -1449,12 +1590,14 @@ def _uncovered_location_requirements(
         if location_datum(feature) != "bbox" or authored_location_omitted(model, feature):
             continue
         parameters: tuple[str, ...]
-        if isinstance(feature, HoleFeature):
+        if isinstance(feature, HoleFeature | PatternFeature):
             view = _END_ON[feature.frame.axis]
-            measured = "y" if feature.frame.axis == "x" else "x"
-            parameters = (
-                f"{feature.LOCATION_OFF_AXIS_STEM}.{measured}",
-                f"{feature.LOCATION_OFF_AXIS_STEM}.z",
+            bbox: Any = model.bbox
+            datum = (float(bbox.min.X), float(bbox.min.Y), float(bbox.min.Z))
+            parameters = tuple(
+                hole_location_parameter_id(feature, member, axis)
+                for member, _point, axes in hole_location_references(model, feature, datum)
+                for axis in axes
             )
         elif isinstance(feature, SlotFeature):
             view = _END_ON[_plane_normal(feature)]

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -115,7 +115,11 @@ from draftwright.model.ir import (
     ToleranceDecoration,
 )
 from draftwright.model.planner import LOCATION_ROLE as _LOCATION_ROLE
-from draftwright.model.planner import dimension_placement_options, validate_dimension_placement
+from draftwright.model.planner import (
+    dimension_placement_options,
+    location_components,
+    validate_dimension_placement,
+)
 from draftwright.model.planner import location_role as _location_role
 from draftwright.view_plan import (
     ConstraintSource,
@@ -1235,6 +1239,7 @@ class Sheet:
         role: DimensionParameterId = _UNSET,  # type: ignore[assignment]
         *,
         axis: str | None = None,
+        member: int | Literal["centre"] | None = None,
         view: str | None = None,
         side: str | None = None,
         **removed,
@@ -1276,10 +1281,17 @@ class Sheet:
             raise TypeError(f"dimension() got unexpected keyword(s) {sorted(removed)}")
         if feature is _UNSET or role is _UNSET:
             raise TypeError("dimension() requires a feature and a parameter id")
-        return self._authored_dimension(feature, role, axis=axis, view=view, side=side)
+        return self._authored_dimension(
+            feature, role, axis=axis, member=member, view=view, side=side
+        )
 
     def dimension_options(
-        self, feature, role: DimensionParameterId, *, axis: str | None = None
+        self,
+        feature,
+        role: DimensionParameterId,
+        *,
+        axis: str | None = None,
+        member: int | Literal["centre"] | None = None,
     ) -> dict:
         """Discover view/side pairs accepted by planner placement rules, without building.
 
@@ -1296,9 +1308,9 @@ class Sheet:
         The query neither records an intent nor prepares, recognises, or renders the part.
         """
         _token, target, discriminator, canonical = self._resolve_measurement(
-            feature, role, axis, "dimension_options"
+            feature, role, axis, "dimension_options", member=member
         )
-        request = RequestedDimension(target, canonical, discriminator=discriminator)
+        request = RequestedDimension(target, canonical, discriminator=discriminator, member=member)
         parameter_id = next(
             (
                 parameter.parameter_id
@@ -1308,7 +1320,7 @@ class Sheet:
             ),
             canonical,
         )
-        return {
+        result = {
             "schema": "draftwright.dimension-options",
             "schema_version": 1,
             "scope": "single_dimension_placement_rules",
@@ -1319,12 +1331,25 @@ class Sheet:
             "placements": dimension_placement_options(request),
         }
 
+        if canonical == _LOCATION_ROLE:
+            components = location_components(target)
+            result["location_components"] = components
+            result["member"] = member
+            if member is not None:
+                result["parameter_id"] = next(
+                    component["parameter_id"]
+                    for component in components
+                    if component["member"] == member and component["axis"] == discriminator
+                )
+        return result
+
     def validate_dimension(
         self,
         feature,
         role: DimensionParameterId,
         *,
         axis: str | None = None,
+        member: int | Literal["centre"] | None = None,
         view: str | None = None,
         side: str | None = None,
         **unsupported,
@@ -1347,7 +1372,7 @@ class Sheet:
             "options": None,
         }
         try:
-            options = self.dimension_options(feature, role, axis=axis)
+            options = self.dimension_options(feature, role, axis=axis, member=member)
         except (TypeError, ValueError, IndexError) as exc:
             result["issues"] = [{"code": "invalid_measurement", "message": str(exc)}]
             return result
@@ -1356,18 +1381,23 @@ class Sheet:
             result["issues"] = [
                 {
                     "code": "unsupported_control",
-                    "message": "dimension accepts only axis, view and side placement controls",
+                    "message": "dimension accepts only member, axis, view and side controls",
                     "controls": sorted(unsupported),
                 }
             ]
             return result
         _token, target, discriminator, canonical = self._resolve_measurement(
-            feature, role, axis, "validate_dimension"
+            feature, role, axis, "validate_dimension", member=member
         )
         try:
             validate_dimension_placement(
                 RequestedDimension(
-                    target, canonical, discriminator=discriminator, view=view, side=side
+                    target,
+                    canonical,
+                    discriminator=discriminator,
+                    member=member,
+                    view=view,
+                    side=side,
                 )
             )
         except (TypeError, ValueError) as exc:
@@ -1382,6 +1412,7 @@ class Sheet:
         role: DimensionParameterId,
         *,
         axis: str | None = None,
+        member: int | Literal["centre"] | None = None,
         view: str | None = None,
         side: str | None = None,
     ) -> DimensionIntent:
@@ -1399,7 +1430,7 @@ class Sheet:
         chooses, plus these" and "only these" at once.
         """
         token, target, discriminator, role = self._resolve_measurement(
-            feature, role, axis, "dimension"
+            feature, role, axis, "dimension", member=member
         )
         # The CANONICAL spelling is stored, not what was typed (#963). Otherwise a generated
         # script's dialect depended on how its source model was authored — mirrored sets wrote
@@ -1409,6 +1440,7 @@ class Sheet:
                 "token": token,
                 "role": role,
                 "discriminator": discriminator,
+                "member": member,
                 "view": view,
                 "side": side,
             }
@@ -2590,6 +2622,7 @@ class Sheet:
         role: DimensionParameterId,
         *,
         axis: str | None = None,
+        member: int | Literal["centre"] | None = None,
         view: str | None = None,
         side: str | None = None,
     ):
@@ -2627,12 +2660,13 @@ class Sheet:
             stacklevel=2,
         )
         token, _target, discriminator, role = self._resolve_measurement(
-            feature, role, axis, "add_dimension"
+            feature, role, axis, "add_dimension", member=member
         )
         entry = {
             "token": token,
             "role": role,
             "discriminator": discriminator,
+            "member": member,
             "view": view,
             "side": side,
         }
@@ -2701,7 +2735,13 @@ class Sheet:
             )
 
     def _resolve_measurement(
-        self, feature, role: DimensionParameterId, axis: str | None, verb: str
+        self,
+        feature,
+        role: DimensionParameterId,
+        axis: str | None,
+        verb: str,
+        *,
+        member: int | Literal["centre"] | None = None,
     ):
         """Resolve ``(feature, role, axis)`` to ``(token, feature, discriminator)``, or raise.
 
@@ -2723,6 +2763,11 @@ class Sheet:
                 f"{verb}: {type(target).__name__} has no {role!r} measurement "
                 f"(it carries {sorted(roles)})"
             )
+        if role == _LOCATION_ROLE:
+            RequestedDimension(target, role, discriminator=axis, member=member)
+            return token, target, axis, role
+        if member is not None:
+            raise ValueError("member selects only a location measurement")
         matching = [p for p in params if role in (p.role, p.parameter_id)]
         # ── canonical spelling: the parameter id (#963) ──────────────────────────────
         # A role spelling ("bore") and a parameter id ("bore.diameter") both resolve, and
@@ -2840,6 +2885,7 @@ class Sheet:
                 feature=self._features[self._index_of_token(e["token"])],
                 role=e["role"],
                 discriminator=e["discriminator"],
+                member=e.get("member"),
                 display_decimals=e.get("display_decimals"),
                 view=e.get("view"),
                 side=e.get("side"),
@@ -2868,6 +2914,7 @@ class Sheet:
                 feature=self._features[self._index_of_token(e["token"])],
                 role=e["role"],
                 discriminator=e["discriminator"],
+                member=e.get("member"),
                 display_decimals=e.get("display_decimals"),
                 view=e.get("view"),
                 side=e.get("side"),

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -331,6 +331,17 @@ def _tuple_arg(values) -> str:
     return "(" + ", ".join(vals) + ")"
 
 
+def _hole_group_args(f) -> list[str]:
+    kw = []
+    if f.count and f.count > 1:
+        kw.append(f"count={f.count}")
+    # Preserve members independently of the callout count. A singleton at the frame
+    # origin already has the same member-0 location through the constructor default.
+    if f.members and (len(f.members) > 1 or f.members[0] != f.frame.origin):
+        kw.append("members=[" + ", ".join(_pt(m) for m in f.members) + "]")
+    return kw
+
+
 def _hole_line(f, object_ref: str | None = None, *, exact_parameter: str | None = None) -> str:
     if getattr(f, "profile", None) == "double_d":
         kw = [
@@ -344,6 +355,7 @@ def _hole_line(f, object_ref: str | None = None, *, exact_parameter: str | None 
             kw.append(f"depth={_n(f.depth)}")
         if f.profile_direction is not None:
             kw.append(f"profile_direction={_direction(f.profile_direction)}")
+        kw.extend(_hole_group_args(f))
         return f"sheet.double_d_bore({', '.join(kw)})"
     kw = (
         [object_ref]
@@ -354,13 +366,7 @@ def _hole_line(f, object_ref: str | None = None, *, exact_parameter: str | None 
             f'axis="{f.frame.axis}"',
         ]
     )
-    if f.count and f.count > 1:
-        kw.append(f"count={f.count}")
-        # A count-group carries its member positions; without them the render collapses to a
-        # single hole at the anchor (fidelity loss). Patterns recompute members from the
-        # arrangement, so only a plain count-group needs them spelled out.
-        if f.members:
-            kw.append("members=[" + ", ".join(_pt(m) for m in f.members) + "]")
+    kw.extend(_hole_group_args(f))
     if f.cbore:
         kw.append(f"cbore=({_n(f.cbore[0])}, {_n(f.cbore[1])})")
     if f.spotface:
@@ -1304,17 +1310,19 @@ def unmirrored_dimensions(model) -> list[str]:
     # exists in the walk and would never reach the file. Checking the request alone reported
     # a turned part as fully mirrorable while its rotational dimensions had no name.
     requested = {
-        (id(feature), role)
-        for feature, role, _disc in _mirrored_requests(declared, synthesised)
+        (id(feature), role, discriminator, member)
+        for feature, role, discriminator, member in _mirrored_requests(declared, synthesised)
         if not _feature_line(feature).lstrip().startswith("#")
     }
 
-    def _asked(feature, parameter_id: str) -> bool:
+    def _asked(feature, parameter_id: str, discriminator=None, member=None) -> bool:
         # A line names either the full parameter id ("bore.diameter") or the bare role
         # ("bore"); a correlated set emits one line covering N members.
-        return (id(feature), parameter_id) in requested or (
+        return (id(feature), parameter_id, discriminator, member) in requested or (
             id(feature),
             parameter_id.split(".")[0],
+            discriminator,
+            member,
         ) in requested
 
     # ONE interpreter, the same one the emitter serialises (#946). This used to walk
@@ -1345,9 +1353,15 @@ def unmirrored_dimensions(model) -> list[str]:
         if feature is None:
             # Model-level — the overall height of a part with no envelope feature. Only the
             # synthesised envelope can name it, until #976 gives it a declarative target.
-            if synthesised is None or (id(synthesised), "height.length") not in requested:
+            if (
+                synthesised is None
+                or (id(synthesised), "height.length", None, None) not in requested
+            ):
                 missing.append("(bounding box).overall_height")
-        elif not _asked(feature, intent.role) and (id(feature), intent.role) not in consolidated:
+        elif (
+            not _asked(feature, intent.role, intent.discriminator, intent.member)
+            and (id(feature), intent.role) not in consolidated
+        ):
             missing.append(f"{feature.kind}.{intent.role}")
     return sorted(set(missing))
 
@@ -1365,11 +1379,10 @@ def _is_mirrorable(model) -> bool:
 
 
 def _mirrored_requests(declared, declared_envelope=None):
-    """One `(feature, role)` per dimension the planner CHOSE — the mirror's content.
+    """The compiler's feature/role/axis/member selectors, serialized for the mirror.
 
-    Emitted per addressable UNIT, never per member: a `step_height` ladder and a rotational
-    body's bores are one `AddressableDimension` holding N, so one line drops the set and
-    there is no member line to mislead (ADR 4 (was 0016) identity tier 3).
+    A step-height ladder and rotational bores remain correlated units. Hole locations carry
+    separate member/axis selectors so an emitted line can omit exactly one component.
 
     From the planner's INTENT, never from placed annotations. Walking the drawing is the
     obvious way to build a mirror and it is wrong: a dimension the solver dropped would
@@ -1393,7 +1406,7 @@ def _mirrored_requests(declared, declared_envelope=None):
             # The synthesised envelope is what makes it nameable; `mirror_model` supplies it.
             if declared_envelope is None:
                 continue
-            out.append((declared_envelope, "height.length", None))
+            out.append((declared_envelope, "height.length", None, None))
             continue
         if declared_envelope is not None and feature is declared_envelope:
             # The synthesised envelope exists ONLY to make the overall height nameable, so
@@ -1403,7 +1416,7 @@ def _mirrored_requests(declared, declared_envelope=None):
             # `addressable()` has already collapsed them to one intent.
             if intent.role != "height.length":
                 continue
-        out.append((feature, intent.role, None))
+        out.append((feature, intent.role, intent.discriminator, intent.member))
     return out
 
 
@@ -1413,11 +1426,11 @@ def _requested_display_decimals(model, feature, role, discriminator) -> int | No
 
 
 def _requested_intent_policy(
-    model, feature, role, discriminator
+    model, feature, role, discriminator, member=None
 ) -> tuple[int | None, str | None, str | None]:
     """Display and placement policy attached to an augmenting referential intent."""
     for request in model.requested_dimensions:
-        if request.feature is not feature:
+        if request.feature is not feature or request.member != member:
             continue
         matches = (
             request.role == role if "." in request.role else role.startswith(f"{request.role}.")
@@ -1481,7 +1494,7 @@ def _dimension_block(model, names: dict[int, str], synthesised_envelope=None) ->
         ]
     requests = (
         [
-            (a.feature, a.role, a.discriminator, a.display_decimals, a.view, a.side)
+            (a.feature, a.role, a.discriminator, a.display_decimals, a.view, a.side, a.member)
             for a in model.authored_dimensions
         ]
         if model.authored_dimensions is not None
@@ -1493,8 +1506,9 @@ def _dimension_block(model, names: dict[int, str], synthesised_envelope=None) ->
         # the location with it.
         else [
             (
-                *request,
+                *request[:3],
                 *_requested_intent_policy(model, *request),
+                request[3],
             )
             for request in _mirrored_requests(model, synthesised_envelope)
         ]
@@ -1516,7 +1530,7 @@ def _dimension_block(model, names: dict[int, str], synthesised_envelope=None) ->
         # automatic one does, rather than in prose a reader has to trust.
         "sheet.authored_dimensions()",
     ]
-    for feature, role, discriminator, display_decimals, view, side in requests:
+    for feature, role, discriminator, display_decimals, view, side, member in requests:
         name = names.get(id(feature))
         if name is None:
             # Reachable for a kind with no declarative verb (its line is a comment, so it
@@ -1539,7 +1553,7 @@ def _dimension_block(model, names: dict[int, str], synthesised_envelope=None) ->
             if discriminator and "." not in role[role.find(".") + 1 :]
             else ""
         )
-        placement = ""
+        placement = "" if member is None else f", member={member!r}"
         if view is not None:
             placement += f', view="{view}"'
         if side is not None:

--- a/tests/test_adr0018_view_selection.py
+++ b/tests/test_adr0018_view_selection.py
@@ -187,7 +187,8 @@ class TestTheAsymmetricCounterexample:
         assert caught.value.planned == ("front", "side")
         assert {item.identity.parameter for item in caught.value.uncovered} == {
             "bore.diameter",
-            "location.location",
+            "location.location.member.0.x",
+            "location.location.member.0.y",
         }
         assert all(item.preferred_view == "plan" for item in caught.value.uncovered)
         assert "hole_1.bore.diameter" in str(caught.value)
@@ -212,7 +213,8 @@ class TestTheAsymmetricCounterexample:
             build_drawing(part, model=model, _views=("front", "side"))
 
         assert [item.identity.parameter for item in caught.value.uncovered] == [
-            "location.location"
+            "location.location.member.0.x",
+            "location.location.member.0.y",
         ]
         assert "hole_1.location" in str(caught.value)
         assert "bore.diameter" not in str(caught.value), "the authored omission stays omitted"
@@ -222,7 +224,7 @@ class TestTheAsymmetricCounterexample:
         assert y_names, "the approved Y member must re-home rather than disappear"
         assert {drawing.view_of(name) for name in y_names} == {"plan"}
 
-    def test_the_adrs_two_requirement_diagnostic_is_executable(self):
+    def test_missing_view_diagnostics_name_extent_and_location_components(self):
         from dataclasses import replace
 
         from draftwright.model.ir import RequestedDimension
@@ -245,7 +247,8 @@ class TestTheAsymmetricCounterexample:
 
         assert [(item.label, item.preferred_view) for item in caught.value.uncovered] == [
             ("envelope.depth.length", "side"),
-            ("hole_1.location", "plan"),
+            ("hole_1.location.location.member.0.x", "plan"),
+            ("hole_1.location.location.member.0.y", "plan"),
         ]
 
     def test_the_same_view_is_droppable_when_the_feature_turns(self):
@@ -267,8 +270,8 @@ class TestTheAsymmetricCounterexample:
         assert {item.identity.parameter for item in caught.value.uncovered} == {
             "bore.diameter",
             "depth.length",
-            "location_off_axis.y",
-            "location_off_axis.z",
+            "location_off_axis.location.member.0.y",
+            "location_off_axis.location.member.0.z",
         }
         assert all(item.preferred_view == "side" for item in caught.value.uncovered)
 
@@ -287,8 +290,8 @@ class TestTheAsymmetricCounterexample:
         with pytest.raises(ViewPlanIncomplete) as caught:
             build_drawing(part, model=model, _views=("front", "plan"))
         assert {item.identity.parameter for item in caught.value.uncovered} == {
-            "location_off_axis.y",
-            "location_off_axis.z",
+            "location_off_axis.location.member.0.y",
+            "location_off_axis.location.member.0.z",
         }
 
 
@@ -320,7 +323,8 @@ class TestAnExtentMovesOrIsReported:
             compile_dimensions(model, planned_views=("front", "side"))
         assert {item.identity.parameter for item in caught.value.uncovered} >= {
             "bore.diameter",
-            "location.location",
+            "location.location.member.0.x",
+            "location.location.member.0.y",
         }
 
     @pytest.mark.parametrize(

--- a/tests/test_audit_differential.py
+++ b/tests/test_audit_differential.py
@@ -471,7 +471,7 @@ def test_a_real_build_records_which_measurement_its_location_dims_draw():
     assert identified["m_locx0"] == [
         {
             "feature": identified["m_locx0"][0]["feature"],
-            "parameter_id": "location.location",
+            "parameter_id": "location.location.member.0.x",
         }
     ]
     assert identified["m_locx0"][0]["feature"].startswith("hole@"), "located hole"
@@ -608,7 +608,7 @@ def test_a_location_dim_two_features_share_records_both_measurements():
     )
     keys = dwg.measurement_keys("m_locx0")
     assert len(keys) == 2, "it measures BOTH holes' feature location, not neither"
-    assert {k["parameter_id"] for k in keys} == {"location.location"}
+    assert {k["parameter_id"] for k in keys} == {"location.location.member.0.x"}
     assert len({k["feature"] for k in keys}) == 2, "two distinct holes, not one repeated"
 
 

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -671,7 +671,11 @@ class TestAPositionIsADimension:
         assert len(locations) == 2
         assert {
             key["parameter_id"] for name in locations for key in drawing.measurement_keys(name)
-        } == {"location_pattern.location"}
+        } == {
+            f"location_pattern.location.member.0.{measured}"
+            for measured in "xyz"
+            if measured != axis
+        }
 
     def test_a_Z_normal_pattern_location_still_works(self):
         """The false-positive half: narrowing eligibility must not cost the case that works."""

--- a/tests/test_issue_1143_hole_completeness.py
+++ b/tests/test_issue_1143_hole_completeness.py
@@ -310,12 +310,12 @@ def test_shared_location_marks_retain_addressable_and_physical_axis_identities()
     x_keys = drawing.measurement_keys("m_locx0")
     y_keys = drawing.measurement_keys("m_locy0")
     assert {key["parameter_id"] for key in x_keys} == {
-        "location.location",
-        "location_pattern.location",
+        "location.location.member.0.x",
+        "location_pattern.location.centre.x",
     }
     assert {key["parameter_id"] for key in y_keys} == {
-        "location.location",
-        "location_pattern.location",
+        "location.location.member.0.y",
+        "location_pattern.location.centre.y",
     }
     assert len({key["feature"] for key in x_keys}) == 2
     assert len({key["feature"] for key in y_keys}) == 2
@@ -1806,13 +1806,18 @@ def test_cross_hole_locations_retain_both_off_axis_measurement_identities():
         for key in drawing.measurement_keys(name)
         if key["parameter_id"].startswith("location_off_axis.")
     }
-    assert placed_location_ids == {"location_off_axis.y", "location_off_axis.z"}
+    assert placed_location_ids == {
+        "location_off_axis.location.member.0.y",
+        "location_off_axis.location.member.0.z",
+    }
 
     z_mark = next(
         name
         for name in drawing.annotations()
         if any(
-            key["parameter_id"] == "location_off_axis.z" for key in drawing.measurement_keys(name)
+            key["parameter_id"]
+            in {"location_off_axis.location.member.0.z", "location_off_axis.location.member.1.z"}
+            for key in drawing.measurement_keys(name)
         )
     )
     measurement_ids = tuple(drawing.registry.measurement_of(z_mark))
@@ -1843,7 +1848,9 @@ def test_grouped_off_axis_locations_require_every_physical_member_mark():
         name
         for name in drawing.annotations_of(feature)
         if any(
-            key["parameter_id"] == "location_off_axis.z" for key in drawing.measurement_keys(name)
+            key["parameter_id"]
+            in {"location_off_axis.location.member.0.z", "location_off_axis.location.member.1.z"}
+            for key in drawing.measurement_keys(name)
         )
     ]
     assert len(z_marks) == 2
@@ -2037,7 +2044,7 @@ def test_eccentric_longitudinal_boss_is_not_the_turned_profile_axis():
         for name in drawing.annotations_of(feature)
         for key in drawing.measurement_keys(name)
         if key["parameter_id"].startswith("location_off_axis.")
-    } == {"location_off_axis.y", "location_off_axis.z"}
+    } == {"location_off_axis.location.member.0.y", "location_off_axis.location.member.0.z"}
     assert {
         item.parameter_id: item.state
         for item in _outcomes(drawing)
@@ -2074,7 +2081,9 @@ def test_nearby_distinct_member_locations_are_dropped_not_semantically_merged():
     assert {parameter for _feature, parameter in drop.hole_requirement_ids} == {
         "location.location.x"
     }
-    assert {measurement.parameter for measurement in drop.measurement_ids} == {"location.location"}
+    assert {measurement.parameter for measurement in drop.measurement_ids} == {
+        "location.location.member.1.x"
+    }
 
 
 def test_live_locate_restores_member_level_location_provenance():
@@ -2154,13 +2163,58 @@ def test_successful_hole_table_escalation_carries_every_replaced_requirement():
     hole_count = len([feature for feature in drawing.model().features if feature.kind == "hole"])
     assert hole_count == 16
     keys = drawing.measurement_keys("hole_table_plan")
-    assert len(keys) == hole_count * 2
+    assert len(keys) == hole_count * 3  # diameter and two independently identified ordinates
     assert len({(key["feature"], key["parameter_id"]) for key in keys}) == len(keys)
     outcomes = _outcomes(drawing)
     assert len(outcomes) == hole_count * 4
     assert all(item.state == "placed" for item in outcomes)
     assert not [issue for issue in drawing.lint() if issue.code.startswith("hole_requirement_")]
     assert _completeness(drawing)["audited_score"] == 1.0
+
+
+@pytest.mark.parametrize("axis", ["x", "y"])
+def test_hole_table_leaves_an_unauthored_location_axis_blank(monkeypatch, axis):
+    from draftwright.drawing import Drawing
+
+    captured = []
+    original = Drawing.add_table
+
+    def capture_rows(self, rows, **kwargs):
+        captured.append(tuple(tuple(row) for row in rows))
+        return original(self, rows, **kwargs)
+
+    monkeypatch.setattr(Drawing, "add_table", capture_rows)
+    sheet = Sheet.from_part(_dense_scattered_plate(), page="A3")
+    holes = [feature for feature in sheet.features if feature.kind == "hole"]
+    assert len(holes) == 16
+    for feature in holes:
+        sheet.dimension(feature, "bore.diameter")
+        sheet.dimension(feature, "location", member=0, axis=axis)
+    drawing = sheet.build()
+    assert "hole_table_plan" in drawing.annotations()
+    rows = captured[-1]
+    assert rows[0][:5] == ("TAG", "⌀", "DEPTH", "X", "Y")
+    cells = [
+        row[offset : offset + 5]
+        for row in rows[1:]
+        for offset in range(0, len(row), 5)
+        if row[offset]
+    ]
+    assert len(cells) == 16
+    selected, omitted = (3, 4) if axis == "x" else (4, 3)
+    assert all(row[selected] and row[omitted] == "" for row in cells)
+    keys = drawing.measurement_keys("hole_table_plan")
+    assert len(keys) == 32
+    assert {key["parameter_id"] for key in keys} == {
+        "bore.diameter",
+        f"location.location.member.0.{axis}",
+    }
+    omitted_axis = "y" if axis == "x" else "x"
+    assert {
+        item.state
+        for item in _outcomes(drawing)
+        if item.parameter_id == f"location.location.{omitted_axis}"
+    } == {"suppressed"}
 
 
 def test_scattered_hole_table_preserves_placed_pattern_location_evidence():

--- a/tests/test_issue_1146_scale_completeness.py
+++ b/tests/test_issue_1146_scale_completeness.py
@@ -136,7 +136,7 @@ def test_default_fallback_returns_largest_complete_standard_scale_and_reports_de
     }
     (blocker,) = drawing.scale_decision["blockers"]
     assert blocker["code"] == "location_ref_dropped"
-    assert blocker["measurements"][0]["parameter"] == "location.location"
+    assert blocker["measurements"][0]["parameter"] == "location.location.member.0.x"
     assert blocker["hole_requirements"][0]["parameter"] == "location.location.x"
     assert [(item["scale"], item["status"]) for item in drawing.scale_decision["attempts"]] == [
         (1.0, "incomplete"),

--- a/tests/test_issue_1155_grm04_sheet_use.py
+++ b/tests/test_issue_1155_grm04_sheet_use.py
@@ -31,7 +31,11 @@ def test_grm04_measured_replan_keeps_diameter_and_location_on_a4():
         for measurement in drawing.registry.measurement_of(name)
         if measurement.feature is hole
     }
-    assert {"bore.diameter", "location_off_axis.y", "location_off_axis.z"} <= carried
+    assert {
+        "bore.diameter",
+        "location_off_axis.location.member.0.y",
+        "location_off_axis.location.member.0.z",
+    } <= carried
     assert any(
         "2.4" in str(getattr(drawing.get_annotation(name), "label", ""))
         for name in drawing.annotations()

--- a/tests/test_issue_1262_automatic_turned_views.py
+++ b/tests/test_issue_1262_automatic_turned_views.py
@@ -74,7 +74,8 @@ def test_a_radial_feature_vetoes_reduction_before_any_annotation_can_disappear()
     assert set(attempt["uncovered"]) == {
         "hole_1.bore.diameter",
         "hole_1.bore.depth",
-        "hole_1.location",
+        "hole_1.location.location.member.0.x",
+        "hole_1.location.location.member.0.y",
     }
 
 

--- a/tests/test_issue_1357_framed_activation.py
+++ b/tests/test_issue_1357_framed_activation.py
@@ -220,5 +220,8 @@ def test_framed_off_axis_pattern_keeps_one_absolute_location_requirement():
     }
 
     assert pattern.frame.axis in {"x", "y"}
-    assert location_ids == {"location_pattern.location"}
+    assert location_ids == {
+        "location_pattern.location.centre.y",
+        "location_pattern.location.centre.z",
+    }
     assert drawing.lint() == []

--- a/tests/test_issue_883_location_identity.py
+++ b/tests/test_issue_883_location_identity.py
@@ -1,0 +1,575 @@
+"""Select the member and measured axis of a location without changing its meaning."""
+
+from dataclasses import replace
+
+import pytest
+from build123d import Box, Cylinder, Pos, Rot
+
+from draftwright import Sheet, SoftDeprecationWarning, build_drawing
+from draftwright.audit import diff_builds
+from draftwright.linting.issues import LintIssue
+from draftwright.model import hole as declared_hole
+from draftwright.model.compiled import compile_dimensions, resolve_feature
+from draftwright.model.ir import (
+    Datum,
+    Frame,
+    PartModel,
+    PatternFeature,
+    PocketFeature,
+    RequestedDimension,
+)
+from draftwright.model.planner import plan_dimensions
+from draftwright.sheet_emit import emit_sheet_script
+from draftwright.view_plan import ViewPlanIncomplete
+
+
+@pytest.fixture(scope="module")
+def grouped_holes():
+    members = ((-15, -10, 0), (15, 10, 0))
+    part = Box(60, 50, 10)
+    for point in members:
+        part -= Pos(*point) * Cylinder(2, 10)
+    return part, members
+
+
+def _sheet(grouped_holes, *, count=2):
+    part, members = grouped_holes
+    sheet = Sheet(part, scale=2).authored_dimensions()
+    holes = sheet.hole(diameter=4, depth=10, axis="z", at=members[0], members=members, count=count)
+    sheet.dimension(holes, "bore.diameter")
+    return sheet, holes
+
+
+def _locations(drawing):
+    return {
+        name: (drawing.get_annotation(name).label, drawing.measurement_keys(name))
+        for name in drawing.annotations()
+        if any("location" in key["parameter_id"] for key in drawing.measurement_keys(name))
+    }
+
+
+@pytest.fixture(scope="module")
+def coarse_drawing(grouped_holes):
+    sheet, holes = _sheet(grouped_holes)
+    sheet.dimension(holes, "location")
+    drawing = sheet.build()
+    assert sorted(label for label, _ in _locations(drawing).values()) == ["15", "15", "35", "45"]
+    return drawing
+
+
+def test_each_member_and_axis_has_a_distinct_measurement_identity(coarse_drawing):
+    rows = _locations(coarse_drawing)
+    assert len(rows) == 4 and all(len(keys) == 1 for _, keys in rows.values())
+    identities = {(keys[0]["feature"], keys[0]["parameter_id"]) for _, keys in rows.values()}
+    assert len(identities) == 4, "Neither a member swap nor an axis swap may reuse an identity"
+
+
+@pytest.mark.parametrize(
+    "member,axis,label,name",
+    [
+        (0, "x", "15", "m_locx0"),
+        (0, "y", "15", "m_locy0"),
+        (1, "x", "45", "m_locx1"),
+        (1, "y", "35", "m_locy1"),
+    ],
+)
+def test_fine_location_selects_exactly_one_member_axis(
+    grouped_holes, coarse_drawing, member, axis, label, name
+):
+    sheet, holes = _sheet(grouped_holes)
+    sheet.dimension(holes, "location", member=member, axis=axis)
+    selected = sheet.build()
+    ((_, keys),) = _locations(selected).values()
+    assert list(_locations(selected).values()) == [(label, keys)]
+    assert keys == _locations(coarse_drawing)[name][1]
+    assert {name for name in selected.annotations() if name.startswith("m_loc")} == set(
+        _locations(selected)
+    ), "An unapproved sibling axis must not leak a dimension without provenance"
+
+
+@pytest.mark.parametrize("count", [1, 2])
+def test_fine_location_round_trips_through_a_generated_declaration(grouped_holes, tmp_path, count):
+    sheet, holes = _sheet(grouped_holes, count=count)
+    sheet.dimension(holes, "location", member=1, axis="y")
+    before = sheet.build()
+    source = emit_sheet_script(
+        sheet.model(),
+        "part",
+        str(tmp_path / "drawing"),
+        title="Member location",
+        number="883",
+        scale=2,
+        formats=(),
+    )
+    namespace = {"part": grouped_holes[0]}
+    exec(compile(source, "<member-location>", "exec"), namespace)
+    after = namespace["drawing"]
+    assert _locations(after) == _locations(before)
+    assert [label for label, _ in _locations(after).values()] == ["35"]
+
+
+def test_profiled_group_preserves_member_selection_in_generated_declaration(
+    grouped_holes, tmp_path
+):
+    _part, members = grouped_holes
+    part = Box(60, 50, 10)
+    for point in members:
+        part -= Pos(*point) * (Cylinder(2, 10) & Box(2.8, 8, 10))
+    sheet, handle = _sheet((part, members))
+    sheet.dimension(handle, "location", member=1, axis="y")
+    model = sheet.model()
+    old = model.features[0]
+    feature = replace(old, profile="double_d", across_flats=2.8, profile_direction=(1, 0, 0))
+    model = replace(
+        model,
+        features=[feature, *model.features[1:]],
+        authored_dimensions=tuple(
+            replace(request, feature=feature) if request.feature is old else request
+            for request in model.authored_dimensions
+        ),
+    )
+    before = build_drawing(part, model=model, scale=2)
+    assert [label for label, _ in _locations(before).values()] == ["35"]
+    source = emit_sheet_script(
+        model,
+        "part",
+        str(tmp_path / "drawing"),
+        title="Profiled members",
+        number="883",
+        scale=2,
+        formats=(),
+    )
+    namespace = {"part": part}
+    exec(compile(source, "<profiled-member-location>", "exec"), namespace)
+    after = namespace["drawing"]
+    assert _locations(after) == _locations(before)
+    rebuilt = next(item for item in after.model().features if item.kind == "hole")
+    assert rebuilt.members == members
+    assert rebuilt.count == 2 and rebuilt.profile == "double_d"
+
+
+def test_discovery_names_the_components_that_dimension_accepts(grouped_holes):
+    sheet, holes = _sheet(grouped_holes)
+    before = sheet.model().authored_dimensions
+    options = sheet.dimension_options(holes, "location")
+    components = options["location_components"]
+    assert {(item["member"], item["axis"]) for item in components} == {
+        (0, "x"),
+        (0, "y"),
+        (1, "x"),
+        (1, "y"),
+    }
+    assert len({item["parameter_id"] for item in components}) == 4
+    for component in components:
+        selected = {key: component[key] for key in ("member", "axis")}
+        validation = sheet.validate_dimension(holes, "location", **selected)
+        assert validation["supported"], validation
+        assert validation["options"]["parameter_id"] == component["parameter_id"]
+    assert sheet.model().authored_dimensions == before
+
+
+@pytest.mark.parametrize(
+    "selector",
+    [
+        {"member": True, "axis": "x"},
+        {"member": -1, "axis": "x"},
+        {"member": 2, "axis": "x"},
+        {"member": "0", "axis": "x"},
+        {"member": 0, "axis": "z"},
+        {"member": 0},
+        {"axis": "x"},
+        {"member": "centre", "axis": "x"},
+    ],
+)
+def test_invalid_location_selector_is_refused_before_intent_is_recorded(grouped_holes, selector):
+    sheet, holes = _sheet(grouped_holes)
+    before = sheet.model().authored_dimensions
+    validation = sheet.validate_dimension(holes, "location", **selector)
+    assert not validation["supported"]
+    assert validation["issues"][0]["code"] == "invalid_measurement"
+    with pytest.raises(ValueError):
+        sheet.dimension(holes, "location", **selector)
+    assert sheet.model().authored_dimensions == before
+
+
+def test_member_cannot_select_a_size_or_an_unaddressable_location_family(grouped_holes):
+    sheet, holes = _sheet(grouped_holes)
+    with pytest.raises(ValueError, match="only a location"):
+        sheet.dimension(holes, "bore.diameter", member=0)
+    feature = next(feature for feature in sheet.model().features if feature.kind == "hole")
+    with pytest.raises(ValueError, match="only a location"):
+        RequestedDimension(feature, "bore.diameter", member=0)
+    pocket = PocketFeature(Frame((10, 10, 0), "z"), "y", "x", 8, 20, 4, 10, 4, 24)
+    sheet.features.append(pocket)
+    options = sheet.dimension_options(pocket, "location")
+    assert options["location_components"] == []
+    with pytest.raises(ValueError, match="hole or hole pattern"):
+        sheet.dimension(pocket, "location", member=0, axis="x")
+
+
+def test_missing_datum_reports_the_requested_location_component(grouped_holes):
+    sheet, holes = _sheet(grouped_holes)
+    sheet.dimension(holes, "location", member=1, axis="y")
+    model = replace(sheet.model(), datums=[])
+    diagnostics = [
+        item
+        for item in compile_dimensions(model).diagnostics
+        if item.parameter_id.startswith("location")
+    ]
+    assert {item.parameter_id for item in diagnostics} == {"location.location.member.1.y"}
+    assert all("no datum_xy" in item.reason for item in diagnostics)
+
+
+def test_omitting_the_whole_location_set_keeps_the_coarse_suppression(grouped_holes):
+    sheet, _holes = _sheet(grouped_holes)
+    compiled = compile_dimensions(sheet.model())
+    assert compiled.locations == ()
+    omissions = [item for item in compiled.diagnostics if item.parameter_id.startswith("location")]
+    assert {item.parameter_id for item in omissions} == {"location.location"}
+    assert all("authored" in item.reason for item in omissions)
+
+
+def test_partial_member_omissions_do_not_suppress_an_axis_that_is_still_requested(grouped_holes):
+    sheet, holes = _sheet(grouped_holes)
+    sheet.dimension(holes, "location", member=0, axis="x")
+    sheet.dimension(holes, "location", member=1, axis="y")
+    plan = compile_dimensions(sheet.model())
+    assert {item.id.parameter for item in plan.locations} == {
+        "location.location.member.0.x",
+        "location.location.member.1.y",
+    }
+    assert {
+        item.parameter_id for item in plan.diagnostics if item.parameter_id.startswith("location")
+    } == {"location.location.member.0.y", "location.location.member.1.x"}
+
+
+@pytest.mark.parametrize("axis", ["x", "y", "z"])
+def test_whole_axis_suppression_is_recorded_once_without_losing_member_facts(grouped_holes, axis):
+    sheet, holes = _sheet(grouped_holes)
+    model = sheet.model()
+    feature = replace(model.features[0], frame=Frame((-15, -10, 0), axis))
+    selected, omitted = [component for component in "xyz" if component != axis]
+    model = replace(
+        model,
+        features=[feature],
+        authored_dimensions=(
+            RequestedDimension(feature, "location", discriminator=selected, member=0),
+        ),
+    )
+    plan = compile_dimensions(model)
+    assert len(plan.locations) == 1
+    stem = "location" if axis == "z" else "location_off_axis"
+    physical = f"{stem}.location.{omitted}" if axis == "z" else f"{stem}.{omitted}"
+    omissions = [
+        item.parameter_id for item in plan.diagnostics if item.parameter_id.startswith(stem)
+    ]
+    assert omissions.count(physical) == 1
+    assert set(omissions) == {
+        physical,
+        f"{stem}.location.member.0.{omitted}",
+        f"{stem}.location.member.1.{selected}",
+        f"{stem}.location.member.1.{omitted}",
+    }
+
+
+@pytest.mark.parametrize("axis", ["x", "y", "z"])
+def test_pattern_without_member_positions_reports_omission_in_every_orientation(
+    grouped_holes, axis
+):
+    part, _members = grouped_holes
+    feature = PatternFeature(
+        Frame((0, 0, 0), axis),
+        "linear",
+        2,
+        declared_hole(diameter=4, axis=axis, at=(0, 0, 0)),
+        pitch=20,
+    )
+    model = PartModel(
+        bbox=part.bounding_box(),
+        orientation="prismatic",
+        features=[feature],
+        datums=[Datum(id="datum_xy", kind="point", at=(-30, -25, -5))],
+        authored_dimensions=(RequestedDimension(feature, "location"),),
+    )
+    assert feature.members == ()
+    plan = compile_dimensions(model)
+    assert plan.locations == ()
+    omissions = [item for item in plan.diagnostics if item.parameter_id.startswith("location")]
+    assert len(omissions) == 1
+    assert omissions[0].parameter_id == "location_pattern.location"
+    assert "no members" in omissions[0].reason
+
+
+def test_missing_view_names_only_the_selected_location_component(grouped_holes):
+    sheet, holes = _sheet(grouped_holes)
+    sheet.dimension(holes, "location", member=1, axis="y")
+    with pytest.raises(ViewPlanIncomplete) as caught:
+        plan_dimensions(sheet.model(), planned_views=("front", "side"))
+    locations = [
+        item for item in caught.value.uncovered if item.identity.parameter.startswith("location")
+    ]
+    assert {item.identity.parameter for item in locations} == {"location.location.member.1.y"}
+    assert all(item.preferred_view == "plan" for item in locations)
+
+
+def test_malformed_member_addresses_do_not_certify_a_physical_drop():
+    part = Box(12, 40, 30) - Pos(0, 8, 6) * Rot(0, 90, 0) * Cylinder(3, 12)
+    drawing = build_drawing(part)
+    name = next(
+        name
+        for name in drawing.annotations()
+        if any(
+            key["parameter_id"] == "location_off_axis.location.member.0.z"
+            for key in drawing.measurement_keys(name)
+        )
+    )
+    (measurement,) = drawing.registry.measurement_of(name)
+    drawing.remove(name)
+    original_issues = drawing.registry.issues
+    assert drawing.lint_summary()["by_code"]["hole_requirement_missing"] == 1
+    for parameter in (
+        "location_off_axis.location.member.01.z",
+        "location_off_axis.location.member.-1.z",
+        "location_off_axis.location.member.١.z",
+        "location_off_axis.length.member.0.z",
+        "location_off_axis.location.member.0.q",
+        "unknown.location.member.0.z",
+        measurement.parameter,
+    ):
+        drawing.registry.restore_issues(original_issues)
+        drawing.registry.record_issue(
+            LintIssue(
+                severity="info",
+                code="off_axis_location_dropped",
+                message="recorded test failure",
+                measurement_ids=(replace(measurement, parameter=parameter),),
+            )
+        )
+        missing = drawing.lint_summary()["by_code"].get("hole_requirement_missing", 0)
+        assert missing == (0 if parameter == measurement.parameter else 1), parameter
+
+
+def test_comparison_detects_a_member_swap_with_the_same_name_and_value():
+    members = ((-15, -10, 0), (15, -10, 0))
+    part = Box(60, 50, 10)
+    for point in members:
+        part -= Pos(*point) * Cylinder(2, 10)
+    drawings = []
+    for member in (0, 1):
+        sheet = Sheet(part, scale=2).authored_dimensions()
+        holes = sheet.hole(diameter=4, depth=10, axis="z", at=members[0], members=members, count=2)
+        sheet.dimension(holes, "bore.diameter")
+        sheet.dimension(holes, "location", member=member, axis="y")
+        drawings.append(sheet.build())
+    for drawing in drawings:
+        assert {name: label for name, (label, _) in _locations(drawing).items()} == {
+            "m_locy0": "15"
+        }
+    difference = diff_builds(*drawings)
+    assert difference["measurements_substituted"] == {
+        "m_locy0": (
+            [("hole", "location.location.member.0.y")],
+            [("hole", "location.location.member.1.y")],
+        )
+    }
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_automatic_pattern_augmentation_survives_generated_declaration(
+    grouped_holes, tmp_path, reverse
+):
+    part, members = grouped_holes
+    if reverse:
+        members = tuple(reversed(members))
+    far_member = 0 if reverse else 1
+    sheet = Sheet(part, scale=2)
+    hole = declared_hole(diameter=4, depth=10, axis="z", at=members[0])
+    pattern = sheet.pattern(hole, kind="other", count=2, members=members)
+    with pytest.warns(SoftDeprecationWarning):
+        sheet.auto_dimensions()
+    with pytest.warns(SoftDeprecationWarning):
+        sheet.add_dimension(pattern, "location", member=far_member, axis="x")
+    before = sheet.build()
+    assert sorted(label for label, _ in _locations(before).values()) == ["15", "15", "45"]
+    source = emit_sheet_script(
+        sheet.model(),
+        "part",
+        str(tmp_path / "drawing"),
+        title="Augmented pattern",
+        number="883",
+        scale=2,
+        formats=(),
+    )
+    namespace = {"part": part}
+    exec(compile(source, "<augmented-pattern>", "exec"), namespace)
+    assert _locations(namespace["drawing"]) == _locations(before)
+    line = next(
+        line
+        for line in source.splitlines()
+        if '"location"' in line and 'axis="x"' in line and f"member={far_member}" in line
+    )
+    edited = source.replace(line, "# " + line)
+    namespace = {"part": part}
+    exec(compile(edited, "<omitted-pattern-component>", "exec"), namespace)
+    remaining = _locations(namespace["drawing"])
+    assert sorted(label for label, _ in remaining.values()) == ["15", "15"]
+    assert {keys[0]["parameter_id"]: label for label, keys in remaining.values()} == {
+        keys[0]["parameter_id"]: label
+        for label, keys in _locations(before).values()
+        if label != "45"
+    }
+
+
+def test_addressable_compiler_result_retains_every_location_selector(grouped_holes):
+    sheet, holes = _sheet(grouped_holes)
+    sheet.dimension(holes, "location")
+    model = sheet.model()
+    feature = next(feature for feature in model.features if feature.kind == "hole")
+    intents = [
+        intent
+        for intent in compile_dimensions(model).addressable()
+        if resolve_feature(intent.ref) is feature and intent.role == "location"
+    ]
+    assert len(intents) == 4
+    assert {(intent.member, intent.discriminator) for intent in intents} == {
+        (0, "x"),
+        (0, "y"),
+        (1, "x"),
+        (1, "y"),
+    }
+
+
+@pytest.fixture(scope="module", params=["x", "y"])
+def side_drilled_group(request):
+    axis = request.param
+    members = ((0, -10, -5), (0, 10, 5)) if axis == "x" else ((-15, 0, -5), (15, 0, 5))
+    part = Box(60, 50, 40)
+    rotation = Rot(0, 90, 0) if axis == "x" else Rot(90, 0, 0)
+    depth = 60 if axis == "x" else 50
+    for point in members:
+        part -= Pos(*point) * rotation * Cylinder(2, depth)
+    return part, members, axis, depth
+
+
+@pytest.mark.parametrize("member,component", [(0, 0), (0, 1), (1, 0), (1, 1)])
+def test_side_drilled_group_selects_only_the_named_member_component(
+    side_drilled_group, member, component
+):
+    part, members, normal, depth = side_drilled_group
+    axis = [axis for axis in "xyz" if axis != normal][component]
+    sheet = Sheet(part, scale=2).authored_dimensions()
+    holes = sheet.hole(
+        diameter=4, depth=depth, axis=normal, at=members[0], members=members, count=2
+    )
+    sheet.dimension(holes, "bore.diameter")
+    sheet.dimension(holes, "location", member=member, axis=axis)
+    drawing = sheet.build()
+    ((label, keys),) = _locations(drawing).values()
+    index = "xyz".index(axis)
+    expected = members[member][index] - (-30, -25, -20)[index]
+    assert label == str(expected)
+    assert len(keys) == 1
+    assert keys[0]["parameter_id"] == f"location_off_axis.location.member.{member}.{axis}"
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_emission_preserves_the_declared_member_order(grouped_holes, tmp_path, reverse):
+    part, members = grouped_holes
+    if reverse:
+        members = tuple(reversed(members))
+    sheet = Sheet(part, scale=2).authored_dimensions()
+    holes = sheet.hole(diameter=4, depth=10, axis="z", at=members[0], members=members, count=2)
+    sheet.dimension(holes, "bore.diameter")
+    sheet.dimension(holes, "location", member=0, axis="x")
+    before = sheet.build()
+    source = emit_sheet_script(
+        sheet.model(),
+        "part",
+        str(tmp_path / "drawing"),
+        title="Member order",
+        number="883",
+        scale=2,
+        formats=(),
+    )
+    namespace = {"part": part}
+    exec(compile(source, "<member-order>", "exec"), namespace)
+    assert _locations(namespace["drawing"]) == _locations(before)
+    assert [label for label, _ in _locations(before).values()] == ["45" if reverse else "15"]
+
+
+@pytest.mark.parametrize("fine_first", [False, True])
+def test_coarse_and_fine_location_requests_form_an_idempotent_union(grouped_holes, fine_first):
+    sheet, holes = _sheet(grouped_holes)
+    requests = [{}, {"member": 1, "axis": "y"}]
+    if fine_first:
+        requests.reverse()
+    for request in requests * 2:
+        sheet.dimension(holes, "location", **request)
+    locations = compile_dimensions(sheet.model()).locations
+    assert len(locations) == len({location.id for location in locations}) == 4
+    assert sorted(location.value for location in locations) == [15, 15, 35, 45]
+
+
+@pytest.mark.parametrize("axis,expected", [("x", "30"), ("y", "25")])
+def test_bolt_circle_centre_is_distinct_from_a_member(grouped_holes, tmp_path, axis, expected):
+    part, members = grouped_holes
+    sheet = Sheet(part, scale=2).authored_dimensions()
+    hole = declared_hole(diameter=4, depth=10, axis="z", at=(0, 0, 0))
+    pattern = sheet.pattern(
+        hole,
+        kind="bolt_circle",
+        count=2,
+        bcd=2 * (15**2 + 10**2) ** 0.5,
+        members=members,
+        at=(0, 0, 0),
+    )
+    sheet.dimension(pattern, "bore.diameter")
+    sheet.dimension(pattern, "location", member="centre", axis=axis)
+    before = sheet.build()
+    ((label, keys),) = _locations(before).values()
+    assert label == expected
+    assert keys[0]["parameter_id"] == f"location_pattern.location.centre.{axis}"
+    source = emit_sheet_script(
+        sheet.model(),
+        "part",
+        str(tmp_path / "drawing"),
+        title="Pattern centre",
+        number="883",
+        scale=2,
+        formats=(),
+    )
+    namespace = {"part": part}
+    exec(compile(source, "<pattern-centre>", "exec"), namespace)
+    assert _locations(namespace["drawing"]) == _locations(before)
+
+
+@pytest.mark.parametrize("second_axis", ["x", "y"])
+def test_coincident_ordinate_records_only_approved_owners(second_axis):
+    points = ((-15, -10, 0), (15, -10, 0))
+    part = Box(60, 50, 10)
+    for point, diameter in zip(points, (4, 6), strict=True):
+        part -= Pos(*point) * Cylinder(diameter / 2, 10)
+    sheet = Sheet(part, scale=2).authored_dimensions()
+    handles = []
+    for point, diameter in zip(points, (4, 6), strict=True):
+        handle = sheet.hole(diameter=diameter, depth=10, axis="z", at=point)
+        handles.append(handle)
+        sheet.dimension(handle, "bore.diameter")
+    sheet.dimension(handles[0], "location", member=0, axis="y")
+    sheet.dimension(handles[1], "location", member=0, axis=second_axis)
+    drawing = sheet.build()
+    locations = _locations(drawing)
+    y_name = next(name for name in locations if name.startswith("m_locy"))
+    label, keys = locations[y_name]
+    assert label == "15"
+    assert {key["parameter_id"] for key in keys} == {"location.location.member.0.y"}
+    assert len(keys) == (2 if second_axis == "y" else 1)
+    features = [feature for feature in drawing.model().features if feature.kind == "hole"]
+    assert len(features) == 2
+    if second_axis == "x":
+        assert len(locations) == 2
+        assert y_name in drawing.annotations_of(features[0])
+    else:
+        assert len(locations) == 1
+        drawing.drop(features[0])
+        assert _locations(drawing)[y_name] == (label, keys)

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -2706,7 +2706,8 @@ class TestTheDimensionMirror:
         src = emit_sheet_script(detect_part_model(part), "part", "s", title="T", number="N")
         assert "sheet.auto_dimensions()" not in src
         assert 'sheet.dimension(hole1, "bore.diameter")' in src
-        assert 'sheet.dimension(hole1, "location")' in src
+        assert 'sheet.dimension(hole1, "location", axis="x", member=0)' in src
+        assert 'sheet.dimension(hole1, "location", axis="y", member=0)' in src
         assert 'sheet.dimension(envelope1, "width.length")' in src
 
     def test_commenting_one_line_drops_exactly_that_dimension(self):

--- a/tests/test_suppression_ledger.py
+++ b/tests/test_suppression_ledger.py
@@ -97,7 +97,10 @@ def test_nearby_distinct_locations_retain_both_semantic_identities():
     locations = compile_dimensions(model).locations
     assert len(locations) == 4  # X + Y for each distinct feature
     assert {entry.id.feature for entry in locations} == set(model.features)
-    assert {entry.id.parameter for entry in locations} == {"location.location"}
+    assert {entry.id.parameter for entry in locations} == {
+        "location.location.member.0.x",
+        "location.location.member.0.y",
+    }
     assert {entry.discriminator for entry in locations} == {"x", "y"}
 
 


### PR DESCRIPTION
A grouped hole's X and Y locations previously shared a coarse measurement identity, so an AI could not select one member component or reliably detect an equal-value member swap. `sheet.dimension(hole, "location", member=1, axis="y")` now names that component through validation, planning, compilation, placement provenance and executable script generation. Discovery lists the valid member/axis selectors. The coarse `location` request retains its existing anchor policy.

Coincident marks retain every approved identity. Hole tables leave omitted axes blank, and missing-view, missing-datum and drop diagnostics preserve the selected component. Whole-feature omission remains supported. Review also fixed duplicate whole-axis suppression records, fabricated locations for side-drilled patterns with no members, and generated double-D declarations losing grouped member positions.

Member indices belong to the declared IR tuple and its generated script. They are not durable provider identities across unrelated recognition runs. The remaining same-kind feature correspondence work is #1006. Closes #883; refs #1277, #1466, #1006.

## Architecture and review

Reviewed iteratively against Google's code-review checklist and all five live ADRs. ADR 1: the existing planner/compiler and addressable output own the content. ADR 2: the existing grouping and corridor solve own placement. ADR 3: member indices are carried from IR selection; no recognition run or provider-identity reconstruction is added. ADR 4: fine intent is validated at the IR waist and survives declaration round-trip. ADR 5: omitted/dropped content remains visible, shared owners retain provenance, and physical coverage still derives its inventory independently. No ADR text or invariant changes.

## Validation

- Full `scripts/pr-check --full` exited 0 against the reviewed placement prerequisite (`BASE_REF=000bfdda`): **7,293 passed, 5 skipped, 14 expected failures; 95.96% total coverage and 98% changed-line coverage (200 executable lines, 4 uncovered).** Ruff, formatting, mypy, codespell and strict documentation checks passed.
- Native Z/X/Y member selections, bolt-circle centre, reversed member order, authored and augmenting scripts, shared ordinate ownership, table omission and equal-name/equal-value member swaps are exercised.
- The grouped double-D round-trip failed before its fix and passes afterward. Empty-pattern and duplicate-suppression regressions failed before their fixes; the focused location/physical/suppression selection passed 164 tests.
- Seven intentional mutations each failed a named test: renderer axis filtering, selector deduplication, authored-axis suppression, drop-address grammar, grouped profile emission, aggregate suppression cardinality and member identity derivation. Source was restored before the full gate.

## Stop check

No two consecutive review rounds invalidated the same core strategy. Selection remains in the shared planner/compiler. #1006 retains the distinct task of proving cross-build measurement correspondence; this PR does not claim that broader guarantee.

## Contributor License Agreement

N/A: maintainer-owned repository changes; no new external-contributor CLA attestation is made by this PR.
