### PR TITLE
Score provider damage on a chosen corpus subset, not every fixture

### DIFF
--- a/tests/_mutation_corpus.py
+++ b/tests/_mutation_corpus.py
@@ -1,0 +1,127 @@
+"""The smallest corpus subset that still exercises a provider mutation.
+
+The `weakening_provider_*` / `deleting_provider_*` tests damage the provider and assert
+that the benchmark's score falls. They read `detection` and `parameter_fidelity` only —
+never `downstream_usefulness`, `complete_cases` or `conformant_cases` — yet they scored
+every fixture in the family's corpus, and the drawing_consumer observer builds a full
+drawing per case. Measured on the groove corpus: 4.77 s to re-prove one direction across
+eight fixtures, of which 98% is `build_drawing`.
+
+Scoring two fixtures proves the same direction. What it must NOT do is prove it vacuously,
+so the subset is chosen rather than truncated, and chosen by TAG rather than by position:
+
+* **one negative case**, always. Without a fixture the family must NOT match,
+  `false_positives == 0` is satisfied by a corpus that cannot produce a false positive at
+  all, and `detection.recall == 1.0` is trivially true of nothing.
+
+  Which negative matters. Taking the first in file order picked `chamfer-plain-negative`
+  and `fillet-plain-negative` — plain blocks carrying no bevel geometry whatsoever — so a
+  recogniser mutated to accept any `overlapping-family` shape would still have scored
+  `false_positives == 0`. That is exactly the vacuity the negative is here to prevent, so
+  an `ambiguous` or `overlapping-family` negative is preferred: one that the family could
+  plausibly claim and must not. `_NO_CONFUSABLE_NEGATIVE` records the two corpora that
+  offer none, rather than letting the weaker choice pass unremarked.
+
+* **the positive expecting the most facts** (`BenchmarkCase.expected`), so the damaged
+  parameters are actually present to be scored. Ties are the norm — five positives tie in
+  pockets, six in polygonal-stock — so the tie is broken on `case_id`. Without that, the
+  exact ratios these tests assert would be pinned to JSON key order, and reformatting a
+  corpus file (touching no code) could silently re-point a test at different geometry.
+
+`assert_reduced_corpus_is_sound` is the precondition that keeps this honest: the same
+subset must score a clean 1.0. A subset that is already failing would let a damage
+assertion pass for the wrong reason. `reduced_baseline_fixture` builds the per-module
+fixture, so a new family adds a call rather than a tenth copy of the same body — the
+growth pattern `test_clone_budget.py` exists to stop.
+
+The full corpus is still scored in full by each module's `test_real_*_corpus_scores_*`,
+which is where the absolute per-family counts live.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+import pytest
+
+#: Corpora offering no `ambiguous` / `overlapping-family` negative, so the plain-block
+#: negative is the only one available. Their `false_positives == 0` assertions are
+#: correspondingly weaker, and adding a confusable negative fixture would strengthen them.
+_NO_CONFUSABLE_NEGATIVE = frozenset({"corpus-chamfers-v1.json", "corpus-turned-steps-v1.json"})
+
+#: Tags marking a negative the family could plausibly claim, and must not.
+_CONFUSABLE = ("ambiguous", "overlapping-family")
+
+
+def reduced_corpus(corpus):
+    """One confusable negative plus the fact-richest positive, chosen deterministically."""
+    negatives = [case for case in corpus.cases if "negative" in _tags(case)]
+    positives = [
+        case
+        for case in corpus.cases
+        if "positive" in _tags(case) and "negative" not in _tags(case)
+    ]
+    assert negatives, (
+        "no negative case: a corpus that cannot produce a false positive makes "
+        "`false_positives == 0` vacuous, so it cannot be reduced this way"
+    )
+    assert positives, "no positive case: `detection.recall` would be vacuous"
+
+    confusable = sorted(
+        (case for case in negatives if any(tag in _tags(case) for tag in _CONFUSABLE)),
+        key=lambda case: case.case_id,
+    )
+    negative = confusable[0] if confusable else sorted(negatives, key=lambda c: c.case_id)[0]
+
+    # `case_id` breaks the tie: `len(expected)` alone leaves the choice to JSON key order.
+    richest = max(positives, key=lambda case: (len(case.expected), case.case_id))
+    assert richest.expected, (
+        f"richest positive {richest.case_id!r} expects no facts, so parameter fidelity "
+        "would be scored over an empty denominator"
+    )
+    return replace(corpus, cases=(negative, richest))
+
+
+def _tags(case) -> tuple[str, ...]:
+    """The case's tags, which `load_corpus` joins into `classification`."""
+    return tuple(case.classification.split("+"))
+
+
+def assert_reduced_corpus_is_sound(evaluate, corpus) -> object:
+    """Score the subset CLEAN and require a perfect result; return it for denominators.
+
+    Every damage assertion in the module is relative to this. If the subset were already
+    imperfect, `score == 0.5` after damage could hold because the fixture was broken
+    rather than because the damage was detected.
+    """
+    clean = evaluate(reduced_corpus(corpus))
+    assert clean.detection.recall == 1.0, (
+        f"reduced corpus does not detect cleanly (recall {clean.detection.recall}); "
+        "damage assertions built on it would pass for the wrong reason"
+    )
+    assert clean.detection.false_positives == 0, (
+        f"reduced corpus false-positives cleanly ({clean.detection.false_positives})"
+    )
+    assert clean.parameter_fidelity.score == 1.0, (
+        f"reduced corpus scores {clean.parameter_fidelity.score} clean, not 1.0"
+    )
+    assert clean.parameter_fidelity.total > 0, "reduced corpus scores no parameters at all"
+    return clean
+
+
+def reduced_baseline_fixture(corpus_path):
+    """The per-module `reduced_baseline` fixture, as a call rather than a tenth copy.
+
+    Module scope, so the clean evaluation is paid once per module — note that under
+    `--dist worksteal` (which `scripts/pr-check --full` uses) xdist may distribute one
+    module across workers and set it up once per worker. CI runs `loadscope` and pays it
+    once.
+    """
+
+    @pytest.fixture(scope="module")
+    def reduced_baseline():
+        from draftwright.evaluation.step_analysis import evaluate_step_corpus, load_corpus
+
+        return assert_reduced_corpus_is_sound(evaluate_step_corpus, load_corpus(corpus_path))
+
+    return reduced_baseline

--- a/tests/test_issue_1370_countersink_completeness_evidence.py
+++ b/tests/test_issue_1370_countersink_completeness_evidence.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 
 import pytest
 from _evidence_contract import assert_missing_model_outcomes_fail_closed
+from _mutation_corpus import reduced_baseline_fixture, reduced_corpus
 from build123d import Box, Compound, Cone, Cylinder, Pos, import_step
 
 from draftwright.evaluation.step_analysis import (
@@ -19,6 +20,9 @@ from draftwright.evaluation.step_analysis import (
 )
 
 CORPUS = Path(__file__).parent / "fixtures" / "evaluation" / "corpus-countersinks-v1.json"
+
+#: Clean score of the subset the damage tests below use, asserted perfect.
+reduced_baseline = reduced_baseline_fixture(CORPUS)
 
 
 def _single_part():
@@ -472,7 +476,7 @@ def test_countersink_observer_fails_closed_when_build_or_recognition_is_unavaila
 
 @pytest.mark.parametrize("corruption", ["nonnumeric-location", "missing-axis"])
 def test_malformed_public_countersink_records_become_missed_instead_of_aborting(
-    monkeypatch, corruption: str
+    monkeypatch, corruption: str, reduced_baseline
 ) -> None:
     from draftwright.drawing import Drawing
 
@@ -500,9 +504,11 @@ def test_malformed_public_countersink_records_become_missed_instead_of_aborting(
     monkeypatch.setattr(Drawing, "recognition", with_malformed_record)
 
     assert _default_observers()["countersinks"](_single_part()) == ()
-    damaged = evaluate_step_corpus(load_corpus(CORPUS))
+    damaged = evaluate_step_corpus(reduced_corpus(load_corpus(CORPUS)))
     assert damaged.detection.matched == 0
-    assert damaged.detection.missed == 7
+    # Every seat that matched cleanly is now missed, stated against the clean subset
+    # rather than the full corpus's count of 7.
+    assert damaged.detection.missed == reduced_baseline.detection.matched
     assert damaged.detection.false_positives == 0
 
 

--- a/tests/test_issue_1370_hole_pattern_completeness_evidence.py
+++ b/tests/test_issue_1370_hole_pattern_completeness_evidence.py
@@ -327,6 +327,11 @@ def test_weakening_provider_arrangement_values_reduces_parameter_fidelity(monkey
         return replace(result, hole_patterns=tuple(changed))
 
     monkeypatch.setattr(analysis, "_result_from_evidence", weakened_patterns)
+    # NOT reduced. The damaged fraction here depends on which pattern kind each fixture
+    # carries — the mutation hits `pitch`, `row_pitch` or `diameter` — so the ratio is a
+    # property of the corpus composition, not of the damage. Measured: the full corpus
+    # scores 14/19 = 0.7368 and the reduced subset 4/6 = 0.6667, so reducing it would
+    # mean inventing a new expected number rather than restating the authored one.
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0

--- a/tests/test_issue_1371_flat_completeness_evidence.py
+++ b/tests/test_issue_1371_flat_completeness_evidence.py
@@ -9,6 +9,7 @@ from _evidence_contract import (
     assert_missing_model_outcomes_fail_closed,
     assert_observer_uses_one_build_owned_recognition,
 )
+from _mutation_corpus import reduced_baseline_fixture, reduced_corpus
 from build123d import Box, Cylinder, Pos, import_step
 
 from draftwright.evaluation.step_analysis import (
@@ -18,6 +19,10 @@ from draftwright.evaluation.step_analysis import (
 )
 
 CORPUS = Path(__file__).parent / "fixtures" / "evaluation" / "corpus-flats-v1.json"
+
+
+#: Clean score of the subset the damage tests below use, asserted perfect.
+reduced_baseline = reduced_baseline_fixture(CORPUS)
 
 
 def _double_d():
@@ -259,7 +264,9 @@ def test_deleting_provider_flats_cannot_shrink_the_independent_denominator(monke
     assert damaged.complete_cases < len(damaged.cases)
 
 
-def test_weakening_provider_across_values_reduces_parameter_fidelity(monkeypatch) -> None:
+def test_weakening_provider_across_values_reduces_parameter_fidelity(
+    monkeypatch, reduced_baseline
+) -> None:
     import draftwright.analysis as analysis
 
     original = analysis._result_from_evidence
@@ -270,10 +277,9 @@ def test_weakening_provider_across_values_reduces_parameter_fidelity(monkeypatch
         return replace(result, flats=flats)
 
     monkeypatch.setattr(analysis, "_result_from_evidence", weakened_flats)
-    damaged = evaluate_step_corpus(load_corpus(CORPUS))
+    damaged = evaluate_step_corpus(reduced_corpus(load_corpus(CORPUS)))
 
     assert damaged.detection.recall == 1.0
     assert damaged.detection.false_positives == 0
-    assert damaged.parameter_fidelity.passed == 18
-    assert damaged.parameter_fidelity.total == 27
+    assert damaged.parameter_fidelity.total == reduced_baseline.parameter_fidelity.total
     assert damaged.parameter_fidelity.score == 2 / 3

--- a/tests/test_issue_1371_polygonal_stock_completeness_evidence.py
+++ b/tests/test_issue_1371_polygonal_stock_completeness_evidence.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 
 import pytest
 from _evidence_contract import assert_observer_uses_one_build_owned_recognition
+from _mutation_corpus import reduced_baseline_fixture, reduced_corpus
 from build123d import Polygon, Pos, RegularPolygon, Rot, extrude, import_step
 
 from draftwright.evaluation.step_analysis import (
@@ -20,6 +21,10 @@ from draftwright.evaluation.step_analysis import (
 )
 
 CORPUS = Path(__file__).parent / "fixtures" / "evaluation" / "corpus-polygonal-stock-v1.json"
+
+
+#: Clean score of the subset the damage tests below use, asserted perfect.
+reduced_baseline = reduced_baseline_fixture(CORPUS)
 
 
 def _stock():
@@ -1082,7 +1087,9 @@ def test_deleting_provider_stock_cannot_shrink_the_independent_denominator(monke
 
 
 @pytest.mark.parametrize("parameter", ("side_count", "across_flats", "length", "flat_supports"))
-def test_weakening_provider_parameters_reduces_parameter_fidelity(monkeypatch, parameter) -> None:
+def test_weakening_provider_parameters_reduces_parameter_fidelity(
+    monkeypatch, parameter, reduced_baseline
+) -> None:
     import draftwright.analysis as analysis
 
     original = analysis._result_from_evidence
@@ -1127,11 +1134,11 @@ def test_weakening_provider_parameters_reduces_parameter_fidelity(monkeypatch, p
         return replace(result, polygonal_stock=tuple(values))
 
     monkeypatch.setattr(analysis, "_result_from_evidence", weakened)
-    damaged = evaluate_step_corpus(load_corpus(CORPUS))
+    damaged = evaluate_step_corpus(reduced_corpus(load_corpus(CORPUS)))
 
     assert damaged.detection.recall == 1.0
     assert damaged.detection.false_positives == 0
-    assert damaged.parameter_fidelity.total == 24
+    assert damaged.parameter_fidelity.total == reduced_baseline.parameter_fidelity.total
     assert damaged.parameter_fidelity.passed < damaged.parameter_fidelity.total
 
 
@@ -1163,6 +1170,9 @@ def test_constant_canonical_values_cannot_pass_the_varied_positive_oracle(monkey
         return replace(result, polygonal_stock=tuple(values))
 
     monkeypatch.setattr(analysis, "_result_from_evidence", hard_coded)
+    # NOT reduced: this oracle is about VARIATION across positives. A subset with one
+    # positive lets constant canonical values pass legitimately, so reducing it removes
+    # the very thing under test — it failed exactly that way when tried.
     damaged = evaluate_step_corpus(load_corpus(CORPUS))
 
     assert damaged.detection.recall == 1.0

--- a/tests/test_issue_1372_groove_completeness_evidence.py
+++ b/tests/test_issue_1372_groove_completeness_evidence.py
@@ -10,6 +10,7 @@ from _evidence_contract import (
     assert_missing_model_outcomes_fail_closed,
     assert_observer_uses_one_build_owned_recognition,
 )
+from _mutation_corpus import reduced_baseline_fixture, reduced_corpus
 from build123d import Align, Cylinder, Pos, import_step
 
 from draftwright.evaluation.step_analysis import (
@@ -19,6 +20,12 @@ from draftwright.evaluation.step_analysis import (
 )
 
 CORPUS = Path(__file__).parent / "fixtures" / "evaluation" / "corpus-grooves-v1.json"
+
+
+#: Clean score of the subset the damage tests below use, asserted perfect.
+reduced_baseline = reduced_baseline_fixture(CORPUS)
+
+
 _MIN = (Align.CENTER, Align.CENTER, Align.MIN)
 
 
@@ -596,7 +603,9 @@ def test_deleting_provider_grooves_cannot_shrink_independent_denominator(monkeyp
 
 
 @pytest.mark.parametrize("field", ("width", "diameter"))
-def test_weakening_provider_measurements_reduces_parameter_fidelity(monkeypatch, field) -> None:
+def test_weakening_provider_measurements_reduces_parameter_fidelity(
+    monkeypatch, field, reduced_baseline
+) -> None:
     import draftwright.analysis as analysis
 
     original = analysis._result_from_evidence
@@ -609,17 +618,20 @@ def test_weakening_provider_measurements_reduces_parameter_fidelity(monkeypatch,
         return replace(result, grooves=grooves)
 
     monkeypatch.setattr(analysis, "_result_from_evidence", weakened_grooves)
-    damaged = evaluate_step_corpus(load_corpus(CORPUS))
+    damaged = evaluate_step_corpus(reduced_corpus(load_corpus(CORPUS)))
 
     assert damaged.detection.recall == 1.0
     assert damaged.detection.false_positives == 0
-    assert damaged.parameter_fidelity.passed == 10
-    assert damaged.parameter_fidelity.total == 20
+    # The denominator may not shrink under damage, and half the parameters must fail:
+    # the authored 10-of-20 ratio, now stated against the subset's own clean total.
+    assert damaged.parameter_fidelity.total == reduced_baseline.parameter_fidelity.total
     assert damaged.parameter_fidelity.score == 0.5
 
 
 @pytest.mark.parametrize("field", ("axis", "at"))
-def test_weakening_provider_identity_reduces_detection_recall(monkeypatch, field) -> None:
+def test_weakening_provider_identity_reduces_detection_recall(
+    monkeypatch, field, reduced_baseline
+) -> None:
     import draftwright.analysis as analysis
 
     original = analysis._result_from_evidence
@@ -642,11 +654,13 @@ def test_weakening_provider_identity_reduces_detection_recall(monkeypatch, field
         return replace(result, grooves=values)
 
     monkeypatch.setattr(analysis, "_result_from_evidence", weakened_grooves)
-    damaged = evaluate_step_corpus(load_corpus(CORPUS))
+    damaged = evaluate_step_corpus(reduced_corpus(load_corpus(CORPUS)))
 
     assert damaged.detection.recall == 0.0
-    assert damaged.detection.missed == 10
-    assert damaged.detection.false_positives == 10
+    # Every groove that matched cleanly is now both missed and reported in the wrong
+    # place — stated against the clean run, not a full-corpus constant.
+    assert damaged.detection.missed == reduced_baseline.detection.matched
+    assert damaged.detection.false_positives == reduced_baseline.detection.matched
 
 
 def test_deleting_groove_declaration_cannot_shrink_quality_denominator() -> None:

--- a/tests/test_issue_1372_pad_completeness_evidence.py
+++ b/tests/test_issue_1372_pad_completeness_evidence.py
@@ -11,6 +11,7 @@ from _evidence_contract import (
     assert_missing_model_outcomes_fail_closed,
     assert_observer_uses_one_build_owned_recognition,
 )
+from _mutation_corpus import reduced_baseline_fixture, reduced_corpus
 from build123d import Align, Box, Location
 
 from draftwright.evaluation.step_analysis import (
@@ -24,6 +25,12 @@ from draftwright.evaluation.step_analysis import (
 )
 
 CORPUS = Path(__file__).parent / "fixtures" / "evaluation" / "corpus-rectangular-pads-v1.json"
+
+
+#: Clean score of the subset the damage tests below use, asserted perfect.
+reduced_baseline = reduced_baseline_fixture(CORPUS)
+
+
 _MIN = (Align.MIN, Align.MIN, Align.MIN)
 _PLANE_AXES = {"x": ("y", "z"), "y": ("z", "x"), "z": ("x", "y")}
 
@@ -696,7 +703,7 @@ def _weaken_parameter(pad, parameter: str):
 
 @pytest.mark.parametrize("parameter", ("width", "length", "height"))
 def test_weakening_provider_measurements_reduces_parameter_fidelity(
-    monkeypatch, parameter
+    monkeypatch, parameter, reduced_baseline
 ) -> None:
     import draftwright.analysis as analysis
 
@@ -710,16 +717,18 @@ def test_weakening_provider_measurements_reduces_parameter_fidelity(
         )
 
     monkeypatch.setattr(analysis, "_result_from_evidence", weakened_pads)
-    damaged = evaluate_step_corpus(load_corpus(CORPUS))
+    damaged = evaluate_step_corpus(reduced_corpus(load_corpus(CORPUS)))
 
     assert damaged.detection.recall == 1.0
     assert damaged.detection.false_positives == 0
-    assert damaged.parameter_fidelity.passed == 24
-    assert damaged.parameter_fidelity.total == 36
+    assert damaged.parameter_fidelity.score == 2 / 3
+    assert damaged.parameter_fidelity.total == reduced_baseline.parameter_fidelity.total
 
 
 @pytest.mark.parametrize("field", ("direction", "attachment"))
-def test_weakening_provider_identity_reduces_detection_recall(monkeypatch, field) -> None:
+def test_weakening_provider_identity_reduces_detection_recall(
+    monkeypatch, field, reduced_baseline
+) -> None:
     import draftwright.analysis as analysis
 
     original = analysis._result_from_evidence
@@ -744,11 +753,11 @@ def test_weakening_provider_identity_reduces_detection_recall(monkeypatch, field
         return replace(result, pads=tuple(values))
 
     monkeypatch.setattr(analysis, "_result_from_evidence", weakened_pads)
-    damaged = evaluate_step_corpus(load_corpus(CORPUS))
+    damaged = evaluate_step_corpus(reduced_corpus(load_corpus(CORPUS)))
 
     assert damaged.detection.recall == 0.0
-    assert damaged.detection.missed == 12
-    assert damaged.detection.false_positives == 12
+    assert damaged.detection.missed == reduced_baseline.detection.matched
+    assert damaged.detection.false_positives == reduced_baseline.detection.matched
 
 
 def test_deleting_pad_declaration_cannot_shrink_quality_denominator() -> None:

--- a/tests/test_issue_1372_pocket_completeness_evidence.py
+++ b/tests/test_issue_1372_pocket_completeness_evidence.py
@@ -10,6 +10,7 @@ from _evidence_contract import (
     assert_missing_model_outcomes_fail_closed,
     assert_observer_uses_one_build_owned_recognition,
 )
+from _mutation_corpus import reduced_baseline_fixture, reduced_corpus
 from build123d import Box, Pos, import_step
 
 from draftwright.evaluation.step_analysis import (
@@ -19,6 +20,10 @@ from draftwright.evaluation.step_analysis import (
 )
 
 CORPUS = Path(__file__).parent / "fixtures" / "evaluation" / "corpus-pockets-v1.json"
+
+
+#: Clean score of the subset the damage tests below use, asserted perfect.
+reduced_baseline = reduced_baseline_fixture(CORPUS)
 
 
 def _lone():
@@ -413,7 +418,9 @@ def test_deleting_provider_pockets_cannot_shrink_independent_denominator(monkeyp
     assert damaged.complete_cases < len(damaged.cases)
 
 
-def test_weakening_provider_widths_reduces_parameter_fidelity(monkeypatch) -> None:
+def test_weakening_provider_widths_reduces_parameter_fidelity(
+    monkeypatch, reduced_baseline
+) -> None:
     import draftwright.analysis as analysis
 
     original = analysis._result_from_evidence
@@ -464,12 +471,11 @@ def test_weakening_provider_widths_reduces_parameter_fidelity(monkeypatch) -> No
         return replace(result, section_recesses=tuple(changed))
 
     monkeypatch.setattr(analysis, "_result_from_evidence", weakened_pockets)
-    damaged = evaluate_step_corpus(load_corpus(CORPUS))
+    damaged = evaluate_step_corpus(reduced_corpus(load_corpus(CORPUS)))
 
     assert damaged.detection.recall == 1.0
     assert damaged.detection.false_positives == 0
-    assert damaged.parameter_fidelity.passed == 39
-    assert damaged.parameter_fidelity.total == 52
+    assert damaged.parameter_fidelity.total == reduced_baseline.parameter_fidelity.total
     assert damaged.parameter_fidelity.score == 0.75
 
 

--- a/tests/test_issue_1372_polygonal_boss_completeness_evidence.py
+++ b/tests/test_issue_1372_polygonal_boss_completeness_evidence.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 
 import pytest
 from _evidence_contract import assert_observer_uses_one_build_owned_recognition
+from _mutation_corpus import reduced_baseline_fixture, reduced_corpus
 from build123d import Align, Box, Pos, RegularPolygon, Rot, extrude, import_step
 
 from draftwright.evaluation.step_analysis import (
@@ -20,6 +21,12 @@ from draftwright.evaluation.step_analysis import (
 )
 
 CORPUS = Path(__file__).parent / "fixtures" / "evaluation" / "corpus-polygonal-bosses-v1.json"
+
+
+#: Clean score of the subset the damage tests below use, asserted perfect.
+reduced_baseline = reduced_baseline_fixture(CORPUS)
+
+
 _CENTER = (Align.CENTER, Align.CENTER, Align.CENTER)
 
 
@@ -682,7 +689,9 @@ def test_deleting_provider_bosses_cannot_shrink_the_independent_denominator(
     "parameter",
     ("side_count", "across_flats", "height", "flat_supports"),
 )
-def test_weakening_provider_parameters_reduces_parameter_fidelity(monkeypatch, parameter) -> None:
+def test_weakening_provider_parameters_reduces_parameter_fidelity(
+    monkeypatch, parameter, reduced_baseline
+) -> None:
     import draftwright.analysis as analysis
 
     original = analysis._result_from_evidence
@@ -754,11 +763,11 @@ def test_weakening_provider_parameters_reduces_parameter_fidelity(monkeypatch, p
         return replace(result, polygonal_bosses=tuple(values))
 
     monkeypatch.setattr(analysis, "_result_from_evidence", weakened)
-    damaged = evaluate_step_corpus(load_corpus(CORPUS))
+    damaged = evaluate_step_corpus(reduced_corpus(load_corpus(CORPUS)))
 
     assert damaged.detection.recall == 1.0
     assert damaged.detection.false_positives == 0
-    assert damaged.parameter_fidelity.total == 40
+    assert damaged.parameter_fidelity.total == reduced_baseline.parameter_fidelity.total
     assert damaged.parameter_fidelity.passed < damaged.parameter_fidelity.total
 
     if parameter == "side_count":
@@ -778,7 +787,9 @@ def test_weakening_provider_parameters_reduces_parameter_fidelity(monkeypatch, p
         assert quality["audited_score"] == 0.0
 
 
-def test_shifting_provider_identity_reduces_detection_recall(monkeypatch) -> None:
+def test_shifting_provider_identity_reduces_detection_recall(
+    monkeypatch, reduced_baseline
+) -> None:
     import draftwright.analysis as analysis
 
     original = analysis._result_from_evidence
@@ -804,11 +815,11 @@ def test_shifting_provider_identity_reduces_detection_recall(monkeypatch) -> Non
         return replace(result, polygonal_bosses=tuple(values))
 
     monkeypatch.setattr(analysis, "_result_from_evidence", shifted)
-    damaged = evaluate_step_corpus(load_corpus(CORPUS))
+    damaged = evaluate_step_corpus(reduced_corpus(load_corpus(CORPUS)))
 
     assert damaged.detection.recall == 0.0
-    assert damaged.detection.missed == 10
-    assert damaged.detection.false_positives == 10
+    assert damaged.detection.missed == reduced_baseline.detection.matched
+    assert damaged.detection.false_positives == reduced_baseline.detection.matched
 
 
 def test_deleting_declared_boss_cannot_shrink_quality_denominator() -> None:

--- a/tests/test_issue_1373_plate_completeness_evidence.py
+++ b/tests/test_issue_1373_plate_completeness_evidence.py
@@ -12,6 +12,7 @@ from _evidence_contract import (
     assert_missing_model_outcomes_fail_closed,
     assert_observer_uses_one_build_owned_recognition,
 )
+from _mutation_corpus import reduced_baseline_fixture, reduced_corpus
 from build123d import (
     Align,
     Box,
@@ -34,6 +35,12 @@ from draftwright.evaluation.step_analysis import (
 )
 
 CORPUS = Path(__file__).parent / "fixtures" / "evaluation" / "corpus-plates-v1.json"
+
+
+#: Clean score of the subset the damage tests below use, asserted perfect.
+reduced_baseline = reduced_baseline_fixture(CORPUS)
+
+
 _CENTER_MIN = (Align.CENTER, Align.CENTER, Align.MIN)
 
 
@@ -1313,7 +1320,7 @@ def test_malformed_provider_plate_cannot_pass_or_shrink_the_denominator(monkeypa
 
 
 def test_symmetric_provider_interval_damage_preserves_identity_but_loses_fidelity(
-    monkeypatch,
+    monkeypatch, reduced_baseline
 ) -> None:
     import draftwright.analysis as analysis
 
@@ -1327,15 +1334,17 @@ def test_symmetric_provider_interval_damage_preserves_identity_but_loses_fidelit
         return replace(result, plates=plates)
 
     monkeypatch.setattr(analysis, "_result_from_evidence", weakened)
-    damaged = evaluate_step_corpus(load_corpus(CORPUS))
+    damaged = evaluate_step_corpus(reduced_corpus(load_corpus(CORPUS)))
 
     assert damaged.detection.recall == 1.0
     assert damaged.detection.false_positives == 0
-    assert damaged.parameter_fidelity.passed == 0
-    assert damaged.parameter_fidelity.total == 20
+    assert damaged.parameter_fidelity.score == 0.0
+    assert damaged.parameter_fidelity.total == reduced_baseline.parameter_fidelity.total
 
 
-def test_shifting_provider_interval_reduces_detection_recall(monkeypatch) -> None:
+def test_shifting_provider_interval_reduces_detection_recall(
+    monkeypatch, reduced_baseline
+) -> None:
     import draftwright.analysis as analysis
 
     original = analysis._result_from_evidence
@@ -1348,15 +1357,17 @@ def test_shifting_provider_interval_reduces_detection_recall(monkeypatch) -> Non
         return replace(result, plates=plates)
 
     monkeypatch.setattr(analysis, "_result_from_evidence", shifted)
-    damaged = evaluate_step_corpus(load_corpus(CORPUS))
+    damaged = evaluate_step_corpus(reduced_corpus(load_corpus(CORPUS)))
 
     assert damaged.detection.recall == 0.0
-    assert damaged.detection.missed == 20
-    assert damaged.detection.false_positives == 20
+    assert damaged.detection.missed == reduced_baseline.detection.matched
+    assert damaged.detection.false_positives == reduced_baseline.detection.matched
 
 
 @pytest.mark.parametrize("field", ("u", "v"))
-def test_shifting_provider_transverse_witness_reduces_detection_recall(monkeypatch, field) -> None:
+def test_shifting_provider_transverse_witness_reduces_detection_recall(
+    monkeypatch, field, reduced_baseline
+) -> None:
     import draftwright.analysis as analysis
 
     original = analysis._result_from_evidence
@@ -1369,11 +1380,11 @@ def test_shifting_provider_transverse_witness_reduces_detection_recall(monkeypat
         return replace(result, plates=plates)
 
     monkeypatch.setattr(analysis, "_result_from_evidence", shifted)
-    damaged = evaluate_step_corpus(load_corpus(CORPUS))
+    damaged = evaluate_step_corpus(reduced_corpus(load_corpus(CORPUS)))
 
     assert damaged.detection.recall == 0.0
-    assert damaged.detection.missed == 20
-    assert damaged.detection.false_positives == 20
+    assert damaged.detection.missed == reduced_baseline.detection.matched
+    assert damaged.detection.false_positives == reduced_baseline.detection.matched
 
 
 def test_deleting_plate_declarations_cannot_shrink_quality_denominator() -> None:

--- a/tests/test_issue_1374_chamfer_completeness_evidence.py
+++ b/tests/test_issue_1374_chamfer_completeness_evidence.py
@@ -10,6 +10,7 @@ from _evidence_contract import (
     assert_missing_model_outcomes_fail_closed,
     assert_observer_uses_one_build_owned_recognition,
 )
+from _mutation_corpus import reduced_baseline_fixture, reduced_corpus
 from build123d import Axis, Box, Cylinder, GeomType, Pos, chamfer, import_step
 
 from draftwright.evaluation.step_analysis import (
@@ -20,6 +21,10 @@ from draftwright.evaluation.step_analysis import (
 )
 
 CORPUS = Path(__file__).parent / "fixtures" / "evaluation" / "corpus-chamfers-v1.json"
+
+
+#: Clean score of the subset the damage tests below use, asserted perfect.
+reduced_baseline = reduced_baseline_fixture(CORPUS)
 
 
 def _lone():
@@ -520,7 +525,9 @@ def test_deleting_provider_chamfers_cannot_shrink_independent_denominator(monkey
 
 
 @pytest.mark.parametrize("field", ["leg1", "leg2", "angle"])
-def test_weakening_provider_chamfer_parameters_reduces_fidelity(monkeypatch, field) -> None:
+def test_weakening_provider_chamfer_parameters_reduces_fidelity(
+    monkeypatch, field, reduced_baseline
+) -> None:
     import draftwright.analysis as analysis
 
     original = analysis._result_from_evidence
@@ -533,12 +540,12 @@ def test_weakening_provider_chamfer_parameters_reduces_fidelity(monkeypatch, fie
         return replace(result, chamfers=values)
 
     monkeypatch.setattr(analysis, "_result_from_evidence", weakened)
-    damaged = evaluate_step_corpus(load_corpus(CORPUS))
+    damaged = evaluate_step_corpus(reduced_corpus(load_corpus(CORPUS)))
 
     assert damaged.detection.recall == 1.0
     assert damaged.detection.false_positives == 0
-    assert damaged.parameter_fidelity.passed == 24
-    assert damaged.parameter_fidelity.total == 36
+    assert damaged.parameter_fidelity.score == 2 / 3
+    assert damaged.parameter_fidelity.total == reduced_baseline.parameter_fidelity.total
 
 
 def test_quality_summary_counts_chamfers_as_audited_requirements() -> None:

--- a/tests/test_issue_1374_fillet_completeness_evidence.py
+++ b/tests/test_issue_1374_fillet_completeness_evidence.py
@@ -10,6 +10,7 @@ from _evidence_contract import (
     assert_missing_model_outcomes_fail_closed,
     assert_observer_uses_one_build_owned_recognition,
 )
+from _mutation_corpus import reduced_baseline_fixture, reduced_corpus
 from build123d import Axis, Box, Cylinder, GeomType, Pos, fillet, import_step
 
 from draftwright.evaluation.step_analysis import (
@@ -20,6 +21,10 @@ from draftwright.evaluation.step_analysis import (
 )
 
 CORPUS = Path(__file__).parent / "fixtures" / "evaluation" / "corpus-fillets-v1.json"
+
+
+#: Clean score of the subset the damage tests below use, asserted perfect.
+reduced_baseline = reduced_baseline_fixture(CORPUS)
 
 
 def _lone():
@@ -490,7 +495,7 @@ def test_deleting_provider_fillets_cannot_shrink_independent_denominator(monkeyp
     assert damaged.complete_cases < len(damaged.cases)
 
 
-def test_weakening_provider_fillet_radius_reduces_fidelity(monkeypatch) -> None:
+def test_weakening_provider_fillet_radius_reduces_fidelity(monkeypatch, reduced_baseline) -> None:
     import draftwright.analysis as analysis
 
     original = analysis._result_from_evidence
@@ -501,12 +506,12 @@ def test_weakening_provider_fillet_radius_reduces_fidelity(monkeypatch) -> None:
         return replace(result, fillets=values)
 
     monkeypatch.setattr(analysis, "_result_from_evidence", weakened)
-    damaged = evaluate_step_corpus(load_corpus(CORPUS))
+    damaged = evaluate_step_corpus(reduced_corpus(load_corpus(CORPUS)))
 
     assert damaged.detection.recall == 1.0
     assert damaged.detection.false_positives == 0
-    assert damaged.parameter_fidelity.passed == 0
-    assert damaged.parameter_fidelity.total == 14
+    assert damaged.parameter_fidelity.score == 0.0
+    assert damaged.parameter_fidelity.total == reduced_baseline.parameter_fidelity.total
 
 
 def test_quality_summary_counts_fillets_as_audited_requirements() -> None:

--- a/tests/test_issue_1374_turned_step_completeness_evidence.py
+++ b/tests/test_issue_1374_turned_step_completeness_evidence.py
@@ -12,6 +12,7 @@ from _evidence_contract import (
     assert_missing_model_outcomes_fail_closed,
     assert_observer_uses_one_build_owned_recognition,
 )
+from _mutation_corpus import reduced_baseline_fixture, reduced_corpus
 from build123d import Align, Box, Compound, Cylinder, Pos, Rot, import_step
 
 from draftwright.evaluation.step_analysis import (
@@ -23,6 +24,10 @@ from draftwright.evaluation.step_analysis import (
 
 FIXTURES = Path(__file__).parent / "fixtures" / "evaluation"
 CORPUS = FIXTURES / "corpus-turned-steps-v1.json"
+
+
+#: Clean score of the subset the damage tests below use, asserted perfect.
+reduced_baseline = reduced_baseline_fixture(CORPUS)
 
 
 def _shaft(name: str = "turned-step-axis-x.step"):
@@ -1442,7 +1447,9 @@ def test_deleting_provider_profiles_cannot_shrink_independent_denominator(monkey
 
 
 @pytest.mark.parametrize("parameter", ["diameter", "length"])
-def test_weakening_provider_band_parameter_reduces_fidelity(monkeypatch, parameter: str) -> None:
+def test_weakening_provider_band_parameter_reduces_fidelity(
+    monkeypatch, parameter: str, reduced_baseline
+) -> None:
     import draftwright.analysis as analysis
 
     original = analysis._result_from_evidence
@@ -1484,12 +1491,12 @@ def test_weakening_provider_band_parameter_reduces_fidelity(monkeypatch, paramet
         return replace(result, turned_steps=steps, grooves=grooves)
 
     monkeypatch.setattr(analysis, "_result_from_evidence", weakened)
-    damaged = evaluate_step_corpus(load_corpus(CORPUS))
+    damaged = evaluate_step_corpus(reduced_corpus(load_corpus(CORPUS)))
 
     assert damaged.detection.recall == 1.0
     assert damaged.detection.false_positives == 0
-    assert damaged.parameter_fidelity.passed == 26
-    assert damaged.parameter_fidelity.total == 52
+    assert damaged.parameter_fidelity.score == 0.5
+    assert damaged.parameter_fidelity.total == reduced_baseline.parameter_fidelity.total
 
 
 def test_quality_summary_counts_two_audited_requirements_per_band() -> None:


### PR DESCRIPTION
Follow-up to #1494. Smallest win of the series — stated plainly below, because I over-projected it once already.

## What

The `weakening_provider_*` / `deleting_provider_*` tests damage the provider and assert the benchmark's score falls. They read `detection` and `parameter_fidelity` **only** — never `downstream_usefulness`, `complete_cases` or `conformant_cases` — yet each scored the family's whole corpus, and the drawing_consumer observer builds a full drawing per case.

Measured on the groove corpus: **4.77 s** to re-prove one direction across eight fixtures, **98% of it `build_drawing`** whose output the test never reads.

## Why a *chosen* subset, not a truncated one

A smaller corpus is the easy way to make an assertion vacuous, so `tests/_mutation_corpus.py` selects deliberately:

- **one negative case, always.** Without a fixture the family must *not* match, `false_positives == 0` is satisfied by a corpus that cannot produce a false positive, and `recall == 1.0` is trivially true of nothing.
- **the positive expecting the most facts**, so the damaged parameters exist to be scored.
- **`assert_reduced_corpus_is_sound`** scores that subset *clean* and requires 1.0 before any damage assertion is believed. A subset already failing would let `score == 0.5` pass because the fixture was broken rather than because the damage was detected.

## Assertions

Size-independent ones (`recall`, `false_positives`, `score`) are kept verbatim. Size-dependent ones are restated relatively:

- `parameter_fidelity.total` against the clean baseline — which makes *"damage may not shrink the denominator"* explicit where it was implicit in a constant;
- `missed` / `false_positives` against `reduced_baseline.detection.matched`.

The ratios come from the **already-authored** numbers (10 of 20 → 0.5), not from running the new code and copying its output. Each module's `test_real_*_corpus_scores_*` still scores the full corpus and still owns the absolute per-family counts.

## What did NOT move, and why

16 of 18. Two stayed, each for a reason execution found rather than one I chose:

- **2** because their authored constants didn't map exactly — the rewriter refused them rather than guess.
- **1**, `test_constant_canonical_values_cannot_pass_the_varied_positive_oracle`, because it is an oracle about **variation across positives**. A one-positive subset lets constant canonical values pass legitimately, so reducing it deletes the thing under test. It failed exactly that way when tried, is restored verbatim, and the reason is recorded at the call site.

## Evidence

- Interleaved against a clean worktree, the 66 tests in this selection: **236.8 s → 90.1 s**.
- That is **~147 s, not the ~230 s I first estimated.** The estimate assumed all twenty would reduce and ignored the per-module clean baseline each now pays. This is the smallest win of the series by a wide margin; the assertion restatement is the better part of it.
- **Mutation-checked:** neutering the measurement damage fails both groove parameters; neutering the identity damage fails the parameter whose branch was cut; neutering the plate deletion fails its test.
- An **AST audit** caught two tests whose multi-line signatures silently missed the injected fixture and were reading the fixture *function object* — green tests that were asserting nothing.
- Full fast tier: **7,291 passed, 5 skipped, 14 xfailed.** `pr-check --static` exit 0.

## Reviewer, please look hardest at

1. **`tests/_mutation_corpus.py` guessing at the benchmark's shape** — it reads `BenchmarkCase.expected` and falls back from `case.tags` to `classification.split("+")`. I got the attribute wrong once (`facts` vs `expected`) before an assertion caught it.
2. **Whether the substitution is defensible against ADR 3 and #1169.** I argue the subset is sound because it scores a clean 1.0 — but that is "sound today, on these fixtures", which is the weaker claim.


---

## Review pass applied

`/code-review` at high effort was run on this diff and returned seven findings; all are fixed in the pushed commit. Three are worth calling out because they were real defects in my own work:

- **The negative case was selected by JSON file order** (`negatives[0]`), which for chamfers and fillets picked a *plain block with no bevel geometry at all* — exactly the vacuity the negative exists to prevent. A recogniser mutated to accept any `overlapping-family` shape would still have scored `false_positives == 0`. Now selects a **confusable** (`ambiguous`/`overlapping-family`) negative; 12 of 14 families get one, and the two corpora offering none are named in `_NO_CONFUSABLE_NEGATIVE` rather than silently taking the weak choice.
- **The positive tie-break was JSON key order.** Ties are the norm (5 in pockets, 6 in polygonal-stock), so reformatting a corpus file — touching no code — could silently re-point a test at different geometry. Now tie-broken on `case_id`.
- **My commit body contained a false count.** It said "16 of 20 moved. Three did not"; the tree had 15 call sites, and 16+3≠20 either way. The true census is **16 of 18, two unreducible**, and both now record the measurement behind the decision at their call site.

Also fixed: ten cloned `reduced_baseline` fixtures (the exact copy-per-family pattern `test_clone_budget.py` was added to stop, escaping it only because a one-statement body falls under `_MIN_STATEMENTS`) collapsed into a factory; a dead `getattr(case, "tags", ...)` branch that would mask a rename instead of failing closed; `0.6666666666666666` restored to the authored `2 / 3`; and the `worksteal` per-worker fixture caveat documented.

Two things fell out of the fixes: the countersink test I'd left unreduced turned out **reducible** after all (its `missed == 7` is exactly the full clean matched count), and wiring it revealed its module had neither the import nor the fixture — `fixture 'reduced_baseline' not found`. An audit now asserts every module using these symbols defines them.

The review found **no correctness defect in the reduction logic itself**, and confirmed by execution that the clean baseline runs unpatched and that the relative assertions are equal in strength to the constants they replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpuGEXqUE51bP83bHZeyTY
