### PR TITLE
test: gate PRs on real-part annotation survival

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,28 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+  test-real-part-canary:
+    # One real STEP build checks fixed occurrence/measurement expectations and exports
+    # before merge (#827). Linux/Python 3.12 matches the post-merge slow-suite kernel;
+    # the compatibility matrix covers the other supported Python/kernel resolutions.
+    # Run once, outside that matrix. The test has a 120 s execution budget; this
+    # job limit also bounds installation and a native-kernel hang.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          python-version: "3.12"
+      - name: Install dependencies
+        run: uv sync --group dev
+      - name: Check real-part semantics and production exports
+        run: uv run pytest tests/test_issue_827_real_part_canary.py -m real_part_canary -v -s --durations=1
+
   test-slow:
     # Heavy end-to-end CTC fixture builds (minutes each); run once, not across
     # the full OS/Python matrix.
@@ -264,7 +286,7 @@ jobs:
     # skips this job, and GitHub counts a skipped required check as satisfied — so a
     # broken test suite would report a green gate.
     if: always()
-    needs: [lint, test, coverage, test-slow, test-platform-canary]
+    needs: [lint, test, coverage, test-slow, test-platform-canary, test-real-part-canary]
     runs-on: ubuntu-latest
     permissions:
       statuses: write # Attach the dispatched post-release gate to its generated PR head.
@@ -277,8 +299,9 @@ jobs:
           COVERAGE: ${{ needs.coverage.result }}
           SLOW: ${{ needs.test-slow.result }}
           CANARY: ${{ needs.test-platform-canary.result }}
+          REAL_PART: ${{ needs.test-real-part-canary.result }}
         run: |
-          echo "lint=$LINT test=$TEST coverage=$COVERAGE slow=$SLOW canary=$CANARY"
+          echo "lint=$LINT test=$TEST coverage=$COVERAGE slow=$SLOW canary=$CANARY real-part=$REAL_PART"
           failed=0
           for pair in "lint:$LINT" "test:$TEST" "coverage:$COVERAGE" "canary:$CANARY"; do
             name=${pair%%:*}
@@ -302,6 +325,16 @@ jobs:
             fi
           elif [[ "$SLOW" != "skipped" ]]; then
             echo "::error::slow ran unexpectedly for $EVENT_NAME (result: $SLOW)"
+            failed=1
+          fi
+          # A skipped PR canary must not silently satisfy this required check.
+          if [[ "$EVENT_NAME" == "pull_request" ]]; then
+            if [[ "$REAL_PART" != "success" ]]; then
+              echo "::error::real-part canary did not pass (result: $REAL_PART)"
+              failed=1
+            fi
+          elif [[ "$REAL_PART" != "skipped" ]]; then
+            echo "::error::real-part canary ran unexpectedly for $EVENT_NAME (result: $REAL_PART)"
             failed=1
           fi
           exit $failed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,7 +157,8 @@ checks. Target is 100% passing. Tiers (#153):
   class/module scope grouping with `loadscope`. The tier grows with every
   trust fix; a critique-style test should share a module-scoped built drawing,
   not mint a new dense fixture.
-- **`-m slow`** (CTC fixture builds) — CI-only.
+- **`-m slow`** (integration builds, including CTC fixtures) — full tier in post-merge CI.
+  The bounded `-m real_part_canary` tuner STEP test also runs once before merge (#827).
 
 For reproducible build-cost profiling, use a fresh output directory and state the expected
 collection census explicitly:
@@ -174,10 +175,11 @@ records pytest phases of at least 5 ms for attribution. Do not reuse an output d
 already contains worker profiles.
 
 Coverage is kept out of the default addopts (it adds ~13% locally); the CI
-workflow passes the `--cov` flags. CI runs the full fast tier (3×3 OS/Python
-matrix, parallelised with `-n auto`) on every PR; the **slow tier runs post-merge
-on `main`**, not as a PR gate (#153) — a regression there is caught right after
-merge rather than blocking every PR for ~19 min.
+workflow passes the `--cov` flags. Each PR runs the full fast tier on Linux across
+supported Python versions, plus smaller macOS/Windows platform canaries. One
+real-part canary checks fixed tuner-fixture measurements and exports before merge;
+the **full slow tier runs post-merge on `main`** (#153, #827). The wider platform
+matrix remains available weekly, manually, or with the `full-matrix` PR label.
 
 ## Working practices — evidence, not confidence
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,29 @@ tiers and the architecture overview, and `docs/adr/` for the design decisions
 behind layout, scaling, and annotation placement — please read the relevant ADRs
 before changing those areas.
 
+### Real-part PR canary
+
+Every pull request builds `tests/fixtures/tuner_jig_blind_obround_pockets.step`
+once on Linux/Python 3.12, matching the post-merge integration kernel. This common
+part exposed annotation losses during the Quiddity migration: five rounded
+pockets, their grouped dimensions, pitch, distinct X/Y locations, and twenty
+corner radii give useful coverage in a small fixture. The test checks fixed
+geometry and measurement expectations, exact occurrence/member ownership,
+expected lint, and valid SVG/DXF exports. It does not snapshot layout bytes or
+derive completeness solely from whichever features recognition returns.
+
+Run it locally with:
+
+```
+uv run pytest tests/test_issue_827_real_part_canary.py -m real_part_canary -v -s --durations=1
+```
+
+The test has a 120-second execution budget and prints its build/audit/export
+runtime. The hosted job has a separate ten-minute limit including setup. Its
+result must be successful before merge; a skipped result fails the aggregate
+gate. The test also belongs to `slow`, so the default fast matrix excludes it
+and the full post-merge integration suite retains it.
+
 ### Coverage
 
 CI measures line and branch coverage on the full fast tier and enforces the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,13 +81,15 @@ include = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 timeout = 300
-# `slow` covers the heavy end-to-end builds over the large NIST CTC fixtures
+# `slow` covers end-to-end integration builds, including the large NIST CTC fixtures
 # (minutes each), deselected by default. `smoke` is a curated, build-light subset
 # (~30 s) for a quick local "did I break something obvious" check — run it with
 # `uv run pytest -m smoke`. The default run is the full fast tier (`-m 'not slow'`,
-# ~8 min); CI owns that plus the slow tier across the OS/Python matrix.
+# runtime depends on worker count). CI runs one real-part canary before merge,
+# the full slow tier after merge, and the fast tier across its compatibility matrix.
 markers = [
-    "slow: heavy end-to-end CTC fixture builds (deselected by default)",
+    "slow: end-to-end integration builds, including CTC fixtures (deselected by default)",
+    "real_part_canary: bounded real STEP semantic/export gate, selected once in PR CI",
     "smoke: curated build-light subset for a fast local check (~30 s)",
     "unit: pure-logic inner-loop tier — constructs NO OCC geometry (enforced by conftest, #656)",
 ]

--- a/tests/test_issue_827_real_part_canary.py
+++ b/tests/test_issue_827_real_part_canary.py
@@ -1,0 +1,143 @@
+"""A fixed semantic denominator for the restored five-pocket tuner STEP fixture.
+
+Selected once in PR CI, and retained in the post-merge integration tier. The
+expected geometry and measurements are fixture facts, not a count of whatever
+the current detector happened to return. Export success alone cannot pass this.
+"""
+
+import xml.etree.ElementTree as ET
+from collections import Counter
+from pathlib import Path
+from time import monotonic
+
+import ezdxf
+import pytest
+
+from draftwright import build_drawing
+
+pytestmark = [pytest.mark.slow, pytest.mark.real_part_canary, pytest.mark.timeout(120)]
+FIXTURE = Path(__file__).parent / "fixtures/tuner_jig_blind_obround_pockets.step"
+CENTRES_Y = (21.2, 48.4, 75.6, 102.8, 130.0)
+
+
+def test_tuner_retains_occurrences_and_measurements_through_export(tmp_path):
+    start = monotonic()
+    drawing = build_drawing(FIXTURE)
+    (pattern,) = [f for f in drawing.model().features if f.kind == "pocket_pattern"]
+    assert pattern.count == 5 and len(pattern.members) == 5
+    assert sorted(point[1] for point in pattern.members) == pytest.approx(CENTRES_Y)
+    assert all((point[0], point[2]) == pytest.approx((-5, 8.5)) for point in pattern.members)
+    assert (
+        pattern.member.width,
+        pattern.member.length,
+        pattern.member.depth,
+        pattern.member.corner_radius,
+        pattern.pitch,
+    ) == pytest.approx((7.9, 13.6, 19, 3.94, 27.2))
+
+    sources = drawing.recognition().section_recesses
+    assert len(sources) == 5 and drawing.recognition().section_recess_refusals == ()
+    ownership = drawing.recognition_ownership()
+    refs = [
+        ref
+        for ref in ownership.evidence.features
+        if any(ownership.evidence.record(ref) is source for source in sources)
+    ]
+    assert len(refs) == 5
+    bindings = [ownership.binding_for(ref) for ref in refs]
+    assert all(binding is not None and binding.feature is pattern for binding in bindings)
+    assert {binding.member_index for binding in bindings} == set(range(5))
+    for ref, binding in zip(refs, bindings, strict=True):
+        source = ownership.evidence.record(ref)
+        assert pattern.members[binding.member_index][1] == pytest.approx(
+            source.geometry.frame.origin[1]
+        )
+
+    snapshot = drawing.measurement_snapshot()
+    assert not snapshot.unknown
+    for parameter, value in [
+        ("pocket_width.length", 7.9),
+        ("pocket_length.length", 13.6),
+        ("pocket_depth.length", 19),
+        ("pitch.length", 27.2),
+    ]:
+        claims = [c for c in snapshot.claims if c.owner is pattern and c.parameter == parameter]
+        assert len(claims) == 1, ("missing critical pattern measurement", parameter)
+        assert len(claims[0].meaning) == 1 and claims[0].meaning[0][0] == pytest.approx(value)
+        expected_text = "4× 27.2" if parameter == "pitch.length" else "5× 7.9 × 13.6 × 19 DEEP"
+        assert claims[0].rendered[0] == expected_text
+
+    locations = [
+        c
+        for c in snapshot.claims
+        if c.owner is pattern and c.parameter == "location_pocket_pattern.location"
+    ]
+    assert len(locations) == 2
+    expected = {
+        "location_pocket_pattern.location.x": 10.0,
+        "location_pocket_pattern.location.y": 83.6,
+    }
+    observed = set()
+    for claim in locations:
+        _, components = claim.witnesses
+        assert len(components) == 1
+        component, at = components[0]
+        assert component in expected and component not in observed
+        observed.add(component)
+        assert at == pytest.approx((-5, 75.6, 8.5))
+        assert float(claim.rendered[0]) == pytest.approx(expected[component]), (
+            "location value substituted",
+            component,
+        )
+        assert claim.rendered[2] == pytest.approx(expected[component]), (
+            "location path substituted",
+            component,
+        )
+    assert observed == expected.keys()
+
+    # Every rounded corner also needs its radius; losing the whole family must
+    # fail even if recognition-relative completeness and lint both look clean.
+    blends = [f for f in drawing.model().features if f.kind == "blend"]
+    assert len(blends) == 20 and all(f.radius == pytest.approx(3.94) for f in blends)
+    for blend in blends:
+        (claim,) = [
+            c for c in snapshot.claims if c.owner is blend and c.parameter == "blend.radius"
+        ]
+        assert claim.meaning[0][0] == pytest.approx(3.94)
+        assert claim.rendered[0] == "20× R3.9"
+
+    report = drawing.report()["recognition"]
+    occurrences = [r for r in report["occurrences"] if r["family"] == "section_recesses"]
+    assert len(occurrences) == 5
+    assert sorted(
+        r["record"]["geometry"]["frame"]["origin"][1] for r in occurrences
+    ) == pytest.approx(CENTRES_Y)
+    ids = {r["id"] for r in occurrences}
+    assert len(ids) == 5
+    assert all(
+        r["disposition"] == "absorbed" and r["reason_code"] == "pocket_pattern_member"
+        for r in occurrences
+    )
+    requirements = [r for r in report["requirements"] if r["family"] == "pocket_patterns"]
+    assert len(requirements) == 7
+    assert {r["parameter_id"] for r in requirements} == {
+        "grouping.count",
+        "pocket_width.length",
+        "pocket_length.length",
+        "pocket_depth.length",
+        "pitch.length",
+        "location_pocket_pattern.location.x",
+        "location_pocket_pattern.location.y",
+    }
+    assert all(r["state"] == "placed" and set(r["occurrence_ids"]) == ids for r in requirements)
+    assert Counter(issue.code for issue in drawing.lint()) == {"step_dim_withheld": 1}
+
+    paths = drawing.export(str(tmp_path / "tuner"), formats=("svg", "dxf"))
+    svg = ET.parse(paths["svg"]).getroot()
+    assert svg.tag == "{http://www.w3.org/2000/svg}svg"
+    assert svg.findall(".//{http://www.w3.org/2000/svg}path")
+    dxf = ezdxf.readfile(paths["dxf"])
+    assert not dxf.audit().has_errors and len(dxf.modelspace()) > 0
+    print(
+        f"Tuner real-part canary: {monotonic() - start:.2f}s for build, semantic audit and exports"
+    )

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -250,12 +250,52 @@ def test_aggregate_gate_waits_for_slow_and_requires_success_on_main(event_name, 
             "COVERAGE": coverage,
             "SLOW": slow,
             "CANARY": canary,
+            "REAL_PART": "success" if event_name == "pull_request" else "skipped",
         },
         check=False,
         capture_output=True,
         text=True,
     )
     assert (completed.returncode == 0) is passes, completed.stdout + completed.stderr
+
+
+@pytest.mark.parametrize("result", ["success", "failure", "cancelled", "skipped", ""])
+def test_real_part_canary_requires_actual_success_before_merge(result):
+    gate = _job(_workflow("ci.yml"), "ci-ok")
+    assert "test-real-part-canary" in _needs(gate)
+    assert "if: always()" in gate
+    assert "REAL_PART: ${{ needs.test-real-part-canary.result }}" in gate
+    completed = subprocess.run(
+        [_bash(), "-eu", "-o", "pipefail", "-c", _literal_run(gate)],
+        env={
+            **os.environ,
+            "EVENT_NAME": "pull_request",
+            "LINT": "success",
+            "TEST": "success",
+            "COVERAGE": "success",
+            "SLOW": "skipped",
+            "CANARY": "success",
+            "REAL_PART": result,
+        },
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert (completed.returncode == 0) is (result == "success"), (
+        completed.stdout + completed.stderr
+    )
+
+
+def test_real_part_canary_runs_once_with_an_execution_budget():
+    job = _job(_workflow("ci.yml"), "test-real-part-canary")
+    assert "if: github.event_name == 'pull_request'" in job
+    assert "runs-on: ubuntu-latest" in job and 'python-version: "3.12"' in job
+    assert "matrix:" not in job and "continue-on-error:" not in job
+    assert "timeout-minutes: 10" in job
+    assert (
+        "run: uv run pytest tests/test_issue_827_real_part_canary.py "
+        "-m real_part_canary -v -s --durations=1"
+    ) in job
 
 
 def test_project_coverage_allows_only_a_small_refactor_fluctuation():


### PR DESCRIPTION
Pull requests currently miss the real-part integration tier, allowing annotation losses to reach main. Add one tuner STEP canary that requires the five supported pockets, twenty corner radii, grouped dimensions, pitch and distinct X/Y location measurements to survive the production build, lint and SVG/DXF export path.

The canary uses fixed fixture expectations and exact occurrence/member ownership. Removing its grouped pocket callout or swapping the actual 10/83.6 location labels makes the named test fail before lint/export can mask the loss. A dedicated Linux/Python 3.12 job matches the post-merge integration kernel and runs once per PR. `ci-ok` requires actual success; failed, cancelled, skipped and missing results cannot pass. The full post-merge slow suite retains this test.

Validation:
- Canary passes locally on Python 3.14 and 3.12 (both supported kernel resolutions).
- 29 workflow tests pass; deliberately admitting skipped/missing canary results fails the named gate tests.
- Removed-callout and same-kind location-substitution mutations both fail the named real-part canary for the expected semantic reason.
- Full local preflight passes: 7329 passed, 5 skipped, 14 xfailed in 5m24; 95.99% total coverage. Ruff, formatting, mypy, codespell and strict documentation build pass. The [hosted Linux/Python 3.12 canary](https://github.com/pzfreo/draftwright/actions/runs/34089219334/job/101639139489) passed: 7.67 seconds for the test call, 16.23 seconds for pytest, and 31 seconds for the complete job.

Google review: iterative self-review of design, functionality, complexity, tests, naming, comments, style and documentation; no independent reviewer is claimed. ADR 1 uses the public one-engine build surface; ADR 2 preserves shared placement and avoids byte/layout snapshots; ADR 3 verifies existing exact occurrence bindings; ADR 4 changes no declared intent or compiler boundary; ADR 5 adds a fixed semantic denominator and demonstrated loss/substitution failures. No ADR amendment.

The test budget is 120 seconds and the whole job is capped at ten minutes. The measured hosted run is within both bounds.

Closes #827. Refs #1277 and #1485.
