### PR TITLE
ci: validate exact development version bumps without the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ on:
   workflow_dispatch:
     inputs:
       post_release_bump:
-        description: Run one canonical coverage suite for an automated post-release version PR
+        description: Validate an automated post-release version PR; use normal CI for any other diff
         required: false
         default: false
         type: boolean
       post_release_pr_number:
-        description: PR number receiving Codecov patch/project statuses for the version bump
+        description: PR number for the branch-SHA-bound post-release checks
         required: false
         type: string
 
@@ -30,7 +30,92 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      version_only: ${{ steps.classify.outputs.version_only }}
+      head: ${{ steps.classify.outputs.head }}
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Classify the complete diff using the base commit's verifier
+        id: classify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          POST_RELEASE: ${{ inputs.post_release_bump }}
+          FULL_MATRIX: ${{ contains(github.event.pull_request.labels.*.name, 'full-matrix') }}
+          PR_NUMBER: ${{ inputs.post_release_pr_number }}
+        run: |
+          version_only=false
+          if [[ "$EVENT_NAME" == "workflow_dispatch" && "$POST_RELEASE" == "true" \
+                && "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
+            # A dispatch input is a request, not proof. Bind it to an open, same-repo
+            # PR against main and the immutable SHA this workflow checked out.
+            if gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" > "$RUNNER_TEMP/bump-pr.json"; then
+              BASE_SHA=$(jq -r --arg sha "$GITHUB_SHA" --arg repo "$GITHUB_REPOSITORY" \
+                'select(.state == "open" and .head.sha == $sha and .base.ref == "main"
+                  and .head.repo.full_name == $repo) | .base.sha' "$RUNNER_TEMP/bump-pr.json") || BASE_SHA=""
+              if [[ "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+                git fetch --no-tags origin "$BASE_SHA" || BASE_SHA=""
+              fi
+            fi
+          fi
+          if [[ "$EVENT_NAME" == "pull_request" || "$EVENT_NAME" == "push" \
+                || ( "$EVENT_NAME" == "workflow_dispatch" && "$POST_RELEASE" == "true" ) ]]; then
+            if [[ "$BASE_SHA" =~ ^[0-9a-f]{40}$ && "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]] \
+                && git show "$BASE_SHA:scripts/check-version-bump" > "$RUNNER_TEMP/check-version-bump.py"; then
+              version_only=$(python3 "$RUNNER_TEMP/check-version-bump.py" "$BASE_SHA" "$HEAD_SHA")
+            fi
+          fi
+          if [[ "$FULL_MATRIX" == "true" ]]; then
+            version_only=false
+          fi
+          echo "version_only=$version_only" >> "$GITHUB_OUTPUT"
+          echo "head=$HEAD_SHA" >> "$GITHUB_OUTPUT"
+          echo "version-only=$version_only"
+
+  version-only:
+    needs: changes
+    if: needs.changes.outputs.version_only == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      id-token: write # Codecov's explicit no-code-change status; no fabricated coverage.
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ needs.changes.outputs.head }}
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: true
+          python-version: "3.12"
+      - name: Validate the lockfile and build package metadata without installing CAD dependencies
+        run: |
+          uv lock --check
+          uv build
+      - name: Report the proven version-only change to Codecov
+        if: github.event_name != 'push'
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
+        with:
+          run_command: empty-upload
+          fail_ci_if_error: true
+          override_commit: ${{ needs.changes.outputs.head }}
+          override_pr: ${{ inputs.post_release_pr_number || github.event.pull_request.number }}
+          use_oidc: true
+
   lint:
+    needs: changes
+    if: needs.changes.outputs.version_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -51,7 +136,8 @@ jobs:
   test:
     # The PR is the compatibility gate. A merge to protected main has already passed these
     # exact checks, so main keeps lint + the slow post-merge safety net without repeating them.
-    if: github.event_name != 'push' && !inputs.post_release_bump
+    needs: changes
+    if: github.event_name != 'push' && needs.changes.outputs.version_only != 'true'
     permissions:
       contents: read
     strategy:
@@ -139,7 +225,8 @@ jobs:
           ${{ matrix.shard && format('--splits 2 --group {0}', matrix.shard) || '' }}
 
   coverage:
-    if: github.event_name == 'pull_request' || inputs.post_release_bump
+    needs: changes
+    if: (github.event_name == 'pull_request' || inputs.post_release_bump) && needs.changes.outputs.version_only != 'true'
     # The Python 3.13 compatibility entry, which also carries coverage. Unsharded it
     # was the pull request's critical path: measured on run 34078991086 it took 63
     # minutes while the slowest sharded compatibility leg took 42, so every PR waited
@@ -197,8 +284,8 @@ jobs:
     # The canonical reports and the ONE Codecov upload, over both shards combined.
     # Kept a separate job so only it needs an OIDC token, and so Codecov receives a
     # single complete upload rather than two partial ones racing to compute a status.
-    if: github.event_name == 'pull_request' || inputs.post_release_bump
-    needs: coverage
+    if: (github.event_name == 'pull_request' || inputs.post_release_bump) && needs.changes.outputs.version_only != 'true'
+    needs: [changes, coverage]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -258,7 +345,8 @@ jobs:
     # the compatibility matrix covers the other supported Python/kernel resolutions.
     # Run once, outside that matrix. The test has a 120 s execution budget; this
     # job limit also bounds installation and a native-kernel hang.
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.version_only != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -283,7 +371,8 @@ jobs:
     # generated layout is deterministic, so these heavy real-part standards builds
     # rarely catch anything the PR fast tier misses. They stay as a safety net on
     # main; a regression here is caught right after merge.
-    if: github.event_name == 'push'
+    needs: changes
+    if: github.event_name == 'push' && needs.changes.outputs.version_only != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
@@ -310,7 +399,8 @@ jobs:
     # per-PR legs are what exhausted the Actions allowance (see the matrix comment
     # above) — the full non-Linux surface stays on the weekly sweep and the
     # `full-matrix` label.
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: github.event_name == 'pull_request' && needs.changes.outputs.version_only != 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -336,19 +426,16 @@ jobs:
         run: uv run pytest tests/ -m "smoke or unit" -n auto --dist loadscope
 
   ci-ok:
-    # The single status check branch protection should require.
-    #
-    # Protection currently names each matrix leg individually — `test (macos-latest, 3.12)`
-    # and nine others. A required context that names a job is only satisfied when a job of
-    # that exact name reports, so changing the matrix at all leaves those contexts stuck on
-    # "Expected" and makes every pull request permanently unmergeable. Requiring this job
-    # instead lets the matrix change shape without touching repository settings.
+    # Required alongside codecov/project. This aggregate keeps protection independent
+    # of matrix shape while requiring the exact jobs selected by the verified diff.
     #
     # `if: always()` is load-bearing, not decoration. Without it a failing dependency
     # skips this job, and GitHub counts a skipped required check as satisfied — so a
     # broken test suite would report a green gate.
     if: always()
     needs:
+      - changes
+      - version-only
       - lint
       - test
       - coverage
@@ -363,6 +450,10 @@ jobs:
       - name: Require every gating job to have succeeded or been legitimately skipped
         env:
           EVENT_NAME: ${{ github.event_name }}
+          POST_RELEASE: ${{ inputs.post_release_bump }}
+          CHANGES: ${{ needs.changes.result }}
+          VERSION_ONLY: ${{ needs.changes.outputs.version_only }}
+          VERSION_CHECK: ${{ needs.version-only.result }}
           LINT: ${{ needs.lint.result }}
           TEST: ${{ needs.test.result }}
           COVERAGE: ${{ needs.coverage.result }}
@@ -371,44 +462,46 @@ jobs:
           CANARY: ${{ needs.test-platform-canary.result }}
           REAL_PART: ${{ needs.test-real-part-canary.result }}
         run: |
-          echo "lint=$LINT test=$TEST coverage=$COVERAGE report=$COVERAGE_REPORT" \
-               "slow=$SLOW canary=$CANARY real-part=$REAL_PART"
+          if [[ "$CHANGES" != "success" || ! "$VERSION_ONLY" =~ ^(true|false)$ ]]; then
+            echo "::error::change classification did not produce a valid result"
+            exit 1
+          fi
+          if [[ "$VERSION_ONLY" == "true" ]]; then
+            expected_version=success
+            expected_lint=skipped
+            expected_test=skipped
+            expected_coverage=skipped
+            expected_slow=skipped
+            expected_canary=skipped
+          else
+            expected_version=skipped
+            expected_lint=success
+            expected_test=success
+            expected_coverage=skipped
+            expected_slow=skipped
+            expected_canary=skipped
+            if [[ "$EVENT_NAME" == "push" ]]; then
+              expected_test=skipped
+              expected_slow=success
+            elif [[ "$EVENT_NAME" == "pull_request" ]]; then
+              expected_coverage=success
+              expected_canary=success
+            elif [[ "$EVENT_NAME" == "workflow_dispatch" && "$POST_RELEASE" == "true" ]]; then
+              expected_coverage=success
+            fi
+          fi
           failed=0
-          for pair in "lint:$LINT" "test:$TEST" "coverage:$COVERAGE" \
-                      "coverage-report:$COVERAGE_REPORT" "canary:$CANARY"; do
-            name=${pair%%:*}
-            result=${pair#*:}
-            # `skipped` is a pass: `test` does not run on push and `coverage` runs only on
-            # pull_request, by design. `failure` and `cancelled` are not passes.
-            case "$result" in
-              success|skipped) ;;
-              *) echo "::error::$name did not pass (result: $result)"; failed=1 ;;
-            esac
+          for pair in "version:$VERSION_CHECK:$expected_version" "lint:$LINT:$expected_lint" \
+                      "test:$TEST:$expected_test" "coverage:$COVERAGE:$expected_coverage" \
+                      "coverage-report:$COVERAGE_REPORT:$expected_coverage" \
+                      "slow:$SLOW:$expected_slow" "canary:$CANARY:$expected_canary" \
+                      "real-part:$REAL_PART:$expected_canary"; do
+            IFS=: read -r name result expected <<< "$pair"
+            if [[ "$result" != "$expected" ]]; then
+              echo "::error::$name: expected $expected, got $result"
+              failed=1
+            fi
           done
-
-          # The slow suite is deliberately post-merge only. On a push to main it is a
-          # required result, while every other trigger must see the conditional job as
-          # skipped. Keeping it out of the generic success-or-skipped loop prevents a
-          # skipped or failed main slow suite from being reported as a green aggregate.
-          if [[ "$EVENT_NAME" == "push" ]]; then
-            if [[ "$SLOW" != "success" ]]; then
-              echo "::error::slow did not pass on main (result: $SLOW)"
-              failed=1
-            fi
-          elif [[ "$SLOW" != "skipped" ]]; then
-            echo "::error::slow ran unexpectedly for $EVENT_NAME (result: $SLOW)"
-            failed=1
-          fi
-          # A skipped PR canary must not silently satisfy this required check.
-          if [[ "$EVENT_NAME" == "pull_request" ]]; then
-            if [[ "$REAL_PART" != "success" ]]; then
-              echo "::error::real-part canary did not pass (result: $REAL_PART)"
-              failed=1
-            fi
-          elif [[ "$REAL_PART" != "skipped" ]]; then
-            echo "::error::real-part canary ran unexpectedly for $EVENT_NAME (result: $REAL_PART)"
-            failed=1
-          fi
           exit $failed
 
       - name: Attach successful post-release gate to the generated PR head

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -115,7 +115,7 @@ jobs:
           git push origin HEAD:"$branch"
           gh pr create --base main --head "$branch" \
             --title "chore: bump version to ${new_version} after ${RELEASE_TAG}" \
-            --body "Branch-protection-safe post-release development-version bump. Publication already succeeded for \`${RELEASE_TAG}\`; this PR changes only build/lock identity. A single-runner regular coverage gate is dispatched; the slow tier is intentionally not run for a version-only bump."
+            --body "Branch-protection-safe post-release development-version bump. Publication already succeeded for \`${RELEASE_TAG}\`; this PR changes only build/lock identity. A diff-verified version-only check is dispatched; any other change requires normal CI."
           pr_number=$(gh pr view "$branch" --json number --jq .number)
           gh workflow run ci.yml --ref "$branch" \
             -f post_release_bump=true -f post_release_pr_number="$pr_number"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,12 +188,22 @@ already contains worker profiles.
 Coverage is kept out of the default addopts (it adds ~13% locally); the CI
 workflow passes the `--cov` flags, in the two `coverage` shards whose data
 `coverage-report` combines for the single Codecov upload and the `fail_under`
-gate. Each PR runs the full fast tier on Linux across supported Python versions,
+gate. PRs requiring normal CI run the full fast tier across supported Python versions,
 each split into two pytest-split shards, plus smaller macOS/Windows platform
 canaries. One real-part canary checks fixed tuner-fixture measurements and
 exports before merge; the **full slow tier runs post-merge on `main`** (#153,
 #827). The wider platform matrix remains available weekly, manually, or with the
 `full-matrix` PR label.
+
+Exact next-patch development-version bumps use a short metadata path on PRs, the
+post-release dispatch and the resulting main push. The base commit's
+`scripts/check-version-bump` must prove that the entire Git diff changes only the
+matching Draftwright version records in `pyproject.toml` and `uv.lock`, including
+unchanged file modes and all other bytes. It then checks the lock and builds the
+package without installing CAD dependencies. Codecov's `empty-upload` supplies
+its no-code-change status; branch protection still requires Codecov and `ci-ok`.
+Mixed edits or unavailable proof use normal CI. Schedules and ordinary manual
+runs keep the full matrix. The classifier requires Python 3.11+ (`tomllib`).
 
 ## Working practices — evidence, not confidence
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,8 @@ before changing those areas.
 
 ### Real-part PR canary
 
-Every pull request builds `tests/fixtures/tuner_jig_blind_obround_pockets.step`
+Every PR other than a verified version-only bump builds
+`tests/fixtures/tuner_jig_blind_obround_pockets.step`
 once on Linux/Python 3.12, matching the post-merge integration kernel. This common
 part exposed annotation losses during the Quiddity migration: five rounded
 pockets, their grouped dimensions, pitch, distinct X/Y locations, and twenty
@@ -54,8 +55,8 @@ uv run pytest tests/test_issue_827_real_part_canary.py -m real_part_canary -v -s
 
 The test has a 120-second execution budget and prints its build/audit/export
 runtime. The hosted job has a separate ten-minute limit including setup. Its
-result must be successful before merge; a skipped result fails the aggregate
-gate. The test also belongs to `slow`, so the default fast matrix excludes it
+result must be successful on the normal PR path; a skipped result there fails
+the aggregate gate. The test also belongs to `slow`, so the default fast matrix excludes it
 and the full post-merge integration suite retains it.
 
 ### Coverage
@@ -124,3 +125,10 @@ the installed package. Never commit a path or Git override.
 - Run `scripts/pr-check --quick` while iterating and `scripts/pr-check` before the final push.
 
 Questions or commercial-licensing enquiries: paul@fremantle.org.
+
+Automated next-development-version PRs take a short CI path only when the complete
+diff proves an exact patch increment in the project and matching lockfile record.
+The base commit's verifier checks that no other content or file modes changed.
+These PRs run `uv lock --check` and `uv build`, with Codecov's explicit
+`empty-upload` status. Any additional edit or missing proof uses normal CI; a
+branch name or dispatch flag alone cannot select the short path.

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,9 @@ coverage:
       default:
         target: auto
         threshold: 0.5%
+
+# These metadata files have no executable lines. Only the base-owned complete-diff
+# verifier may select empty-upload; dependency or configuration edits run normal CI.
+ignore:
+  - '^pyproject\.toml$'
+  - '^uv\.lock$'

--- a/scripts/check-version-bump
+++ b/scripts/check-version-bump
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Prove a complete Git diff changes only the next development-version identity.
+
+Print true only for an exact patch increment in both canonical metadata records.
+All other diffs, malformed metadata and unavailable history select normal CI.
+The workflow executes this script from the comparison BASE, never from the PR.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+
+import tomllib
+
+
+def git(*args: str) -> bytes:
+    return subprocess.check_output(["git", *args], stderr=subprocess.DEVNULL)
+
+
+def version_only(base: str, head: str) -> bool:
+    """Return whether the two immutable trees differ only by a patch dev bump."""
+    if not all(re.fullmatch(r"[0-9a-f]{40}", ref) for ref in (base, head)):
+        return False
+    try:
+        git("merge-base", "--is-ancestor", base, head)
+        paths = git("diff", "--no-renames", "--name-only", "-z", base, head).split(b"\0")
+        if set(paths) != {b"pyproject.toml", b"uv.lock", b""}:
+            return False
+        documents = {}
+        for ref in (base, head):
+            for path in ("pyproject.toml", "uv.lock"):
+                entry = git("ls-tree", ref, "--", path).decode()
+                if not entry.startswith("100644 blob "):
+                    return False
+                documents[ref, path] = git("show", f"{ref}:{path}").decode()
+
+        old_project = tomllib.loads(documents[base, "pyproject.toml"])["project"]
+        current = old_project["version"]
+        match = re.fullmatch(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\.dev0)?", current)
+        if old_project["name"] != "draftwright" or not match:
+            return False
+        major, minor, patch = map(int, match.groups())
+        target = f"{major}.{minor}.{patch + 1}.dev0"
+        for ref, expected in ((base, current), (head, target)):
+            project = tomllib.loads(documents[ref, "pyproject.toml"])["project"]
+            packages = tomllib.loads(documents[ref, "uv.lock"])["package"]
+            own = [package for package in packages if package["name"] == "draftwright"]
+            if (
+                project["version"] != expected
+                or len(own) != 1
+                or own[0]["version"] != expected
+                or own[0]["source"] != {"editable": "."}
+            ):
+                return False
+
+        # Byte equality after replacing the two exact records rejects dependency,
+        # tool configuration, comments, whitespace and unrelated lockfile edits too.
+        for path, header in (("pyproject.toml", "[project]"), ("uv.lock", "[[package]]")):
+            before = f'{header}\nname = "draftwright"\nversion = "{current}"\n'
+            after = f'{header}\nname = "draftwright"\nversion = "{target}"\n'
+            original = documents[base, path]
+            if (
+                original.count(before) != 1
+                or original.replace(before, after) != documents[head, path]
+            ):
+                return False
+        return True
+    except (subprocess.CalledProcessError, UnicodeError, ValueError, KeyError, TypeError):
+        return False
+
+
+if __name__ == "__main__":
+    print(str(len(sys.argv) == 3 and version_only(*sys.argv[1:])).lower())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,6 +188,7 @@ _UNIT_MODULES = frozenset(
         "test_recogniser_adoption.py",
         "test_registry.py",
         "test_workflows.py",
+        "test_version_bump_ci.py",
     }
 )
 

--- a/tests/test_version_bump_ci.py
+++ b/tests/test_version_bump_ci.py
@@ -1,0 +1,250 @@
+"""A cheap CI path must prove the entire change is only a development version bump."""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+from test_workflows import _bash, _job, _literal_run, _workflow
+
+pytestmark = pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="The CI verifier uses stdlib tomllib on Python 3.11+"
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _git(root, *args):
+    return subprocess.check_output(["git", *args], cwd=root, text=True).strip()
+
+
+@pytest.fixture
+def bump_repo(tmp_path):
+    _git(tmp_path, "init", "-q")
+    _git(tmp_path, "config", "user.email", "ci@example.invalid")
+    _git(tmp_path, "config", "user.name", "CI test")
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "draftwright"\nversion = "0.4.21.dev0"\n'
+        'dependencies = ["quiddity==0.2.4"]\n'
+    )
+    (tmp_path / "uv.lock").write_text(
+        'version = 1\n[[package]]\nname = "draftwright"\nversion = "0.4.21.dev0"\n'
+        'source = { editable = "." }\n'
+        '[[package]]\nname = "quiddity"\nversion = "0.2.4"\n'
+    )
+    (tmp_path / "engine.py").write_text("answer = 42\n")
+    (tmp_path / "scripts").mkdir()
+    shutil.copyfile(ROOT / "scripts/check-version-bump", tmp_path / "scripts/check-version-bump")
+    _git(tmp_path, "add", ".")
+    _git(tmp_path, "commit", "-qm", "base")
+    base = _git(tmp_path, "rev-parse", "HEAD")
+    for name in ("pyproject.toml", "uv.lock"):
+        path = tmp_path / name
+        path.write_text(path.read_text().replace("0.4.21.dev0", "0.4.22.dev0"))
+    return tmp_path, base
+
+
+def _classify(root, base, head):
+    result = subprocess.run(
+        [sys.executable, str(ROOT / "scripts/check-version-bump"), base, head],
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    assert result.stdout.strip() in {"true", "false"}
+    return result.stdout.strip() == "true"
+
+
+def _commit(root):
+    _git(root, "add", "-A")
+    _git(root, "commit", "-qm", "candidate")
+    return _git(root, "rev-parse", "HEAD")
+
+
+def test_exact_next_development_version_qualifies(bump_repo):
+    root, base = bump_repo
+    head = _commit(root)
+    assert _git(root, "diff", "--name-only", base, head).splitlines() == [
+        "pyproject.toml",
+        "uv.lock",
+    ]
+    assert _classify(root, base, head)
+
+
+@pytest.mark.parametrize(
+    ("path", "old", "new"),
+    [
+        ("pyproject.toml", "0.4.22.dev0", "0.4.23.dev0"),
+        ("uv.lock", "0.4.22.dev0", "0.4.21.dev0"),
+        ("pyproject.toml", "quiddity==0.2.4", "quiddity==0.2.5"),
+        ("uv.lock", 'version = "0.2.4"', 'version = "0.2.5"'),
+        ("uv.lock", 'editable = "."', 'editable = "elsewhere"'),
+        ("pyproject.toml", "[project]", "[project]\nversion = 123"),
+        ("pyproject.toml", 'name = "draftwright"', 'name = "different"'),
+        ("engine.py", "answer = 42", "answer = 0"),
+    ],
+    ids=[
+        "skip-patch",
+        "lock-mismatch",
+        "dependency",
+        "resolution",
+        "source",
+        "malformed",
+        "name",
+        "code",
+    ],
+)
+def test_other_changes_require_normal_ci(bump_repo, path, old, new):
+    root, base = bump_repo
+    target = root / path
+    text = target.read_text()
+    assert text.count(old) == 1
+    target.write_text(text.replace(old, new))
+    assert not _classify(root, base, _commit(root))
+
+
+@pytest.mark.parametrize(
+    "change", ["extra-file", "deleted-file", "rename", "comment", "mode", "duplicate-owner"]
+)
+def test_complete_tree_proof_rejects_non_version_changes(bump_repo, change):
+    root, base = bump_repo
+    if change == "extra-file":
+        (root / ".hidden-config").write_text("changed\n")
+    elif change == "deleted-file":
+        (root / "engine.py").unlink()
+    elif change == "rename":
+        (root / "engine.py").rename(root / "renamed.py")
+    elif change == "comment":
+        with (root / "pyproject.toml").open("a") as f:
+            f.write("# extra edit\n")
+    elif change == "mode":
+        _git(root, "config", "core.filemode", "true")
+        _git(root, "add", "-A")
+        _git(root, "update-index", "--chmod=+x", "pyproject.toml")
+        # Commit the index directly: Windows has no POSIX executable filesystem bit.
+        _git(root, "commit", "-qm", "mode change")
+        assert not _classify(root, base, _git(root, "rev-parse", "HEAD"))
+        return
+    else:
+        with (root / "uv.lock").open("a") as f:
+            f.write('[[package]]\nname = "draftwright"\nversion = "0.4.22.dev0"\n')
+    assert not _classify(root, base, _commit(root))
+
+
+def test_missing_or_unrelated_history_and_no_diff_require_normal_ci(bump_repo):
+    root, base = bump_repo
+    head = _commit(root)
+    assert not _classify(root, "0" * 40, head)
+    assert not _classify(root, "--help", head)
+    assert not _classify(root, base, base)
+    assert not _classify(root, head, base)
+    unrelated = _git(
+        root, "commit-tree", _git(root, "rev-parse", f"{base}^{{tree}}"), "-m", "unrelated"
+    )
+    assert _git(root, "diff", "--exit-code", base, unrelated) == ""
+    assert not _classify(root, unrelated, head)
+
+
+@pytest.mark.skipif(os.name == "nt", reason="The classification shell runs on Ubuntu only")
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        "pr",
+        "push",
+        "dispatch",
+        "stale-head",
+        "foreign-repo",
+        "closed-pr",
+        "other-base",
+        "ordinary-manual",
+        "schedule",
+        "changed-verifier",
+        "full-matrix",
+        "api-failure",
+        "malformed-response",
+        "missing-base",
+    ],
+)
+def test_workflow_classification_binds_dispatch_and_executes_the_base_verifier(
+    bump_repo, scenario
+):
+    root, base = bump_repo
+    if scenario == "changed-verifier":
+        (root / "scripts/check-version-bump").write_text('print("true")\n')
+    head = _commit(root)
+    _git(root, "remote", "add", "origin", str(root))
+    event = "workflow_dispatch"
+    if scenario in {"pr", "changed-verifier", "full-matrix"}:
+        event = "pull_request"
+    elif scenario in {"push", "schedule"}:
+        event = scenario
+    metadata = {
+        "state": "closed" if scenario == "closed-pr" else "open",
+        "head": {
+            "sha": base if scenario == "stale-head" else head,
+            "repo": {"full_name": "other/repo" if scenario == "foreign-repo" else "test/repo"},
+        },
+        "base": {
+            "sha": "0" * 40 if scenario == "missing-base" else base,
+            "ref": "other" if scenario == "other-base" else "main",
+        },
+    }
+    # Outputs and mocked API response live outside the tracked candidate tree.
+    runtime = root / "runtime"
+    runtime.mkdir()
+    output = runtime / "classification-output"
+    response = runtime / "pr-metadata.json"
+    response.write_text(
+        "invalid JSON" if scenario == "malformed-response" else json.dumps(metadata)
+    )
+    env = {
+        **os.environ,
+        "EVENT_NAME": event,
+        "BASE_SHA": base if event in {"pull_request", "push"} else "",
+        "HEAD_SHA": head,
+        "GITHUB_SHA": head,
+        "GITHUB_REPOSITORY": "test/repo",
+        "POST_RELEASE": "false" if scenario == "ordinary-manual" else "true",
+        "PR_NUMBER": "1",
+        "FULL_MATRIX": "true" if scenario == "full-matrix" else "false",
+        "RUNNER_TEMP": str(runtime),
+        "GITHUB_OUTPUT": str(output),
+        "PR_METADATA": str(response),
+        "TEST_PYTHON": sys.executable,
+    }
+    shell = 'gh() { cat "$PR_METADATA"; }\npython3() { "$TEST_PYTHON" "$@"; }\n'
+    if scenario == "api-failure":
+        shell = "gh() { return 1; }\n"
+    result = subprocess.run(
+        [
+            _bash(),
+            "-eu",
+            "-o",
+            "pipefail",
+            "-c",
+            shell + _literal_run(_job(_workflow("ci.yml"), "changes")),
+        ],
+        env=env,
+        cwd=root,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+    expected = "true" if scenario in {"pr", "push", "dispatch"} else "false"
+    assert output.read_text().splitlines() == [f"version_only={expected}", f"head={head}"]
+
+
+@pytest.mark.parametrize("target", ["0.4.20.dev0", "0.4.23.dev0", "0.5.0.dev0", "0.4.22"])
+def test_matching_versions_still_require_exact_next_patch_dev0(bump_repo, target):
+    root, base = bump_repo
+    for name in ("pyproject.toml", "uv.lock"):
+        path = root / name
+        text = path.read_text()
+        assert text.count("0.4.22.dev0") == 1
+        path.write_text(text.replace("0.4.22.dev0", target))
+    assert not _classify(root, base, _commit(root))

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -118,7 +118,9 @@ def test_pull_requests_run_linux_only_to_stay_inside_the_runner_budget():
         }
 
     assert "if: github.event_name != 'push'" in test_job
-    assert "if: github.event_name == 'pull_request'" in _job(workflow, "coverage")
+    assert "if: (github.event_name == 'pull_request' || inputs.post_release_bump)" in _job(
+        workflow, "coverage"
+    )
 
 
 def test_the_full_matrix_stays_reachable_without_editing_the_workflow():
@@ -135,12 +137,14 @@ def test_main_runs_static_and_slow_gates_without_repeating_fast_matrix():
     workflow = _workflow("ci.yml")
 
     assert "push:\n    branches: [main]" in workflow
-    assert "if:" not in _job(workflow, "lint")
+    assert "needs.changes.outputs.version_only" in _job(workflow, "lint")
     assert "if: github.event_name == 'push'" in _job(workflow, "test-slow")
     # `test` also serves the weekly sweep and workflow_dispatch, so it is gated on "not a
     # merge to main" rather than on "is a pull request".
     assert "if: github.event_name != 'push'" in _job(workflow, "test")
-    assert "if: github.event_name == 'pull_request'" in _job(workflow, "coverage")
+    assert "if: (github.event_name == 'pull_request' || inputs.post_release_bump)" in _job(
+        workflow, "coverage"
+    )
 
 
 def test_slow_gate_distributes_individual_cases_instead_of_serialising_modules():
@@ -234,7 +238,7 @@ def test_slow_gate_distributes_individual_cases_instead_of_serialising_modules()
         ),
         pytest.param(
             "workflow_dispatch",
-            ("success", "skipped", "success", "success", "skipped", "skipped"),
+            ("success", "success", "success", "success", "skipped", "skipped"),
             True,
             id="post-release-manual-green",
         ),
@@ -251,6 +255,12 @@ def test_aggregate_gate_waits_for_slow_and_requires_success_on_main(event_name, 
         env={
             **os.environ,
             "EVENT_NAME": event_name,
+            "POST_RELEASE": "true"
+            if coverage == "success" and event_name == "workflow_dispatch"
+            else "false",
+            "CHANGES": "success",
+            "VERSION_ONLY": "false",
+            "VERSION_CHECK": "skipped",
             "LINT": lint,
             "TEST": test,
             "COVERAGE": coverage,
@@ -277,6 +287,10 @@ def test_real_part_canary_requires_actual_success_before_merge(result):
         env={
             **os.environ,
             "EVENT_NAME": "pull_request",
+            "POST_RELEASE": "false",
+            "CHANGES": "success",
+            "VERSION_ONLY": "false",
+            "VERSION_CHECK": "skipped",
             "LINT": "success",
             "TEST": "success",
             "COVERAGE": "success",
@@ -371,3 +385,91 @@ def test_version_updater_changes_only_project_and_lock_identity(tmp_path: Path, 
     lock = (tmp_path / "uv.lock").read_text()
     package = lock.split('[[package]]\nname = "draftwright"', 1)[1].split("[[package]]", 1)[0]
     assert f'version = "{target}"' in package
+
+
+@pytest.mark.parametrize("event_name", ["pull_request", "push", "workflow_dispatch"])
+@pytest.mark.parametrize(
+    ("overrides", "passes"),
+    [
+        ({}, True),
+        ({"CHANGES": "failure"}, False),
+        ({"CHANGES": "skipped"}, False),
+        ({"VERSION_ONLY": ""}, False),
+        ({"VERSION_CHECK": "failure"}, False),
+        ({"VERSION_CHECK": "skipped"}, False),
+        ({"VERSION_CHECK": "cancelled"}, False),
+        ({"TEST": "failure"}, False),
+        ({"COVERAGE": "success"}, False),
+        ({"SLOW": "success"}, False),
+    ],
+    ids=[
+        "verified",
+        "classifier-failed",
+        "classifier-skipped",
+        "missing-proof",
+        "build-failed",
+        "build-skipped",
+        "build-cancelled",
+        "tests-failed",
+        "coverage-ran",
+        "slow-ran",
+    ],
+)
+def test_version_only_gate_requires_proof_and_successful_metadata_build(
+    event_name, overrides, passes
+):
+    gate = _job(_workflow("ci.yml"), "ci-ok")
+    env = {
+        **os.environ,
+        "EVENT_NAME": event_name,
+        "POST_RELEASE": "true" if event_name == "workflow_dispatch" else "false",
+        "CHANGES": "success",
+        "VERSION_ONLY": "true",
+        "VERSION_CHECK": "success",
+        "LINT": "skipped",
+        "TEST": "skipped",
+        "COVERAGE": "skipped",
+        "COVERAGE_REPORT": "skipped",
+        "SLOW": "skipped",
+        "CANARY": "skipped",
+        "REAL_PART": "skipped",
+        **overrides,
+    }
+    completed = subprocess.run(
+        [_bash(), "-eu", "-o", "pipefail", "-c", _literal_run(gate)],
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert (completed.returncode == 0) is passes, completed.stdout + completed.stderr
+
+
+def test_version_only_path_is_narrow_and_keeps_required_statuses():
+    workflow = _workflow("ci.yml")
+    classifier = _job(workflow, "changes")
+    assert 'git show "$BASE_SHA:scripts/check-version-bump"' in classifier
+    assert ".head.sha == $sha" in classifier and ".head.repo.full_name == $repo" in classifier
+    assert '.base.ref == "main"' in classifier
+    assert "fetch-depth: 0" in classifier
+    assert "pull_request_target" not in workflow
+    for name in (
+        "lint",
+        "test",
+        "coverage",
+        "coverage-report",
+        "test-slow",
+        "test-platform-canary",
+        "test-real-part-canary",
+    ):
+        job = _job(workflow, name)
+        assert "changes" in _needs(job)
+        assert "needs.changes.outputs.version_only != 'true'" in job
+    quick = _job(workflow, "version-only")
+    assert "needs.changes.outputs.version_only == 'true'" in quick
+    assert "uv lock --check" in quick and "uv build" in quick
+    assert "uv sync" not in quick and "pytest" not in quick
+    assert "run_command: empty-upload" in quick and "force:" not in quick
+    assert "fail_ci_if_error: true" in quick
+    assert "override_commit: ${{ needs.changes.outputs.head }}" in quick
+    assert {"changes", "version-only"} <= _needs(_job(workflow, "ci-ok"))

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -331,6 +331,12 @@ def test_project_coverage_allows_only_a_small_refactor_fluctuation():
         "      default:\n"
         "        target: auto\n"
         "        threshold: 0.5%\n"
+        "\n"
+        "# These metadata files have no executable lines. Only the base-owned complete-diff\n"
+        "# verifier may select empty-upload; dependency or configuration edits run normal CI.\n"
+        "ignore:\n"
+        "  - '^pyproject\\.toml$'\n"
+        "  - '^uv\\.lock$'\n"
     )
 
 


### PR DESCRIPTION
Post-release development-version bumps currently run the geometry test matrix and coverage suite despite changing only two version records. A later rebase starts another full run, and merging the bump also starts the slow suite.

Add a short path for an exact next-patch `.dev0` increment in `pyproject.toml` and the matching Draftwright record in `uv.lock`. A verifier loaded from the comparison base checks the complete Git diff, ancestry, regular-file modes, metadata consistency and exact preservation of every other byte. The dispatch path also binds the request to an open same-repository PR against main at the checked-out SHA. Mixed edits, missing proof, ordinary manual runs, schedules and the `full-matrix` label retain normal CI.

Verified bumps run `uv lock --check` and `uv build` without installing CAD dependencies. Codecov's documented `empty-upload` supplies its no-code-change status, with the two non-executable metadata files explicitly excluded in `codecov.yml`. The existing `codecov/project` and `ci-ok` protections remain required. The aggregate gate requires classification and metadata checks to succeed, and accepts skipped test jobs only on the proven short path. The same classification avoids the slow suite on the resulting main push.

Validation:
- 97 focused workflow, classifier and clone-budget checks passed on both Python 3.14 and Python 3.12.
- Nine deliberate faults were rejected by named guards: extra source, dependency edits, file modes, version sequencing, ancestry, an edited head verifier, missing classification missing metadata checks and missing Codecov metadata exclusions.
- Static preflight and actionlint 1.7.12 passed.
- On the actual merged version-bump commit, lock validation took 0.02s and the wheel-from-sdist build took 4.09s locally. Hosted draft probe #1498 passed in 52 seconds including both required statuses (run 34108284575), with the geometry, coverage and lint jobs skipped. After merge, the ordinary PR and release dispatch both passed on draft probe #1500 (runs 34111978028 and 34111999736), each completing Actions in 40 seconds. Codecov project and the dispatched ci-ok status both passed.

Google checklist and ADR review: iterative self-review found no remaining substantive local issues. This changes CI policy only; ADRs 1–4's engine, placement, recognition and declared-intent boundaries remain unchanged. ADR 5's evidence principle is reflected in the exact diff proof and explicit no-code-change status. No ADR amendment or branch-protection change is needed.

[Codecov empty-upload documentation](https://docs.codecov.com/docs/cli-options#empty-upload)

Hosted review iteration: the first draft probe completed its Actions jobs in 44 seconds but Codecov reported “Testable files changed”. Inspection of Codecov’s server implementation showed that its default non-testable extensions omit TOML and lock files. Added exact anchored exclusions for these two files; the official config validator accepts them. The corrected hosted probe passed both Codecov checks and ci-ok in 52 seconds. Auto-merge was restored after observing those results.
