### PR TITLE
Render coverage artefacts before the fail_under gate, and stop the clone guard measuring coincidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,13 +223,22 @@ jobs:
 
       - name: Combine the shards and render the canonical reports
         # `relative_files = true` (pyproject) anchors both shards' paths at the repository
-        # root, so the two data files combine without runner-specific rewriting.
-        # `coverage report` is what applies `fail_under = 90`, now over the whole suite.
+        # root, so the data files combine without runner-specific rewriting.
+        #
+        # `coverage-data-*` rather than naming the shards: the shard count already lives in
+        # the matrix and in `--splits`, and a third place to update silently combines a
+        # subset — which `coverage report` would then measure against `fail_under`.
+        #
+        # ORDER IS LOAD-BEARING. `report` is what applies `fail_under = 90`, and the step
+        # runs under `bash -e`, so rendering the artefacts after it means a coverage breach
+        # aborts before `coverage.xml` and `htmlcov/` exist — the upload below then warns
+        # on an empty artefact and Codecov receives nothing, exactly when the drop needs
+        # diagnosing. pytest-cov rendered every report before failing; keep that property.
         run: |
-          uv run coverage combine coverage-data-1 coverage-data-2
-          uv run coverage report --show-missing
+          uv run coverage combine coverage-data-*
           uv run coverage xml
           uv run coverage html -d htmlcov
+          uv run coverage report --show-missing
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,18 +158,20 @@ checks. Target is 100% passing. Tiers (#153):
   trust fix; a critique-style test should share a module-scoped built drawing,
   not mint a new dense fixture.
 - **`-m slow`** (integration builds, including CTC fixtures) — full tier in post-merge CI.
+  The bounded `-m real_part_canary` tuner STEP test also runs once before merge (#827).
 
 The suite may not grow by CLONING. `tests/test_clone_budget.py` compares test bodies
 with identifiers, attributes and literals erased — the shape — across modules, and
-fails when the count of cross-module copies rises above `CLONE_BUDGET`. It exists
-because the two natural checks both miss this codebase's cloning style: identical test
-NAMES miss it (each copy is renamed for its family) and identical ASTs miss it (each
-copy substitutes its family's symbols). Thirteen copies of one three-statement body
-went unnoticed that way, each paying for a real `build_drawing` on every CI run.
+fails when the count of cross-module copies rises above `CLONE_BUDGET`. It counts only
+shapes recurring in at least `_MIN_GROUP_MEMBERS` modules, because a bare pair is usually
+coincidence — templated cloning shows up as a family. It exists because the two natural
+checks both miss this codebase's cloning style: identical test NAMES miss it (each copy is
+renamed for its family) and identical ASTs miss it (each copy substitutes its family's
+symbols). Thirteen copies of one three-statement body went unnoticed that way, each paying
+for a real `build_drawing` on every CI run.
 When it fails, parametrize over the symbol that varies — `tests/_evidence_contract.py`
 is the worked example — and ratchet `CLONE_BUDGET` down. Raising it needs a reason in
 the PR body, like `fail_under`.
-  The bounded `-m real_part_canary` tuner STEP test also runs once before merge (#827).
 
 For reproducible build-cost profiling, use a fresh output directory and state the expected
 collection census explicitly:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,10 @@ dev = [
     "jsonschema>=4,<5",
     "mypy>=2.1.0",
     "pytest>=8",
+    # `coverage` is invoked directly by the CI `coverage-report` job (combine/xml/html/
+    # report); it arrives transitively via pytest-cov, but the job depends on the console
+    # script, so declare it.
+    "coverage>=7",
     "pytest-cov>=5",
     "pytest-split>=0.8",
     "pytest-timeout>=2",

--- a/tests/test_clone_budget.py
+++ b/tests/test_clone_budget.py
@@ -15,8 +15,10 @@ The two obvious ways to detect that both fail here, which is why it went unnotic
 identical test NAMES miss it (every clone is renamed for its family) and identical
 ASTs miss it (every clone substitutes its family's identifiers and literals). So this
 guard compares test bodies with identifiers, attributes, literals and argument names
-erased — the SHAPE — and only across modules, since same-module repetition is a much
-weaker smell and often a deliberate readability choice.
+erased — the SHAPE — across modules, since same-module repetition is a much weaker smell
+and often a deliberate readability choice, and only where a shape recurs in at least
+`_MIN_GROUP_MEMBERS` places, since a bare pair is usually coincidence rather than a
+template.
 
 The fix when this fails is not to raise the budget. It is to parametrize over the
 one thing that varies, which keeps every assertion and deletes the copies. Lower the
@@ -33,11 +35,22 @@ from pathlib import Path
 
 TESTS = Path(__file__).parent
 
-#: Cross-module structurally identical test bodies, counted as `group size - 1`.
-#: Measured at 94 on 2026-09-07, after collapsing the thirteen `_<family>_model_outcomes`
-#: copies and the eleven one-recognition copies into `tests/_evidence_contract.py`.
+#: Cross-module structurally identical test bodies, counted as `group size - 1`, over
+#: groups of at least `_MIN_GROUP_MEMBERS`. Measured at 33 on 2026-09-07.
 #: RATCHET DOWN ONLY — see the module docstring.
-CLONE_BUDGET = 94
+CLONE_BUDGET = 33
+
+#: A shape must recur in at least this many modules to count as templated cloning.
+#:
+#: At two, the guard was measuring coincidence. 61 of its 70 groups were pairs, and the
+#: pairs are ordinary tests that happen to share a shape once identifiers and literals are
+#: erased — `test_add_dimension.py::test_a_tuple_swap_invalidates_rather_than_retargets`
+#: against `test_sheet_identity_invariant.py::test_a_tuple_swap_raises`. With the budget
+#: sitting exactly on the measured count, the next PR adding any three-statement test that
+#: collided by accident would have failed CI telling its author to "parametrize and delete
+#: the copies", which would usually be wrong — and a gate that cries wolf gets raised
+#: rather than obeyed. Templated cloning shows up as a family, not a pair.
+_MIN_GROUP_MEMBERS = 3
 
 #: A body must have at least this many statements, and this many AST nodes, before it
 #: counts. Short bodies (`build; assert`) collide by chance and would make the guard
@@ -99,7 +112,7 @@ def _clone_groups() -> dict[str, list[tuple[str, str]]]:
     return {
         digest: members
         for digest, members in shapes.items()
-        if len({module for module, _ in members}) > 1
+        if len({module for module, _ in members}) > 1 and len(members) >= _MIN_GROUP_MEMBERS
     }
 
 

--- a/tests/test_step_analysis_evaluation.py
+++ b/tests/test_step_analysis_evaluation.py
@@ -245,6 +245,19 @@ def test_versioned_corpus_has_independent_provenance_and_required_case_classes()
 
 
 def test_real_step_corpus_scores_all_layers_and_topology_variants_deterministically() -> None:
+    """The ONLY remaining repeat-evaluation check, and it covers this corpus alone.
+
+    The per-family `*_completeness_evidence` modules each ran `evaluate_step_corpus`
+    twice to assert `first == second`; those fourteen copies were removed in #1494 as
+    duplicated work, on the grounds that the invariant belongs to `evaluate_step_corpus`
+    and is owned here. That is true of the FUNCTION but not of the corpora: this test
+    loads `corpus-v1.json`, whose scope is `("holes",)`, so repeat-determinism is no
+    longer exercised on the pocket, plate, groove, turned-step, chamfer, fillet, flat,
+    pad, boss, stock, countersink, double-D or hole-pattern corpora. CLAUDE.md rates an
+    in-process repeat as weak evidence anyway — string hashing is stable for a given
+    PYTHONHASHSEED — so this is a deliberate trade, recorded here rather than left as an
+    overstatement in a merged PR body.
+    """
     corpus = load_corpus(CORPUS)
 
     first = evaluate_step_corpus(corpus)

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -306,6 +306,49 @@ def test_real_part_canary_runs_once_with_an_execution_budget():
     ) in job
 
 
+def test_coverage_artefacts_are_rendered_before_the_fail_under_gate():
+    """A coverage-floor breach must still produce the XML and HTML that explain it.
+
+    `coverage report` applies `fail_under = 90` and the step runs under `bash -e`, so
+    ordering it before `xml`/`html` means a breach aborts the step, the artefact upload
+    (which runs `if: !cancelled()` with `if-no-files-found: warn`) silently uploads
+    nothing, and Codecov receives no upload — precisely when the drop needs diagnosing.
+    pytest-cov rendered every report before raising fail-under; this keeps that.
+    """
+    job = _job(_workflow("ci.yml"), "coverage-report")
+    commands = [
+        line.strip() for line in job.splitlines() if line.strip().startswith("uv run coverage")
+    ]
+
+    assert commands, "coverage-report no longer runs coverage directly"
+    rendered = [i for i, c in enumerate(commands) if " xml" in c or " html" in c]
+    gate = [i for i, c in enumerate(commands) if c.startswith("uv run coverage report")]
+    assert rendered and gate, f"expected render and report commands, got {commands}"
+    assert max(rendered) < min(gate), (
+        f"`coverage report` applies fail_under and aborts the step; render the artefacts "
+        f"first. Got order: {commands}"
+    )
+
+
+def test_coverage_combine_follows_the_shard_matrix():
+    """The shard count lives in the matrix and `--splits`; combine must not restate it.
+
+    Naming the data files (`coverage-data-1 coverage-data-2`) is a third place to keep in
+    step. Raising the shard count without updating it combines a subset, which
+    `coverage report` then measures against `fail_under` as though it were the suite.
+    """
+    workflow = _workflow("ci.yml")
+    job = _job(workflow, "coverage-report")
+
+    assert "coverage combine coverage-data-*" in job, (
+        "combine should glob the shard artefacts rather than naming each one"
+    )
+    shards = _job(workflow, "coverage")
+    assert "--splits 2" in shards and "shard: [1, 2]" in shards, (
+        "shard count is declared in the matrix and --splits; this test pins them together"
+    )
+
+
 def test_project_coverage_allows_only_a_small_refactor_fluctuation():
     """Deleting above-average covered modules must not block a tested extraction."""
     policy = (ROOT / "codecov.yml").read_text(encoding="utf-8")

--- a/uv.lock
+++ b/uv.lock
@@ -724,6 +724,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "codespell" },
+    { name = "coverage" },
     { name = "hypothesis" },
     { name = "jsonschema" },
     { name = "mypy" },
@@ -760,6 +761,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "codespell", specifier = ">=2.3.0" },
+    { name = "coverage", specifier = ">=7" },
     { name = "hypothesis", specifier = ">=6" },
     { name = "jsonschema", specifier = ">=4,<5" },
     { name = "mypy", specifier = ">=2.1.0" },


### PR DESCRIPTION
Review findings against #1494, which merged without a review pass. Six findings, all fixed.

## 1. Coverage artefacts were never written on a floor breach (medium)

`coverage report` applies `fail_under = 90`, and the combine step runs under `bash -e`. Ordering it before `coverage xml` / `coverage html` meant a coverage drop aborted the step **before either artefact existed**. The upload step runs `if: !cancelled()` with `if-no-files-found: warn`, so it uploaded an empty artefact and Codecov received nothing — silently, and only on the runs where you actually need the XML and HTML to find the drop.

pytest-cov rendered every `--cov-report` *before* raising fail-under. #1494 lost that property when it moved rendering into an explicit step. Reordered so the gate runs last.

`test_coverage_artefacts_are_rendered_before_the_fail_under_gate` fails if the order is put back — mutation-checked.

## 2. The clone guard was measuring coincidence (medium)

`CLONE_BUDGET = 94` sat exactly on the measured count, with a shape coarse enough that **61 of its 70 groups were bare pairs** — ordinary tests sharing a shape once identifiers and literals are erased:

```
test_add_dimension.py::test_a_tuple_swap_invalidates_rather_than_retargets
test_sheet_identity_invariant.py::test_a_tuple_swap_raises
```

With zero headroom, the next PR adding any three-statement test that collided by accident would fail CI telling its author to "parametrize and delete the copies" — usually wrongly. A gate that cries wolf gets raised rather than obeyed.

`_MIN_GROUP_MEMBERS = 3` counts only shapes recurring in three or more modules. Templated cloning shows up as a family, not a pair. Budget **94 → 33**.

Verified both directions:
- a coincidental pair added across two modules no longer trips it;
- a twelfth member of the real eleven-member family still does (`34 cross-module clones, budget 33`).

## 3. Shard count hard-coded in three places (low)

`shard: [1, 2]`, `--splits 2`, and `coverage combine coverage-data-1 coverage-data-2`, with nothing tying them together. Going to three shards would have combined two of three data files and measured two thirds of the suite against `fail_under`. Combine now globs `coverage-data-*`; `test_coverage_combine_follows_the_shard_matrix` pins the matrix and `--splits` together.

## 4. `coverage` undeclared (low)

The report job invokes the `coverage` console script directly; it reached the environment only transitively via `pytest-cov`. Added to the dev group.

## 5. #1494 overstated what the retained determinism test covers (low)

Its body said the repeat-evaluation invariant stayed owned by `test_step_analysis_evaluation.py`. True of the *function*, false of the *corpora*: that test loads `corpus-v1.json`, whose scope is `("holes",)` — confirmed. So repeat-determinism is no longer exercised on the other thirteen family corpora. Still defensible under CLAUDE.md's reading of in-process repeats as weak evidence, but now recorded at the test instead of overstated in a merged PR body.

## 6. CLAUDE.md continuation orphaned (low)

#1494's insert landed between the `-m slow` bullet and its continuation line, reattaching the `-m real_part_canary` sentence to the wrong paragraph. Fixed.

---

Full fast tier: **7,293 passed, 5 skipped, 14 xfailed.** `pr-check --static` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpuGEXqUE51bP83bHZeyTY