### PR TITLE
Detect measurement substitutions and unresolved correspondence

### DIFF
--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -102,8 +102,10 @@ to place the dimension; location selection supplies no page coordinates.
 `compare_measurements()` compares named compiled measurements, including their owner,
 parameter, nominal value, tolerance, directional span and rendered claim text. Linear
 dimensions also retain their measured path lengths in model units, so exchanging labels
-between two spans cannot hide behind an unchanged label multiset. Reuse the feature
-objects in a declaration when editing placement intent:
+between two spans cannot hide behind an unchanged label multiset. Recorded per-annotation
+spans and location components also distinguish equal-valued axes under a coarse parameter
+id. These are provenance claims; independent lint must still check physical targets.
+Reuse the feature objects in a declaration when editing placement intent:
 
 ```python
 from dataclasses import replace

--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -97,6 +97,49 @@ to place the dimension; location selection supplies no page coordinates.
 
 ## Sheet
 
+### Comparing measurements after a declaration edit
+
+`compare_measurements()` compares named compiled measurements, including their owner,
+parameter, nominal value, tolerance, directional span and rendered claim text. Reuse the
+feature objects in a declaration when editing placement intent:
+
+```python
+from dataclasses import replace
+from draftwright import build_drawing
+from draftwright.audit import compare_measurements
+
+original_model = sheet.model()
+edited_model = replace(
+    original_model,
+    authored_dimensions=tuple(
+        replace(request, side="left") if request.role == "height.length" else request
+        for request in original_model.authored_dimensions
+    ),
+)
+before = build_drawing(part, model=original_model)
+after = build_drawing(part, model=edited_model)
+result = compare_measurements(before, after)
+print(result["status"], result["lost"], result["changed"], result["unknown"])
+```
+
+The status is `preserved`, `changed` or `unknown`. An unresolved owner or unconfirmed
+claim prevents `preserved`. For an in-place edit, capture
+`before = drawing.measurement_snapshot()` before changing the drawing, then compare
+that snapshot with the edited drawing. Snapshots retain process-local feature references.
+
+Separately rebuilt declarations do not acquire correspondence from equal geometry or
+inventory order. If the caller knows the correspondence, pass
+`feature_pairs=((old_feature, new_feature), ...)`. Each pair must name exact owners in
+the respective snapshots and the correspondence must be one-to-one. These are caller
+assertions; the comparison checks measurement meaning under them. Output owner numbers
+are positions in the before snapshot for presentation, not durable identities.
+
+`diff_builds()` includes this result as `measurement_comparison` and detects same-kind
+substitutions between shared declared owners. A clear annotation diff can still have
+unknown measurement correspondence. Use independent `lint_summary()["quality"]`
+evidence alongside the comparison: named-measurement preservation does not establish
+physical completeness, pin preservation or release readiness.
+
 ::: draftwright.sheet.Sheet
     options:
       filters: public

--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -100,8 +100,10 @@ to place the dimension; location selection supplies no page coordinates.
 ### Comparing measurements after a declaration edit
 
 `compare_measurements()` compares named compiled measurements, including their owner,
-parameter, nominal value, tolerance, directional span and rendered claim text. Reuse the
-feature objects in a declaration when editing placement intent:
+parameter, nominal value, tolerance, directional span and rendered claim text. Linear
+dimensions also retain their measured path lengths in model units, so exchanging labels
+between two spans cannot hide behind an unchanged label multiset. Reuse the feature
+objects in a declaration when editing placement intent:
 
 ```python
 from dataclasses import replace

--- a/src/draftwright/audit.py
+++ b/src/draftwright/audit.py
@@ -1,70 +1,159 @@
-"""audit — diff two builds and ask what went missing (#996 WP1 step 2).
+"""Compare finished drawings and captured measurement claims.
 
-The suppression ledger (`Drawing.suppressions()`) says which rule removed a measurement. It
-answers *why* a dimension is absent — but only for absences some code path remembered to
-record. Three consecutive review rounds on #999 found suppression paths that recorded nothing,
-each caught by a person hunting for it rather than by the ledger noticing its own gap.
+``diff_builds`` reports named annotation losses, gains, changed labels and substitutions.
+It never lets a candidate suppression explanation cancel a loss. The legacy explanation
+join is approximate: feature kind plus parameter, sufficient for a hint but not ownership.
 
-**A diff does not depend on that.** If a dimension is present in one build and absent in
-another, something removed it, whether or not anything wrote it down. That is how #997 was
-actually found: not from the four issue reports describing its symptoms, but from `50x50` vs
-`50x40`.
+``compare_measurements`` checks named compiled claims using exact feature references shared
+by the two declarations, or explicit caller-supplied feature pairs. Equal geometry, labels
+and inventory order establish no correspondence. Unmatched owners and unconfirmed claims
+produce unknown results. A caller-supplied pair asserts correspondence; the comparison
+checks the measurement meaning under that assertion and does not verify physical identity.
+Capture ``Drawing.measurement_snapshot()`` before mutating a live drawing.
 
-## What this cannot do, stated first
+The comparison scope is named compiled measurements. It checks their recorded owner,
+parameter, nominal value, tolerance, directional span and rendered claim text. It does not
+establish physical completeness, inspect unnamed annotations or certify an engineering
+release. Use independent lint/requirement evidence alongside it. Claim verification retains
+its own attribution limits, described in ``linting.evidence.verify_measurement_claims``.
 
-A placed annotation carries measurement identity only where the renderer recorded one
-(#1002) — otherwise its name is an engine-assigned registry slot, not a handle on what it
-measures. **Identity is partial, and every limit below is a consequence of where it is
-missing.** Which renderers record it is not described here in prose, because a prose
-description of that set has now been wrong TWICE: first it named only the direct-placing
-group while four compiled-plan renderers dropped their ids (Codex r1), then it listed a
-four-item exception set while the entire shared machined-feature renderer — chamfers,
-fillets, flats, pockets, grooves, boss diameters — recorded nothing (Codex r3). The prose
-was believable both times, which is the point.
-
-The answer lives in `tests/test_audit_differential.py`, whose ratchet scans both placement
-paths (corridor candidates and direct `ctx.place`) across the whole `annotations/` package,
-and whose EXEMPT map IS the exception inventory — every entry carrying its reason, and a
-stale entry failing so the list cannot outlive the gaps it describes. Read that, not a
-second prose inventory here.
-
-Even where identity IS recorded, matching it across two builds is approximate. The ledger's
-key embeds the feature's origin and scalars, so it cannot join two builds that differ — the
-join uses `_correspondence` instead, which keeps the feature's KIND and drops its
-coordinates. Two features of one kind are therefore not separated: a same-count swap of one
-slot's width for another's is invisible (**#1006**). Multiplicity IS compared — as a multiset,
-so a grouped callout dropping a member is caught — but a like-for-like exchange is not.
-
-- **A replaced measurement can reuse an annotation name.** Recorded parameter and member
-  identities allow ``measurements_substituted`` to report changes even when the displayed
-  value agrees. The same-kind, same-parameter feature swap described above remains a gap.
-- **A loss is attributed only where identity exists, and only by kind.** Where identity is
-  recorded the join is on ``(feature kind, parameter_id)`` — precise enough to separate an
-  envelope's width from a slot's, not precise enough to separate two slots. Where it is not
-  recorded the loss reads "nothing claims it" whether or not a rule removed it: unknown,
-  deliberately, rather than guessed. The first cut inferred attribution from annotation
-  NAMES by substring and cancelled real alarms with unrelated suppressions.
-- **An unnamed annotation is invisible.** ``Drawing.annotations()`` returns only *named*
-  annotations by contract, so anything placed without a name cannot be compared here at all.
-- **A legacy or external labelless callout exposes presence only.** Generated hole leaders
-  retain their geometric callout's semantic text, so a changed diameter/depth is observable.
-  A user-supplied or older ``Leader`` may still have ``label == ""``; its loss is reported,
-  but two such present annotations remain indistinguishable by content.
-
-Closing the rest needs the remaining renderers to record identity too (#754). Until then this
-is a **triage aid, not a proof** — and shaped so its weakest part cannot silence its strongest:
-a candidate suppression annotates a loss, it never removes it.
-An earlier cut let a weak substring match cancel the alarm outright, so any newly-suppressed
-``width.*`` excused every lost annotation whose name contained "width", across unrelated
-features (Codex #1001). That is the exact false confidence this epic exists to remove.
-
-A leaf by construction: it reads the public surface of two finished ``Drawing``s and imports
-nothing from the engine, so the thing it measures can never come to depend on it.
+The module imports no engine code. Drawings supply their public snapshots and registry
+reads; no cross-run provider identity is reconstructed or serialized.
 """
 
 from __future__ import annotations
 
 from collections import Counter
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MeasurementClaim:
+    """A named rendered claim and its compiled meaning, retained in one process."""
+
+    owner: object
+    parameter: str
+    annotation: str
+    meaning: tuple
+    rendered: tuple
+
+
+@dataclass(frozen=True)
+class MeasurementSnapshot:
+    """A captured drawing read, with declaration-local references rather than durable IDs."""
+
+    owners: tuple
+    claims: tuple[MeasurementClaim, ...]
+    unknown: tuple[tuple[str, str], ...] = ()
+
+
+def compare_measurements(before, after, *, feature_pairs=()) -> dict:
+    """Compare captured or finished drawings within an explicit declaration correspondence.
+
+    Shared feature objects correspond automatically. ``feature_pairs`` may explicitly pair
+    an owner from each snapshot; these pairs are caller assertions, never inferred from
+    geometry or inventory order. Unknown ownership or unreadable claims prevent preservation.
+    The scope is named compiled measurements, not physical completeness of the whole part.
+    """
+    if not isinstance(before, MeasurementSnapshot):
+        before = before.measurement_snapshot()
+    if not isinstance(after, MeasurementSnapshot):
+        after = after.measurement_snapshot()
+    before_owners = {id(owner): index for index, owner in enumerate(before.owners)}
+    after_owners = {id(owner): index for index, owner in enumerate(after.owners)}
+    correspondence = {key: key for key in before_owners.keys() & after_owners.keys()}
+    paired_after = set(correspondence.values())
+    for old, new in feature_pairs:
+        old_id, new_id = id(old), id(new)
+        if old_id not in before_owners or new_id not in after_owners:
+            raise ValueError("feature pairs must name exact owners in the two snapshots")
+        if correspondence.get(old_id) == new_id:
+            continue
+        if old_id in correspondence or new_id in paired_after:
+            raise ValueError("feature correspondence must be one-to-one and unambiguous")
+        correspondence[old_id] = new_id
+        paired_after.add(new_id)
+
+    unknown = [
+        {"side": side, "annotation": name, "reason": reason}
+        for side, snapshot in (("before", before), ("after", after))
+        for name, reason in snapshot.unknown
+    ]
+    reverse = {new: old for old, new in correspondence.items()}
+
+    def index_claims(snapshot, side):
+        indexed: dict[tuple, list] = {}
+        for claim in snapshot.claims:
+            owner = id(claim.owner)
+            paired = owner if side == "before" and owner in correspondence else reverse.get(owner)
+            if paired is None:
+                unknown.append(
+                    {
+                        "side": side,
+                        "annotation": claim.annotation,
+                        "reason": "owner_correspondence_unknown",
+                    }
+                )
+                continue
+            indexed.setdefault((paired, claim.parameter), []).append(claim)
+        return indexed
+
+    old_claims, new_claims = index_claims(before, "before"), index_claims(after, "after")
+
+    def description(key, claims):
+        return {
+            "owner": before_owners[key[0]],
+            "parameter_id": key[1],
+            "annotations": sorted(claim.annotation for claim in claims),
+        }
+
+    lost, gained, changed = [], [], []
+    old_unknown = {name for name, _reason in before.unknown}
+    new_unknown = {name for name, _reason in after.unknown}
+    for key in sorted(
+        old_claims.keys() | new_claims.keys(), key=lambda key: (before_owners[key[0]], key[1])
+    ):
+        old, new = old_claims.get(key, []), new_claims.get(key, [])
+        if not new:
+            if not any(claim.annotation in new_unknown for claim in old):
+                lost.append(description(key, old))
+        elif not old:
+            if not any(claim.annotation in old_unknown for claim in new):
+                gained.append(description(key, new))
+        else:
+            remaining = list(new)
+            for claim in old:
+                match = next(
+                    (
+                        index
+                        for index, candidate in enumerate(remaining)
+                        if claim.meaning == candidate.meaning
+                        and claim.rendered == candidate.rendered
+                    ),
+                    None,
+                )
+                if match is None:
+                    break
+                remaining.pop(match)
+            else:
+                if not remaining:
+                    continue
+            changed.append(description(key, old))
+    if not before.claims and not after.claims:
+        unknown.append({"side": "both", "annotation": None, "reason": "no_compiled_measurements"})
+    return {
+        "status": "changed"
+        if lost or gained or changed
+        else "unknown"
+        if unknown
+        else "preserved",
+        "scope": "named_compiled_measurements",
+        "lost": lost,
+        "gained": gained,
+        "changed": changed,
+        "unknown": unknown,
+    }
+
 
 #: Sheet FURNITURE — the annotation types that carry no measurement. Everything else counts.
 #:
@@ -159,12 +248,29 @@ def diff_builds(before, after) -> dict:
     - ``candidate_explanations`` — ``{lost name: [reason, ...]}``, a **hint** at which
       newly-gained suppression might account for a loss, joined on ``(feature kind,
       parameter_id)`` where the renderer recorded identity, and absent where it did not.
+    - ``measurement_comparison`` — the bounded ``compare_measurements`` result for real
+      drawings; ``None`` for protocol stand-ins without measurement snapshots. An empty
+      annotation diff does not establish preservation when this result is unknown.
 
     The hint does not subtract from ``dimensions_lost``. The join is by feature KIND, so it
     cannot separate two features of one kind, and a weak match that cancels an alarm is worse
     than no match at all — it manufactures the confidence this epic exists to remove.
     """
     before_dims, after_dims = _measurements(before), _measurements(after)
+    comparison = None
+    exact_owners = {}
+    if hasattr(before, "measurement_snapshot") and hasattr(after, "measurement_snapshot"):
+        before_snapshot, after_snapshot = (
+            before.measurement_snapshot(),
+            after.measurement_snapshot(),
+        )
+        comparison = compare_measurements(before_snapshot, after_snapshot)
+        after_owners = {id(owner) for owner in after_snapshot.owners}
+        exact_owners = {
+            id(owner): f"{getattr(owner, 'kind', type(owner).__name__)}#{index}"
+            for index, owner in enumerate(before_snapshot.owners)
+            if id(owner) in after_owners
+        }
     lost = {n: v for n, v in before_dims.items() if n not in after_dims}
     gained = {n: v for n, v in after_dims.items() if n not in before_dims}
     changed = {n: (v, after_dims[n]) for n, v in before_dims.items() if after_dims.get(n, v) != v}
@@ -185,12 +291,35 @@ def diff_builds(before, after) -> dict:
     #
     # Hole location IDs carry the declared member and measured axis. This detects component
     # substitutions even when the rendered name and value agree. The feature-kind join still
-    # cannot distinguish unrelated same-kind owners; that remaining gap is tracked in #1006.
+    # cannot distinguish same-kind owners. Exact shared declaration references below can;
+    # unrelated builds retain an explicitly unknown measurement comparison.
     substituted: dict[str, tuple] = {}
     for name in set(before_dims) & set(after_dims):
         b_ids, a_ids = _identities(before, name), _identities(after, name)
         if b_ids and a_ids and b_ids != a_ids:
             substituted[name] = (sorted(b_ids.elements()), sorted(a_ids.elements()))
+        elif exact_owners:
+
+            def exact(drawing):
+                identities = drawing.registry.measurement_of(name)
+                if not identities or any(
+                    id(item.feature) not in exact_owners for item in identities
+                ):
+                    return None
+                return Counter(
+                    (exact_owners[id(item.feature)], item.parameter) for item in identities
+                )
+
+            exact_before, exact_after = exact(before), exact(after)
+            if (
+                exact_before is not None
+                and exact_after is not None
+                and exact_before != exact_after
+            ):
+                substituted[name] = (
+                    sorted(exact_before.elements()),
+                    sorted(exact_after.elements()),
+                )
 
     # Attribution, on the cross-build correspondence key. The first cut matched a
     # suppression's parameter stem against the annotation's NAME by substring, so a
@@ -219,6 +348,7 @@ def diff_builds(before, after) -> dict:
         "suppressions_gained": gained_supp,
         "suppressions_lost": lost_supp,
         "candidate_explanations": candidates,
+        "measurement_comparison": comparison,
     }
 
 
@@ -242,6 +372,15 @@ def explain(diff: dict) -> list[str]:
     # gained, disguised as neither (#1002) — so it ranks with the losses.
     for name, (was, now) in sorted(diff.get("measurements_substituted", {}).items()):
         out.append(f"SUBSTITUTED: {name} now draws {now}, was {was}")
+    comparison = diff.get("measurement_comparison")
+    if comparison:
+        for measurement in comparison["changed"]:
+            out.append(
+                f"MEASUREMENT CHANGED: {measurement['parameter_id']} "
+                f"on owner {measurement['owner']}"
+            )
+    if comparison and comparison["unknown"]:
+        out.append("UNKNOWN: measurement preservation is unresolved for some named claims")
     for feature, parameter, reason in diff["suppressions_gained"]:
         out.append(f"suppressed: {parameter} on {feature} — {reason}")
     for name, label in sorted(diff["dimensions_gained"].items()):

--- a/src/draftwright/audit.py
+++ b/src/draftwright/audit.py
@@ -12,8 +12,10 @@ checks the measurement meaning under that assertion and does not verify physical
 Capture ``Drawing.measurement_snapshot()`` before mutating a live drawing.
 
 The comparison scope is named compiled measurements. It checks their recorded owner,
-parameter, nominal value, tolerance, directional span and rendered claim text. It does not
-establish physical completeness, inspect unnamed annotations or certify an engineering
+parameter, nominal value, tolerance, directional span and rendered claim text. A linear
+dimension also retains its scale-normalised measured path length, keeping its text tied
+to the quantity that annotation draws even when several claims share one coarse id.
+It does not establish physical completeness, inspect unnamed annotations or certify an engineering
 release. Use independent lint/requirement evidence alongside it. Claim verification retains
 its own attribution limits, described in ``linting.evidence.verify_measurement_claims``.
 

--- a/src/draftwright/audit.py
+++ b/src/draftwright/audit.py
@@ -15,6 +15,8 @@ The comparison scope is named compiled measurements. It checks their recorded ow
 parameter, nominal value, tolerance, directional span and rendered claim text. A linear
 dimension also retains its scale-normalised measured path length, keeping its text tied
 to the quantity that annotation draws even when several claims share one coarse id.
+Recorded per-annotation spans and location components retain distinctions hidden by a
+coarse parameter id. These records remain source claims, not proof of a physical target.
 It does not establish physical completeness, inspect unnamed annotations or certify an engineering
 release. Use independent lint/requirement evidence alongside it. Claim verification retains
 its own attribution limits, described in ``linting.evidence.verify_measurement_claims``.
@@ -38,6 +40,7 @@ class MeasurementClaim:
     annotation: str
     meaning: tuple
     rendered: tuple
+    witnesses: tuple = ()
 
 
 @dataclass(frozen=True)
@@ -131,6 +134,7 @@ def compare_measurements(before, after, *, feature_pairs=()) -> dict:
                         for index, candidate in enumerate(remaining)
                         if claim.meaning == candidate.meaning
                         and claim.rendered == candidate.rendered
+                        and claim.witnesses == candidate.witnesses
                     ),
                     None,
                 )

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1316,6 +1316,7 @@ class Drawing:
 
         from draftwright.audit import _FURNITURE, MeasurementClaim, MeasurementSnapshot
         from draftwright.linting.evidence import compiled_values, verify_measurement_claims
+        from draftwright.linting.structural import dimension_path_measurement
         from draftwright.model.compiled import compile_dimensions
 
         model = self.model()
@@ -1329,6 +1330,12 @@ class Drawing:
         for name, type_name in self.annotations().items():
             if type_name in _FURNITURE:
                 continue
+            annotation = self.registry.named(name)
+            path = dimension_path_measurement(annotation, self.scale)
+            # Paper-space arithmetic can introduce sub-nanometre roundoff when
+            # a view moves or rescales. Compiled values/spans remain unrounded;
+            # this extra observed length only binds the text to its drawn path.
+            measured_length = None if path is None else round(path[0] / path[1], 9)
             identities = self.registry.measurement_of(name)
             if not identities:
                 unknown.append((name, "measurement_identity_unavailable"))
@@ -1380,6 +1387,7 @@ class Drawing:
                                 for row in getattr(self.registry.named(name), "table_rows", ())
                                 or ()
                             ),
+                            measured_length,
                         ),
                     )
                 )

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1389,6 +1389,16 @@ class Drawing:
                             ),
                             measured_length,
                         ),
+                        (
+                            deepcopy(getattr(annotation, "_dw_measurement_span", None)),
+                            tuple(
+                                (component, deepcopy(at))
+                                for feature, component, at in getattr(
+                                    annotation, "covers_hole_locations", ()
+                                )
+                                if feature is identity.feature
+                            ),
+                        ),
                     )
                 )
         return MeasurementSnapshot(tuple(model.features), tuple(claims), tuple(unknown))

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1295,14 +1295,95 @@ class Drawing:
         the annotation measures nothing. Which renderers record it is enforced by the ratchet
         in `tests/test_audit_differential.py`; treat presence as exact and absence as unknown.
 
-        Exact **within** a build. Across two builds the key cannot match directly, because
-        `feature_key` embeds coordinates and scalars a differential deliberately changes —
-        `draftwright.audit` joins on the feature's kind instead.
+        These keys describe geometry and have the collision limits of ``feature_key``.
+        For declaration-local ownership and meaning comparisons, capture
+        :meth:`measurement_snapshot`; geometry descriptions alone do not prove correspondence.
         """
         return [
             {"feature": feature_key(mid.feature), "parameter_id": mid.parameter}
             for mid in self._registry.measurement_of(name)
         ]
+
+    def measurement_snapshot(self):
+        """Capture named measurement claims for a declaration-local edit comparison.
+
+        Use :func:`draftwright.audit.compare_measurements` to compare snapshots. Capture
+        before mutating a drawing. Owner references stay local to this process; separately
+        rebuilt declarations need an explicit correspondence, never a geometry-key guess.
+        This read compiles the existing model and reads recorded claim text, without recognition.
+        """
+        from copy import deepcopy
+
+        from draftwright.audit import _FURNITURE, MeasurementClaim, MeasurementSnapshot
+        from draftwright.linting.evidence import compiled_values, verify_measurement_claims
+        from draftwright.model.compiled import compile_dimensions
+
+        model = self.model()
+        if model is None:
+            return MeasurementSnapshot((), (), (("", "model_unavailable"),))
+        plan = compile_dimensions(model)
+        values = compiled_values(plan)
+        outcomes = verify_measurement_claims(self.registry, plan)
+        claims = []
+        unknown = []
+        for name, type_name in self.annotations().items():
+            if type_name in _FURNITURE:
+                continue
+            identities = self.registry.measurement_of(name)
+            if not identities:
+                unknown.append((name, "measurement_identity_unavailable"))
+            for identity in identities:
+                approved = tuple(
+                    item
+                    for item in values.get(identity, ())
+                    if item.id is not None and item.id.feature is identity.feature
+                )
+                evidence = [
+                    item
+                    for item in outcomes
+                    if item.annotation == name
+                    and item.measurement is not None
+                    and getattr(item.measurement, "feature", None) is identity.feature
+                    and item.parameter_id == identity.parameter
+                ]
+                if (
+                    not approved
+                    or not evidence
+                    or any(item.state != "confirmed" for item in evidence)
+                ):
+                    unknown.append((name, "compiled_claim_unconfirmed"))
+                    continue
+                meaning = tuple(
+                    (
+                        item.value,
+                        deepcopy(item.tolerance),
+                        item.span,
+                        item.axis,
+                        item.discriminator,
+                        item.location_member,
+                    )
+                    for item in approved
+                )
+                claims.append(
+                    MeasurementClaim(
+                        identity.feature,
+                        identity.parameter,
+                        name,
+                        meaning,
+                        (
+                            str(
+                                getattr(self.registry.named(name), "label", None)
+                                or getattr(self.registry.named(name), "_annotate_label", "")
+                            ),
+                            tuple(
+                                tuple(str(cell) for cell in row)
+                                for row in getattr(self.registry.named(name), "table_rows", ())
+                                or ()
+                            ),
+                        ),
+                    )
+                )
+        return MeasurementSnapshot(tuple(model.features), tuple(claims), tuple(unknown))
 
     @property
     def solve_trace(self):

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -1089,10 +1089,15 @@ def _is_angular_label(label: str) -> bool:
 _MATERIAL_LABEL_DISCREPANCY = 0.05
 
 
-def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0, box_cache=None) -> None:
+def dimension_path_measurement(item, drawing_scale: float = 1.0):
+    """Return a linear dimension's measured page length and its applicable scale.
+
+    Shared by structural lint and measurement snapshots so a claim's text remains
+    associated with the quantity drawn by that annotation. Angular labels have no
+    linear path measurement under this contract.
+    """
     label = _item_label(item)
     measured = getattr(item, "measured_length", None)
-
     # An ANGULAR label is denominated in degrees; `measured_length` is a projected path in
     # millimetres. Comparing them is a category error, not a discrepancy — it reported a
     # 60 deg dovetail flank as "differs from measured path length 16.000 by 275.0%",
@@ -1108,33 +1113,41 @@ def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0, box_cache=Non
     # every path into lint", which is false. Tagging the annotation with its kind would fix
     # that properly; it is not done here because nothing angular now reaches the renderer.
     #
-    # Both guards apply: an angular label is skipped outright (its units differ), and a
-    # repeat label is read as its producer declared it (#1153).
+    if measured is None or _is_angular_label(label):
+        return None
+    # When drawing_scale != 1.0 the geometry was scaled up before projecting
+    # (e.g. part.scale(5) for a 7.5 mm feature drawn at 5:1). The measured
+    # path length is the *scaled* length; the label carries the *real* value.
+    # Divide measured by the scale factor before comparing so a 37.5 mm
+    # measured segment with label "7.5" at 5:1 is accepted, not flagged.
+    #
+    # PER ANNOTATION. An enlarged detail view (#42) tags its dims with `_dw_scale`, and the
+    # caller used to pre-split the item list by that tag and call `lint_drawing` once per
+    # group so this comparison saw the right scale. That split is what made the PAIRWISE
+    # checks blind across groups: two annotations in different groups were never compared,
+    # and a detail view's dims and its own caption are ALWAYS in different groups while
+    # being spatially adjacent by construction — the pair most likely to collide was the
+    # one pair never checked (#1216).
+    #
+    # Reading the tag here instead lets `lint_drawing` run once over every annotation.
+    # `drawing_scale` remains the sheet default for the untagged majority, and stays the
+    # right value for the page-level `world_ext` check above, which is about the sheet and
+    # not about any one annotation.
+    # `drawing_scale` is validated positive by `lint_drawing`; a per-annotation `_dw_scale`
+    # is not on that path, so it is guarded here rather than assumed.
+    item_scale = getattr(item, "_dw_scale", drawing_scale)
+    if not item_scale or item_scale <= 0:
+        item_scale = drawing_scale
+    return measured, item_scale
+
+
+def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0, box_cache=None) -> None:
+    label = _item_label(item)
+    measurement = dimension_path_measurement(item, drawing_scale)
+    # A repeat label is read as its producer declared it (#1153).
     label_val = _label_reading(item, label)
-    if label_val is not None and measured is not None and not _is_angular_label(label):
-        # When drawing_scale != 1.0 the geometry was scaled up before projecting
-        # (e.g. part.scale(5) for a 7.5 mm feature drawn at 5:1). The measured
-        # path length is the *scaled* length; the label carries the *real* value.
-        # Divide measured by the scale factor before comparing so a 37.5 mm
-        # measured segment with label "7.5" at 5:1 is accepted, not flagged.
-        #
-        # PER ANNOTATION. An enlarged detail view (#42) tags its dims with `_dw_scale`, and the
-        # caller used to pre-split the item list by that tag and call `lint_drawing` once per
-        # group so this comparison saw the right scale. That split is what made the PAIRWISE
-        # checks blind across groups: two annotations in different groups were never compared,
-        # and a detail view's dims and its own caption are ALWAYS in different groups while
-        # being spatially adjacent by construction — the pair most likely to collide was the
-        # one pair never checked (#1216).
-        #
-        # Reading the tag here instead lets `lint_drawing` run once over every annotation.
-        # `drawing_scale` remains the sheet default for the untagged majority, and stays the
-        # right value for the page-level `world_ext` check above, which is about the sheet and
-        # not about any one annotation.
-        # `drawing_scale` is validated positive by `lint_drawing`; a per-annotation `_dw_scale`
-        # is not on that path, so it is guarded here rather than assumed.
-        item_scale = getattr(item, "_dw_scale", drawing_scale)
-        if not item_scale or item_scale <= 0:
-            item_scale = drawing_scale
+    if label_val is not None and measurement is not None:
+        measured, item_scale = measurement
         effective_measured = measured / item_scale
         if effective_measured > 1e-6:
             ratio = abs(label_val - effective_measured) / effective_measured

--- a/tests/test_issue_1006_measurement_comparison.py
+++ b/tests/test_issue_1006_measurement_comparison.py
@@ -181,6 +181,14 @@ def test_feature_pair_must_reference_the_exact_snapshot_inventory(declared_pair)
         compare_measurements(drawing, drawing, feature_pairs=((holes[0], holes[1]),))
 
 
+def _replace_with_provenance(drawing, old, new, provenance):
+    for attr, value in vars(provenance).items():
+        if attr.startswith("covers_") or (attr.startswith("_dw_") and attr != "_dw_spec"):
+            setattr(new, attr, value)
+    drawing.items[next(i for i, item in enumerate(drawing.items) if item is old)] = new
+    drawing.registry.replace_object(old, new)
+
+
 @pytest.mark.parametrize(
     ("fixture", "names"),
     [
@@ -207,12 +215,7 @@ def test_swapping_labels_between_coarse_claims_changes_the_measurements(fixture,
             spec.draft,
             **dict(spec.kwargs, label=original[1 - index].label),
         )
-        for attr, value in vars(old).items():
-            if attr.startswith("covers_") or (attr.startswith("_dw_") and attr != "_dw_spec"):
-                setattr(new, attr, value)
-        item_index = next(i for i, item in enumerate(drawing.items) if item is old)
-        drawing.items[item_index] = new
-        drawing.registry.replace_object(old, new)
+        _replace_with_provenance(drawing, old, new, old)
     assert sum(issue.code == "label_vs_measured" for issue in drawing.lint(physical=False)) == 2
     result = compare_measurements(before, drawing)
     assert result["status"] == "changed", result
@@ -227,3 +230,40 @@ def test_a_scale_change_preserves_real_dimension_measurements():
     assert any(getattr(item, "measured_length", None) for item in before.items)
     result = compare_measurements(before, after)
     assert result["status"] == "preserved", result
+
+
+def test_equal_valued_location_axes_keep_their_recorded_component_identity():
+    part = Box(50, 50, 30) - Pos(10, 10, 10) * Box(22, 14, 10)
+    drawing = build_drawing(part)
+    x = drawing.get_annotation("m_locx0")
+    y = drawing.get_annotation("m_locy0")
+    assert x.label == y.label == "35"
+    assert x.covers_hole_locations[0][1].endswith(".x")
+    assert y.covers_hole_locations[0][1].endswith(".y")
+    before = drawing.measurement_snapshot()
+    # Substitute another real Y dimension, including its producer-recorded axis,
+    # for X. The coarse registry id, label and measured length all remain equal.
+    spec = y._dw_spec
+    duplicate = _dim(spec.p1, spec.p2, spec.side, spec.distance, spec.draft, **spec.kwargs)
+    _replace_with_provenance(drawing, x, duplicate, y)
+
+    result = compare_measurements(before, drawing)
+    assert result["status"] == "changed", result
+    assert result["changed"]
+
+
+def test_a_changed_dimension_path_cannot_keep_its_original_claim():
+    drawing = build_drawing(Box(60, 40, 10), scale=2)
+    old = drawing.get_annotation("dim_height")
+    before = drawing.measurement_snapshot()
+    spec = old._dw_spec
+    end = (spec.p2[0], spec.p2[1] + drawing.scale, spec.p2[2])
+    new = _dim(spec.p1, end, spec.side, spec.distance, spec.draft, **spec.kwargs)
+    assert new.label == old.label
+    assert new.measured_length != old.measured_length
+    _replace_with_provenance(drawing, old, new, old)
+    assert any(issue.code == "label_vs_measured" for issue in drawing.lint(physical=False))
+
+    result = compare_measurements(before, drawing)
+    assert result["status"] == "changed", result
+    assert result["changed"]

--- a/tests/test_issue_1006_measurement_comparison.py
+++ b/tests/test_issue_1006_measurement_comparison.py
@@ -1,0 +1,179 @@
+"""A declaration edit must preserve owners and meaning, not merely counts or labels."""
+
+from dataclasses import replace
+
+import pytest
+from build123d import Box, Cylinder, Pos
+
+from draftwright import Sheet, build_drawing
+from draftwright.audit import compare_measurements, diff_builds, explain
+from draftwright.model.ir import RequestedDimension
+
+
+@pytest.fixture(scope="module")
+def declared_pair():
+    part = Box(60, 50, 10)
+    points = ((-15, -10, 0), (15, 10, 0))
+    sheet = Sheet(part, scale=2).authored_dimensions()
+    for point in points:
+        part -= Pos(*point) * Cylinder(2, 10)
+        sheet.hole(diameter=4, at=point, axis="z", depth=10)
+    model = sheet.model()
+    holes = tuple(item for item in model.features if item.kind == "hole")
+    assert len(holes) == 2 and holes[0] is not holes[1]
+    model = replace(model, authored_dimensions=(RequestedDimension(holes[0], "bore.diameter"),))
+    return part, model, holes
+
+
+def _build(part, model):
+    return build_drawing(part, model=model, scale=2)
+
+
+def test_same_kind_same_label_owner_substitution_is_a_loss_and_gain(declared_pair):
+    part, model, holes = declared_pair
+    before = _build(part, model)
+    after = _build(
+        part, replace(model, authored_dimensions=(RequestedDimension(holes[1], "bore.diameter"),))
+    )
+    difference = diff_builds(before, after)
+    assert difference["dimensions_lost"] == difference["dimensions_changed"] == {}
+    assert difference["measurements_substituted"]
+    result = compare_measurements(before, after)
+    assert result["status"] == "changed"
+    assert [row["parameter_id"] for row in result["lost"]] == ["bore.diameter"]
+    assert [row["parameter_id"] for row in result["gained"]] == ["bore.diameter"]
+    assert result["lost"][0]["owner"] != result["gained"][0]["owner"]
+
+
+def test_rebuilt_equal_features_are_unknown_without_an_explicit_pair(declared_pair):
+    part, model, holes = declared_pair
+    replacement = replace(holes[0])
+    assert replacement == holes[0] and replacement is not holes[0]
+    after_model = replace(
+        model,
+        features=[replacement, holes[1]],
+        authored_dimensions=(RequestedDimension(replacement, "bore.diameter"),),
+    )
+    before, after = _build(part, model), _build(part, after_model)
+    assert compare_measurements(before, after)["status"] == "unknown"
+    result = compare_measurements(before, after, feature_pairs=((holes[0], replacement),))
+    assert result["status"] == "preserved", result
+
+
+def test_a_layout_edit_preserves_compiled_measurements(declared_pair):
+    part, model, _holes = declared_pair
+    before = _build(part, model)
+    after = _build(
+        part,
+        replace(
+            model,
+            authored_dimensions=tuple(replace(r, side="left") for r in model.authored_dimensions),
+        ),
+    )
+    result = compare_measurements(before, after)
+    assert result["status"] == "preserved", result
+
+
+def test_a_datum_change_hidden_by_label_rounding_changes_meaning(declared_pair):
+    part, model, holes = declared_pair
+    model = replace(
+        model,
+        authored_dimensions=(
+            RequestedDimension(holes[0], "location", member=0, discriminator="x"),
+        ),
+        datums=[replace(model.datums[0], at=(-29.999, -25, -5))],
+    )
+    before = _build(part, model)
+    datum = model.datums[0]
+    altered = replace(datum, at=(datum.at[0] + 0.001, *datum.at[1:]))
+    after = _build(part, replace(model, datums=[altered]))
+    assert not diff_builds(before, after)["dimensions_changed"]
+    result = compare_measurements(before, after)
+    assert result["status"] == "changed", result
+    assert result["changed"][0]["parameter_id"] == "location.location.member.0.x"
+
+
+def test_a_tolerance_change_is_not_preservation(declared_pair):
+    part, model, holes = declared_pair
+    before = _build(part, replace(model, decorations={(holes[0], "diameter"): 0.1}))
+    after = _build(part, replace(model, decorations={(holes[0], "diameter"): 0.1001}))
+    result = compare_measurements(before, after)
+    assert result["status"] == "changed", result
+    assert result["changed"][0]["parameter_id"] == "bore.diameter"
+
+
+def test_moving_feature_and_datum_together_changes_the_reference_span(declared_pair):
+    part, model, holes = declared_pair
+    model = replace(
+        model,
+        authored_dimensions=(
+            RequestedDimension(holes[0], "location", member=0, discriminator="x"),
+        ),
+    )
+    before = _build(part, model)
+    datum = model.datums[0]
+    # Both offsets read 15 mm, but their physical reference points differ.
+    assert holes[0].frame.origin[0] == -15 and datum.at[0] == -30
+    moved = replace(holes[0], frame=replace(holes[0].frame, origin=(-5, -10, 0)))
+    moved_part = Box(60, 50, 10)
+    for feature in (moved, holes[1]):
+        moved_part -= Pos(*feature.frame.origin) * Cylinder(2, 10)
+    after = _build(
+        moved_part,
+        replace(
+            model,
+            features=[moved, holes[1]],
+            datums=[replace(datum, at=(-20, *datum.at[1:]))],
+            authored_dimensions=(
+                RequestedDimension(moved, "location", member=0, discriminator="x"),
+            ),
+        ),
+    )
+    assert not diff_builds(before, after)["dimensions_changed"]
+    result = compare_measurements(before, after, feature_pairs=((holes[0], moved),))
+    assert result["status"] == "changed", result
+    assert result["changed"][0]["parameter_id"] == "location.location.member.0.x"
+
+
+def test_snapshot_retains_a_measurement_removed_from_the_live_drawing(declared_pair):
+    part, model, _holes = declared_pair
+    drawing = _build(part, model)
+    before = drawing.measurement_snapshot()
+    assert len(before.claims) == 1
+    drawing.remove(before.claims[0].annotation)
+    result = compare_measurements(before, drawing)
+    assert result["status"] == "changed"
+    assert len(result["lost"]) == 1
+
+
+def test_changed_claim_text_cannot_hide_behind_the_same_confirmed_number(declared_pair):
+    part, model, _holes = declared_pair
+    drawing = _build(part, model)
+    before = drawing.measurement_snapshot()
+    assert len(before.claims) == 1
+    drawing.registry.named(before.claims[0].annotation).label = "⌀4 ±0.2 THRU"
+    result = compare_measurements(before, drawing)
+    assert result["status"] == "changed", result
+
+
+def test_a_claim_missing_its_compiled_value_is_unknown(declared_pair):
+    part, model, _holes = declared_pair
+    drawing = _build(part, model)
+    before = drawing.measurement_snapshot()
+    drawing.registry.named(before.claims[0].annotation).label = "⌀999 THRU"
+    result = compare_measurements(before, drawing)
+    assert result["status"] == "unknown"
+    assert result["lost"] == []
+    assert any(item["reason"] == "compiled_claim_unconfirmed" for item in result["unknown"])
+    reverse = compare_measurements(drawing, before)
+    assert reverse["status"] == "unknown" and reverse["gained"] == []
+    assert any(line.startswith("UNKNOWN:") for line in explain(diff_builds(drawing, drawing)))
+
+
+def test_feature_pair_must_reference_the_exact_snapshot_inventory(declared_pair):
+    part, model, holes = declared_pair
+    drawing = _build(part, model)
+    with pytest.raises(ValueError, match="exact owners"):
+        compare_measurements(drawing, drawing, feature_pairs=((replace(holes[0]), holes[0]),))
+    with pytest.raises(ValueError, match="one-to-one"):
+        compare_measurements(drawing, drawing, feature_pairs=((holes[0], holes[1]),))

--- a/tests/test_issue_1006_measurement_comparison.py
+++ b/tests/test_issue_1006_measurement_comparison.py
@@ -1,11 +1,13 @@
 """A declaration edit must preserve owners and meaning, not merely counts or labels."""
 
 from dataclasses import replace
+from pathlib import Path
 
 import pytest
 from build123d import Box, Cylinder, Pos
 
 from draftwright import Sheet, build_drawing
+from draftwright._core import _dim
 from draftwright.audit import compare_measurements, diff_builds, explain
 from draftwright.model.ir import RequestedDimension
 
@@ -177,3 +179,51 @@ def test_feature_pair_must_reference_the_exact_snapshot_inventory(declared_pair)
         compare_measurements(drawing, drawing, feature_pairs=((replace(holes[0]), holes[0]),))
     with pytest.raises(ValueError, match="one-to-one"):
         compare_measurements(drawing, drawing, feature_pairs=((holes[0], holes[1]),))
+
+
+@pytest.mark.parametrize(
+    ("fixture", "names"),
+    [
+        ("grm04_drive_plate.step", ("dim_step_0", "dim_step_1")),
+        ("tuner_jig_blind_obround_pockets.step", ("m_locx0", "m_locy0")),
+    ],
+    ids=["step-spans", "pocket-location-axes"],
+)
+def test_swapping_labels_between_coarse_claims_changes_the_measurements(fixture, names):
+    drawing = build_drawing(Path(__file__).parent / "fixtures" / fixture)
+    original = [drawing.get_annotation(name) for name in names]
+    assert original[0].label != original[1].label
+    before = drawing.measurement_snapshot()
+    assert not before.unknown
+    # Rebuild real dimension geometry with exchanged labels while retaining its
+    # recorded ownership and spans. The two labels still form the same multiset.
+    for index, old in enumerate(original):
+        spec = old._dw_spec
+        new = _dim(
+            spec.p1,
+            spec.p2,
+            spec.side,
+            spec.distance,
+            spec.draft,
+            **dict(spec.kwargs, label=original[1 - index].label),
+        )
+        for attr, value in vars(old).items():
+            if attr.startswith("covers_") or (attr.startswith("_dw_") and attr != "_dw_spec"):
+                setattr(new, attr, value)
+        item_index = next(i for i, item in enumerate(drawing.items) if item is old)
+        drawing.items[item_index] = new
+        drawing.registry.replace_object(old, new)
+    assert sum(issue.code == "label_vs_measured" for issue in drawing.lint(physical=False)) == 2
+    result = compare_measurements(before, drawing)
+    assert result["status"] == "changed", result
+    assert result["changed"]
+
+
+def test_a_scale_change_preserves_real_dimension_measurements():
+    part = Box(60, 40, 10)
+    before = build_drawing(part, scale=1)
+    after = build_drawing(part, model=before.model(), scale=2)
+    assert before.scale == 1 and after.scale == 2
+    assert any(getattr(item, "measured_length", None) for item in before.items)
+    result = compare_measurements(before, after)
+    assert result["status"] == "preserved", result

--- a/tests/test_issue_1357_framed_activation.py
+++ b/tests/test_issue_1357_framed_activation.py
@@ -180,7 +180,9 @@ def test_rigid_motion_preserves_requirements_and_build_diff():
 
     assert _requirements(baseline) == _requirements(moved)
     assert baseline.annotations() == moved.annotations()
-    assert diff_builds(baseline, moved) == {
+    difference = diff_builds(baseline, moved)
+    assert difference.pop("measurement_comparison")["status"] == "unknown"
+    assert difference == {
         "dimensions_lost": {},
         "dimensions_gained": {},
         "dimensions_changed": {},

--- a/tests/test_issue_1382_framed_step_family_evidence.py
+++ b/tests/test_issue_1382_framed_step_family_evidence.py
@@ -182,7 +182,9 @@ def test_raw_and_framed_step_families_preserve_requirements_dsl_and_ink_under_ri
     assert _requirements(raw, kind) == _requirements(framed, kind) == _requirements(moved, kind)
     assert _ink(raw, kind) == _ink(framed, kind) == _ink(moved, kind)
     assert raw.lint() == framed.lint() == moved.lint() == []
-    assert diff_builds(framed, moved) == _NO_BUILD_DIFF
+    difference = diff_builds(framed, moved)
+    assert difference.pop("measurement_comparison")["status"] == "unknown"
+    assert difference == _NO_BUILD_DIFF
 
     generated, source = _generated_drawing(moved.working_part, moved.model())
     assert f"sheet.{sheet_word}(" in source

--- a/tests/test_issue_1466_semantic_sides.py
+++ b/tests/test_issue_1466_semantic_sides.py
@@ -8,6 +8,7 @@ import pytest
 from build123d import Box, Cylinder, Pos
 
 from draftwright import Sheet, build_drawing
+from draftwright.audit import compare_measurements
 from draftwright.linting.issues import LintIssue
 from draftwright.model import hole
 from draftwright.sheet_emit import emit_sheet_script, generate_sheet_script
@@ -90,6 +91,28 @@ def test_discovery_and_emission_preserve_the_supported_sides(grm04_scripts):
         (r.role, r.view, r.side) for r in model.authored_dimensions
     ]
     assert _measurements(namespace["drawing"]) == _measurements(edited["drawing"])
+
+
+def test_grm04_edit_preserves_measurement_meaning_under_shared_declaration(grm04_scripts):
+    original, _edited, _out = grm04_scripts
+    before = original["drawing"]
+    model = before.model()
+    requests = tuple(
+        replace(request, side="left")
+        if request.role in {"bore.diameter", "height.length"}
+        else request
+        for request in model.authored_dimensions
+    )
+    assert sum(request.side == "left" for request in requests) == 3
+    after = build_drawing(
+        original["part"], model=replace(model, authored_dimensions=requests), scale=4
+    )
+    assert any(issue.code == "annotation_ink_overlap" for issue in before.lint())
+    assert not any(
+        issue.code in {"annotation_overlap", "annotation_ink_overlap"} for issue in after.lint()
+    )
+    comparison = compare_measurements(before, after)
+    assert comparison["status"] == "preserved", comparison
 
 
 def _side_sheet(kind, side, **options):


### PR DESCRIPTION
## Symptom and evidence

A same-count swap between two same-kind features could reuse an annotation name and label without `diff_builds` reporting a measurement substitution. Native review cases also exposed unequal labels exchanged between coarse step/location claims, and equal-valued X/Y location substitutions.

The comparison now retains exact declaration owners, compiled meaning, recorded claim text, scale-normalised linear path lengths, and existing per-annotation span/component evidence. GRM04 step-label swaps, tuner location-label swaps, a duplicated equal-valued Y component, and a changed dimension path all report a change. The supported GRM04 side edit clears the demonstrated annotation crossing while preserving named measurements.

Closes #1006; refs #1277, #883, #1466.

## Contract and scope

`Drawing.measurement_snapshot()` captures named compiled claims before an in-place edit. `audit.compare_measurements()` accepts snapshots or finished drawings and reports `preserved`, `changed` or `unknown`. Shared feature objects establish correspondence. Optional one-to-one `feature_pairs` are explicit caller assertions over exact snapshot owners; equal geometry, inventory order and rounded descriptions establish no correspondence.

An unresolved owner or unconfirmed claim prevents preservation. A removed annotation is a loss; a present unconfirmed claim is unknown. The result covers named compiled measurements and recorded provenance. It does not independently prove physical targets, unnamed annotation completeness, pin preservation or release readiness. Physical lint and requirement checks remain necessary. Approximate suppression explanations still cannot cancel an observed loss.

Reviewed iteratively against Google's design, functionality, complexity, tests, naming, comments, style and documentation checklist and all five live ADRs. ADR 1: audit remains a leaf and Drawing owns the read through the existing compiler. ADR 2: no placement changes or alternative solver. ADR 3: no recognition or reconstructed provider identity. ADR 4: intent-only edits reuse declared owners; generated-script checks remain executable. ADR 5: unknown is explicit, and recorded claims are not promoted to independent physical proof. Structural lint and snapshots share the existing per-annotation path/scale calculation. No ADR invariant or text changes.

## Validation

- Final `BASE_REF=origin/main scripts/pr-check --full` exited 0 on head `1520f5ab7021d29484de195165e7cbf184b3bbe1`: **7,309 passed, 5 skipped, 14 expected failures; 95.95% total coverage and 97% changed-line coverage (137 executable lines, 3 uncovered)**. Static checks and strict documentation passed.
- Fifteen native comparison cases cover owner substitution, unrelated rebuilt owners, explicit pairing, valid placement/scale edits, rounded nominal changes, tolerance and reference-span changes, deletion, changed claim text, unconfirmed claims, label swaps, equal-valued component substitution and altered dimension paths. Automatic real STEP, declared and generated-script paths are included in the final full suite.
- Nine final-source deliberate faults failed named tests after the unmutated baseline passed: path binding, scale normalisation, recorded component binding, false-loss classification, owner correspondence, unknown classification, text comparison, reference-span evidence and tolerance comparison. Source was restored byte-for-byte before full preflight. The reference-span mutation removes all redundant span channels together.
- A code-object call counter observed zero recognition calls during snapshot/comparison on the final source; subsequent physical critique exercised the counter and observed one recognition aggregate build.
- Rebased onto merged CTC fix #1491 (`main` at `68643bf8`), producing head `6b66b85366af5370109dec14c92566a3f8a18bc6`. The PR patch is unchanged (stable patch ID `dc9dc304bf8cff76dae9269370e17cefa576721d`); the only tree difference from the full-preflight head is #1491's slow-test correction. The fifteen comparison cases and corrected CTC-01 AP203 test pass together on both Python 3.14 and 3.12: **16 passed on each**.
- Required CI must pass on this rebased head before merge. The full slow tier remains the repository's post-merge main gate.

## Stop check

Review found missing per-annotation evidence after owner pairing; the exact-owner correspondence strategy did not change. The additional path/component checks use existing producer records and shared lint calculations, without geometry-based owner reconstruction. Physical completeness, bounded collision repair and independent leader-target assurance retain their scoped follow-ups.

## Contributor License Agreement

N/A: maintainer-owned repository changes; no new external-contributor CLA attestation is made by this PR.
