### PR TITLE
fix: keep diameter leaders on physical targets and verify their authority

### DIFF
--- a/docs/multi-feature-object-reference-workflow.md
+++ b/docs/multi-feature-object-reference-workflow.md
@@ -184,7 +184,7 @@ Measured from the snippet above on 2026-09-05 (draftwright 0.4.x, `Sheet.build()
   `m_dia_x3` (the four turned diameters), `m_steplen0` (the journal's length), `hc_side0`
   (the `M2×0.4` tap callout, on the side view), `m_gdt0` (the `M3×0.5` note),
   `centerline_front`, `m_cm0`, `title_block` and `note_iso_nts`.
-- **Two `warning`-level lint notes, and no errors.** Both are correct reports about this
+- **Three `warning`-level lint notes, and no errors.** These report the limits of this
   deliberately-short example, not failures of the workflow:
 
   ```
@@ -194,6 +194,9 @@ Measured from the snippet above on 2026-09-05 (draftwright 0.4.x, `Sheet.build()
                               hole at (0.8, 0.0, 0.0) all 4 physical requirements, which
                               no IR feature claimed, cannot be joined to measurement
                               provenance without guessing
+  diameter_leader_target_unverifiable
+                              hc_side0: the diameter leader's physical boundary cannot
+                              be verified
   ```
 
   The first is the authored-set contract working: only one `step.length` was declared, so
@@ -205,7 +208,8 @@ Measured from the snippet above on 2026-09-05 (draftwright 0.4.x, `Sheet.build()
   a four-shoulder part 20 mm long. The second warning is explained under
   [Why `sheet.hole(features.tap)` works](#why-sheethofeatures-tap-works) below.
 
-  Neither of the two is an `error`. `plan_incomplete` is what an error looks like.
+  The third follows the same missing hole join: the declared tap leader's physical target
+  cannot be certified. None is an `error`. `plan_incomplete` is what an error looks like.
 
 ## Why `sheet.hole(features.tap)` works
 

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -70,10 +70,11 @@ issue. The contract test derives package record outputs, converter registries, l
 and emitter branches independently, so copying a new name into the declaration alone cannot make CI
 pass.
 
-### Quiddity 0.2.2 runtime contract
+### Quiddity 0.2.4 runtime contract
 
-[#1471](https://github.com/pzfreo/draftwright/issues/1471) moves production recognition to the
-published `quiddity==0.2.2` package. Its public `quiddity`, `quiddity.evidence` and
+[#1486](https://github.com/pzfreo/draftwright/pull/1486) adopts the published
+`quiddity==0.2.4` package after the migration in
+[#1471](https://github.com/pzfreo/draftwright/issues/1471). Its public `quiddity`, `quiddity.evidence` and
 `quiddity.inspection` surfaces supply recognition, exact occurrence evidence and declared geometry
 reads. There is one recognition aggregate per build; consumers project that result rather than
 calling the document builder to obtain another run.
@@ -87,8 +88,10 @@ builder is a serialization front door, not another feature family or a productio
 
 The shared adapter reads the published frame, profile, run interval and ends and lowers supported
 principal-axis geometry to the existing pocket, channel and blind-slot IR. It preserves the opening
-direction and edge anchoring and rejects malformed records. Unsupported profiles and sloped ends
-remain explicit unsupported outcomes; they receive no invented dimensions. Pattern members resolve
+direction and edge anchoring and rejects malformed records. Supported rounded rectangular pockets
+retain their corner radius, and supported cylindrical-mouth pockets carry maximum-depth intent
+rather than an invented uniform depth. Valid profiles and end shapes outside the drafting grammar
+remain explicit unsupported outcomes, including the two-plane passage cases. Pattern members resolve
 to the original records in the same aggregate before they share a drawing owner. Missing members,
 duplicate indices, cross-body grouping and inconsistent lattice geometry fail closed.
 
@@ -98,20 +101,24 @@ Recognition refusals retain source provenance and contribute an unsupported outc
 fabricated position. Report and inspection schema v2 name `producer.quiddity`; their v1 schemas
 remain available for existing documents.
 
-The 0.4.20 release includes these known Quiddity 0.2.2 limitations:
+The common-part restoration checks the five rounded tuner-jig pockets and their grouped callout,
+corner radii, pitch and absolute locations; pockets cut into cylindrical stock; and the pierced
+U-channel's supported channel measurements. Automatic recognition, declared input and executed
+Sheet scripts retain the supported recess facts. These checks do not turn a successfully rendered
+part into a completeness guarantee.
 
-- Some mixed line/arc and nested pockets, including the tuner-jig and dense #915 STEP fixtures,
-  are refused: [Quiddity #536](https://github.com/pzfreo/quiddity/issues/536).
-- Bores intersecting channel walls, floors or an edge-open recess can prevent recognition:
-  [Quiddity #538](https://github.com/pzfreo/quiddity/issues/538).
-- A pocket cut into cylindrical stock can be refused:
-  [Quiddity #541](https://github.com/pzfreo/quiddity/issues/541).
+The preceding Draftwright 0.4.20 / Quiddity 0.2.2 release documented annotation losses for mixed
+and nested pockets ([Quiddity #536](https://github.com/pzfreo/quiddity/issues/536)), bore-intersected
+or edge-open recesses ([#538](https://github.com/pzfreo/quiddity/issues/538)), and pockets in
+cylindrical stock ([#541](https://github.com/pzfreo/quiddity/issues/541)). Those historical limitations
+must not be used to excuse the common cases restored in #1486. Conversely, recognising more source
+profiles does not imply that every profile now has a supported drafting grammar. General complex
+pockets and nonuniform passages can still produce explicit unsupported requirements.
 
-These cases can lose automatic annotations that the previous provider emitted. Check recognition
-refusals and lint when using affected geometry. An explicit refusal makes the limitation visible;
-it does not establish drawing completeness. The regression cases remain in the suite as strict
-expected failures linked to the upstream issues. Other recognition, declaration, placement,
-reporting and coverage checks remain release gates.
+Check the source occurrence outcomes, placed requirements and lint for affected geometry.
+Regression expectations are reassessed per fixture: a restored supported case must pass, while an
+unsupported case must retain its truthful diagnostic rather than an approximate old annotation.
+Recognition, declaration, placement, reporting and coverage checks remain release gates.
 
 `bosses` remains a fully consumed reference family. `repeating-radial-profiles` remains geometry-only
 critique evidence for a separately authored gear declaration, with no inferred gear feature.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,6 @@ dev = [
     "pytest-split>=0.8",
     "pytest-timeout>=2",
     "pytest-xdist>=3",
-    # Released provider used by the migration parity tests; production remains on 0.4.14.
     "ruff>=0.4",
     "tomli>=2; python_version < '3.11'",
 ]

--- a/src/draftwright/_geometry.py
+++ b/src/draftwright/_geometry.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 from inspect import signature
 
-from build123d import Compound, GeomType, Shape
+from build123d import Compound, Edge, GeomType, Shape, Vector
 from quiddity import full_cylinders
 
 _log = logging.getLogger(__name__)
@@ -1229,3 +1229,24 @@ def _blend_profile_arcs(faces, radius):
         for edge in face.edges()
         if edge.geom_type != GeomType.LINE
     )
+
+
+def _projected_edge_distance(edge, tip, project):
+    """Distance from a page point's projection line to the actual trimmed OCC edge."""
+    origin = project(0, 0, 0)
+    basis = [project(*(1 if i == j else 0 for i in range(3))) for j in range(3)]
+    u = Vector(*(point[0] - origin[0] for point in basis))
+    v = Vector(*(point[1] - origin[1] for point in basis))
+    normal = u.cross(v).normalized()
+    centre = edge.center()
+    projected = project(*centre)
+    point = (
+        centre
+        + u * ((tip[0] - projected[0]) / u.dot(u))
+        + v * ((tip[1] - projected[1]) / v.dot(v))
+    )
+    # Curve length bounds the distance from its centre to any point on it and
+    # avoids recomputing physical bounding boxes on every repeated lint call.
+    reach = edge.length + 1
+    line = Edge.make_line(point - normal * reach, point + normal * reach)
+    return edge.distance_to(line)

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -2149,12 +2149,19 @@ def _leader_anchors(s, edge, side, y, to_page, elbow_dx, draft, scale):
     centre = to_page(rep)
     if side == "right":
         elbow = (edge + elbow_dx, y)
-        tip = _rim_tip(centre, elbow, dia, scale, callout=callout, location=rep, to_page=to_page)
-        tip = (min(tip[0], edge - draft.arrow_length), tip[1])
     else:
         elbow = (edge - elbow_dx, y)
-        tip = _rim_tip(centre, elbow, dia, scale, callout=callout, location=rep, to_page=to_page)
-        tip = (max(tip[0], edge + draft.arrow_length), tip[1])
+    # The native arrow builder needs room for its head before the shelf. Extend
+    # the elbow when necessary; moving the rim tip would falsify the target.
+    minimum = dia * scale / 2 + draft.arrow_length + draft.line_width
+    dy = elbow[1] - centre[1]
+    if math.hypot(elbow[0] - centre[0], dy) < minimum:
+        dx = math.sqrt(max(0.0, minimum * minimum - dy * dy))
+        elbow = (centre[0] + (dx if side == "right" else -dx), y)
+    # The target is the bore boundary, even when it lies near the strip edge.
+    # Moving one tip coordinate for arrow clearance detaches it from that boundary.
+    # Probe and placement judge the footprint of this same physical anchor.
+    tip = _rim_tip(centre, elbow, dia, scale, callout=callout, location=rep, to_page=to_page)
     return tip, elbow
 
 

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1003,8 +1003,8 @@ class Drawing:
 
         This experimental, read-only view is available for raw automatic recognition and
         after the first physical critique of a declared drawing. It is ``None`` before that
-        lazy critique, for a bare drawing, and for framed recognition while the provider lacks
-        a public framed-evidence contract. Draftwright never reruns recognition merely to fill
+        lazy critique, for a bare drawing, and for the framed path, which has not adopted
+        the provider's framed-evidence contract. Draftwright never reruns recognition merely to fill
         this value. The returned evidence borrows exact faces from the source part, so callers
         must not mutate that part while using the evidence view.
         """
@@ -4062,6 +4062,10 @@ class Drawing:
                 registry=self._registry,
                 omissions=self._build.omissions,
                 assembly=self.assembly,
+                project=self.at,
+                evidence=self._build.recognition_evidence,
+                ownership=self._build.recognition_ownership,
+                declared=self.model_declared,
             )
             issues += lint_channel_coverage(
                 working_part,

--- a/src/draftwright/linting/blend_coverage.py
+++ b/src/draftwright/linting/blend_coverage.py
@@ -6,10 +6,13 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Literal
 
-from build123d import Edge, Vector
 from quiddity import RecognitionResult
 
-from draftwright._geometry import _blend_profile_arcs, _straight_blend_faces
+from draftwright._geometry import (
+    _blend_profile_arcs,
+    _projected_edge_distance,
+    _straight_blend_faces,
+)
 from draftwright.blend_contract import (
     blend_provider_key,
     is_exact_blend_feature,
@@ -221,25 +224,6 @@ def lint_blend_coverage(
     return issues
 
 
-def _projected_arc_distance(edge, tip, project):
-    """Distance from a page point's projection line to the actual trimmed OCC edge."""
-    origin = project(0, 0, 0)
-    basis = [project(*(1 if i == j else 0 for i in range(3))) for j in range(3)]
-    u = Vector(*(point[0] - origin[0] for point in basis))
-    v = Vector(*(point[1] - origin[1] for point in basis))
-    normal = u.cross(v).normalized()
-    centre = edge.center()
-    projected = project(*centre)
-    point = (
-        centre
-        + u * ((tip[0] - projected[0]) / u.dot(u))
-        + v * ((tip[1] - projected[1]) / v.dot(v))
-    )
-    reach = edge.bounding_box().size.length + 1
-    line = Edge.make_line(point - normal * reach, point + normal * reach)
-    return edge.distance_to(line)
-
-
 def lint_blend_leader_targets(*, registry, cylinders, project, evidence=None, ownership=None):
     """Judge placed straight-Blend radius tips against their physical trimmed arcs.
 
@@ -297,7 +281,7 @@ def lint_blend_leader_targets(*, registry, cylinders, project, evidence=None, ow
             )
         elif (
             min(
-                _projected_arc_distance(edge, tip, lambda x, y, z: project(view, x, y, z))
+                _projected_edge_distance(edge, tip, lambda x, y, z: project(view, x, y, z))
                 for edge in arcs
             )
             > 2e-3

--- a/src/draftwright/linting/hole_coverage.py
+++ b/src/draftwright/linting/hole_coverage.py
@@ -15,7 +15,7 @@ from typing import Literal
 from quiddity import HoleSpec, RecognitionResult, countersink_matches_hole
 
 from draftwright._core import _decode_hole_location_fact
-from draftwright._geometry import _END_ON, _is_principal_axis
+from draftwright._geometry import _END_ON, _is_principal_axis, _projected_edge_distance
 from draftwright.linting._registry import satisfaction_ids
 from draftwright.linting.issues import (
     UNJOINED_PARAMETER_ID,
@@ -23,6 +23,7 @@ from draftwright.linting.issues import (
     is_placement_drop,
     requirement_subject,
 )
+from draftwright.linting.profiled_bore_coverage import profiled_bore_target_sources
 
 HoleRequirementState = Literal[
     "placed",
@@ -1146,6 +1147,112 @@ def hole_requirement_outcomes(
     return outcomes
 
 
+def lint_hole_leader_targets(
+    *,
+    registry,
+    outcomes,
+    project,
+    evidence=None,
+    ownership=None,
+    declared=False,
+    features=(),
+    recognition=None,
+):
+    """Check finished diameter tips against the named occurrence's trimmed physical edges.
+
+    Automatic builds use exact recorded ownership. Declared builds reuse the hole
+    requirement ledger's validated physical joins; geometry proximity never selects an owner.
+    """
+    source_owners: dict[int, dict[int, object]] = defaultdict(dict)
+    for outcome in outcomes:
+        for feature in outcome.features:
+            hole = getattr(feature, "member", feature)
+            for source in outcome.source_records:
+                sites = _members(source)
+                member_sites = _members(feature)
+                if (
+                    all(site in member_sites for site in sites)
+                    or (not hole.through)
+                    and source.depth is not None
+                    and all(
+                        site in member_sites
+                        for site in _tool_center_members(source, sites, source.depth)
+                    )
+                ):
+                    source_owners[id(feature)][id(source)] = source
+    valid_evidence = evidence is not None and getattr(evidence, "result", None) is recognition
+    if declared and valid_evidence:
+        for owner_id, sources in profiled_bore_target_sources(
+            features, evidence.result.double_d_bores
+        ).items():
+            source_owners[owner_id].update((id(source), source) for source in sources)
+    issues = []
+    for name in sorted(registry.names()):
+        measurements = registry.measurement_of(name)
+        if not any(m.parameter == "bore.diameter" for m in measurements):
+            continue
+        annotation = registry.named(name)
+        tip = getattr(annotation, "tip", None)
+        if tip is None:
+            continue
+        feature = registry.feature_of(name)
+        view = registry.view_of(name)
+        refs: tuple = ()
+        if (
+            valid_evidence
+            and view is not None
+            and any(m.feature is feature and m.parameter == "bore.diameter" for m in measurements)
+        ):
+            if ownership is not None:
+                if ownership.evidence is evidence:
+                    refs = tuple(
+                        binding.occurrence
+                        for binding in ownership.bindings
+                        if any(owner is feature for owner in binding.features)
+                        and evidence.family(binding.occurrence) in {"holes", "double_d_bores"}
+                    )
+            elif declared:
+                sources = source_owners.get(id(feature), {})
+                refs = tuple(
+                    ref
+                    for ref in evidence.features
+                    if sources.get(id(evidence.record(ref))) is evidence.record(ref)
+                )
+        edges = tuple(
+            edge
+            for ref in refs
+            for face in evidence.defining_faces(ref)
+            for edge in evidence.face(face).edges()
+        )
+        if not edges:
+            issues.append(
+                LintIssue(
+                    severity="warning",
+                    code="diameter_leader_target_unverifiable",
+                    message=f"{name}: the diameter leader's physical boundary cannot be verified",
+                    location=tip,
+                    measurement_ids=measurements,
+                )
+            )
+        elif (
+            min(
+                _projected_edge_distance(edge, tip, lambda x, y, z: project(view, x, y, z))
+                for edge in edges
+            )
+            > 2e-3
+        ):
+            issues.append(
+                LintIssue(
+                    severity="warning",
+                    code="diameter_leader_target_mismatch",
+                    message=f"{name}: the diameter leader tip does not touch its named physical boundary",
+                    location=tip,
+                    measurement_ids=measurements,
+                )
+            )
+    return issues
+
+
 def lint_hole_coverage(
     part,
     *,
@@ -1154,6 +1261,10 @@ def lint_hole_coverage(
     registry,
     omissions=(),
     assembly=None,
+    project=None,
+    evidence=None,
+    ownership=None,
+    declared=False,
 ) -> list[LintIssue]:
     """Report unaccounted hole requirements without duplicating explicit drop findings."""
     if assembly is None:
@@ -1165,7 +1276,8 @@ def lint_hole_coverage(
         "unverifiable": "cannot be joined to measurement provenance without guessing",
     }
     issues = []
-    for outcome in hole_requirement_outcomes(recognition, features, registry, omissions):
+    outcomes = hole_requirement_outcomes(recognition, features, registry, omissions)
+    for outcome in outcomes:
         if outcome.state in {"placed", "satisfied_by_structured_note", "dropped"}:
             continue
         noun = "hole" if outcome.source_kind == "hole" else f"{outcome.member_count}-hole pattern"
@@ -1177,5 +1289,16 @@ def lint_hole_coverage(
                     f"{noun} at {outcome.source_at} {requirement_subject(outcome, noun='requirement')} {messages[outcome.state]}"
                 ),
             )
+        )
+    if project is not None:
+        issues += lint_hole_leader_targets(
+            registry=registry,
+            outcomes=outcomes,
+            project=project,
+            evidence=evidence,
+            ownership=ownership,
+            declared=declared,
+            features=features,
+            recognition=recognition,
         )
     return issues

--- a/src/draftwright/linting/profiled_bore_coverage.py
+++ b/src/draftwright/linting/profiled_bore_coverage.py
@@ -13,7 +13,7 @@ from typing import Literal
 
 from quiddity import RecognitionResult
 
-from draftwright._geometry import _fmt
+from draftwright._geometry import _fmt, _is_principal_axis
 from draftwright.linting._registry import annotation_owner, satisfaction_ids
 from draftwright.linting.issues import LintIssue
 
@@ -44,29 +44,76 @@ def _canonical_direction(value) -> tuple[float, float, float]:
     return (clean[0], clean[1], clean[2])
 
 
-def profiled_bore_key(profile, axis, through, major, across, direction) -> tuple:
+def profiled_bore_key(profile, axis, through, major, across, direction, *, precision=3) -> tuple:
     """Canonical physical/callout identity for one double-D specification."""
     return (
         str(profile),
         _axis_letter(axis),
         bool(through),
-        round(float(major), 3),
-        round(float(across), 3),
+        round(float(major), precision),
+        round(float(across), precision),
         _canonical_direction(direction),
     )
 
 
-def _site(point, axis) -> tuple[float, float, float]:
+def _site(point, axis, *, precision=3) -> tuple[float, float, float]:
     """Physical profile site with the through-axis coordinate made irrelevant."""
-    result = [round(float(component), 3) for component in point]
+    result = [round(float(component), precision) for component in point]
     result["xyz".index(_axis_letter(axis))] = 0.0
     return (result[0], result[1], result[2])
 
 
-def _feature_sites(feature) -> tuple[tuple[float, float, float], ...]:
+def _feature_sites(feature, *, precision=3) -> tuple[tuple[float, float, float], ...]:
     members = tuple(getattr(feature, "members", ()) or ())
     points = members or (feature.frame.origin,)
-    return tuple(_site(point, feature.frame.axis) for point in points)
+    return tuple(_site(point, feature.frame.axis, precision=precision) for point in points)
+
+
+def profiled_bore_target_sources(features, records):
+    """Unambiguous declared owners at provider precision, for physical target checks."""
+    candidates = []
+    for feature in features:
+        if getattr(feature, "profile", None) != "double_d":
+            continue
+        key = profiled_bore_key(
+            feature.profile,
+            feature.frame.axis,
+            feature.through,
+            feature.diameter,
+            feature.across_flats,
+            feature.profile_direction,
+            precision=6,
+        )
+        sites = Counter(_feature_sites(feature, precision=6))
+        if sum(sites.values()) == feature.count:
+            candidates.append((feature, key, sites))
+    matches: dict[int, list] = {}
+    physical_sites: dict[int, Counter] = {}
+    for record in records:
+        if not _is_principal_axis(record.axis):
+            continue
+        key = profiled_bore_key(
+            "double_d",
+            record.axis,
+            record.through,
+            record.major_diameter,
+            record.across_flats,
+            record.flat_direction,
+            precision=6,
+        )
+        site = _site(record.location, record.axis, precision=6)
+        owners = [
+            feature for feature, expected, sites in candidates if key == expected and site in sites
+        ]
+        if len(owners) == 1:
+            owner_id = id(owners[0])
+            matches.setdefault(owner_id, []).append(record)
+            physical_sites.setdefault(owner_id, Counter())[site] += 1
+    return {
+        id(feature): tuple(matches[id(feature)])
+        for feature, _, sites in candidates
+        if physical_sites.get(id(feature)) == sites
+    }
 
 
 def _same_site(first, second) -> bool:

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -248,6 +248,8 @@ _FIDELITY_CODES = frozenset(
         "label_vs_measured",
         "radius_leader_target_mismatch",
         "radius_leader_target_unverifiable",
+        "diameter_leader_target_mismatch",
+        "diameter_leader_target_unverifiable",
         "declared_feature_absent",
         "gear_repeat_count_mismatch",
         "gear_axis_mismatch",

--- a/tests/test_issue_1357_framed_activation.py
+++ b/tests/test_issue_1357_framed_activation.py
@@ -226,4 +226,10 @@ def test_framed_off_axis_pattern_keeps_one_absolute_location_requirement():
         "location_pattern.location.centre.y",
         "location_pattern.location.centre.z",
     }
-    assert drawing.lint() == []
+    # The framed path preserves dimensional meaning but exposes no exact face/
+    # occurrence authority yet. Physical target lint must report that limitation.
+    assert drawing.recognition_evidence() is None
+    assert drawing.recognition_ownership() is None
+    (issue,) = drawing.lint()
+    assert issue.code == "diameter_leader_target_unverifiable"
+    assert issue.measurement_ids

--- a/tests/test_issue_1378_diameter_leader_targets.py
+++ b/tests/test_issue_1378_diameter_leader_targets.py
@@ -1,0 +1,205 @@
+"""Diameter leaders must touch the physical boundary of the hole they name."""
+
+from dataclasses import replace
+
+import pytest
+from build123d import Box, Cylinder, GeomType, Pos, Rot, Vertex
+
+from draftwright import build_drawing
+
+
+def _hole_leader(drawing):
+    (feature,) = [f for f in drawing.model().features if f.kind == "hole"]
+    (name,) = [
+        name
+        for name in drawing.annotations_of(feature)
+        if hasattr(drawing.get_annotation(name), "tip")
+    ]
+    return feature, name, drawing.get_annotation(name)
+
+
+def _physical_gap(drawing):
+    _, name, leader = _hole_leader(drawing)
+    view = drawing.view_of(name)
+    arcs = [
+        edge
+        for edge in drawing.working_part.edges()
+        if edge.geom_type == GeomType.CIRCLE and abs(edge.radius - 4) < 1e-6
+    ]
+    assert len(arcs) == 2, "fixture must have exactly the two bore rims"
+    distances = []
+    for arc in arcs:
+        centre = arc.arc_center
+        u = arc.position_at(0) - centre
+        v = arc.tangent_at(0) * arc.radius
+        c = drawing.at(view, *centre)
+        pu = drawing.at(view, *(centre + u))
+        pv = drawing.at(view, *(centre + v))
+        ux, uy = pu[0] - c[0], pu[1] - c[1]
+        vx, vy = pv[0] - c[0], pv[1] - c[1]
+        dx, dy = leader.tip[0] - c[0], leader.tip[1] - c[1]
+        determinant = ux * vy - uy * vx
+        assert abs(determinant) > 1e-6, "the diameter view must expose the bore rim"
+        point = (
+            centre
+            + u * ((dx * vy - dy * vx) / determinant)
+            + v * ((ux * dy - uy * dx) / determinant)
+        )
+        distances.append(arc.distance_to(Vertex(point)))
+    return min(distances)
+
+
+@pytest.mark.parametrize("margin", [1, 2])
+@pytest.mark.parametrize("scale", [1, 2, 4])
+def test_automatic_diameter_tip_stays_on_bore_rim_near_sheet_strip(margin, scale):
+    part = Box(20, 20, 5) - Pos(6 - margin, 0, 0) * Cylinder(4, 5)
+    drawing = build_drawing(part, scale=scale)
+    assert _physical_gap(drawing) < 1e-6
+    assert not [i for i in drawing.lint() if i.code.startswith("diameter_leader_target_")]
+
+
+@pytest.mark.parametrize("mode", ["declared", "live", "deferred"])
+@pytest.mark.parametrize("rotation", [(0, 0, 0), (0, 90, 0), (90, 0, 0)])
+def test_diameter_target_survives_declared_and_edit_paths(mode, rotation):
+    part = Rot(*rotation) * (Box(20, 20, 5) - Pos(5, 0, 0) * Cylinder(4, 5))
+    drawing = build_drawing(part, scale=2)
+    feature, _, _ = _hole_leader(drawing)
+    if mode == "declared":
+        drawing = build_drawing(drawing.working_part, model=drawing.model(), scale=2)
+    else:
+        drawing.drop(feature)
+        if mode == "live":
+            drawing.callout(feature)
+        else:
+            with drawing.deferred():
+                drawing.callout(feature)
+    assert _physical_gap(drawing) < 1e-6
+    assert not [i for i in drawing.lint() if i.code.startswith("diameter_leader_target_")]
+
+
+def test_lint_rejects_tip_in_blank_material_and_lowers_fidelity(monkeypatch):
+    drawing = build_drawing(Box(20, 20, 5) - Pos(5, 0, 0) * Cylinder(4, 5), scale=2)
+    _, name, leader = _hole_leader(drawing)
+    before = drawing.lint_summary()["quality"]["fidelity"]
+    tip = drawing.at(drawing.view_of(name), 8.65, 0, 0)
+    monkeypatch.setattr(
+        leader,
+        "location",
+        Pos(tip[0] - leader.tip[0], tip[1] - leader.tip[1], 0) * leader.location,
+    )
+    assert _physical_gap(drawing) == pytest.approx(0.35)
+    issues = [i for i in drawing.lint() if i.code == "diameter_leader_target_mismatch"]
+    assert len(issues) == 1 and name in issues[0].message
+    assert issues[0].measurement_ids == drawing.registry.measurement_of(name)
+    assert issues[0].location == leader.tip
+    after = drawing.lint_summary()["quality"]["fidelity"]
+    assert after["score"] < before["score"]
+    assert after["by_code"]["diameter_leader_target_mismatch"] == 1
+
+
+@pytest.mark.parametrize("withdraw", ["faces", "ownership", "foreign_evidence", "owner", "view"])
+def test_lint_requires_the_named_holes_physical_authority(monkeypatch, withdraw):
+    from draftwright.linting.hole_coverage import (
+        hole_requirement_outcomes,
+        lint_hole_leader_targets,
+    )
+
+    drawing = build_drawing(Box(20, 20, 5) - Pos(5, 0, 0) * Cylinder(4, 5), scale=2)
+    evidence = drawing.recognition_evidence()
+    kwargs = dict(
+        registry=drawing.registry,
+        outcomes=hole_requirement_outcomes(
+            drawing.recognition(), drawing.model().features, drawing.registry
+        ),
+        project=drawing.at,
+        evidence=evidence,
+        ownership=drawing.recognition_ownership(),
+        recognition=drawing.recognition(),
+    )
+    assert lint_hole_leader_targets(**kwargs) == []
+    if withdraw == "faces":
+        monkeypatch.setattr(type(evidence), "defining_faces", lambda *_: ())
+    elif withdraw == "ownership":
+        kwargs["ownership"] = None
+    elif withdraw == "foreign_evidence":
+        kwargs["evidence"] = object()
+    elif withdraw == "owner":
+        monkeypatch.setattr(drawing.registry, "feature_of", lambda *_: None)
+    else:
+        monkeypatch.setattr(drawing.registry, "view_of", lambda *_: None)
+    (issue,) = lint_hole_leader_targets(**kwargs)
+    assert issue.code == "diameter_leader_target_unverifiable"
+    assert issue.measurement_ids
+
+
+@pytest.mark.parametrize("declared", [False, True])
+def test_double_d_target_uses_trimmed_profile_including_flats(declared, monkeypatch):
+    part = Box(30, 30, 10) - (Cylinder(5, 20) & Box(7.2, 30, 20))
+    drawing = build_drawing(part)
+    if declared:
+        drawing = build_drawing(drawing.working_part, model=drawing.model())
+    feature, name, leader = _hole_leader(drawing)
+    assert feature.profile == "double_d" and feature.across_flats == 7.2
+    assert not [i for i in drawing.lint() if i.code.startswith("diameter_leader_target_")]
+    # The missing parent-circle portion is not a physical Double-D boundary.
+    tip = drawing.at(drawing.view_of(name), 5, 0, 0)
+    monkeypatch.setattr(
+        leader,
+        "location",
+        Pos(tip[0] - leader.tip[0], tip[1] - leader.tip[1], 0) * leader.location,
+    )
+    assert any(i.code == "diameter_leader_target_mismatch" for i in drawing.lint())
+
+
+def test_split_declared_holes_cannot_claim_the_other_members_rim(monkeypatch):
+    part = Box(50, 30, 5) - Pos(-10, 0, 0) * Cylinder(4, 5) - Pos(10, 0, 0) * Cylinder(4, 5)
+    automatic = build_drawing(part)
+    (group,) = [f for f in automatic.model().features if f.kind == "hole"]
+    assert group.count == 2
+    singles = [
+        replace(group, frame=replace(group.frame, origin=point), count=1, members=(point,))
+        for point in group.members
+    ]
+    model = replace(
+        automatic.model(),
+        features=tuple(f for f in automatic.model().features if f is not group) + tuple(singles),
+    )
+    drawing = build_drawing(automatic.working_part, model=model)
+    assert not [i for i in drawing.lint() if i.code.startswith("diameter_leader_target_")]
+    (name,) = [
+        n for n in drawing.annotations_of(singles[0]) if hasattr(drawing.get_annotation(n), "tip")
+    ]
+    leader = drawing.get_annotation(name)
+    other = singles[1].frame.origin
+    tip = drawing.at(drawing.view_of(name), other[0] + 4, other[1], other[2])
+    monkeypatch.setattr(
+        leader,
+        "location",
+        Pos(tip[0] - leader.tip[0], tip[1] - leader.tip[1], 0) * leader.location,
+    )
+    issues = [i for i in drawing.lint() if i.code == "diameter_leader_target_mismatch"]
+    assert len(issues) == 1 and name in issues[0].message
+
+
+@pytest.mark.parametrize(
+    "defect", ["diameter", "site", "axis", "duplicate_record", "duplicate_owner"]
+)
+def test_declared_profile_target_requires_precise_unique_physical_support(defect):
+    from draftwright.linting.profiled_bore_coverage import profiled_bore_target_sources
+
+    drawing = build_drawing(Box(30, 30, 10) - (Cylinder(5, 20) & Box(7.2, 30, 20)))
+    feature, _, _ = _hole_leader(drawing)
+    (record,) = drawing.recognition().double_d_bores
+    features, records = (feature,), (record,)
+    assert profiled_bore_target_sources(features, records) == {id(feature): records}
+    if defect == "diameter":
+        records = (replace(record, major_diameter=record.major_diameter + 0.0004),)
+    elif defect == "site":
+        records = (replace(record, location=(0.0004, *record.location[1:])),)
+    elif defect == "axis":
+        records = (replace(record, axis=(0.6, 0, 0.8)),)
+    elif defect == "duplicate_record":
+        records = (record, replace(record))
+    else:
+        features = (feature, replace(feature))
+    assert profiled_bore_target_sources(features, records) == {}

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4675,6 +4675,7 @@ class TestAutoHoleAnnotations:
         a = dwg._analysis
         plan_right = a.PV_X + (a.bb.max.X - a.cx) * a.SCALE
         arrow_len = dwg.draft.arrow_length
+        assert 2 * a.SCALE < arrow_len, "fixture must expose the old rim-clamp defect"
         old_corridor = 0.6 * a.DIM_PAD  # ≈ 10.8 mm — the old, oversized offset
         hc_plan_names = [n for n in dwg.annotations() if n.startswith("hc_plan")]
         assert hc_plan_names, "Expected at least one plan-view bore callout"
@@ -4688,10 +4689,12 @@ class TestAutoHoleAnnotations:
                 f"{name}: elbow x={ldr.elbow[0]:.3f} is too far from view "
                 f"(should be < plan_right + 0.6×DIM_PAD = {plan_right + old_corridor:.3f})"
             )
-            # Arrowhead must still sit inside the view.
-            assert ldr.tip[0] + arrow_len <= plan_right + 1e-6, (
-                f"{name}: arrowhead back at {ldr.tip[0] + arrow_len:.3f} "
-                f"exceeds plan_right={plan_right:.3f}"
+            # The bore has less edge margin than the arrow length. Its head may
+            # extend past the silhouette; clamping the tip instead puts it off
+            # the named rim (#1378). Preserve the compact elbow and real target.
+            centre = dwg.at("plan", 15, 0, 0)
+            assert math.hypot(ldr.tip[0] - centre[0], ldr.tip[1] - centre[1]) == pytest.approx(
+                3 * a.SCALE
             )
 
     @pytest.mark.timeout(60)

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -4254,7 +4254,11 @@ def test_the_object_reference_doc_example_actually_runs(tmp_path):
         for line in r.stdout.splitlines()
         if line.startswith(("info ", "warning ", "error "))
     )
-    assert findings == ["axial_length_missing", "hole_requirement_unverifiable"], findings
+    assert findings == [
+        "axial_length_missing",
+        "diameter_leader_target_unverifiable",
+        "hole_requirement_unverifiable",
+    ], findings
     assert not any(line.startswith("error ") for line in r.stdout.splitlines()), r.stdout
 
     # Everything the "What you should see" section promises, pinned against the real run.


### PR DESCRIPTION
A diameter leader near a part edge could be clamped off its bore rim while lint stayed clean. Keep the tip on the physical rim, extend an undersized elbow enough for the native arrow, and independently check finished diameter tips against the named occurrence's actual trimmed edges.

The check requires exact run evidence and ownership for automatic builds. Declared holes reuse the existing physical requirement joins with member-specific filtering; declared double-D profiles require precise, unique physical support. Radius and diameter lint share one geometry-distance helper. Misplaced and unverifiable targets carry measurement IDs and lower fidelity. Framed builds currently expose no face/occurrence authority, and the documentation's inconsistent through-tap/blind-hole declaration has no proven join; both retain explicit unverifiable findings.

A separate documentation commit refreshes the Quiddity 0.2.4 runtime contract for the restored common recess cases and retains the unsupported-profile limits. It changes no executable source, tests or parsed project configuration.

Validation:
- Full local Python 3.12 slow integration tier: **46 passed, 2 expected failures in 268.46 seconds**, including CTC AP203/AP242 exports and the real-part canary. Run against the published head `d87db28e`; worktree unchanged.
- Full local preflight: 7,358 passed, 5 skipped, 14 expected failures; 96.02% total coverage and 100% changed executable coverage (93 lines). All static and documentation gates pass.
- 29 new target cases cover physical rim contact, scales/axes, declared/live/deferred edits, wrong tips, missing authority, trimmed double-D profiles and cross-member substitutions. Python 3.12 also passes these and the former dense-table/fit short-arrow crash.
- Ten deliberate faults fail their named guards: distance, missing ownership, profile axis/owner/record/precision, short-arrow protection, rim clamp, repeated bounding boxes and wrong-member authority.
- Public SVG/PNG exported and PNG inspected; a generated STEP script executes with a correct physical tip and no target findings.

Iterative Google checklist review resolved seven initial full-suite failures, including a native short-arrow crash, cache overhead and an old test that required the erroneous rim clamp. Final self-review has no substantive findings; no independent reviewer is claimed. ADR 1 keeps state and module ranks; ADR 2 retains shared probe/render placement; ADR 3 reuses one inventory and exact authority; ADR 4 preserves declared intent and executable scripts; ADR 5 makes missing proof and wrong targets visible. No ADR amendment.

Closes #1378. Refs #1277 and #1466.

Parent #1492 merged as `61261aa7`. This PR now targets main at head `8af1bed3`, with auto-squash enabled. Branch protection required rebasing onto the parent squash commit; the complete source tree is unchanged from the tested `d87db28e`/`f1ddf8ba` candidate (`git diff --exit-code` passed). Required CI is running in [34092421299](https://github.com/pzfreo/draftwright/actions/runs/34092421299).
