### PR TITLE
Repair dimension ink through bounded shared candidates

### DIFF
--- a/docs/adr/0005-trust-and-honest-failure.md
+++ b/docs/adr/0005-trust-and-honest-failure.md
@@ -21,8 +21,8 @@ the compiled plan as its inventory: a feature the planner omitted must still be 
 is reported as separate components — completeness, restraint, legibility, fidelity — never a
 composite, and the completeness figure is `audited_score`, named for its bound in the field name
 itself because the qualifier in a sibling key is lost the moment the number is quoted. Repair is
-an allowlisted safety net for one mechanically clear case; the structural cure for a collision
-class is a placement rule, not a peephole.
+an allowlisted safety net using mechanically clear fixes and the shared placement solver;
+the structural cure for a collision class remains a placement rule.
 
 **Every statement carries its provenance, and every absence is reported.** An annotation knows
 which intent produced it, recorded once at the render seam and never parsed back out of a name.
@@ -45,10 +45,16 @@ proves nothing about a guard that was never mutated.
    `test_import_boundaries.py` (`test_linting_does_not_import_model`). Lint *may* compare a claim
    the drawing makes against the plan — that contributes no denominator.
    `test_issue_1217_the_facility_is_shared.py`.
-3. **Repair is allowlisted and idempotent.** `repair.py` handles `dim_inside_part` only, never
-   executes an arbitrary suggestion, attempts once, and never increases issue counts.
+3. **Repair is allowlisted and idempotent.** `repair.py` handles `dim_inside_part` and the
+   demonstrated axis-aligned dimension `annotation_ink_overlap` class; it never executes an
+   arbitrary suggestion. Ink repair tries the shared bounded candidate solver with along-span
+   choices and at most one established typography-derived stacking tier per operation. It
+   accepts only strict improvement with no increased lint-code/severity component, preserving
+   requirements, confirmed measurement claims, annotation membership and pins; rejection restores
+   the original items and registry. Infeasible choices retain explicit findings.
    `test_make_drawing.py` (`test_repair_dim_inside_part_flips_side`,
-   `test_repair_idempotent_on_clean_drawing`, `test_repair_does_not_increase_issue_counts`).
+   `test_repair_idempotent_on_clean_drawing`, `test_repair_does_not_increase_issue_counts`),
+   `test_issue_1333_bounded_ink_repair.py`. Maintainer approved this extension on 2026-09-07 (#1490).
 4. **Provenance is recorded once, at the seam, for every feature kind.** `annotations_of(feature)`
    equals exactly what `drop(feature)` removes; no pass resolves a feature from an annotation name.
    `test_render_seam.py`, `test_make_drawing.py` (`test_drop_is_complete_for_a_multi_feature_prismatic_part`,

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -3683,23 +3683,34 @@ class Drawing:
         mechanically-clear violations and re-lint, bounded to *max_iter* passes:
 
         - ``dim_inside_part`` — the offset is on the wrong side; flip it once.
-        ``annotation_overlap`` is intentionally not repaired here anymore: the
-        corridor/strip solvers own primary placement, and a fixed-step nudge would
-        reintroduce a second placement policy.
+        - ``annotation_ink_overlap`` — try the shared dimension candidate solver
+          once, with along-span choices and at most one existing stacking tier.
+          Pins, authored sides, annotation membership and confirmed measurements
+          survive; every lint-code/severity component must stay the same or improve,
+          and at least one must improve. An infeasible candidate leaves the findings.
 
         Only engine-built dimensions (carrying ``_dw_spec``) are re-placeable;
         leaders, callouts and standards-judgement issues (e.g.
         ``missing_principal_dimension``) are left for the caller. Each side flip
-        is attempted at most once and overlap pushes only move outward, so the
-        loop terminates and a clean drawing is returned unchanged.
+        is attempted at most once; a clean drawing is returned unchanged.
 
-        A pass that would *net-increase* the issue count (e.g. an overlap push
-        that shoves a label out of frame on a tight sheet) is rolled back and the
-        loop stops, so :meth:`repair` never makes a drawing worse.
+        Wrong-side flips retain their issue-count rollback guard. Rejected ink
+        candidates restore the original items and registry; an exception during
+        candidate critique also restores them before propagating the error.
 
         Returns ``self`` for chaining.
         """
-        return repair_drawing(self, max_iter)
+        from draftwright.annotations._common import prevent_dimension_label_ink
+
+        def ink_candidates(dimensions, pins):
+            return prevent_dimension_label_ink(
+                dimensions,
+                page=(_MARGIN, _MARGIN, self.page_w - _MARGIN, self.page_h - _MARGIN),
+                immutable=pins,
+                perpendicular_step=self.draft.font_size + 2 * self.draft.pad_around_text,
+            )
+
+        return repair_drawing(self, max_iter, ink_candidates=ink_candidates)
 
     # -- output ---------------------------------------------------------------
     def lint(self, *, physical: bool = True):
@@ -3711,7 +3722,7 @@ class Drawing:
         ``physical=False`` asks for the **placement** critique only — geometry/standards
         checks over what is on the sheet — and skips the feature-coverage half that needs a
         recognition inventory of the solid. That is what the repair loop wants (it acts on
-        ``dim_inside_part`` and nothing else, ADR 5 (was 0002)), and on a declared build it is the
+        the allowlisted placement codes in ADR 5), and on a declared build it is the
         difference between exporting a drawing and recognising the part to no purpose
         (#1022). The default stays the full critique: a caller asking "is this drawing
         right?" means both halves.

--- a/src/draftwright/linting/suggest.py
+++ b/src/draftwright/linting/suggest.py
@@ -66,6 +66,14 @@ def _suggest_fix(issue, dwg) -> str | None:
             f"# HoleCallout(..., count={need}, draft=dwg.draft)"
         )
 
+    if code == "annotation_ink_overlap":
+        return (
+            "# Try bounded shared-solver repair for axis-aligned dimension ink.\n"
+            "# Pins and measurements are preserved; infeasible crossings remain visible.\n"
+            "dwg.repair()\n"
+            "issues = dwg.lint()"
+        )
+
     if code == "annotation_overlap":
         # Message: "labels 'A' and 'B' overlap by ...".
         if "move what is drawn" in issue.message:

--- a/src/draftwright/repair.py
+++ b/src/draftwright/repair.py
@@ -1,19 +1,20 @@
 """The deterministic lint→repair safety net (#138 / ADR 1 (was 0005); #30 / ADR 5 (was 0002)).
 
-The solver path now owns annotation placement. Repair is deliberately narrow:
-it only handles the mechanically-clear wrong-side dimension case and never performs
-fixed-step overlap placement. `Drawing.repair()` remains the public wrapper; these
-helpers take the drawing as `dwg` (duck-typed — `lint` / `items` / `_registry`), so
-this module imports only `_core`, never `make_drawing` — no cycle.
+The solver path owns annotation placement. Repair handles wrong-side dimensions
+and a bounded dimension-ink candidate supplied by that same solver. Drawing
+supplies the higher-ranked candidate function; this module never imports it.
 """
 
 from __future__ import annotations
 
+from collections import Counter
+
 from draftwright._core import _QUOTED_RE, _dim
+from draftwright.audit import compare_measurements
 
 # Lint codes the repair loop can mechanically resolve, and the side flip used to
 # move a dimension that landed on the wrong side of its witness points.
-_REPAIRABLE_CODES = frozenset({"dim_inside_part"})
+_REPAIRABLE_CODES = frozenset({"dim_inside_part", "annotation_ink_overlap"})
 _OPPOSITE_SIDE = {"above": "below", "below": "above", "left": "right", "right": "left"}
 
 
@@ -36,6 +37,11 @@ def _find_dim(dwg, label):
     return None
 
 
+def _swap_annotation(dwg, old, new):
+    dwg.items[next(i for i, item in enumerate(dwg.items) if item is old)] = new
+    dwg.registry.replace_object(old, new)
+
+
 def _replace_dim(dwg, old, new):
     """Swap *old* for *new* in ``dwg.items``, preserving its name and any per-view
     scale tag (so a re-placed detail-view dim stays at scale)."""
@@ -52,8 +58,7 @@ def _replace_dim(dwg, old, new):
         new._dw_measurement_span = old._dw_measurement_span
     if getattr(old, "_dw_authored_side", None) is not None:
         new._dw_authored_side = old._dw_authored_side
-    dwg.items[dwg.items.index(old)] = new
-    dwg.registry.replace_object(old, new)
+    _swap_annotation(dwg, old, new)
 
 
 def _repair_dim_inside_part(dwg, issue) -> bool:
@@ -74,20 +79,77 @@ def _repair_dim_inside_part(dwg, issue) -> bool:
     return True
 
 
-def repair_drawing(dwg, max_iter: int = 3):
+def _repair_annotation_ink(dwg, choose_candidates, before):
+    """Try one shared-solver batch; commit only a content-preserving improvement."""
+    if "annotation_ink_overlap" not in _REPAIRABLE_CODES or not any(
+        issue.code == "annotation_ink_overlap" for issue in before
+    ):
+        return
+    original = list(dwg.iter_annotations())
+    pins = dwg.registry.pinned_names()
+    measurements = dwg.measurement_snapshot()
+    if measurements.unknown:
+        return  # an unconfirmed measurement cannot authorise an automatic move
+    candidates = choose_candidates(original, pins)
+    if [name for name, _ in candidates] != [name for name, _ in original]:
+        return
+    changes = [
+        (old, new)
+        for (_, old), (_, new) in zip(original, candidates, strict=True)
+        if old is not new
+    ]
+    if not changes:
+        return
+    for (name, old), (_, new) in zip(original, candidates, strict=True):
+        if old is new:
+            continue
+        a, b = getattr(old, "_dw_spec", None), getattr(new, "_dw_spec", None)
+        if (
+            name in pins
+            or a is None
+            or b is None
+            or (a.p1, a.p2, a.side) != (b.p1, b.p2, b.side)
+            or getattr(old, "_dw_authored_side", None) != getattr(new, "_dw_authored_side", None)
+        ):
+            return
+    items = list(dwg.items)
+    registry = dwg.registry.snapshot()
+    accepted = False
+    try:
+        for old, new in changes:
+            # The shared solver already carries provenance. Judge its candidate
+            # as returned, without overwriting evidence that the comparison reads.
+            _swap_annotation(dwg, old, new)
+        after = dwg.lint(physical=False)
+        before_counts = Counter((issue.code, issue.severity) for issue in before)
+        after_counts = Counter((issue.code, issue.severity) for issue in after)
+        accepted = (
+            bool(before_counts - after_counts)
+            and not (after_counts - before_counts)
+            and compare_measurements(measurements, dwg)["status"] == "preserved"
+        )
+    finally:
+        if not accepted:
+            dwg.items[:] = items
+            dwg.registry.restore(registry)
+
+
+def repair_drawing(dwg, max_iter: int = 3, *, ink_candidates=None):
     """Close the lint→repair loop; see :meth:`Drawing.repair` for the contract.
     Returns *dwg* for chaining.
 
     Lints ``physical=False`` — the placement critique only. This loop acts on
-    ``_REPAIRABLE_CODES`` (``dim_inside_part``) and nothing else, so the feature-coverage
+    ``_REPAIRABLE_CODES`` and nothing else, so the feature-coverage
     half was computed and discarded on every iteration; on a declared build it also forced
     the recognition ADR 4 (was 0011) says that path skips (#1022). It makes the net-worsened
     comparison below stricter too: coverage issues cannot change from re-placing a
     dimension, so counting them only diluted the ratio.
     """
+    if max_iter <= 0:
+        return dwg
+    before = dwg.lint(physical=False)
     flipped: set = set()
     for _ in range(max_iter):
-        before = dwg.lint(physical=False)
         if not before:
             break
         snap_annotations = list(dwg.items)
@@ -106,37 +168,16 @@ def repair_drawing(dwg, max_iter: int = 3):
                     changed = True
         if not changed:
             break
-        if len(dwg.lint(physical=False)) > len(before):
-            # The repairs net-worsened the sheet — undo this pass and stop.
-            #
-            # Note what this counts: EVERY placement issue, while `_REPAIRABLE_CODES`
-            # holds one. So a code the loop cannot target still decides whether a
-            # repair survives. A flip that corrects a `dim_inside_part` while moving
-            # its dimension line across a neighbour's label nets +1 and is undone,
-            # leaving the wrong-side dimension in place.
-            #
-            # Not one-directional, though: the flip moves the dimension line, which
-            # IS the ink `annotation_ink_overlap` measures, so it can clear a
-            # crossing as readily as create one. An earlier revision of this comment
-            # claimed such codes "can vote a repair down but never vote one up",
-            # which the measurement quoted below does not establish and the geometry
-            # contradicts.
-            #
-            # Measured over the population where it can actually occur. A first
-            # measurement counted zero flips across the 23 STEP fixtures, which was
-            # true and beside the point: `dim_inside_part` fires on Python-built
-            # parts, so that corpus cannot exercise this at all. Instrumenting
-            # `_repair_dim_inside_part` across the **whole test suite** records 2
-            # flips, of which 0 net-worsen counting ink and 0 are reverted because of
-            # it. So the veto is reachable and does not currently fire.
-            #
-            # The asymmetry is pre-existing and structural rather than anything #1321
-            # introduced — it acquires a new member with every lint code added — and
-            # it dissolves once #1333 makes these codes repairable, at which point the
-            # loop can improve what it is being judged on.
+        after = dwg.lint(physical=False)
+        if len(after) > len(before):
+            # Preserve the wrong-side handler's existing rollback contract. Ink
+            # candidates below use the stricter per-code/severity comparison.
             dwg.items[:] = snap_annotations
             dwg.registry.restore(snap_registry)
             break
+        before = after
+    if ink_candidates is not None:
+        _repair_annotation_ink(dwg, ink_candidates, before)
     return dwg
 
 

--- a/tests/test_issue_1333_bounded_ink_repair.py
+++ b/tests/test_issue_1333_bounded_ink_repair.py
@@ -1,0 +1,287 @@
+"""Repair must clear real ink collisions without trading away drawing content."""
+
+import pytest
+from build123d import Box, Pos, Rot
+
+from draftwright import build_drawing
+from draftwright.audit import compare_measurements
+from draftwright.linting.ink_overlap import segments_of
+
+
+def _geometry(item):
+    box = item.bounding_box()
+    label = getattr(item, "label_bbox", None)
+    return (
+        tuple(box.min),
+        tuple(box.max),
+        None if label is None else tuple(label),
+        segments_of(item),
+    )
+
+
+def test_repair_clears_parallel_dimension_ink_and_preserves_measurements_and_pins():
+    # The rotated blind pocket from #916 has two parallel dimensions on the same
+    # line: each one's stroke crosses the other's text. Disable build-time repair
+    # so this remains a direct public repair regression when the handler lands.
+    part = Rot(90, 0, 0) * (Box(50, 50, 30) - Pos(10, 10, 10) * Box(22, 14, 10))
+    drawing = build_drawing(part, repair=False)
+    before = drawing.lint(physical=False)
+    assert [issue.code for issue in before] == [
+        "annotation_ink_overlap",
+        "annotation_ink_overlap",
+    ]
+    measurements = drawing.measurement_snapshot()
+    annotations = dict(drawing.iter_annotations())
+    assert "m_env_width" in annotations
+    pins = {name: item for name, item in annotations.items() if name != "m_env_width"}
+    pin_geometry = {name: _geometry(item) for name, item in pins.items()}
+    for name in pins:
+        drawing.pin(name)
+
+    assert drawing.repair() is drawing
+
+    assert set(drawing.annotations()) == set(annotations)
+    assert all(drawing.get_annotation(name) is item for name, item in pins.items())
+    assert drawing.registry.pinned_names() == frozenset(pins)
+    assert {name: _geometry(drawing.get_annotation(name)) for name in pins} == pin_geometry
+    assert compare_measurements(measurements, drawing)["status"] == "preserved"
+    assert drawing.lint(physical=False) == []
+
+    repaired = dict(drawing.iter_annotations())
+    drawing.repair()
+    assert all(drawing.get_annotation(name) is item for name, item in repaired.items())
+    assert drawing.lint(physical=False) == []
+
+
+def test_pins_keep_an_infeasible_ink_collision_visible_without_moving_geometry():
+    part = Rot(90, 0, 0) * (Box(50, 50, 30) - Pos(10, 10, 10) * Box(22, 14, 10))
+    drawing = build_drawing(part, repair=False)
+    before = drawing.lint(physical=False)
+    assert [issue.code for issue in before] == [
+        "annotation_ink_overlap",
+        "annotation_ink_overlap",
+    ]
+    original = dict(drawing.iter_annotations())
+    geometry = {name: _geometry(item) for name, item in original.items()}
+    measurements = drawing.measurement_snapshot()
+    for name in original:
+        drawing.pin(name)
+
+    drawing.repair()
+
+    assert set(drawing.annotations()) == set(original)
+    assert all(drawing.get_annotation(name) is item for name, item in original.items())
+    assert {name: _geometry(item) for name, item in drawing.iter_annotations()} == geometry
+    assert drawing.registry.pinned_names() == frozenset(original)
+    assert compare_measurements(measurements, drawing)["status"] == "preserved"
+    assert drawing.lint(physical=False) == before
+
+
+@pytest.mark.parametrize(
+    "fault",
+    [
+        "span",
+        "pin",
+        "membership",
+        "equal_lint",
+        "lint_error",
+        "unknown",
+        "authored_side",
+        "witness_points",
+    ],
+)
+def test_bad_candidates_cannot_bypass_preservation_and_rollback(monkeypatch, fault):
+    from draftwright.annotations import _common
+
+    part = Rot(90, 0, 0) * (Box(50, 50, 30) - Pos(10, 10, 10) * Box(22, 14, 10))
+    drawing = build_drawing(part, repair=False)
+    original = dict(drawing.iter_annotations())
+    for name in original:
+        if name != "m_env_width":
+            drawing.pin(name)
+    before = drawing.lint(physical=False)
+    measurements = drawing.measurement_snapshot()
+    items = list(drawing.items)
+    registry = drawing.registry.snapshot()
+    candidates = _common.prevent_dimension_label_ink(
+        list(original.items()),
+        page=(0, 0, drawing.page_w, drawing.page_h),
+        immutable=drawing.registry.pinned_names(),
+        perpendicular_step=drawing.draft.font_size + 2 * drawing.draft.pad_around_text,
+    )
+    changed = [(name, item) for name, item in candidates if item is not original[name]]
+    assert [name for name, _ in changed] == ["m_env_width"]
+    new = changed[0][1]
+    # First prove this is a useful candidate, independently of repair's decision.
+    try:
+        drawing.items[
+            next(i for i, item in enumerate(items) if item is original["m_env_width"])
+        ] = new
+        drawing.registry.replace_object(original["m_env_width"], new)
+        assert drawing.lint(physical=False) == []
+        assert compare_measurements(measurements, drawing)["status"] == "preserved"
+        if fault == "span":
+            new._dw_measurement_span = ((1, 2, 3), (51, 2, 3))
+            assert drawing.lint(physical=False) == []
+            assert compare_measurements(measurements, drawing)["status"] == "changed"
+    finally:
+        drawing.items[:] = items
+        drawing.registry.restore(registry)
+
+    if fault == "pin":
+        drawing.pin("m_env_width")  # the candidate was computed before this pin
+    elif fault == "membership":
+        candidates = [(name, item) for name, item in candidates if name != "m_env_width"]
+    elif fault == "authored_side":
+        new._dw_authored_side = "left"
+    elif fault == "witness_points":
+        new._dw_spec.p1 = tuple(value + 1 for value in new._dw_spec.p1)
+    elif fault == "unknown":
+        identity = drawing.registry.identity_of("m_env_width")
+        drawing.registry.reapply("m_env_width", dict(identity, measurement=()))
+        assert drawing.measurement_snapshot().unknown
+    registry = drawing.registry.snapshot()
+    attempts = []
+
+    def choose(*_args, **_kwargs):
+        attempts.append(True)
+        return candidates
+
+    monkeypatch.setattr(_common, "prevent_dimension_label_ink", choose)
+    lint = drawing.lint
+    if fault in {"equal_lint", "lint_error"}:
+
+        def judge(**kwargs):
+            if drawing.get_annotation("m_env_width") is new:
+                if fault == "lint_error":
+                    raise RuntimeError("critique unavailable")
+                return before  # moving without strict improvement is not a repair
+            return lint(**kwargs)
+
+        monkeypatch.setattr(drawing, "lint", judge)
+    if fault == "lint_error":
+        with pytest.raises(RuntimeError, match="critique unavailable"):
+            drawing.repair()
+    else:
+        drawing.repair()
+    assert bool(attempts) == (fault != "unknown")
+    assert all(a is b for a, b in zip(drawing.items, items, strict=True))
+    assert drawing.registry.snapshot() == registry
+    assert drawing.lint(physical=False) == before
+
+
+def test_automatic_and_declared_builds_use_the_same_recognition_free_repair():
+    from conftest import recognition_consumer_calls
+
+    part = Rot(90, 0, 0) * (Box(50, 50, 30) - Pos(10, 10, 10) * Box(22, 14, 10))
+    raw = build_drawing(part, repair=False)
+    assert len(raw.lint(physical=False)) == 2
+    automatic = build_drawing(part)
+    assert automatic.lint(physical=False) == []
+    with recognition_consumer_calls() as counts:
+        declared = build_drawing(part, model=raw.model(), repair=False)
+        before = declared.measurement_snapshot()
+        assert len(declared.lint(physical=False)) == 2
+        declared.repair()
+        assert declared.lint(physical=False) == []
+        assert compare_measurements(before, declared)["status"] == "preserved"
+    assert dict(counts) == {}
+
+
+def test_partial_repair_keeps_infeasibility_visible_and_is_idempotent():
+    part = Rot(90, 0, 0) * (Box(50, 50, 30) - Pos(10, 10, 10) * Box(22, 14, 10))
+    drawing = build_drawing(part, scale=2, repair=False)
+    assert [issue.code for issue in drawing.lint(physical=False)] == ["annotation_ink_overlap"] * 3
+    before = drawing.measurement_snapshot()
+    drawing.repair()
+    assert [issue.code for issue in drawing.lint(physical=False)] == ["annotation_ink_overlap"]
+    assert compare_measurements(before, drawing)["status"] == "preserved"
+    repaired = list(drawing.items)
+    drawing.repair()
+    assert all(a is b for a, b in zip(drawing.items, repaired, strict=True))
+    assert [issue.code for issue in drawing.lint(physical=False)] == ["annotation_ink_overlap"]
+
+
+def test_zero_repair_budget_keeps_the_actual_collision_untouched(monkeypatch):
+    from draftwright.annotations import _common
+
+    part = Rot(90, 0, 0) * (Box(50, 50, 30) - Pos(10, 10, 10) * Box(22, 14, 10))
+    drawing = build_drawing(part, repair=False)
+    before = drawing.lint(physical=False)
+    assert [issue.code for issue in before] == ["annotation_ink_overlap"] * 2
+    items = list(drawing.items)
+
+    def unexpected(*args, **kwargs):
+        pytest.fail("zero budget must not construct repair candidates")
+
+    monkeypatch.setattr(_common, "prevent_dimension_label_ink", unexpected)
+    drawing.repair(max_iter=0)
+    assert all(a is b for a, b in zip(drawing.items, items, strict=True))
+    assert drawing.lint(physical=False) == before
+
+
+def test_repair_rejects_a_lower_issue_count_that_introduces_label_overlap(monkeypatch):
+    from draftwright.annotations import _common
+
+    part = Rot(90, 0, 0) * (Box(50, 50, 30) - Pos(10, 10, 10) * Box(22, 14, 10))
+    drawing = build_drawing(part, repair=False)
+    before = drawing.lint(physical=False)
+    assert [issue.code for issue in before] == [
+        "annotation_ink_overlap",
+        "annotation_ink_overlap",
+    ]
+    original = dict(drawing.iter_annotations())
+    for name in original:
+        if name != "m_env_width":
+            drawing.pin(name)
+    items = list(drawing.items)
+    registry = drawing.registry.snapshot()
+    geometry = {name: _geometry(item) for name, item in original.items()}
+    measurements = drawing.measurement_snapshot()
+
+    # Establish the adverse candidate from the actual shared solver. Along-span
+    # choices clear both ink crossings but create a different kind of collision.
+    candidate = dict(
+        _common.prevent_dimension_label_ink(
+            list(original.items()),
+            page=(0, 0, drawing.page_w, drawing.page_h),
+            immutable=drawing.registry.pinned_names(),
+        )
+    )
+    changed = {name for name in original if original[name] is not candidate[name]}
+    assert changed == {"m_env_width"}
+    try:
+        for name in changed:
+            old, new = original[name], candidate[name]
+            drawing.items[next(i for i, item in enumerate(drawing.items) if item is old)] = new
+            drawing.registry.replace_object(old, new)
+        adverse = drawing.lint(physical=False)
+        assert [issue.code for issue in adverse] == ["annotation_overlap"]
+        assert len(adverse) < len(before)
+        assert compare_measurements(measurements, drawing)["status"] == "preserved"
+    finally:
+        drawing.items[:] = items
+        drawing.registry.restore(registry)
+
+    attempts = []
+
+    def adverse_choices(dimensions, **_options):
+        dimensions = list(dimensions)
+        assert "m_env_width" in {name for name, _ in dimensions}
+        attempts.append(True)
+        return [(name, candidate.get(name, item)) for name, item in dimensions]
+
+    monkeypatch.setattr(_common, "prevent_dimension_label_ink", adverse_choices)
+    drawing.repair()
+
+    # The candidate must actually be attempted: the old no-op repair cannot pass
+    # this rejection test merely by leaving the original drawing untouched.
+    assert attempts, "The bounded repair must evaluate the adverse shared-solver candidate"
+    assert len(drawing.items) == len(items)
+    assert all(a is b for a, b in zip(drawing.items, items, strict=True))
+    assert set(drawing.annotations()) == set(original)
+    assert all(drawing.get_annotation(name) is item for name, item in original.items())
+    assert drawing.registry.snapshot() == registry
+    assert {name: _geometry(item) for name, item in drawing.iter_annotations()} == geometry
+    assert compare_measurements(measurements, drawing)["status"] == "preserved"
+    assert drawing.lint(physical=False) == before

--- a/tests/test_issue_1466_semantic_sides.py
+++ b/tests/test_issue_1466_semantic_sides.py
@@ -52,9 +52,12 @@ def test_side_edit_clears_demonstrated_crossing_without_losing_measurements(grm0
     before, after = original["drawing"], edited["drawing"]
     before_issues = before.lint()
     assert any(
-        issue.code == "annotation_ink_overlap" and "⌀2.4 THRU" in issue.message
+        issue.code in {"annotation_overlap", "annotation_ink_overlap"}
+        and "⌀2.4 THRU" in issue.message
         for issue in before_issues
     ), "The fixture must exhibit the hole/location collision before editing"
+    # Bounded build-time repair can now clear the ink crossings while leaving
+    # the existing label overlap. The authored side edit must clear that too.
     assert before.scale == after.scale == 4
     assert not any(
         issue.code in {"annotation_overlap", "annotation_ink_overlap", "placement_unsatisfiable"}
@@ -107,7 +110,11 @@ def test_grm04_edit_preserves_measurement_meaning_under_shared_declaration(grm04
     after = build_drawing(
         original["part"], model=replace(model, authored_dimensions=requests), scale=4
     )
-    assert any(issue.code == "annotation_ink_overlap" for issue in before.lint())
+    assert any(
+        issue.code in {"annotation_overlap", "annotation_ink_overlap"}
+        and "⌀2.4 THRU" in issue.message
+        for issue in before.lint()
+    )
     assert not any(
         issue.code in {"annotation_overlap", "annotation_ink_overlap"} for issue in after.lint()
     )

--- a/tests/test_issue_916_pocket_leader.py
+++ b/tests/test_issue_916_pocket_leader.py
@@ -70,35 +70,11 @@ def test_pocket_rim_tip_is_axis_independent(rotation):
     # clears the page's dimensioning floor depends on which view it lands in: of the
     # orientations here only `x-depth` reports it. This test is about the leader's tip, so it
     # asserts the leader draws nothing wrong rather than pinning an orientation-dependent set.
-    # The `y-depth` orientation crosses a pair of location dimensions over each
-    # other's labels (#1321/#1332) — '50' 3.3 mm through '35', and '35' 3.2 mm back
-    # through '50'. Two obscured labels, two defects; rendered at 600 dpi and
-    # confirmed. Named rather than filtered by code, so this sheet cannot quietly
-    # accumulate a third crossing. `z-depth` and `x-depth` carry none, and the
-    # unrotated fixture above still asserts a wholly clean sheet.
-    known = {("50", "35"), ("35", "50")} if pocket.depth_axis == "y" else set()
-
-    def _pair(issue):
-        for crosser, crossed in known:
-            if (
-                f"'{crosser}' draws" in issue.message
-                and f"through the label '{crossed}'" in issue.message
-            ):
-                return (crosser, crossed)
-        return None
-
-    crossings = [i for i in dwg.lint() if i.code == "annotation_ink_overlap"]
-    unexpected = [
-        issue
-        for issue in dwg.lint()
-        if issue.code not in {"step_dim_withheld", "annotation_ink_overlap"}
-    ]
+    # #1333's shared repair now clears the y-depth 35/50 dimension crossings;
+    # its own regression proves both crossings before repair and preservation
+    # afterwards. Keep this rim-target test strict: no crossing is exempt now.
+    unexpected = [issue for issue in dwg.lint() if issue.code != "step_dim_withheld"]
     assert [issue.code for issue in unexpected] == []
-    # An EXACT set, not `any(...)`. Two crossings in the SAME direction used to
-    # satisfy both this and the count below, so the test did not pin the "two
-    # obscured labels, one each way" claim its comment makes.
-    assert {_pair(i) for i in crossings} == known, [i.message for i in crossings]
-    assert len(crossings) == len(known)
 
 
 @pytest.mark.parametrize("axis", ["long", "width"], ids=["long-axis", "width-axis"])

--- a/tests/test_pitch_dim_footprint.py
+++ b/tests/test_pitch_dim_footprint.py
@@ -159,11 +159,12 @@ def test_grid_pitch_dim_constructions_bounded(monkeypatch):
     import draftwright._core as core
 
     pitch_builds = 0
+    assembling = False
     real_dimension = core.Dimension
 
     def counting_dimension(p1, p2, side, distance, draft, **kwargs):
         nonlocal pitch_builds
-        if "× " in (kwargs.get("label") or ""):
+        if assembling and "× " in (kwargs.get("label") or ""):
             pitch_builds += 1
         return real_dimension(p1, p2, side, distance, draft, **kwargs)
 
@@ -174,14 +175,20 @@ def test_grid_pitch_dim_constructions_bounded(monkeypatch):
     real_assemble = builder_mod._assemble
 
     def counting_assemble(*args, **kwargs):
-        nonlocal compiles
+        nonlocal compiles, assembling
         compiles += 1
-        return real_assemble(*args, **kwargs)
+        assembling = True
+        try:
+            return real_assemble(*args, **kwargs)
+        finally:
+            assembling = False
 
     monkeypatch.setattr(builder_mod, "_assemble", counting_assemble)
     monkeypatch.setattr(core, "Dimension", counting_dimension)
     dwg = build_drawing(_grid_plate())
 
+    # Count the initial placement phase this performance guard protects. #1333
+    # also uses bounded candidate construction during the separate repair pass.
     placed = [name for name, _ in dwg.iter_annotations() if name.startswith("dim_pitch_")]
     assert placed, "fixture no longer places pitch dims — the guard lost its subject"
     assert compiles >= 1


### PR DESCRIPTION
A rotated blind pocket places its 35 mm location dimension and 50 mm envelope dimension on the same line, obscuring both labels. `Drawing.repair()` now clears that demonstrated collision through the existing shared candidate solver while preserving the drawing's measurements and pins.

Repair tries one bounded batch of along-span choices and at most one existing typography-derived stacking tier. It accepts only a strict improvement with no increased lint-code/severity component, unchanged annotation membership and authored sides, and preserved confirmed measurement claims. It restores the original items and registry on rejection or a critique exception. Unknown measurement authority prevents a move; infeasible findings remain visible. At scale 2 the pocket improves from three crossings to one and remains unchanged on a second repair call.

Paul approved the proposed ADR 5 extension on 2026-09-07. The ADR now records that boundary and its guard tests. The other four ADRs remain unchanged: Drawing supplies the higher-ranked shared solver to repair; the model, requirements, views and recognition authority stay intact; declared repair performs no recognition. No new planner, coordinate-placement API or arbitrary suggestion execution is introduced.

The existing GRM04 side edit still clears its remaining hole/location label overlap after automatic repair removes two ink findings. The pocket rim-target test now requires zero crossings instead of retaining an obsolete allowance. The pitch-footprint construction test counts its original initial-placement phase; its unchanged budget still catches deliberate geometry probing (88 builds against a limit of nine).

Validation and iterative Google/ADR review:

- Full local preflight: **7,323 passed, 5 skipped, 14 expected failures**; **95.99% total coverage, 100% changed-line coverage** (55 executable lines). Ruff, formatting, mypy, codespell and strict documentation build pass.
- **46 focused checks pass on both Python 3.12/build123d 0.10 and Python 3.14/build123d 0.11**, including public repair, pins, altered witnesses/sides, missing membership, critique failure, zero budget, partial repair, declaration parity and existing side/rim/placement-budget integrations.
- **39 native builds on each kernel**: ten small corpus factories plus the rotated pocket, GRM04 STEP and tuner-jig STEP, each at requested scales 1, 2 and 4. Ink findings fall from 14 to 6 across four improved cases; no lint category worsens, changed drawings preserve their named measurements and all second repair calls are stable.
- **13 deliberate faults caught by named tests**: allowlist, tier, component veto, strict improvement, measurement preservation, pins, membership, both rollback halves, unknown authority, authored sides, witness endpoints and the footprint performance guard. Mutations ran in a verified source overlay, leaving the tested repository source intact.
- Public before/after SVG/PNG exports inspected. Iterative review covered design, functionality, complexity, tests, naming, comments, style, documentation and all five live ADRs; substantive findings were fixed and rechecked.

This is bounded dimension repair, not a promise that every collision can be removed. Named compiled measurements do not establish arbitrary physical completeness or leader-target correctness; the real-part canary and general target validation remain separate #1277 deliveries.

Closes #1333. Refs #1277, #1466.
