### PR TITLE
Fix the post-merge CTC-01 diagnostic expectation for Quiddity 0.2.4

### DIFF
--- a/tests/test_e2e_standards.py
+++ b/tests/test_e2e_standards.py
@@ -150,9 +150,37 @@ def test_ctc_ap203_exports_honest_diagnostic_no_degenerate_arcs(tmp_path, n):
     dxf = _p["dxf"]
     _assert_ctc_diagnostic_contract(dwg, svg, dxf, expect_incomplete=n != "01")
     if n == "01":
-        # Quiddity 0.2.2 reclassifies/refuses the former pockets. The smaller plan
-        # fits, but recognition gaps must remain visible; this is not completeness.
-        assert "section_recess_recognition_refused" in {issue.code for issue in dwg.lint()}
+        # Quiddity 0.2.4 recognises both complex blind pockets. Their 12- and
+        # 20-edge profiles remain outside the drafting grammar, so a fitting plan
+        # must still report both unsupported requirements, without inventing a
+        # provider refusal. These are fixture expectations, not a plan denominator.
+        recognition = dwg.recognition()
+        assert recognition is not None
+        assert recognition.section_recess_refusals == ()
+        pockets = [
+            recess
+            for recess in recognition.section_recesses
+            if recess.classification.feature_kind == "pocket"
+        ]
+        assert sorted(
+            (
+                len(pocket.geometry.profile.boundary),
+                pocket.geometry.run_interval[1] - pocket.geometry.run_interval[0],
+            )
+            for pocket in pockets
+        ) == [(12, 2.0), (20, 2.0)]
+        issues = dwg.lint()
+        assert not any(issue.code == "section_recess_recognition_refused" for issue in issues)
+        unsupported = [
+            issue for issue in issues if issue.code == "prismatic_pocket_requirement_unsupported"
+        ]
+        assert len(unsupported) == 2
+        assert all(issue.severity == "warning" for issue in unsupported)
+        for edges in (12, 20):
+            assert any(
+                f"recognised {edges}-sided blind prismatic recess 2 mm deep" in issue.message
+                for issue in unsupported
+            )
     # The #19 fix: no circle-edge-on degenerate arcs leak into the SVG.
     data = Path(svg).read_text(encoding="utf-8")
     degenerate = [


### PR DESCRIPTION
Main's post-merge CTC-01 AP203 test still requires a Quiddity 0.2.2 recognition refusal, so the slow suite fails after the 0.2.4 upgrade. The provider now recognises both complex pockets; this test instead requires their known 12- and 20-edge, 2 mm-deep profiles and two explicit unsupported-drafting warnings, and rejects a fabricated provider refusal. The existing build and export checks remain intact.

Reproduced in main CI runs [34068352250](https://github.com/pzfreo/draftwright/actions/runs/34068352250) and [34071637687](https://github.com/pzfreo/draftwright/actions/runs/34071637687). The corrected named build/lint/SVG/DXF test passes on Python 3.12/build123d 0.10 and Python 3.14/build123d 0.11. Deliberately removing one unsupported-pocket diagnostic makes that test fail at the new two-diagnostic assertion; the mutation was restored. Full static checks pass.

Local review followed [Google's checklist](https://google.github.io/eng-practices/review/reviewer/looking-for.html) and ADRs 1–5, with no substantive findings remaining. This changes only the existing regression: no pipeline, placement, recognition, declaration or ADR changes. Fixture expectations come from the known source profiles, and unsupported requirements remain visible without claiming the drawing is complete. The #827 semantic PR canary remains separate outstanding work.

Refs #1485, #1277.
