### PR TITLE
DO NOT MERGE: verify merged version-only CI and release dispatch

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "draftwright"
-version = "0.4.22.dev0"
+version = "0.4.23.dev0"
 description = "Automated technical-drawing generation for build123d"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -702,7 +702,7 @@ wheels = [
 
 [[package]]
 name = "draftwright"
-version = "0.4.22.dev0"
+version = "0.4.23.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "antlr4-python3-runtime" },


### PR DESCRIPTION
Disposable hosted validation for #1497. This draft changes only the next development version in the two metadata records. Verify classification, lock/build, Codecov no-code-change status and the aggregate gate. Close without merging after verification; this is not a release or a requested version increment.
