### PR TITLE
deps: adopt Quiddity 0.2.5 recognition performance improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,9 @@
 
 ### Changed
 
+- Updated the exact Quiddity runtime and declared-inspection contract to 0.2.5 for the
+  provider's recognition performance improvements.
+
 - Production recognition now consumes published `quiddity==0.2.2`. Unified section-recess
   occurrences and their same-run patterns feed the existing pocket, channel and blind-slot
   drawing grammar. Original occurrence ownership, independent completeness and explicit

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -70,10 +70,10 @@ issue. The contract test derives package record outputs, converter registries, l
 and emitter branches independently, so copying a new name into the declaration alone cannot make CI
 pass.
 
-### Quiddity 0.2.4 runtime contract
+### Quiddity 0.2.5 runtime contract
 
-[#1486](https://github.com/pzfreo/draftwright/pull/1486) adopts the published
-`quiddity==0.2.4` package after the migration in
+The runtime pins the published `quiddity==0.2.5` package, following the 0.2.4 adoption in
+[#1486](https://github.com/pzfreo/draftwright/pull/1486) and the migration in
 [#1471](https://github.com/pzfreo/draftwright/issues/1471). Its public `quiddity`, `quiddity.evidence` and
 `quiddity.inspection` surfaces supply recognition, exact occurrence evidence and declared geometry
 reads. There is one recognition aggregate per build; consumers project that result rather than

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "build123d>=0.9.0,<0.11 ; python_full_version < '3.13'",
     "build123d>=0.11,<0.12 ; python_full_version >= '3.13'",
     "build123d-drafting-helpers>=0.14.2",
-    "quiddity==0.2.4",
+    "quiddity==0.2.5",
     "numpy>=1.24",
     # PNG raster export (SVG→PDF→PNG). Both permissively licensed (Pillow HPND; pypdfium2
     # Apache-2.0 wrapping Google PDFium BSD-3) and ship pre-built wheels with NO native system

--- a/src/draftwright/inspection_contract.py
+++ b/src/draftwright/inspection_contract.py
@@ -16,7 +16,7 @@ from quiddity.inspection import inspection_api_manifest
 CONSUMER_INSPECTION_FORMAT = "draftwright-inspection-api"
 CONSUMER_INSPECTION_FORMAT_VERSION = 1
 SUPPORTED_INSPECTION_API_MAJOR = 1
-SUPPORTED_RECOGNISER_VERSION = "0.2.4"
+SUPPORTED_RECOGNISER_VERSION = "0.2.5"
 _DISTRIBUTION = "quiddity"
 _PROVIDER_FORMAT = "quiddity-inspection-api"
 _NAMESPACE = "quiddity.inspection"

--- a/tests/test_inspection_contract.py
+++ b/tests/test_inspection_contract.py
@@ -26,7 +26,7 @@ def _manifest() -> dict:
 def test_installed_pypi_wheel_satisfies_the_inspection_contract() -> None:
     distribution = importlib.metadata.distribution("quiddity")
 
-    assert distribution.version == "0.2.4"
+    assert distribution.version == "0.2.5"
     assert distribution.read_text("direct_url.json") is None
     assert (
         Path(inspect.getfile(inspection.inspection_api_manifest))

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -159,7 +159,7 @@ def test_section_recess_family_covers_the_published_geometry_and_occurrence_cont
     assert not retired & package.keys()
     assert not retired & consumer.keys()
     family = package["section-recesses"]
-    assert INSTALLED_PACKAGE_VERSION == "0.2.4"
+    assert INSTALLED_PACKAGE_VERSION == "0.2.5"
     assert family["introduced_in"] == "0.2.0"
     assert family["census_output"] == "RecognitionResult.section_recesses"
     expected_fields = {

--- a/uv.lock
+++ b/uv.lock
@@ -750,7 +750,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.24" },
     { name = "pillow", specifier = ">=10" },
     { name = "pypdfium2", specifier = ">=4" },
-    { name = "quiddity", specifier = "==0.2.4" },
+    { name = "quiddity", specifier = "==0.2.5" },
     { name = "reportlab", specifier = ">=4.0" },
     { name = "steputils", specifier = "==0.1" },
     { name = "svglib", specifier = ">=1.5" },
@@ -2579,15 +2579,15 @@ wheels = [
 
 [[package]]
 name = "quiddity"
-version = "0.2.4"
+version = "0.2.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/5d/2037c329df5c131dd25da926a884b91da425a277e0d593bd480de0e79b8b/quiddity-0.2.4.tar.gz", hash = "sha256:81a29e2d827a53cdfdaf6ecff3a74570d15c438edcb13be9f086b7997e2dca7d", size = 14804668, upload-time = "2026-09-06T19:01:37.8Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/d7/9a3a7686941c3147aad406abc36b4cb5b97887d47960a5e4a37eb2ca431b/quiddity-0.2.5.tar.gz", hash = "sha256:dc2f36d8848f2a6553e82b88e2b382c6024d43d7c51579d9b8b36d024cce64da", size = 14857329, upload-time = "2026-09-07T13:04:10.854Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/6b/9a0ff63b437f5832ff59ae3bba3bd5259db00b8cd7b25f27d3805d77de6a/quiddity-0.2.4-py3-none-any.whl", hash = "sha256:303b33ef50f391264000772d6198ab42b39212b4be102c401c252719aeda4304", size = 497323, upload-time = "2026-09-06T19:01:35.696Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a2/ea9de2a6d389bd67cad2391e15045b8563d31666fb8306f1cd521e3ea546/quiddity-0.2.5-py3-none-any.whl", hash = "sha256:22d91ebc85624dbb56203ba5540b2c3c9ae7ba82bdea32d7536fe4391ad59997", size = 517010, upload-time = "2026-09-07T13:04:08.574Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Update Draftwright’s exact Quiddity dependency from 0.2.4 to the published 0.2.5 release, which contains recognition performance improvements. Update the declared-inspection version contract, its installed-package assertions, and the runtime documentation together. The lockfile changes only Quiddity and Draftwright’s matching requirement; all other dependency records are unchanged.

Validation so far: 307 focused tests passed on Python 3.14, covering the recognition and inspection contracts, adapter registry, one-run lifecycle, rounded/curved pockets, the real-part export canary, physical leader targets and bounded repair. Static preflight passed. The full slow corpus also passed on Python 3.12: 46 passed and 2 expected failures in 335.60s. An isolated stale-pin mutation made the existing installed-wheel test fail as expected. Full local preflight passed: 7,358 passed, 5 skipped and 14 expected failures on Python 3.14 in 299.82s, with 100% changed-line coverage. Hosted CI passed on the reviewed commit (run 34125964369), including both required checks. Merged as f40cde6b; its full tree matches the reviewed and locally tested head.

Google checklist and ADR review: the change adopts provider optimizations at the existing recognition boundary (ADR 3), retaining the exact-version check and installed-manifest validation. The compiler pipeline (ADR 1), shared placement (ADR 2), declared-intent front door (ADR 4), and occurrence/measurement evidence (ADR 5) remain unchanged. No ADR invariant changes or new drawing API are needed. Existing semantic expectations are retained; no test inventory is weakened. Google checklist self-review found no remaining substantive findings; local and hosted validation are green.

Upstream release: https://github.com/pzfreo/quiddity/releases/tag/quiddity-v0.2.5
