### PR TITLE
Adopt quiddity 0.2.5: one body signature per solid per recognition run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+### Changed
+
+- Adopt `quiddity==0.2.5`, which computes the body correlation signature once per solid per
+  recognition run instead of once per family. Recognition records and drawings are unchanged;
+  B-spline-heavy parts build materially faster (the wheel fixture ~2×, CTC-01 −5%).
+
 ### Added
 
 - Report schema v1 now projects one recognition-owned physical requirement ledger shared with

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -70,6 +70,18 @@ issue. The contract test derives package record outputs, converter registries, l
 and emitter branches independently, so copying a new name into the declaration alone cannot make CI
 pass.
 
+### Quiddity 0.2.5 runtime contract
+
+Adopts the published `quiddity==0.2.5` package. The public record surface, the 27-family
+manifest and every consumed schema version are unchanged from 0.2.4: the release routes each
+whole-solid query (bounding box, volume, area) through one run-scoped property cache, so the
+body correlation signature that every family reads is computed once per solid instead of once
+per family. Measured in Draftwright on the 292-face wheel fixture (`issue_1058_wheel_rh.step`),
+signing fell from nine 0.57 s computations to one, and the whole build from 11.8–18.3 s to
+5.4–5.5 s interleaved on one host; CTC-01 AP242 fell 5%, and GRM03/GRM04 were unchanged.
+Recognition scores on the groove, plate, turned-step and holes corpora are identical under
+0.2.5, and the full fast tier passes with only the five version literals changed.
+
 ### Quiddity 0.2.4 runtime contract
 
 [#1486](https://github.com/pzfreo/draftwright/pull/1486) adopts the published

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "build123d>=0.9.0,<0.11 ; python_full_version < '3.13'",
     "build123d>=0.11,<0.12 ; python_full_version >= '3.13'",
     "build123d-drafting-helpers>=0.14.2",
-    "quiddity==0.2.4",
+    "quiddity==0.2.5",
     "numpy>=1.24",
     # PNG raster export (SVG→PDF→PNG). Both permissively licensed (Pillow HPND; pypdfium2
     # Apache-2.0 wrapping Google PDFium BSD-3) and ship pre-built wheels with NO native system

--- a/src/draftwright/inspection_contract.py
+++ b/src/draftwright/inspection_contract.py
@@ -16,7 +16,7 @@ from quiddity.inspection import inspection_api_manifest
 CONSUMER_INSPECTION_FORMAT = "draftwright-inspection-api"
 CONSUMER_INSPECTION_FORMAT_VERSION = 1
 SUPPORTED_INSPECTION_API_MAJOR = 1
-SUPPORTED_RECOGNISER_VERSION = "0.2.4"
+SUPPORTED_RECOGNISER_VERSION = "0.2.5"
 _DISTRIBUTION = "quiddity"
 _PROVIDER_FORMAT = "quiddity-inspection-api"
 _NAMESPACE = "quiddity.inspection"

--- a/tests/test_inspection_contract.py
+++ b/tests/test_inspection_contract.py
@@ -26,7 +26,7 @@ def _manifest() -> dict:
 def test_installed_pypi_wheel_satisfies_the_inspection_contract() -> None:
     distribution = importlib.metadata.distribution("quiddity")
 
-    assert distribution.version == "0.2.4"
+    assert distribution.version == "0.2.5"
     assert distribution.read_text("direct_url.json") is None
     assert (
         Path(inspect.getfile(inspection.inspection_api_manifest))

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -159,7 +159,7 @@ def test_section_recess_family_covers_the_published_geometry_and_occurrence_cont
     assert not retired & package.keys()
     assert not retired & consumer.keys()
     family = package["section-recesses"]
-    assert INSTALLED_PACKAGE_VERSION == "0.2.4"
+    assert INSTALLED_PACKAGE_VERSION == "0.2.5"
     assert family["introduced_in"] == "0.2.0"
     assert family["census_output"] == "RecognitionResult.section_recesses"
     expected_fields = {

--- a/uv.lock
+++ b/uv.lock
@@ -750,7 +750,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.24" },
     { name = "pillow", specifier = ">=10" },
     { name = "pypdfium2", specifier = ">=4" },
-    { name = "quiddity", specifier = "==0.2.4" },
+    { name = "quiddity", specifier = "==0.2.5" },
     { name = "reportlab", specifier = ">=4.0" },
     { name = "steputils", specifier = "==0.1" },
     { name = "svglib", specifier = ">=1.5" },
@@ -2579,15 +2579,15 @@ wheels = [
 
 [[package]]
 name = "quiddity"
-version = "0.2.4"
+version = "0.2.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8e/5d/2037c329df5c131dd25da926a884b91da425a277e0d593bd480de0e79b8b/quiddity-0.2.4.tar.gz", hash = "sha256:81a29e2d827a53cdfdaf6ecff3a74570d15c438edcb13be9f086b7997e2dca7d", size = 14804668, upload-time = "2026-09-06T19:01:37.8Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/d7/9a3a7686941c3147aad406abc36b4cb5b97887d47960a5e4a37eb2ca431b/quiddity-0.2.5.tar.gz", hash = "sha256:dc2f36d8848f2a6553e82b88e2b382c6024d43d7c51579d9b8b36d024cce64da", size = 14857329, upload-time = "2026-09-07T13:04:10.854Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/6b/9a0ff63b437f5832ff59ae3bba3bd5259db00b8cd7b25f27d3805d77de6a/quiddity-0.2.4-py3-none-any.whl", hash = "sha256:303b33ef50f391264000772d6198ab42b39212b4be102c401c252719aeda4304", size = 497323, upload-time = "2026-09-06T19:01:35.696Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/a2/ea9de2a6d389bd67cad2391e15045b8563d31666fb8306f1cd521e3ea546/quiddity-0.2.5-py3-none-any.whl", hash = "sha256:22d91ebc85624dbb56203ba5540b2c3c9ae7ba82bdea32d7536fe4391ad59997", size = 517010, upload-time = "2026-09-07T13:04:08.574Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Provider adoption, per CLAUDE.md a PR-body matter, not an ADR change. Five version literals plus the lock; no other code.

## Why

Profiling a real-part build (`issue_1058_wheel_rh.step`, one solid, 292 B-spline faces) put **75% of 19.7 s in recognition**, and **26% of the whole build in one provider function**: `body_signature` — bounding box, volume and area of the solid, rounded — computed **nine times per build on the same solid** (`IsSame` confirmed 8 of 9 identical), 0.57 s each because `area` integrates `BRepGProp.SurfaceProperties` over every face. Twelve family call sites each re-derived the key via `unambiguous_body_keys`.

quiddity fixed it upstream (`1765d10` *share one body correlation signature across families*, `d43ede7` *route every whole-solid query through the run's property cache*) and released **0.2.5** today. Signature values are unchanged — an absent cache means a fresh one.

## Measured

Interleaved on one quiet host, best of three per round, two rounds:

| part | 0.2.4 | 0.2.5 |
|---|---|---|
| wheel (292 B-spline faces) | 11.80 / 18.28 s | **5.40 / 5.52 s** |
| CTC-01 AP242 | 4.16 / 4.40 s | 3.98 / 4.03 s |
| GRM03 | 2.30 / 2.37 s | 2.35 / 2.36 s |
| GRM04 | 1.82 / 1.91 s | 1.84 / 1.88 s |

The gain lands where faces are expensive to integrate; prismatic parts are unchanged. An earlier reading showing CTC-01 *slower* under 0.2.5 was taken while an 18-worker suite ran on the same host and is discarded.

## Exactness

- `evaluate_step_corpus` scores on the groove, plate, turned-step and holes corpora: **identical** under 0.2.5.
- Full fast tier under a 0.2.5 overlay with the *pinned* tree: 7,279 passed, **14 failed, every one the literal version gate** (`installed package version mismatch: expected '0.2.4', got '0.2.5'`). This PR changes exactly those literals.
- Full fast tier on this branch in its own environment: **7,358 passed, 5 skipped, 14 xfailed.** `pr-check --static` exit 0.

## Not in this PR

The review's other production item — memoising rendered-annotation tessellation in `leaders.py` — was built, proven byte-exact, and then **measured at no wall-clock gain** (CTC-01 3.87→3.84 s) despite 26% fewer tessellations. cProfile had inflated the cost of many small `tessellate` calls. It is not being proposed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DpuGEXqUE51bP83bHZeyTY