### PR TITLE
Support editable profile angles and recover short shoulder dimensions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,8 @@ Compact map, bottom to top:
   lifecycle), `recognition_ownership.py` (run-local accepted-occurrence outcomes, including
   final-IR binding, group/pattern absorption, and settled ownerless consumer policy),
   `plate_correspondence.py` (pure shared Plate-record/final-IR correspondence predicates),
+  `profile_angles.py` (face-profile drafting requirements from issued ordered supports),
+  `angular_geometry.py` (analytic angular ink boxes shared by sizing and rendering),
   `recogniser_policy.py` (single Draftwright-owned unsupported/deferred/evidence-only policy),
   `recogniser_schema.py` (consumer-owned public record schema versions shared by validation and
   reporting),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -95,6 +95,8 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
     PMI/GD&T, envelope/OD, centre-mark and step-length passes converged (ADR 1 (was 0015),
     #200/#208/#237) — the old per-feature `annotations/{turned,pmi}.py` modules
     were deleted as each migrated here.
+  - **`annotations/angular.py`** — angular arc/arrow/extension ink and analytic
+    radius-dependent footprints, consumed through the shared corridor solve.
   - **`annotations/holes.py`** — hole/pattern callouts, balloons, location dims
     (incl. side-drilled #133), pitch/grid dims, slots (the largest *pass*).
   - **`annotations/leaders.py`** — the one bounded late inventory for compatible
@@ -198,6 +200,8 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
 - **`linting/`** — the lint subpackage (#138 / ADR 1 (was 0005); ADR 3 (was 0007): draftwright
   owns linting): `coverage.py` (`lint_feature_coverage` + `CoverageState`),
   `structural.py` (geometry/standards checks), `issues.py` (the `LintIssue` type),
+  `angular.py` (degree claims and actual angular ink, with explicit unavailable
+  physical-support evidence),
   `gear_coverage.py` (declared gear table/profile reconciliation), and `suggest.py`
   (`_suggest_fix`, #29 snippets). Depends only on `_core`, the pure
   `plate_correspondence` leaf,

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ keep that table, this document, and `CLAUDE.md`'s compact map in step. The
 The dependency graph is a DAG (the #138 / ADR 1 (was 0005) split is complete). Bottom to
 top: leaf modules (`layout.py`, `registry.py`, `fonts.py`, `_geometry.py`,
 `fits.py`, `intents.py`, `recognition_cache.py`, `recognition_ownership.py`,
-`plate_correspondence.py`, `recogniser_policy.py`, `recogniser_schema.py`,
+`plate_correspondence.py`, `profile_angles.py`, `angular_geometry.py`, `recogniser_policy.py`, `recogniser_schema.py`,
 `recognition_frame.py`, `oriented_slot_contract.py`, `feature_identity.py`, and the strict
 `blend_contract.py` provider-record boundary) →
 `_core.py` → stage modules (`export.py`,
@@ -225,6 +225,14 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   unsupported/deferred/evidence-only occurrences are classified; remaining conditional
   cross-family records stay unclassified.
 - **`plate_correspondence.py`** — pure shared Plate-record/final-IR correspondence predicates.
+- **`profile_angles.py`** — bounded face-profile angle requirements projected from Quiddity's
+  ordered supports, with issued body/profile identity retained outside the IR. The detection
+  adapter creates the ordinary declared angle feature and records its owner in
+  `RecognitionOwnership.profile_angles`; these are drafting requirements, not additional
+  accepted recognition occurrences.
+- **`angular_geometry.py`** — analytic angular boxes from support rays, fixed typography
+  and paper-space drafting clearances. Composition and rendering share this geometry;
+  page/scale trials consume numeric boxes without constructing CAD annotation objects.
   Model assembly uses their feature dependency sets only while recording exact same-run
   occurrence ownership; completeness lint uses the same predicates for requirement ownership.
   The leaf imports neither consumer, recogniser implementation, nor drawing state.

--- a/docs/reference/draftwright-report-v3.schema.json
+++ b/docs/reference/draftwright-report-v3.schema.json
@@ -1,0 +1,420 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://draftwright.dev/schema/draftwright-report-v3.schema.json",
+  "title": "Draftwright report v3",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "schema_version",
+    "status",
+    "producer",
+    "source",
+    "outputs",
+    "recognition",
+    "lint"
+  ],
+  "properties": {
+    "schema": {
+      "const": "draftwright-report"
+    },
+    "schema_version": {
+      "const": 3
+    },
+    "status": {
+      "enum": [
+        "bounded-clear",
+        "needs-attention"
+      ]
+    },
+    "producer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "draftwright",
+        "quiddity"
+      ],
+      "properties": {
+        "draftwright": {
+          "type": "string",
+          "minLength": 1
+        },
+        "quiddity": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "name"
+      ],
+      "properties": {
+        "kind": {
+          "enum": [
+            "build123d",
+            "step"
+          ]
+        },
+        "name": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "outputs": {
+      "type": "object",
+      "description": "Reserved for the later sidecar/export integration."
+    },
+    "recognition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "coverage",
+        "identity_scope",
+        "occurrences",
+        "requirements",
+        "summary",
+        "owners"
+      ],
+      "properties": {
+        "coverage": {
+          "const": "accepted-occurrences-and-profile-requirements"
+        },
+        "identity_scope": {
+          "const": "report-local"
+        },
+        "occurrences": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/occurrence"
+          }
+        },
+        "requirements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/requirement_outcome"
+          }
+        },
+        "summary": {
+          "$ref": "#/$defs/summary"
+        },
+        "owners": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/owner"
+          }
+        }
+      }
+    },
+    "lint": {
+      "type": "object",
+      "description": "The existing Drawing.lint_summary() JSON contract."
+    }
+  },
+  "$defs": {
+    "owner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "requirement_refs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "coverage",
+        "ids"
+      ],
+      "properties": {
+        "coverage": {
+          "enum": [
+            "ledger",
+            "not-projected",
+            "not-applicable",
+            "deferred",
+            "unavailable"
+          ]
+        },
+        "ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "requirement_outcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "family",
+        "occurrence_ids",
+        "owner_ids",
+        "parameter_id",
+        "state",
+        "reason_code",
+        "annotations",
+        "representation",
+        "representation_reason"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "family": {
+          "type": "string",
+          "minLength": 1
+        },
+        "occurrence_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "owner_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "parameter_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
+        },
+        "state": {
+          "enum": [
+            "placed",
+            "satisfied_by_structured_note",
+            "suppressed",
+            "dropped",
+            "missing",
+            "unverifiable",
+            "unsupported"
+          ]
+        },
+        "reason_code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "annotations": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        },
+        "representation": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "representation_reason": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "profile_source": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "profile_id",
+            "support_ids"
+          ],
+          "properties": {
+            "kind": {
+              "const": "planar_outer_profile"
+            },
+            "profile_id": {
+              "type": "string",
+              "pattern": "^profile:[1-9][0-9]*$"
+            },
+            "support_ids": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "pattern": "^support:[1-9][0-9]*$"
+              }
+            }
+          }
+        }
+      },
+      "oneOf": [
+        {
+          "not": {
+            "required": [
+              "profile_source"
+            ]
+          },
+          "properties": {
+            "occurrence_ids": {
+              "minItems": 1
+            },
+            "family": {
+              "not": {
+                "const": "outer_profile_angles"
+              }
+            }
+          }
+        },
+        {
+          "required": [
+            "profile_source"
+          ],
+          "properties": {
+            "family": {
+              "const": "outer_profile_angles"
+            },
+            "occurrence_ids": {
+              "maxItems": 0
+            }
+          }
+        }
+      ]
+    },
+    "occurrence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "family",
+        "record_type",
+        "record_schema_version",
+        "record",
+        "disposition",
+        "reason_code",
+        "tracking",
+        "owners",
+        "requirements"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "family": {
+          "type": "string",
+          "minLength": 1
+        },
+        "record_type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "record_schema_version": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "record": {
+          "type": "object"
+        },
+        "disposition": {
+          "enum": [
+            "represented",
+            "absorbed",
+            "unsupported",
+            "deferred",
+            "evidence_only",
+            "unexpectedly_missing"
+          ]
+        },
+        "reason_code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tracking": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "owners": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/owner"
+          }
+        },
+        "requirements": {
+          "$ref": "#/$defs/requirement_refs"
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "total",
+        "represented",
+        "absorbed",
+        "unsupported",
+        "deferred",
+        "evidence_only",
+        "unexpectedly_missing"
+      ],
+      "properties": {
+        "total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "represented": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "absorbed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "unsupported": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "deferred": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "evidence_only": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "unexpectedly_missing": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    }
+  }
+}

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -70,9 +70,9 @@ issue. The contract test derives package record outputs, converter registries, l
 and emitter branches independently, so copying a new name into the declaration alone cannot make CI
 pass.
 
-### Quiddity 0.2.5 runtime contract
+### Quiddity 0.2.6 runtime contract
 
-The runtime pins the published `quiddity==0.2.5` package, following the 0.2.4 adoption in
+The runtime pins the published `quiddity==0.2.6` package, following the 0.2.4 adoption in
 [#1486](https://github.com/pzfreo/draftwright/pull/1486) and the migration in
 [#1471](https://github.com/pzfreo/draftwright/issues/1471). Its public `quiddity`, `quiddity.evidence` and
 `quiddity.inspection` surfaces supply recognition, exact occurrence evidence and declared geometry

--- a/docs/reference/reports.md
+++ b/docs/reference/reports.md
@@ -1,7 +1,7 @@
 # Machine-readable reports
 
-`Drawing.report()` returns a JSON-compatible Draftwright report. Version 2 is a
-bounded first contract: it projects the accepted occurrences from one raw automatic recognition
+`Drawing.report()` returns a JSON-compatible Draftwright report. Version 3 is a
+bounded contract: it projects the accepted occurrences from one raw automatic recognition
 run, their exact consumer dispositions and final IR owners, the recognition-owned semantic
 requirement ledger, and `Drawing.lint_summary()`.
 
@@ -20,17 +20,18 @@ report or filesystem failure leaves an existing destination unchanged. Temporary
 best-effort when the filesystem itself refuses it, and a cleanup error never masks the primary
 failure. Parent directories are not created implicitly.
 
-Version 2 names the actual recognition provider in `producer.quiddity`.
+Version 3 adds exact outer-profile support sources for angular requirements.
+[Version 2](draftwright-report-v2.schema.json) named the actual recognition provider in `producer.quiddity`.
 [Version 1](draftwright-report-v1.schema.json) used `producer.b123d-recognisers`
 and remains available for existing documents. Readers must select the schema using
 `schema_version`; a Quiddity version is not a b123d-recognisers version.
 
 The closed top-level schema is published as
-[`draftwright-report-v2.schema.json`](draftwright-report-v2.schema.json). `schema` is always
+[`draftwright-report-v3.schema.json`](draftwright-report-v3.schema.json). `schema` is always
 `"draftwright-report"`; consumers must check `schema_version` before interpreting the document.
 The schema deliberately closes its report-owned objects. Adding a field to one of those objects,
 changing a meaning, or removing a field requires a new schema version. Only the explicitly open
-payload containers (`record`, `outputs`, and `lint`) can gain producer-owned fields under version 2.
+payload containers (`record`, `outputs`, and `lint`) can gain producer-owned fields under version 3.
 
 Occurrence, owner, and requirement IDs are deterministic **within one report**. They are allocated
 from the provider's accepted-occurrence order, Draftwright's final IR order, and the existing typed
@@ -50,6 +51,16 @@ row reports the semantic state (`placed`, structured-note satisfaction, `suppres
 measurement/satisfaction provenance. An empty `annotations` list does not mean no ink exists: some
 compound renderer facts have typed semantic evidence without an independently addressable
 annotation identity.
+
+Outer-profile angles use `profile_source` instead of an accepted occurrence: its
+`kind` is `planar_outer_profile`, with a report-local `profile_id` and two
+`support_ids`. Their `occurrence_ids` are empty. These IDs are allocated on first
+use; no opaque provider reference or topology index is serialized. The physical
+corner remains a requirement when its IR owner or annotation disappears; a missing
+conversion binding is `unverifiable`, and a bound owner absent from the final model
+is `missing`. `recognition.owners` lists all final IR owners so profile-derived
+requirements can reference owners without inventing accepted occurrences.
+Version 1 and 2 schemas remain unchanged for existing documents.
 
 An occurrence's `requirements.coverage` is `ledger` when it references those rows,
 `not-applicable` for evidence-only or already-conveyed physical evidence, `deferred` when the

--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -91,8 +91,12 @@ for finding in drawing.lint():
     print(finding.code, finding.message)
 ```
 
-The supported sector is the non-reflex angle between the two directed rays.
-Reversing their order preserves that angle. For extended supports meeting beyond
+The default `sector="minor"` is the non-reflex angle towards the two witness
+points. `sector="opposite"` selects the vertically opposite sector, extending
+both supports through the vertex. It preserves the numerical angle and can keep
+an exterior dimension beside its corner. The engine never silently switches
+between these sectors or substitutes a supplementary angle.
+Reversing witness order preserves the selected angle. For extended supports meeting beyond
 a rounded corner, use `virtual_vertex=True`; this declares the virtual
 intersection without asserting that the vertex lies on a physical edge.
 Zero-length or collinear rays, oblique planes and unsupported sectors are
@@ -108,6 +112,20 @@ exact feature from `drawing.model()`. Measurement comparison records the angular
 references, so equal-valued support substitutions cannot appear preserved merely
 because the labels match.
 
+`Sheet.angle_pattern(*references)` declares repeated coplanar corners using
+`AngularReference` values from `draftwright.model`. Each corner remains independently
+addressable as `included.angle.member1`, `included.angle.member2`, and so on, in
+declaration order. Request every member with `dimension()` to permit one quantity
+label such as `3× 60°`. Different member tolerances or side preferences produce
+individual labels; omitting one member suppresses that measurement without renumbering
+the others. The generated script retains the full member geometry and each request.
+
+After the conservative strip solve, curved dimensions have up to three
+corner-local radius alternatives at the existing tier spacing. The shared
+placement stage accepts a shorter radius or recovers a dropped candidate only
+when its actual lines and label clear fixed and same-batch ink and fit the page.
+Pinned dimensions retain their solved position.
+
 The lower-level `measured_dimension(kind="angular", ...)` route retains nominal
 author-supplied text. Its explicit `AngularReference` supplies the same ray
 geometry; plain Sheet-authored three-point `ref_pts` use `(first, vertex, second)`.
@@ -115,10 +133,19 @@ Imported PMI requires explicit ordering. Structured tolerances on that raw route
 remain unsupported; use the canonical declaration for new authored angles.
 Lint compares degree values at their displayed resolution, inspects the visible
 angular ink and checks complete canonical labels against the compiler. Physical
-support correspondence remains `angular_support_unverifiable` pending the
-provider evidence contract in [Quiddity #579](https://github.com/pzfreo/quiddity/issues/579).
-Automatic profile-angle discovery remains tracked in
-[#1504](https://github.com/pzfreo/draftwright/issues/1504).
+critique checks each claimed corner against finite supports in the cached provider
+evidence, including members represented by a quantity label. Unprovable correspondence
+produces `angular_support_unverifiable`; contradictory supports produce
+`angular_support_mismatch`.
+
+Automatic drawings derive outside-profile angular requirements from ordered face
+supports in Quiddity 0.2.6. Angles already defined by a recognised chamfer or
+regular-polygon callout do not add duplicate automatic requirements. This requires
+the same run's exact face or shared-edge evidence, not matching numerical angles;
+explicit angle declarations remain available on those corners.
+Verified profile repetitions can share a quantity label;
+equal numerical angles alone do not establish a pattern. The requirement audit retains
+one outcome per physical corner even when several share one mark.
 
 ## Selecting a hole location component
 
@@ -223,6 +250,12 @@ omission suppresses a view. `add_view(...)`, `add_section_view(...)` and
 `add_detail_view(...)` augment an explicitly selected `auto_views()` source. `row(...)` and
 `column(...)` are shorthand for whole-view relations. A principal-view handle's `pin((x, y))`
 anchors its projection origin in page millimetres; it never positions an annotation.
+
+A detail around a turned step with an approved `step.length` uses a profile view
+and redraws that length through the shared dimension pass. For example,
+`s.detail_view("A", around=shoulder).scale(3)` retains its measurement identity and
+tolerance at three times the sheet scale. Omitted measurements stay omitted. An
+authored recovery detail that cannot place its dimension raises an error.
 
 Principal orthographic views share the sheet scale and reject `.scale(...)`. Detail and
 isometric handles may carry an independent positive factor. Infeasible relations, scales and

--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -67,6 +67,49 @@ build. Build and lint still assess the resulting Sheet. A
 query never replaces an existing dimension request. Keep the original feature handle for edits;
 these reports do not introduce persistent feature identities or new lane, route or pin controls.
 
+## Explicit angular measurements
+
+`measured_dimension(kind="angular", ...)` accepts an `AngularReference` in model
+coordinates. Its vertex and two witness points identify directed rays; they do
+not position the annotation. The engine chooses a true-angle principal view and
+places the arc, arrows and complete label through the shared corridor solver.
+
+```python
+from math import sqrt
+from build123d import Polygon, extrude
+from draftwright import Sheet
+from draftwright.model import AngularReference
+
+part = extrude(Polygon((0, 0), (30, 0), (15, 15 * sqrt(3)), align=None), amount=3)
+sheet = Sheet(part).authored_dimensions()
+angle = sheet.measured_dimension(
+    kind="angular", value=60, label="60°", dominant_axis="z", ref_pts=(),
+    angular_reference=AngularReference(
+        vertex=(0, 0, 3), first=(15, 0, 3), second=(7.5, 7.5 * sqrt(3), 3),
+    ),
+)
+drawing = sheet.build()
+for finding in drawing.lint():
+    print(finding.code, finding.message)
+```
+
+The supported sector is the non-reflex angle between the two directed rays.
+Reversing their order preserves that angle. For extended supports meeting beyond
+a rounded corner, use `virtual_vertex=True`; this declares the virtual
+intersection without asserting that the vertex lies on a physical edge.
+Zero-length or collinear rays and unsupported sectors are rejected. Oblique
+planes and structured angular tolerances currently produce
+`dimension_kind_unsupported`; insufficient page space produces a placement drop.
+
+Plain Sheet-authored three-point references also use `(first, vertex, second)`.
+Imported PMI does not infer this ordering: it requires an explicit angular
+reference. The authored label is retained verbatim, and lint compares its degree
+value with the projected rays and inspects the visible angular ink. Physical
+support correspondence remains `angular_support_unverifiable` pending the
+provider evidence contract in [Quiddity #579](https://github.com/pzfreo/quiddity/issues/579).
+Automatic profile-angle discovery and canonical angle selectors are still tracked
+in [#1504](https://github.com/pzfreo/draftwright/issues/1504).
+
 ## Selecting a hole location component
 
 Use `location` alone to request the usual location set. To select one component of a hole

--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -67,27 +67,25 @@ build. Build and lint still assess the resulting Sheet. A
 query never replaces an existing dimension request. Keep the original feature handle for edits;
 these reports do not introduce persistent feature identities or new lane, route or pin controls.
 
-## Explicit angular measurements
+## Angular measurements
 
-`measured_dimension(kind="angular", ...)` accepts an `AngularReference` in model
-coordinates. Its vertex and two witness points identify directed rays; they do
-not position the annotation. The engine chooses a true-angle principal view and
-places the arc, arrows and complete label through the shared corridor solver.
+`Sheet.angle()` derives an included angle from a vertex and two witness points
+in model coordinates. Select its canonical `included.angle` measurement with
+`dimension()`. The engine chooses a true-angle principal view and places the arc,
+arrows and complete compiler-owned label through the shared corridor solver.
 
 ```python
 from math import sqrt
 from build123d import Polygon, extrude
 from draftwright import Sheet
-from draftwright.model import AngularReference
 
 part = extrude(Polygon((0, 0), (30, 0), (15, 15 * sqrt(3)), align=None), amount=3)
 sheet = Sheet(part).authored_dimensions()
-angle = sheet.measured_dimension(
-    kind="angular", value=60, label="60°", dominant_axis="z", ref_pts=(),
-    angular_reference=AngularReference(
-        vertex=(0, 0, 3), first=(15, 0, 3), second=(7.5, 7.5 * sqrt(3), 3),
-    ),
+angle = sheet.angle(
+    vertex=(0, 0, 3), first=(15, 0, 3), second=(7.5, 7.5 * sqrt(3), 3),
 )
+angle.tolerance(0.05, on="included.angle")
+sheet.dimension(angle, "included.angle")
 drawing = sheet.build()
 for finding in drawing.lint():
     print(finding.code, finding.message)
@@ -97,18 +95,30 @@ The supported sector is the non-reflex angle between the two directed rays.
 Reversing their order preserves that angle. For extended supports meeting beyond
 a rounded corner, use `virtual_vertex=True`; this declares the virtual
 intersection without asserting that the vertex lies on a physical edge.
-Zero-length or collinear rays and unsupported sectors are rejected. Oblique
-planes and structured angular tolerances currently produce
-`dimension_kind_unsupported`; insufficient page space produces a placement drop.
+Zero-length or collinear rays, oblique planes and unsupported sectors are
+rejected. Insufficient page space produces `angular_dimension_dropped` against
+the named measurement. Symmetric tolerances and lower/upper deviation magnitudes
+retain degree units, including small deviations when the nominal display is
+coarse. Omitting the dimension request suppresses the angle; generated scripts
+retain its reference geometry and tolerances.
 
-Plain Sheet-authored three-point references also use `(first, vertex, second)`.
-Imported PMI does not infer this ordering: it requires an explicit angular
-reference. The authored label is retained verbatim, and lint compares its degree
-value with the projected rays and inspects the visible angular ink. Physical
+After building, `drawing.dimension(feature, "included.angle", pin=True, priority=2)`
+uses the shared corridor in live and deferred edits. As with other edits, use an
+exact feature from `drawing.model()`. Measurement comparison records the angular
+references, so equal-valued support substitutions cannot appear preserved merely
+because the labels match.
+
+The lower-level `measured_dimension(kind="angular", ...)` route retains nominal
+author-supplied text. Its explicit `AngularReference` supplies the same ray
+geometry; plain Sheet-authored three-point `ref_pts` use `(first, vertex, second)`.
+Imported PMI requires explicit ordering. Structured tolerances on that raw route
+remain unsupported; use the canonical declaration for new authored angles.
+Lint compares degree values at their displayed resolution, inspects the visible
+angular ink and checks complete canonical labels against the compiler. Physical
 support correspondence remains `angular_support_unverifiable` pending the
 provider evidence contract in [Quiddity #579](https://github.com/pzfreo/quiddity/issues/579).
-Automatic profile-angle discovery and canonical angle selectors are still tracked
-in [#1504](https://github.com/pzfreo/draftwright/issues/1504).
+Automatic profile-angle discovery remains tracked in
+[#1504](https://github.com/pzfreo/draftwright/issues/1504).
 
 ## Selecting a hole location component
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "build123d>=0.9.0,<0.11 ; python_full_version < '3.13'",
     "build123d>=0.11,<0.12 ; python_full_version >= '3.13'",
     "build123d-drafting-helpers>=0.14.2",
-    "quiddity==0.2.5",
+    "quiddity==0.2.6",
     "numpy>=1.24",
     # PNG raster export (SVG→PDF→PNG). Both permissively licensed (Pillow HPND; pypdfium2
     # Apache-2.0 wrapping Google PDFium BSD-3) and ship pre-built wheels with NO native system

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,11 @@ dependencies = [
     # 3.13+. Mirrors pzfreo/build123d-mcp's dependency handling.
     "build123d>=0.9.0,<0.11 ; python_full_version < '3.13'",
     "build123d>=0.11,<0.12 ; python_full_version >= '3.13'",
+    # Supported build123d releases use OCP 7.x; ocp_gordon 0.3 requires OCP 8.x.
+    "ocp_gordon<0.3",
+    # This novtk release lacks OCP.GccEnt on macOS. The exclusion must reach
+    # published wheels, not only uv's development resolver constraints.
+    "cadquery-ocp-novtk!=7.9.3.1.1 ; python_full_version >= '3.13'",
     "build123d-drafting-helpers>=0.14.2",
     "quiddity==0.2.6",
     "numpy>=1.24",
@@ -187,12 +192,3 @@ skip = "*.stp,*.step,*.svg,*.dxf,*.pdf,uv.lock,.git,*.ttf,*.otf,src/draftwright/
 # `nd` a Dijkstra distance var, `tread` a real word (stair-tread faces), `accreting`
 # a real word, `testof` the `TestOf` class name, and the valid hyphenated re-* forms.
 ignore-words-list = "nd,tread,accreting,testof,re-using,re-declare,re-declared,re-declaring"
-
-[tool.uv]
-# On Python 3.13/3.14, build123d resolves to 0.11, whose OCP kernel is
-# cadquery-ocp-novtk (VTK dropped from the transitive tree — fine here, draftwright
-# renders headless and never imports VTK). Its 7.9.3.1.1 release ships a broken macOS
-# wheel (no OCP.GccEnt module → build123d fails to import), so pin it out. Only bites
-# when novtk is actually resolved (build123d 0.11); harmless on 0.10/cadquery-ocp.
-# Mirrors pzfreo/build123d-mcp. Remove once upstream fixes the wheel.
-constraint-dependencies = ["cadquery-ocp-novtk!=7.9.3.1.1"]

--- a/src/draftwright/_geometry.py
+++ b/src/draftwright/_geometry.py
@@ -585,6 +585,30 @@ def _fmt(v: float, decimals: int | None = None) -> str:
     return str(r) if abs(v - r) < 1e-6 else f"{v:.1f}"
 
 
+def _fmt_angle(value, decimals=None, tolerance=None) -> str:
+    """Complete angular text shared by footprint sizing and compilation.
+
+    This pure formatter approves no content and needs no feature or compiled plan.
+    """
+    nominal = f"{_fmt(value, decimals)}°"
+    if tolerance is None:
+        return nominal
+
+    def magnitude(value):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError("angular tolerance must be a nonnegative degree magnitude")
+        if not math.isfinite(value) or value < 0:
+            raise ValueError("angular tolerance must be finite and nonnegative")
+        # Keep small authored deviations even when nominal display precision is
+        # coarse; formatting a nonzero tolerance as zero would change the claim.
+        return format(Decimal(str(value)), "f")
+
+    if isinstance(tolerance, tuple) and len(tolerance) == 2:
+        lower, upper = tolerance
+        return f"{nominal} +{magnitude(upper)}° -{magnitude(lower)}°"
+    return f"{nominal} ±{magnitude(tolerance)}°"
+
+
 def _boxes_overlap(a, b) -> bool:
     """True when two ``(x0, y0, x1, y1)`` AABBs overlap (strict: a touch is not
     an overlap). The one pairwise test behind both the placement-side

--- a/src/draftwright/angular_geometry.py
+++ b/src/draftwright/angular_geometry.py
@@ -1,0 +1,146 @@
+"""Analytic angular footprints shared by composition and rendered dimensions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import atan2, cos, hypot, pi, sin
+
+
+@dataclass(frozen=True)
+class AngularStyle:
+    """Fixed paper-space dimensions needed for analytic angular ink."""
+
+    arrow_length: float
+    extension_gap: float
+    pad_around_text: float
+    line_width: float
+
+
+def _box(points, padding=0.0):
+    xs, ys = zip(*points, strict=True)
+    return min(xs) - padding, min(ys) - padding, max(xs) + padding, max(ys) + padding
+
+
+def _rotate(point, angle):
+    c, s = cos(angle), sin(angle)
+    x, y = point
+    return c * x - s * y, s * x + c * y
+
+
+class AngularGeometry:
+    """One projected angular intent; only its radius varies during placement.
+
+    Coordinates belong to the already selected true-angle projection. The two
+    directed rays fix the sector: moving an annotation cannot turn an acute
+    dimension into its supplementary angle or move it to the opposite sector.
+    """
+
+    def __init__(self, vertex, first, second, text_size, draft, *, sector="minor"):
+        if sector not in ("minor", "opposite"):
+            raise ValueError("angular ink needs a minor or opposite sector")
+        self.sector = sector
+        self.vertex = tuple(vertex[:2])
+        points = (tuple(first[:2]), tuple(second[:2]))
+        rays = [tuple(p - v for p, v in zip(point, self.vertex, strict=True)) for point in points]
+        lengths = tuple(hypot(*ray) for ray in rays)
+        # Page-fit bisection can project valid model rays far below a nanometre.
+        # Their directions still define the same angle and fixed-size label;
+        # rejecting them here turns an infeasible sheet into a render exception.
+        if min(lengths) == 0:
+            raise ValueError("angular ink needs two nonzero projected rays")
+        rays = [tuple(c / length for c in ray) for ray, length in zip(rays, lengths, strict=True)]
+        if sector == "opposite":
+            rays = [tuple(-component for component in ray) for ray in rays]
+            lengths = tuple(-length for length in lengths)
+        first_ray, second_ray = rays
+        signed = atan2(
+            first_ray[0] * second_ray[1] - first_ray[1] * second_ray[0],
+            sum(a * b for a, b in zip(first_ray, second_ray, strict=True)),
+        )
+        self.sweep = abs(signed)
+        if not 1e-9 < self.sweep < pi - 1e-9:
+            raise ValueError("angular ink needs a nondegenerate minor sector")
+        if signed < 0:
+            first_ray, second_ray = second_ray, first_ray
+            points = points[::-1]
+            lengths = lengths[::-1]
+        self.start = atan2(first_ray[1], first_ray[0])
+        self.middle = self.start + self.sweep / 2
+        self.rays = (first_ray, second_ray)
+        self.witnesses = points
+        self.lengths = lengths
+        self.draft = draft
+        self.text_size = text_size
+        tangent = (self.middle + pi / 2) % (2 * pi)
+        self.text_angle = tangent - pi if pi / 2 < tangent <= 3 * pi / 2 else tangent
+        width, height = self.text_size
+        # This bound leaves room for both arrow shafts and the full text. It also
+        # keeps extension lines beyond their physical witness points. Opposite
+        # witnesses have negative stations: their extensions cross the vertex.
+        self.minimum_radius = max(
+            max(lengths) + draft.extension_gap + draft.arrow_length,
+            (width + height + 2 * draft.pad_around_text + 4 * draft.arrow_length) / self.sweep
+            + height / 2
+            + draft.pad_around_text,
+        )
+
+    @property
+    def bisector(self):
+        return cos(self.middle), sin(self.middle)
+
+    def point(self, radius, angle):
+        x, y = self.vertex
+        return x + radius * cos(angle), y + radius * sin(angle)
+
+    def label_polygon(self, radius):
+        width, height = self.text_size
+        centre = self.point(radius, self.middle)
+        return tuple(
+            tuple(a + b for a, b in zip(centre, _rotate(point, self.text_angle), strict=True))
+            for point in (
+                (-width / 2, -height / 2),
+                (width / 2, -height / 2),
+                (width / 2, height / 2),
+                (-width / 2, height / 2),
+            )
+        )
+
+    def extension_segments(self, radius):
+        end_radius = radius + self.draft.extension_gap
+        return tuple(
+            (
+                self.point(length + self.draft.extension_gap, angle),
+                self.point(end_radius, angle),
+            )
+            for length, angle in zip(
+                self.lengths, (self.start, self.start + self.sweep), strict=True
+            )
+        )
+
+    def arc_intervals(self, radius):
+        width, height = self.text_size
+        gap = atan2(
+            width / 2 + self.draft.pad_around_text,
+            radius - height / 2 - self.draft.pad_around_text,
+        )
+        intervals = ((self.start, self.middle - gap), (self.middle + gap, self.start + self.sweep))
+        if any((end - start) * radius <= self.draft.arrow_length for start, end in intervals):
+            raise ValueError("angular radius cannot carry the complete label and arrows")
+        return intervals
+
+    def footprint(self, radius):
+        """Conservative analytic ink box, including arc extrema and arrow heads.
+
+        The perpendicular extent changes with radius. Supplying this function to
+        the corridor prevents its straight-dimension translation model from
+        hiding obstacles from an angular candidate.
+        """
+        angles = [self.start, self.start + self.sweep]
+        for index in range(-4, 9):
+            angle = index * pi / 2
+            if self.start < angle < self.start + self.sweep:
+                angles.append(angle)
+        points = [self.point(radius, angle) for angle in angles]
+        points.extend(point for segment in self.extension_segments(radius) for point in segment)
+        points.extend(self.label_polygon(radius))
+        return _box(points, self.draft.arrow_length + self.draft.line_width)

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -2053,6 +2053,10 @@ class CorridorCandidate:
     # keeping footprints truthful (``dim_footprint``, ±0.05 mm) is what keeps that
     # fallback rare and the placement identical to the probe path.
     footprint: object | None = None
+    # A candidate can need a minimum geometric clearance (e.g. an angular arc
+    # must carry its complete label). Reject an infeasible tier before building
+    # OCC ink; the caller's normal drop/fallback path remains authoritative.
+    valid_position: object | None = None
 
 
 def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=(), *, key=None, ctx=None):
@@ -2210,6 +2214,7 @@ def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=(), *, k
     anchored = {c.name: c.anchored for c in kept if c.anchored}
     naturals = {c.name: c.natural for c in kept if c.natural is not None}
     foots = {c.name: c.footprint for c in kept if c.footprint is not None}  # analytical (#602)
+    valid_positions = {c.name: c.valid_position for c in kept if c.valid_position is not None}
     left = {
         n
         for n, _ in place_strip_candidates(
@@ -2229,6 +2234,7 @@ def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=(), *, k
             anchored=anchored,
             naturals=naturals,
             footprints=foots,
+            valid_positions=valid_positions,
             corner_reserves=corner_reserves,
             trace=trace,
         )
@@ -2247,6 +2253,7 @@ def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=(), *, k
                 ctx=ctx,
                 force=True,
                 footprints=foots,
+                valid_positions=valid_positions,
                 corner_reserves=corner_reserves,
                 features=feats,
                 measurements=meas,
@@ -2538,6 +2545,7 @@ def place_strip_candidates(
     anchored=None,
     naturals=None,
     footprints=None,
+    valid_positions=None,
     corner_reserves=(),
     trace=None,
     trace_label=None,
@@ -2775,6 +2783,11 @@ def place_strip_candidates(
             pos = res.placed.get(sc.key)
             if pos is None:  # segment over its estimated capacity (shouldn't occur)
                 _reject(name, "over_capacity")
+                rejected.append((name, build))
+                continue
+            valid_position = (valid_positions or {}).get(name)
+            if valid_position is not None and not valid_position(pos):
+                _reject(name, "geometric_clearance")
                 rejected.append((name, build))
                 continue
             # Predicted box, not built geometry (#602): the refill loop re-evaluates

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -13,6 +13,7 @@ import logging
 import math
 import os
 from dataclasses import dataclass, field
+from itertools import chain
 from pathlib import Path
 from typing import Any
 
@@ -33,6 +34,7 @@ from draftwright._geometry import (  # noqa: F401
     _segment_crosses_box,
     _segments_cross_or_overlap,
 )
+from draftwright.annotations.angular import AngularDimension
 from draftwright.layout import StripCandidate, plan_strip
 from draftwright.linting.ink_overlap import (
     MIN_CROSSING_MM,
@@ -44,6 +46,8 @@ from draftwright.linting.issues import LintIssue
 from draftwright.linting.structural import (
     _ann_box,
     _centerline_extent,
+    _edges_intersect_rect,
+    _view_edge_entries,
 )
 from draftwright.model.compiled import resolve_feature
 from draftwright.model.ir import HoleFeature, PatternFeature
@@ -616,6 +620,12 @@ class SolveTrace:
         (with *label*) for a pass-local strip placement outside any corridor."""
         rec: dict = {
             "force": force,
+            # A fallback can use another axis/view while its parent corridor is
+            # still open. Every pass therefore owns its coordinate frame.
+            "label": label,
+            "view": view,
+            "axis": axis,
+            "strip": self._strip_rec(strip),
             "obstacles": [],
             "free_segments": [],
             "placed": [],
@@ -628,10 +638,6 @@ class SolveTrace:
             rec = {
                 "seq": self._next_seq(),
                 "phase": self._phase,
-                "label": label,
-                "view": view,
-                "axis": axis,
-                "strip": self._strip_rec(strip),
                 **rec,
                 "items": [],
             }
@@ -1504,7 +1510,7 @@ def box_within_page_and_clear(bb, page_box, obstacles) -> bool:
     )
 
 
-def annotation_ink_clear(dwg, candidate, *, view=None) -> bool:
+def annotation_ink_clear(dwg, candidate, *, view=None, additional=()) -> bool:
     """Whether *candidate* clears exact decomposable ink and conservative fixed furniture.
 
     A diagonal dimension cannot use the strip system's conservative AABB occupancy as its
@@ -1528,8 +1534,8 @@ def annotation_ink_clear(dwg, candidate, *, view=None) -> bool:
     )
     if candidate_region is None:
         return False
-    for name, annotation in dwg.iter_annotations():
-        owner = dwg.view_of(name)
+    for name, annotation in chain(dwg.iter_annotations(), ((None, item) for item in additional)):
+        owner = dwg.view_of(name) if name is not None else view
         if view is not None and owner is not None and owner != view:
             continue
         annotation_segments = segments_of(annotation)
@@ -1542,9 +1548,9 @@ def annotation_ink_clear(dwg, candidate, *, view=None) -> bool:
             item=annotation,
             segments=annotation_segments,
         )
-        crossable_strokes = isinstance(annotation, (Dimension, SafeDimension)) or (
-            type(annotation).__name__ in CROSSABLE_TYPES
-        )
+        crossable_strokes = isinstance(
+            annotation, (Dimension, SafeDimension, AngularDimension)
+        ) or (type(annotation).__name__ in CROSSABLE_TYPES)
         if annotation_label is not None and annotation_region is None:
             try:
                 conservative_label_hit = _boxes_overlap(candidate_label, annotation_label) or any(
@@ -1593,6 +1599,19 @@ def annotation_ink_clear(dwg, candidate, *, view=None) -> bool:
     return True
 
 
+def view_label_clearance(dwg, view):
+    """A label guard over the same projected edges the structural critic reads.
+
+    Prepare the edges once per batch, outside candidate evaluation. Missing view
+    geometry supplies no guard; unreadable geometry cannot establish clearance.
+    """
+    placed = getattr(dwg, "views", {}).get(view)
+    if not placed or placed[0] is None:
+        return None
+    entries = _view_edge_entries(placed[0], {})
+    return lambda box: entries is not None and not _edges_intersect_rect(entries, box)
+
+
 def prevent_dimension_label_ink(
     dimensions,
     *,
@@ -1600,6 +1619,7 @@ def prevent_dimension_label_ink(
     immutable=(),
     obstacles=(),
     perpendicular_step=None,
+    label_clear=None,
 ):
     """Choose small along-line label offsets for a just-built dimension batch.
 
@@ -1627,12 +1647,14 @@ def prevent_dimension_label_ink(
     whose line-work cannot be cleared by moving labels along their measured spans.
     Fixed *obstacles* do not make an existing contact this local batch's responsibility, but
     no selected move may introduce a new label contact with one.
+    ``label_clear`` optionally checks labels against projected part ink. Unlike
+    pre-existing annotation contacts, these are conflicts to resolve in this batch.
 
     Returns ``[(name, dimension), ...]`` in input order.
     """
 
     original = list(dimensions)
-    if len(original) < 2:
+    if not original or (len(original) < 2 and label_clear is None):
         return original
     immutable = set(immutable)
     obstacles = tuple(obstacles)
@@ -1729,6 +1751,8 @@ def prevent_dimension_label_ink(
         for target, (label, region) in enumerate(zip(labels, regions, strict=True)):
             if label is None or region is None:
                 continue
+            if label_clear is not None and not label_clear(label):
+                found.add(("view", target))
             # Helpers expose no arrow polygons.  The foreign dimension's exact
             # attachment tips still participate, closing the line-metadata gap without
             # guessing the orientation of this dimension's own inside/outside arrows.
@@ -1907,6 +1931,8 @@ def prevent_dimension_label_ink(
                 involved.update((conflict[1], conflict[2]))  # source + crossed label
             elif conflict[0] == "fixed":
                 involved.add(conflict[2])
+            elif conflict[0] == "view":
+                involved.add(conflict[1])
             else:  # label/label
                 involved.update((conflict[1], conflict[2]))
         best = None
@@ -2057,6 +2083,9 @@ class CorridorCandidate:
     # must carry its complete label). Reject an infeasible tier before building
     # OCC ink; the caller's normal drop/fallback path remains authoritative.
     valid_position: object | None = None
+    # Bounded curved-ink alternatives, checked against actual ink after the
+    # conservative strip solve. They preserve the approved content and sector.
+    compact_candidates: object | None = None
 
 
 def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=(), *, key=None, ctx=None):
@@ -2215,6 +2244,7 @@ def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=(), *, k
     naturals = {c.name: c.natural for c in kept if c.natural is not None}
     foots = {c.name: c.footprint for c in kept if c.footprint is not None}  # analytical (#602)
     valid_positions = {c.name: c.valid_position for c in kept if c.valid_position is not None}
+    compactions = {c.name: c.compact_candidates for c in kept if c.compact_candidates is not None}
     left = {
         n
         for n, _ in place_strip_candidates(
@@ -2235,6 +2265,7 @@ def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=(), *, k
             naturals=naturals,
             footprints=foots,
             valid_positions=valid_positions,
+            compact_candidates=compactions,
             corner_reserves=corner_reserves,
             trace=trace,
         )
@@ -2254,6 +2285,7 @@ def solve_corridor(dwg, strip, view, axis, cands, tier, corner_reserves=(), *, k
                 force=True,
                 footprints=foots,
                 valid_positions=valid_positions,
+                compact_candidates=compactions,
                 corner_reserves=corner_reserves,
                 features=feats,
                 measurements=meas,
@@ -2546,6 +2578,7 @@ def place_strip_candidates(
     naturals=None,
     footprints=None,
     valid_positions=None,
+    compact_candidates=None,
     corner_reserves=(),
     trace=None,
     trace_label=None,
@@ -2880,6 +2913,48 @@ def place_strip_candidates(
                 continue
             real = _geom_box(dim)
             solved.append((name, natural if _real_box_conflict(name, real) else dim))
+    # Curved ink can enclose large empty rectangles. After the shared strip
+    # solve, try a bounded contraction using actual segments and labels against
+    # both committed ink and this batch. Never move an anchored dimension.
+    active_names = {name for name, _build in cands}
+    for name, alternatives in (compact_candidates or {}).items():
+        if name not in active_names:
+            continue
+        if (anchored or {}).get(name, False):
+            continue
+        index = next((i for i, (key, _dim) in enumerate(solved) if key == name), None)
+        original = solved[index][1] if index is not None else None
+        others = [item for key, item in solved if key != name]
+        for candidate in alternatives():
+            if original is not None and candidate.arc_radius >= original.arc_radius - 1e-6:
+                break
+            box = _geom_box(candidate)
+            if (
+                box is None
+                or box[0] < _MARGIN
+                or box[1] < _MARGIN
+                or box[2] > dwg.page_w - _MARGIN
+                or box[3] > dwg.page_h - _MARGIN
+                or ((forbid or {}).get(name) is not None and _box_hits(box, (forbid[name],)))
+                or not annotation_ink_clear(dwg, candidate, additional=others)
+            ):
+                continue
+            if index is None:
+                solved.append((name, candidate))
+                todo = [(key, build) for key, build in todo if key != name]
+                if tp is not None:
+                    label = candidate.label_bbox
+                    tp["placed"].append({"name": name, "pos": (label[idx] + label[idx + 2]) / 2})
+            else:
+                solved[index] = (name, candidate)
+                if tp is not None:
+                    entry = next(item for item in tp["placed"] if item["name"] == name)
+                    label = candidate.label_bbox
+                    entry["strip_pos"] = entry["pos"]
+                    entry["pos"] = (label[idx] + label[idx + 2]) / 2
+            if tp is not None:
+                tp.setdefault("angular_contractions", []).append(name)
+            break
     for name, dim in solved:
         # Record feature provenance (ADR 5 (was 0010)): the drain-time seam for corridor-placed
         # dims — `features` maps this batch's names to their source IR feature.

--- a/src/draftwright/annotations/angular.py
+++ b/src/draftwright/annotations/angular.py
@@ -1,0 +1,230 @@
+"""Angular ink and radius-dependent footprints for the shared corridor solve."""
+
+from __future__ import annotations
+
+from math import atan2, ceil, cos, degrees, hypot, pi, radians, sin
+
+from build123d import Align, Arrow, Compound, Edge, Location, Mode, Text, trace
+
+from draftwright._core import _text_size
+from draftwright.fonts import PLEX_MONO
+
+
+def _box(points, padding=0.0):
+    xs, ys = zip(*points, strict=True)
+    return min(xs) - padding, min(ys) - padding, max(xs) + padding, max(ys) + padding
+
+
+def _rotate(point, angle):
+    c, s = cos(angle), sin(angle)
+    x, y = point
+    return c * x - s * y, s * x + c * y
+
+
+class AngularInk:
+    """One projected angular intent; only its radius varies during placement.
+
+    Coordinates belong to the already selected true-angle projection. The two
+    directed rays fix the sector: moving an annotation cannot turn an acute
+    dimension into its supplementary angle or move it to the opposite sector.
+    """
+
+    def __init__(self, vertex, first, second, label, draft):
+        self.vertex = tuple(vertex[:2])
+        points = (tuple(first[:2]), tuple(second[:2]))
+        rays = [tuple(p - v for p, v in zip(point, self.vertex, strict=True)) for point in points]
+        lengths = tuple(hypot(*ray) for ray in rays)
+        if min(lengths) <= 1e-9:
+            raise ValueError("angular ink needs two nonzero projected rays")
+        rays = [tuple(c / length for c in ray) for ray, length in zip(rays, lengths, strict=True)]
+        first_ray, second_ray = rays
+        signed = atan2(
+            first_ray[0] * second_ray[1] - first_ray[1] * second_ray[0],
+            sum(a * b for a, b in zip(first_ray, second_ray, strict=True)),
+        )
+        self.sweep = abs(signed)
+        if not 1e-9 < self.sweep < pi - 1e-9:
+            raise ValueError("angular ink needs a nondegenerate minor sector")
+        if signed < 0:
+            first_ray, second_ray = second_ray, first_ray
+            points = points[::-1]
+            lengths = lengths[::-1]
+        self.start = atan2(first_ray[1], first_ray[0])
+        self.middle = self.start + self.sweep / 2
+        self.rays = (first_ray, second_ray)
+        self.witnesses = points
+        self.lengths = lengths
+        self.label = label
+        self.draft = draft
+        self.font_path = getattr(draft, "font_path", PLEX_MONO)
+        self.text_size = _text_size(
+            label, draft.font_size, self.font_path, draft.font, draft.font_style
+        )
+        tangent = (self.middle + pi / 2) % (2 * pi)
+        self.text_angle = tangent - pi if pi / 2 < tangent <= 3 * pi / 2 else tangent
+        width, height = self.text_size
+        # This bound leaves room for both arrow shafts and the full text. It also
+        # keeps extension lines beyond their physical witness points.
+        self.minimum_radius = max(
+            max(lengths) + draft.extension_gap + draft.arrow_length,
+            (width + height + 2 * draft.pad_around_text + 4 * draft.arrow_length) / self.sweep
+            + height / 2
+            + draft.pad_around_text,
+        )
+
+    @property
+    def bisector(self):
+        return cos(self.middle), sin(self.middle)
+
+    def point(self, radius, angle):
+        x, y = self.vertex
+        return x + radius * cos(angle), y + radius * sin(angle)
+
+    def label_polygon(self, radius):
+        width, height = self.text_size
+        centre = self.point(radius, self.middle)
+        return tuple(
+            tuple(a + b for a, b in zip(centre, _rotate(point, self.text_angle), strict=True))
+            for point in (
+                (-width / 2, -height / 2),
+                (width / 2, -height / 2),
+                (width / 2, height / 2),
+                (-width / 2, height / 2),
+            )
+        )
+
+    def extension_segments(self, radius):
+        end_radius = radius + self.draft.extension_gap
+        return tuple(
+            (
+                self.point(length + self.draft.extension_gap, angle),
+                self.point(end_radius, angle),
+            )
+            for length, angle in zip(
+                self.lengths, (self.start, self.start + self.sweep), strict=True
+            )
+        )
+
+    def arc_intervals(self, radius):
+        width, height = self.text_size
+        gap = atan2(
+            width / 2 + self.draft.pad_around_text,
+            radius - height / 2 - self.draft.pad_around_text,
+        )
+        intervals = ((self.start, self.middle - gap), (self.middle + gap, self.start + self.sweep))
+        if any((end - start) * radius <= self.draft.arrow_length for start, end in intervals):
+            raise ValueError("angular radius cannot carry the complete label and arrows")
+        return intervals
+
+    def footprint(self, radius):
+        """Conservative analytic ink box, including arc extrema and arrow heads.
+
+        The perpendicular extent changes with radius. Supplying this function to
+        the corridor prevents its straight-dimension translation model from
+        hiding obstacles from an angular candidate.
+        """
+        angles = [self.start, self.start + self.sweep]
+        for index in range(-4, 9):
+            angle = index * pi / 2
+            if self.start < angle < self.start + self.sweep:
+                angles.append(angle)
+        points = [self.point(radius, angle) for angle in angles]
+        points.extend(point for segment in self.extension_segments(radius) for point in segment)
+        points.extend(self.label_polygon(radius))
+        return _box(points, self.draft.arrow_length + self.draft.line_width)
+
+    def build(self, radius):
+        return AngularDimension(self, radius)
+
+
+class AngularDimension(Compound):
+    """Arc, arrow heads, complete label and extension lines, with movable metadata."""
+
+    def __init__(self, ink: AngularInk, radius: float):
+        if radius < ink.minimum_radius:
+            raise ValueError("angular radius is below the legibility bound")
+        draft = ink.draft
+        intervals = ink.arc_intervals(radius)
+        shafts = [
+            Edge.make_circle(radius, start_angle=degrees(start), end_angle=degrees(end)).moved(
+                Location((*ink.vertex, 0))
+            )
+            for start, end in intervals
+        ]
+        arrows = [
+            Arrow(
+                draft.arrow_length,
+                shaft,
+                draft.line_width,
+                head_at_start=index == 0,
+                head_type=draft.head_type,
+                mode=Mode.PRIVATE,
+            )
+            for index, shaft in enumerate(shafts)
+        ]
+        segments = ink.extension_segments(radius)
+        extensions = trace(
+            [Edge.make_line((*start, 0), (*end, 0)) for start, end in segments],
+            line_width=draft.line_width,
+            mode=Mode.PRIVATE,
+        )
+        text = Text(
+            ink.label,
+            font_size=draft.font_size,
+            font_path=ink.font_path,
+            font=draft.font,
+            font_style=draft.font_style,
+            align=Align.CENTER,
+            mode=Mode.PRIVATE,
+        )
+        box = text.bounding_box()
+        text = text.moved(
+            Location((-(box.min.X + box.max.X) / 2, -(box.min.Y + box.max.Y) / 2, 0))
+        )
+        centre = ink.point(radius, ink.middle)
+        text = text.moved(Location((*centre, 0), (0, 0, degrees(ink.text_angle))))
+        super().__init__(children=[*arrows, extensions, text], label=ink.label)
+        self._angular_points = (ink.witnesses[0], ink.vertex, ink.witnesses[1])
+        self._label_polygon = ink.label_polygon(radius)
+        self._extension_segments = segments
+        self._radius = radius
+        self._sweep = ink.sweep
+        self._arc_intervals = intervals
+        self._vertex = ink.vertex
+
+    def _point(self, point):
+        rotated = _rotate(point, radians(self.location.orientation.Z))
+        return rotated[0] + self.location.position.X, rotated[1] + self.location.position.Y
+
+    @property
+    def angular_points(self):
+        return tuple(self._point(point) for point in self._angular_points)
+
+    @property
+    def measured_angle(self):
+        return degrees(self._sweep)
+
+    @property
+    def label_polygon(self):
+        return tuple(self._point(point) for point in self._label_polygon)
+
+    @property
+    def label_bbox(self):
+        return _box(self.label_polygon)
+
+    @property
+    def segments(self):
+        # The existing ink critic accepts line segments. Bound arc chord error
+        # by 0.005mm so curved shafts also participate in collision checks.
+        result = list(self._extension_segments)
+        for start, end in self._arc_intervals:
+            count = max(1, ceil((end - start) * (self._radius / 0.04) ** 0.5))
+            points = [
+                (
+                    self._vertex[0] + self._radius * cos(start + (end - start) * index / count),
+                    self._vertex[1] + self._radius * sin(start + (end - start) * index / count),
+                )
+                for index in range(count + 1)
+            ]
+            result.extend(zip(points, points[1:]))
+        return tuple((self._point(start), self._point(end)) for start, end in result)

--- a/src/draftwright/annotations/angular.py
+++ b/src/draftwright/annotations/angular.py
@@ -2,139 +2,33 @@
 
 from __future__ import annotations
 
-from math import atan2, ceil, cos, degrees, hypot, pi, radians, sin
+from math import ceil, cos, degrees, radians, sin
 
 from build123d import Align, Arrow, Compound, Edge, Location, Mode, Text, trace
 
 from draftwright._core import _text_size
+from draftwright.angular_geometry import AngularGeometry, _box, _rotate
 from draftwright.fonts import PLEX_MONO
 
 
-def _box(points, padding=0.0):
-    xs, ys = zip(*points, strict=True)
-    return min(xs) - padding, min(ys) - padding, max(xs) + padding, max(ys) + padding
+class AngularInk(AngularGeometry):
+    """A projected angular intent with measured text and bounded rendered candidates."""
 
-
-def _rotate(point, angle):
-    c, s = cos(angle), sin(angle)
-    x, y = point
-    return c * x - s * y, s * x + c * y
-
-
-class AngularInk:
-    """One projected angular intent; only its radius varies during placement.
-
-    Coordinates belong to the already selected true-angle projection. The two
-    directed rays fix the sector: moving an annotation cannot turn an acute
-    dimension into its supplementary angle or move it to the opposite sector.
-    """
-
-    def __init__(self, vertex, first, second, label, draft):
-        self.vertex = tuple(vertex[:2])
-        points = (tuple(first[:2]), tuple(second[:2]))
-        rays = [tuple(p - v for p, v in zip(point, self.vertex, strict=True)) for point in points]
-        lengths = tuple(hypot(*ray) for ray in rays)
-        if min(lengths) <= 1e-9:
-            raise ValueError("angular ink needs two nonzero projected rays")
-        rays = [tuple(c / length for c in ray) for ray, length in zip(rays, lengths, strict=True)]
-        first_ray, second_ray = rays
-        signed = atan2(
-            first_ray[0] * second_ray[1] - first_ray[1] * second_ray[0],
-            sum(a * b for a, b in zip(first_ray, second_ray, strict=True)),
-        )
-        self.sweep = abs(signed)
-        if not 1e-9 < self.sweep < pi - 1e-9:
-            raise ValueError("angular ink needs a nondegenerate minor sector")
-        if signed < 0:
-            first_ray, second_ray = second_ray, first_ray
-            points = points[::-1]
-            lengths = lengths[::-1]
-        self.start = atan2(first_ray[1], first_ray[0])
-        self.middle = self.start + self.sweep / 2
-        self.rays = (first_ray, second_ray)
-        self.witnesses = points
-        self.lengths = lengths
+    def __init__(self, vertex, first, second, label, draft, *, sector="minor"):
         self.label = label
-        self.draft = draft
         self.font_path = getattr(draft, "font_path", PLEX_MONO)
-        self.text_size = _text_size(
+        text_size = _text_size(
             label, draft.font_size, self.font_path, draft.font, draft.font_style
         )
-        tangent = (self.middle + pi / 2) % (2 * pi)
-        self.text_angle = tangent - pi if pi / 2 < tangent <= 3 * pi / 2 else tangent
-        width, height = self.text_size
-        # This bound leaves room for both arrow shafts and the full text. It also
-        # keeps extension lines beyond their physical witness points.
-        self.minimum_radius = max(
-            max(lengths) + draft.extension_gap + draft.arrow_length,
-            (width + height + 2 * draft.pad_around_text + 4 * draft.arrow_length) / self.sweep
-            + height / 2
-            + draft.pad_around_text,
-        )
-
-    @property
-    def bisector(self):
-        return cos(self.middle), sin(self.middle)
-
-    def point(self, radius, angle):
-        x, y = self.vertex
-        return x + radius * cos(angle), y + radius * sin(angle)
-
-    def label_polygon(self, radius):
-        width, height = self.text_size
-        centre = self.point(radius, self.middle)
-        return tuple(
-            tuple(a + b for a, b in zip(centre, _rotate(point, self.text_angle), strict=True))
-            for point in (
-                (-width / 2, -height / 2),
-                (width / 2, -height / 2),
-                (width / 2, height / 2),
-                (-width / 2, height / 2),
-            )
-        )
-
-    def extension_segments(self, radius):
-        end_radius = radius + self.draft.extension_gap
-        return tuple(
-            (
-                self.point(length + self.draft.extension_gap, angle),
-                self.point(end_radius, angle),
-            )
-            for length, angle in zip(
-                self.lengths, (self.start, self.start + self.sweep), strict=True
-            )
-        )
-
-    def arc_intervals(self, radius):
-        width, height = self.text_size
-        gap = atan2(
-            width / 2 + self.draft.pad_around_text,
-            radius - height / 2 - self.draft.pad_around_text,
-        )
-        intervals = ((self.start, self.middle - gap), (self.middle + gap, self.start + self.sweep))
-        if any((end - start) * radius <= self.draft.arrow_length for start, end in intervals):
-            raise ValueError("angular radius cannot carry the complete label and arrows")
-        return intervals
-
-    def footprint(self, radius):
-        """Conservative analytic ink box, including arc extrema and arrow heads.
-
-        The perpendicular extent changes with radius. Supplying this function to
-        the corridor prevents its straight-dimension translation model from
-        hiding obstacles from an angular candidate.
-        """
-        angles = [self.start, self.start + self.sweep]
-        for index in range(-4, 9):
-            angle = index * pi / 2
-            if self.start < angle < self.start + self.sweep:
-                angles.append(angle)
-        points = [self.point(radius, angle) for angle in angles]
-        points.extend(point for segment in self.extension_segments(radius) for point in segment)
-        points.extend(self.label_polygon(radius))
-        return _box(points, self.draft.arrow_length + self.draft.line_width)
+        super().__init__(vertex, first, second, text_size, draft, sector=sector)
 
     def build(self, radius):
         return AngularDimension(self, radius)
+
+    def compact_candidates(self, step):
+        """Three corner-local alternatives at the existing dimension tier spacing."""
+        for index in range(3):
+            yield self.build(self.minimum_radius + index * step)
 
 
 class AngularDimension(Compound):
@@ -163,10 +57,17 @@ class AngularDimension(Compound):
             for index, shaft in enumerate(shafts)
         ]
         segments = ink.extension_segments(radius)
-        extensions = trace(
-            [Edge.make_line((*start, 0), (*end, 0)) for start, end in segments],
-            line_width=draft.line_width,
-            mode=Mode.PRIVATE,
+        # Opposite-sector extensions cross at the virtual vertex. Keep both
+        # strokes intact rather than fusing away their intersecting boundaries.
+        extensions = Compound(
+            children=[
+                trace(
+                    Edge.make_line((*start, 0), (*end, 0)),
+                    line_width=draft.line_width,
+                    mode=Mode.PRIVATE,
+                )
+                for start, end in segments
+            ]
         )
         text = Text(
             ink.label,
@@ -185,12 +86,17 @@ class AngularDimension(Compound):
         text = text.moved(Location((*centre, 0), (0, 0, degrees(ink.text_angle))))
         super().__init__(children=[*arrows, extensions, text], label=ink.label)
         self._angular_points = (ink.witnesses[0], ink.vertex, ink.witnesses[1])
+        self.angular_sector = ink.sector
         self._label_polygon = ink.label_polygon(radius)
         self._extension_segments = segments
         self._radius = radius
         self._sweep = ink.sweep
         self._arc_intervals = intervals
         self._vertex = ink.vertex
+
+    @property
+    def arc_radius(self):
+        return self._radius
 
     def _point(self, point):
         rotated = _rotate(point, radians(self.location.orientation.Z))

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -30,7 +30,6 @@ from build123d_drafting.helpers import (
     CenterMark,
     HoleCallout,
     Leader,
-    TitleBlock,
 )
 
 from draftwright._core import (
@@ -46,7 +45,6 @@ from draftwright._core import (
     _SLOT_DIM_WIDTH,
     _WITNESS_LIFT_MM,
     DetailRequest,
-    _annotation_diameter_sources,
     _classify_steps,
     _concentric_with_axis,
     _dim,
@@ -92,6 +90,7 @@ from draftwright.annotations._common import (
     strip_free_span,
     strip_obstacles,
     strip_occupants,
+    view_label_clearance,
 )
 from draftwright.annotations.angular import AngularInk
 from draftwright.annotations.leaders import (
@@ -1168,24 +1167,6 @@ def render_centermarks(dwg, furniture_groups, *, ctx) -> int:
     return n
 
 
-def _mentioned_diameters(dwg) -> set[float]:
-    """Diameters already called out on the drawing.
-
-    Structured ``covers_diameters`` is authoritative when present; only genuinely
-    unstructured labels are parsed.  A geometric hole callout's semantic label may also
-    contain a bolt-circle or grid suffix diameter, which locates the pattern but does not
-    cover a physical feature of that diameter (#1142 / ADR 3 (was 0017)).
-    """
-    diams: set[float] = set()
-    for _, ann in dwg.iter_annotations():
-        if isinstance(ann, TitleBlock):
-            continue
-        structured_diameters, text_diameters = _annotation_diameter_sources(ann)
-        diams.update(structured_diameters)
-        diams.update(text_diameters)
-    return diams
-
-
 def _place_what_fits(specs, axis: int, min_gap: float, lo: float, hi: float):
     """Fit as many ø specs as the strip ``[lo, hi]`` holds at ``min_gap`` spacing,
     dropping the SMALLEST-diameter spec first when the full set overflows — so the
@@ -1511,14 +1492,14 @@ def _diameter_source_bounds(dwg, view, feature, diameter) -> tuple[float, float,
     )
 
 
-def _render_typed_diameter_leaders(dwg, a, indexed_buckets, *, prefix, start, ctx) -> int:
-    """Route a typed thread/knurl diameter row through the shared leader solve.
+def _render_diameter_leaders(dwg, a, indexed_buckets, *, prefix, start, ctx) -> int:
+    """Route external diameters through the shared leader solve.
 
     The legacy row deliberately gives every item the widest label's pitch.  That is stable and
     tidy for short diameter strings, but an authoritative manufacturing paragraph cannot share
     that pitch without evicting its siblings.  Collect typed buckets into the global
-    feature-leader solve, which has independent label footprints and multiple clear lanes;
-    short plain buckets retain their byte-stable legacy row.
+    feature-leader solve, which has independent label footprints and multiple clear lanes.
+    Plain diameters that did not fit their row use these same candidates.
     """
     vb = dwg.view_bounds("front")
     if vb is None:
@@ -1593,7 +1574,7 @@ def _render_typed_diameter_leaders(dwg, a, indexed_buckets, *, prefix, start, ct
         dwg,
         a,
         jobs,
-        noun="typed manufacturing diameter",
+        noun="external diameter",
         drop_code="diameter_dropped",
         ctx=ctx,
         geom_clear=True,
@@ -1602,9 +1583,9 @@ def _render_typed_diameter_leaders(dwg, a, indexed_buckets, *, prefix, start, ct
     )
 
 
-def render_diameters(dwg, plan, a, tol: float = 0.15, *, ctx, only=None) -> int:
+def render_diameters(dwg, plan, a, *, ctx, only=None) -> int:
     """ø leaders for a turned part's external step/boss diameters, from the IR —
-    one distinct callout per diameter, in a tidy row below the front view
+    one owned callout per physical diameter measurement, in a tidy row below the front view
     (X-turning), a column to its left (Z-turning), or as radial leaders in the
     end-on front view (Y-turning). Orientation is the feature frame's axis, not
     separate detection paths. Replaces the engine's
@@ -1615,13 +1596,9 @@ def render_diameters(dwg, plan, a, tol: float = 0.15, *, ctx, only=None) -> int:
     finalize() path passes the recorded step/boss ``callout`` intents' features.
     ``None`` (the auto-pass) places every diameter with the historical 0-based
     ``m_dia_{x,z}`` naming; Y-axis leaders use ``m_dia_y``."""
-    mentioned = _mentioned_diameters(dwg)
-    # One distinct callout per (axis, diameter, approved text, manufacturing suffix/owner).
-    # Accumulate EVERY feature that shares that complete printed claim (insertion-ordered),
-    # so provenance (#412) can tag the callout with its single owner — or leave it unowned
-    # when two distinct features genuinely share the same claim.
-    # Keep the compiler-approved text beside the numeric diameter.  Layout still needs the
-    # number for truthful rim geometry; only ``value_text`` may cross into a printed label.
+    # Equal numeric diameters do not establish one physical measurement. Keep the
+    # compiler owner in every key, including plain diameters, so public feature
+    # edits retain their independent provenance and tolerances.
     row_buckets: dict = {}  # semantic print key -> [anchor, dia, text, {features}, tol, ...]
     col_buckets: dict = {}  # Z-turned
     end_buckets: dict = {}  # Y-turned: radial leaders in the end-on front view
@@ -1632,37 +1609,17 @@ def render_diameters(dwg, plan, a, tol: float = 0.15, *, ctx, only=None) -> int:
         if dpd is None:
             continue
         dia = dpd.value
-        # An EXTERNAL thread (#859) makes a distinct callout: a threaded ⌀6 ("ø6 M6x1") and a
-        # plain ⌀6 are NOT the same label. Plain entries key on (⌀, suffix, None) and retain
-        # byte-identical value deduplication; source-owned entries add their opaque canonical
-        # owner below. The first authored tolerance within one legitimate shared bucket wins.
         thr = _manufacturing_suffix(
             g.facts.get("thread"),
             g.facts.get("knurl"),
         )
-        # A coincident plain ⌀ already drawn (a bore, another step) dedups only an UNTHREADED ⌀;
-        # a threaded ⌀ is a distinct callout, so a bare ⌀8 mention must not suppress ø8 M8x1.25.
-        if (
-            thr is None
-            and dpd.display_decimals is None
-            and any(abs(dia - m) <= tol for m in mentioned)
-        ):
+        if dwg.registry.has_measurement(dpd.id):
             continue
         bucket = {"x": row_buckets, "y": end_buckets, "z": col_buckets}.get(g.facts.frame.axis)
         if bucket is None:
             continue
         dtol = dpd.tolerance
-        typed_owner = (
-            g.ref
-            if isinstance(g.facts.get("thread"), ThreadRequirement)
-            or isinstance(g.facts.get("knurl"), KnurlRequirement)
-            else None
-        )
-        # Legacy plain diameters remain deduplicated by value.  A typed requirement is
-        # owned by one canonical feature and may share identical wording with another
-        # source-owned feature; include the opaque compiler owner so neither provenance
-        # nor public ``drop(feature)`` is collapsed into an unowned shared mark.
-        dkey = (round(dia, 2), dpd.value_text, thr, typed_owner)
+        dkey = (g.ref, dpd.value_text, thr)
         entry = bucket.setdefault(dkey, [g.anchor, dia, dpd.value_text, set(), dtol, thr, []])
         entry[3].add(g.ref)
         entry[6].append(g)
@@ -1670,11 +1627,7 @@ def render_diameters(dwg, plan, a, tol: float = 0.15, *, ctx, only=None) -> int:
             entry[4] = dtol
 
     def _item(entry):
-        # The trailing element is the ADR 5 (was 0010) claim: one ø callout stands for every step
-        # sharing this diameter, so it draws each of their diameter dims (#1002). It is the
-        # same derivation the m_dia_y branch below already made; the row/column placers
-        # threaded nothing, so every X- and Z-turned ø callout reached the sheet unclaimed
-        # and no verifier could see it (#1227).
+        # Carry the exact approved identity into the row/column placement.
         a, d, value_text, refs, t, thr, gs = entry
         return (
             _diameter_step_anchor(a, gs),
@@ -1734,7 +1687,7 @@ def render_diameters(dwg, plan, a, tol: float = 0.15, *, ctx, only=None) -> int:
             trace=trace,
             ctx=ctx,
         )
-    placed += _render_typed_diameter_leaders(
+    placed += _render_diameter_leaders(
         dwg,
         a,
         typed_entries,
@@ -1742,12 +1695,26 @@ def render_diameters(dwg, plan, a, tol: float = 0.15, *, ctx, only=None) -> int:
         start=start_x,
         ctx=ctx,
     )
+    unplaced = [
+        entry
+        for _index, entry in plain_entries
+        if any(
+            not dwg.registry.has_measurement(group.dim(kind="diameter").id) for group in entry[6]
+        )
+    ]
+    placed += _render_diameter_leaders(
+        dwg,
+        a,
+        list(enumerate(unplaced)),
+        prefix="m_dia_x",
+        start=start_x + len(row_buckets),
+        ctx=ctx,
+    )
     placed += _diameter_column_left(dwg, _items(col_buckets), start=start_z, trace=trace, ctx=ctx)
 
     # A Y-axis step is end-on in the front view, so the X/Z profile-strip
     # leaders are geometrically inapplicable. Place one radial leader per
-    # distinct diameter around the concentric circles instead. Keep shared-value
-    # provenance honest: a diameter owned by several steps has no single feature.
+    # owned diameter around the concentric circles instead.
     if end_buckets:
         vb = dwg.view_bounds("front")
         if vb is not None:
@@ -1784,13 +1751,11 @@ def render_diameters(dwg, plan, a, tol: float = 0.15, *, ctx, only=None) -> int:
                         representative,
                         reach,
                         rim=dia / 2 * a.SCALE,
+                        directions=_END_DIAMETER_LEAD_DIRS,
                     )
                 ]
-                # This pre-drain consumer deliberately retains the exact #890
-                # greedy semantics: try hole-clear rays first, but preserve the
-                # obstructed Policy-B tail in case every clear ray is blocked by
-                # fixed annotation/page occupancy. Joint filtering here would
-                # change the diameter coverage seen by later semantic passes.
+                # Preserve the existing pre-drain first-clear order, preferring
+                # rays that avoid the bore circles.
                 candidates.sort(
                     key=lambda candidate: _leader_hole_clearance(candidate, hole_circles),
                     reverse=True,
@@ -1799,9 +1764,7 @@ def render_diameters(dwg, plan, a, tol: float = 0.15, *, ctx, only=None) -> int:
                 if thr:
                     label += f" {thr}"
                 name = f"m_dia_y{start_y + i}"
-                # One ø callout stands for every step sharing this diameter, so it draws
-                # each of their diameter dims (#1002). Empty when a group planned none —
-                # recorded as unknown, which is the honest answer, not a guessed id.
+                # Retain the compiler identities of this owned diameter bucket.
                 mids = tuple(
                     pd.id for gp in feature_groups for pd in gp.dims if pd.kind == "diameter"
                 )
@@ -1816,10 +1779,8 @@ def render_diameters(dwg, plan, a, tol: float = 0.15, *, ctx, only=None) -> int:
                 ctx=ctx,
                 geom_clear=True,
             )
-            # These leaders intentionally start on an internal concentric circle
-            # and exit the outer silhouette, just like a bore callout. Structured
-            # diameter coverage both credits completeness lint and exempts that
-            # legitimate shaft crossing from leader_crosses_silhouette.
+            # Internal concentric-circle leaders legitimately exit the outer
+            # silhouette, like bore callouts. Retain their diameter coverage.
             for name, dia in covered_by_name.items():
                 ann = ctx.registry.named(name)
                 if ann is not None:
@@ -3214,6 +3175,14 @@ _POCKET_LEAD_DIRS = (
     (0, -1),
 )
 
+# Independently owned coaxial diameters can exhaust the eight pocket directions.
+# This bounded circular fan supplies additional rim targets to the same solver;
+# every candidate remains radial and is ranked for clearance from projected bores.
+_END_DIAMETER_LEAD_DIRS = (
+    *_POCKET_LEAD_DIRS,
+    *((math.cos(math.pi * i / 16), math.sin(math.pi * i / 16)) for i in range(32) if i % 4),
+)
+
 # The feature anchor lies on a quarter-cylindrical wall, so only the four outward diagonal
 # normals are physically meaningful.  Axial page rays can escape the composed end-view
 # footprint into adjacent-view ink; the diagonal set keeps auto, live and deferred placement
@@ -3988,8 +3957,8 @@ def render_boss_diameters(dwg, plan, a, *, ctx) -> int:
     A *turned* part keeps the diameter row/column (``render_diameters``): there the boss ø sits
     in the OD stack. The turned column-left strip, applied to a prismatic boss, strands its ø
     whenever that narrow strip is tight — dropping the callout even on a half-empty sheet (#629).
-    Run BEFORE ``render_diameters`` so a placed boss ø is 'mentioned' and not re-placed. A boss
-    whose ø a coincident feature already carries is skipped; an unplaceable one drops lint-visibly.
+    Run BEFORE ``render_diameters`` so its placed measurement identity prevents a second
+    rendering of that same boss. An unplaceable one drops lint-visibly.
 
     Placement rides the shared :func:`place_machined_leader_jobs` adapter (#700 — never a sixth copy
     of the ray-exit loop, #637): rim-anchored :func:`_radial_candidates`, accepted with
@@ -4001,7 +3970,6 @@ def render_boss_diameters(dwg, plan, a, *, ctx) -> int:
     draft = dwg.draft
     view_of = _END_ON  # the view looking down the boss axis
     boss_groups = list(plan.of_kind("boss"))
-    mentioned = _mentioned_diameters(dwg)
     reach = draft.font_size + 6 * draft.pad_around_text
     jobs = []
     for bi, g in enumerate(
@@ -4017,13 +3985,7 @@ def render_boss_diameters(dwg, plan, a, *, ctx) -> int:
             getattr(b, "thread", None),
             getattr(b, "knurl", None),
         )
-        # A coincident plain ⌀ dedups only an UNTHREADED boss; a threaded ⌀ is a distinct callout,
-        # so a bare ⌀8 mention (a bore, a step) must not suppress ø8 M8x1.25 (#859).
-        if (
-            thr is None
-            and dpd.display_decimals is None
-            and any(abs(dia - m) <= 0.15 for m in mentioned)
-        ):
+        if dwg.registry.has_measurement(dpd.id):
             continue
         view = view_of.get(b.frame.axis)
         if view is None:
@@ -4850,18 +4812,19 @@ def _step_measurements(segs: list[_StepChainSegment]) -> tuple[Any, ...]:
 
 
 def _record_step_chain_drop(dwg, why: str, *, ctx, measurement=()) -> None:
-    """Record the ``step_dim_dropped`` lint warning when a turned step-length chain
-    is dropped whole (#362). These drops were silent (debug log only) — the user got
+    """Record the ``step_dim_dropped`` warning for unresolved turned lengths.
+    These drops were silent (debug log only) — the user got
     a drawing with no step-length dimensioning and no signal. Mirrors
     ``render_height_ladder``'s prismatic drop, but records ONLY the lint code (not an
     ``Escalation(kind="step")``): that escalation is consumed by
     ``_request_prismatic_detail`` (sections.py), which would redraw *prismatic*
     height-above-base dims for a *turned* chain — the wrong semantics #351 PR-4b
-    removed. A Z-turned-appropriate detail-view remedy is a tracked follow-up."""
+    removed. An authored semantic shoulder detail uses the shared chain pass."""
     ctx.record_issue(
         "warning",
         "step_dim_dropped",
-        f"step-length chain dropped: {why} at this scale (use a detail view)",
+        f"step-length chain dropped: {why} at this scale "
+        "(request Sheet.detail_view(..., around=step) at a larger scale)",
         measurement=measurement,
     )
 
@@ -4877,14 +4840,16 @@ def _draw_step_chain(
     ctx,
     start=0,
     profile_bounds=None,
+    placement_bounds=None,
 ) -> int:
     """Place a turned step-length chain in *view* from structured *segs*, each already
     projected to *view*'s page coords in axis order. Orientation is
     data (the projected span direction): horizontal → chain above the view, vertical
     → chain to the right. A uniform run collapses to one ``N× v`` dim (#230); else a
     per-segment chain, staggered into a near/far tier only when crowded (ISO 129-1,
-    #293); skipped if even two tiers can't separate the labels, or if any dim would
-    fall off the page. ``detail_scale`` tags the dims for label-vs-measured lint when
+    #293). The shared ink solve offers both orientations a far tier; off-page
+    members are reported individually without erasing valid neighbours.
+    ``detail_scale`` tags the dims for label-vs-measured lint when
     drawing inside a scaled detail view. ``allow_collapse=False`` disables the ``N× v``
     collapse — used when the chain mixes a synthetic head-*block* with real steps, where
     a uniform-staircase representative would be a false claim of N equal steps (#307
@@ -4975,25 +4940,9 @@ def _draw_step_chain(
                         {"name": name_prefix, "outcome": "dropped", "reason": "too_dense"}
                     )
                 return 0
-        else:
-            shoulder_ys = sorted({c for seg in segs for c in (seg.pa[1], seg.pb[1])})
-            if any(b - a < tier_step for a, b in zip(shoulder_ys, shoulder_ys[1:])):
-                _log.info("step-length chain skipped: shoulders too close to dimension")
-                _record_step_chain_drop(
-                    dwg,
-                    "turned shoulders too closely spaced to dimension",
-                    ctx=ctx,
-                    measurement=_step_measurements(segs),
-                )
-                if ev is not None:
-                    ev["items"].append(
-                        {
-                            "name": name_prefix,
-                            "outcome": "dropped",
-                            "reason": "shoulders_too_close",
-                        }
-                    )
-                return 0
+        # A short vertical shoulder is not a density test for the whole chain.
+        # Helpers can draw outside arrows, and the shared batch solver below
+        # checks actual labels/ink and offers the same far tier on either axis.
 
         candidates = []
         for i, seg in enumerate(segs):
@@ -5024,19 +4973,28 @@ def _draw_step_chain(
     # the complete batch before the room guard (#1334).  Measurement provenance stays paired
     # by name; only the rendered Dimension survivor changes.
     measurements_by_name = {name: measurements for name, _dim_obj, measurements in candidates}
+    # A body-local profile can sit inside a wider flange in the same view.
+    # Its near tier stays local; the one alternate tier can reach the outer
+    # edge of its assigned view cell without moving measurement supports.
+    cell = placement_bounds or dwg.view_bounds(view)
+    outer_index = 3 if horizontal else 2
+    far_step = max(tier_step, cell[outer_index] - vb[outer_index]) if cell else tier_step
     candidates = [
         (name, dim, measurements_by_name[name])
         for name, dim in prevent_dimension_label_ink(
             [(name, dim) for name, dim, _measurements in candidates],
             page=page,
             obstacles=strip_obstacles(dwg, view=view, crossable=CROSSABLE_TYPES),
-            perpendicular_step=tier_step if horizontal else None,
+            perpendicular_step=far_step,
+            label_clear=view_label_clearance(dwg, view),
         )
     ]
 
-    # Room guard: if any dim would fall off the drawable page, place NONE.
-    for _, dim, _measurements in candidates:
-        box = _anno_box(dim)
+    # Preserve independently placeable measurements when one member is off-page.
+    # A missing neighbour stays explicitly unresolved under its own identity.
+    survivors = []
+    for name, dim, measurements in candidates:
+        box = _geom_box(dim)
         if box is not None and not (
             page[0] <= box[0] and box[2] <= page[2] and page[1] <= box[1] and box[3] <= page[3]
         ):
@@ -5044,14 +5002,13 @@ def _draw_step_chain(
                 dwg,
                 "a dimension would fall off the drawable page",
                 ctx=ctx,
-                measurement=_step_measurements(segs),
+                measurement=measurements,
             )
             if ev is not None:
-                ev["items"].append(
-                    {"name": name_prefix, "outcome": "dropped", "reason": "off_page"}
-                )
-            return 0
-    for name, dim, measurements in candidates:
+                ev["items"].append({"name": name, "outcome": "dropped", "reason": "off_page"})
+            continue
+        survivors.append((name, dim, measurements))
+    for name, dim, measurements in survivors:
         if detail_scale is not None:
             dim._dw_scale = detail_scale
         ctx.place(dim, name, view=view, measurement=measurements)
@@ -5060,7 +5017,7 @@ def _draw_step_chain(
             ev["items"].append(
                 {"name": name, "outcome": "placed", "box": list(b) if b is not None else None}
             )
-    return len(candidates)
+    return len(survivors)
 
 
 def _next_steplen_start(ctx, prefix: str = "m_steplen") -> int:
@@ -5078,6 +5035,83 @@ def _next_steplen_start(ctx, prefix: str = "m_steplen") -> int:
             tail = rest[4:]
             idxs.append(int(tail) if tail.isdigit() else 0)
     return max(idxs) + 1 if idxs else 0
+
+
+def queue_step_detail(dwg, plan, feature, a, *, ctx, view_name, label, factor, source) -> bool:
+    """Redraw an authored shoulder detail through the shared approved-length pass."""
+    target = FeatureRef(feature)
+    groups = [group for group in plan.of_kind("step") if group.ref == target]
+    if len(groups) != 1:
+        return False
+    (group,) = groups
+    length = group.dim(kind="length")
+    if length is None or length.span is None:
+        return False
+    axis = group.facts.frame.axis
+    view = group.view
+    in_plane = {"front": ("x", "z"), "side": ("y", "z"), "plan": ("x", "y")}
+    if view not in in_plane or axis not in in_plane[view]:
+        return False
+    cross = cast(Literal["x", "y", "z"], next(value for value in in_plane[view] if value != axis))
+    ai, ci = "xyz".index(axis), "xyz".index(cross)
+    lo, hi = sorted(point[ai] for point in length.span)
+    context = max(1.0, (hi - lo) / 2)
+    diameter = group.dim(kind="diameter")
+    if diameter is not None:
+        rim = group.facts.frame.origin[ci] + diameter.value / 2
+        cross_lo, cross_hi = rim - context, rim + context
+    else:
+        # Suppression removes diameter content. The crop may still use the
+        # part bounds as context, but it cannot manufacture an omitted label.
+        cross_lo, cross_hi = tuple(a.bb.min)[ci], tuple(a.bb.max)[ci]
+    segment = _StepChainSegment(
+        length.span[0],
+        length.span[1],
+        length.value,
+        length.tolerance,
+        length.measurement_ids,
+        value_text=length.value_text,
+        display_decimals=length.display_decimals,
+    )
+
+    def redraw(dwg, detail_view, coords, detail_scale):
+        projected = replace(segment, pa=coords.pp(*segment.pa), pb=coords.pp(*segment.pb))
+        return _draw_step_chain(
+            dwg,
+            detail_view,
+            [projected],
+            f"{detail_view}_steplen",
+            detail_scale=detail_scale,
+            allow_collapse=False,
+            ctx=ctx,
+        )
+
+    draft = dwg.draft
+    band = 2 * draft.font_size + 6 * draft.pad_around_text + 2 * draft.arrow_length
+    ctx.detail_requests.append(
+        DetailRequest(
+            axis=axis,
+            lo=lo,
+            hi=hi,
+            crop_lo=lo - context,
+            crop_hi=hi + context,
+            scale_needed=a.SCALE * factor,
+            redraw=redraw,
+            pads=lambda _scale: (band, 0.0) if axis == in_plane[view][1] else (0.0, band),
+            source_view=view,
+            cross_axis=cross,
+            cross_lo=cross_lo,
+            cross_hi=cross_hi,
+            kind="authored-step",
+            view_name=view_name,
+            label=label,
+            scale_factor=factor,
+            source=source,
+            measurement_ids=length.measurement_ids,
+            measurement_spans=(length.span,),
+        )
+    )
+    return True
 
 
 def render_step_lengths(
@@ -5812,6 +5846,7 @@ def render_step_lengths(
         ctx=ctx,
         start=start,
         profile_bounds=profile_bounds,
+        placement_bounds=_profile_bounds_hint,
     )
 
 
@@ -6438,7 +6473,7 @@ def render_rotational(dwg, plan, a, *, ctx) -> int:
                 ),
                 "dim_od",
                 view="front",
-                measurement=od_dim.id,
+                measurement=od_dim.measurement_ids,
             )
             n += 1
         _place_axis_centerline(
@@ -6536,7 +6571,7 @@ def render_rotational(dwg, plan, a, *, ctx) -> int:
                 ),
                 "dim_od",
                 view="front",
-                measurement=od_dim.id,
+                measurement=od_dim.measurement_ids,
             )
             n += 1
         _place_axis_centerline(
@@ -6572,7 +6607,7 @@ def render_rotational(dwg, plan, a, *, ctx) -> int:
                 ),
                 "dim_od",
                 view="side",
-                measurement=od_dim.id,
+                measurement=od_dim.measurement_ids,
             )
             n += 1
         _place_axis_centerline(
@@ -7136,6 +7171,9 @@ def _place_corridor_option(
         valid_positions={spec["name"]: spec["valid_position"]}
         if "valid_position" in spec
         else None,
+        compact_candidates={spec["name"]: spec["compact_candidates"]}
+        if "compact_candidates" in spec
+        else None,
         priorities={spec["name"]: priority},
         anchored={spec["name"]: anchored},
         trace=trace,
@@ -7183,6 +7221,7 @@ def _pmi_queue_options(dwg, ctx, options, ax, label, rec):
             natural=primary.get("natural"),
             footprint=primary.get("footprint"),
             valid_position=primary.get("valid_position"),
+            compact_candidates=primary.get("compact_candidates"),
         ),
     )
     return True
@@ -7253,6 +7292,7 @@ def _angular_specs(a, reference, label, name, draft, *, side=None):
         to_page(reference.second),
         label,
         draft,
+        sector=reference.sector,
     )
     options = []
     for index in sorted(range(2), key=lambda i: -abs(ink.bisector[i])):
@@ -7294,6 +7334,7 @@ def _angular_specs(a, reference, label, name, draft, *, side=None):
                 "order": (_PMI_SUBCHAIN, ink.vertex[1 - index], name),
                 "natural": natural,
                 "valid_position": valid_position,
+                "compact_candidates": lambda: ink.compact_candidates(_PMI_SLOT),
                 "build": lambda pos, _radius=radius: ink.build(
                     max(ink.minimum_radius, _radius(pos))
                 ),
@@ -7322,24 +7363,40 @@ def render_angular_dimensions(
     for index, group in enumerate(plan.of_kind("angle")):
         if only is not None and group.ref not in only:
             continue
-        for approved in group.dims:
-            reference = approved.angular_reference
-            if reference is None:
-                raise ValueError("approved included angle has no angular reference")
-            options = _angular_specs(
-                a,
-                reference,
-                approved.final_label,
-                name or f"m_angle_{index}",
-                dwg.draft,
-                side=group.side,
-            )
+        bundles = (group.dims,) if group.shared_label else tuple((d,) for d in group.dims)
+        for members in bundles:
+            label = group.shared_label or members[0].final_label
+            measurement = tuple(member.id for member in members)
+            annotation_name = name or f"m_angle_{index}"
+            if len(bundles) > 1:
+                annotation_name += f"_{members[0].discriminator}"
+            options = []
+            for member in members:
+                reference = member.angular_reference
+                if reference is None:
+                    raise ValueError("approved included angle has no angular reference")
+                options.extend(
+                    _angular_specs(
+                        a,
+                        reference,
+                        label,
+                        annotation_name,
+                        dwg.draft,
+                        side=member.side or group.side,
+                    )
+                )
 
             def placed(annotation_name):
                 if pin:
                     dwg.pin(annotation_name)
 
-            def dropped(_name, _options=options, _approved=approved, _ref=group.ref):
+            def dropped(
+                _name,
+                _options=options,
+                _measurement=measurement,
+                _label=label,
+                _ref=group.ref,
+            ):
                 for option in _options[1:]:
                     if _place_corridor_option(
                         dwg,
@@ -7347,7 +7404,7 @@ def render_angular_dimensions(
                         _ref,
                         ctx=ctx,
                         trace=ctx.trace,
-                        measurement=_approved.id,
+                        measurement=_measurement,
                         priority=rank,
                         anchored=pin,
                     ):
@@ -7356,8 +7413,8 @@ def render_angular_dimensions(
                 ctx.record_issue(
                     "warning",
                     "angular_dimension_dropped",
-                    f"Included angle {_approved.final_label} could not fit its reference sector",
-                    measurement=_approved.id,
+                    f"Included angle {_label} could not fit its reference sector",
+                    measurement=_measurement,
                 )
 
             if not options:
@@ -7379,12 +7436,13 @@ def render_angular_dimensions(
                     on_drop=dropped,
                     force=True,
                     feature=group.ref,
-                    measurement=approved.id,
+                    measurement=measurement,
                     priority=rank,
                     anchored=pin,
                     natural=primary["natural"],
                     footprint=primary["footprint"],
                     valid_position=primary["valid_position"],
+                    compact_candidates=primary["compact_candidates"],
                 ),
             )
             count += 1

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -7107,7 +7107,17 @@ def _pmi_leader_spec(tip, strip, label, name, view, side, draft):
     }
 
 
-def _pmi_place_one(dwg, spec, rec, *, ctx, trace=None):
+def _place_corridor_option(
+    dwg,
+    spec,
+    feature,
+    *,
+    ctx,
+    trace=None,
+    measurement=None,
+    priority=_PMI_CORRIDOR_PRIORITY,
+    anchored=False,
+):
     # *trace* (#736): a PMI dim's post-drop fallback is a standalone strip pass —
     # traced as a pass_event like the other standalone placers.
     left = place_strip_candidates(
@@ -7119,13 +7129,15 @@ def _pmi_place_one(dwg, spec, rec, *, ctx, trace=None):
         _PMI_SLOT,
         ctx=ctx,
         force=True,
-        features={spec["name"]: rec},
+        features={spec["name"]: feature},
+        measurements={spec["name"]: measurement} if measurement is not None else None,
         naturals={spec["name"]: spec["natural"]} if "natural" in spec else None,
         footprints={spec["name"]: spec["footprint"]} if "footprint" in spec else None,
         valid_positions={spec["name"]: spec["valid_position"]}
         if "valid_position" in spec
         else None,
-        priorities={spec["name"]: _PMI_CORRIDOR_PRIORITY},
+        priorities={spec["name"]: priority},
+        anchored={spec["name"]: anchored},
         trace=trace,
         trace_label="pmi_fallback",
     )
@@ -7140,7 +7152,7 @@ def _pmi_queue_options(dwg, ctx, options, ax, label, rec):
 
     def _drop(nm, _alts=alternates, _ax=ax, _label=label, _rec=rec):
         for alt in _alts:
-            if _pmi_place_one(dwg, alt, _rec, ctx=ctx, trace=ctx.trace):
+            if _place_corridor_option(dwg, alt, _rec, ctx=ctx, trace=ctx.trace):
                 _log.info(
                     "PMI dim %s placed on fallback %s/%s",
                     nm,
@@ -7228,8 +7240,7 @@ def _pmi_front_linear(dwg, a, ctx, rec, ax, label, name, primary, secondary, cen
     return placed
 
 
-def _pmi_angular_specs(a, rec, name, draft):
-    reference = rec.angular_reference
+def _angular_specs(a, reference, label, name, draft, *, side=None):
     axis = reference.principal_axis
     view, to_page, zones = {
         "X": ("side", lambda p: (a.proj.side_x(p[1]), a.proj.side_z(p[2])), a.sv_zones),
@@ -7240,7 +7251,7 @@ def _pmi_angular_specs(a, rec, name, draft):
         to_page(reference.vertex),
         to_page(reference.first),
         to_page(reference.second),
-        rec.label,
+        label,
         draft,
     )
     options = []
@@ -7248,10 +7259,10 @@ def _pmi_angular_specs(a, rec, name, draft):
         component = ink.bisector[index]
         if abs(component) < 1e-6:
             continue
-        side = (("left", "right"), ("below", "above"))[index][component > 0]
-        if rec.side is not None and rec.side != side:
+        candidate_side = (("left", "right"), ("below", "above"))[index][component > 0]
+        if side is not None and side != candidate_side:
             continue
-        strip = getattr(zones, side)
+        strip = getattr(zones, candidate_side)
         if strip is None:
             continue
         lo, hi, inner = strip_free_span(strip)
@@ -7277,7 +7288,7 @@ def _pmi_angular_specs(a, rec, name, draft):
             {
                 "name": name,
                 "view": view,
-                "side": side,
+                "side": candidate_side,
                 "strip": strip,
                 "axis": "x" if index == 0 else "y",
                 "order": (_PMI_SUBCHAIN, ink.vertex[1 - index], name),
@@ -7292,6 +7303,92 @@ def _pmi_angular_specs(a, rec, name, draft):
             }
         )
     return options
+
+
+def render_angular_dimensions(
+    dwg,
+    plan,
+    a,
+    *,
+    ctx,
+    only=None,
+    name=None,
+    pin=False,
+    priority=0.0,
+) -> int:
+    """Queue compiler-approved included angles through the shared corridor solve."""
+    count = 0
+    rank = max(float(priority), 100.0) if pin else float(priority)
+    for index, group in enumerate(plan.of_kind("angle")):
+        if only is not None and group.ref not in only:
+            continue
+        for approved in group.dims:
+            reference = approved.angular_reference
+            if reference is None:
+                raise ValueError("approved included angle has no angular reference")
+            options = _angular_specs(
+                a,
+                reference,
+                approved.final_label,
+                name or f"m_angle_{index}",
+                dwg.draft,
+                side=group.side,
+            )
+
+            def placed(annotation_name):
+                if pin:
+                    dwg.pin(annotation_name)
+
+            def dropped(_name, _options=options, _approved=approved, _ref=group.ref):
+                for option in _options[1:]:
+                    if _place_corridor_option(
+                        dwg,
+                        option,
+                        _ref,
+                        ctx=ctx,
+                        trace=ctx.trace,
+                        measurement=_approved.id,
+                        priority=rank,
+                        anchored=pin,
+                    ):
+                        placed(option["name"])
+                        return
+                ctx.record_issue(
+                    "warning",
+                    "angular_dimension_dropped",
+                    f"Included angle {_approved.final_label} could not fit its reference sector",
+                    measurement=_approved.id,
+                )
+
+            if not options:
+                dropped("")
+                continue
+            primary = options[0]
+            register_corridor(
+                ctx,
+                (primary["view"], primary["side"]),
+                primary["strip"],
+                primary["view"],
+                primary["axis"],
+                _PMI_SLOT,
+                CorridorCandidate(
+                    name=primary["name"],
+                    build=primary["build"],
+                    order=primary["order"],
+                    on_place=placed,
+                    on_drop=dropped,
+                    force=True,
+                    feature=group.ref,
+                    measurement=approved.id,
+                    priority=rank,
+                    anchored=pin,
+                    natural=primary["natural"],
+                    footprint=primary["footprint"],
+                    valid_position=primary["valid_position"],
+                ),
+            )
+            count += 1
+    return count
 
 
 def _place_pmi_record(dwg, a, ctx, rec, idx, bore_cfg, draft) -> bool:
@@ -7312,7 +7409,14 @@ def _place_pmi_record(dwg, a, ctx, rec, idx, bore_cfg, draft) -> bool:
 
     if rec.pmi_kind == "angular":
         placed = _pmi_queue_options(
-            dwg, ctx, _pmi_angular_specs(a, rec, f"pmi_angle_{idx}", draft), ax, label, rec
+            dwg,
+            ctx,
+            _angular_specs(
+                a, rec.angular_reference, rec.label, f"pmi_angle_{idx}", draft, side=rec.side
+            ),
+            ax,
+            label,
+            rec,
         )
     elif rec.pmi_kind in ("diameter", "radius"):
         # Bore size: a diameter spans centroid ± value/2; a radius runs centroid → +value

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -93,6 +93,7 @@ from draftwright.annotations._common import (
     strip_obstacles,
     strip_occupants,
 )
+from draftwright.annotations.angular import AngularInk
 from draftwright.annotations.leaders import (
     FeatureLeaderJob,
     collect_feature_leader,
@@ -6679,6 +6680,7 @@ def _record_pmi_drop(ctx, dwg, ax, label, rec):
         ax,
         getattr(rec, "view", None),
         getattr(rec, "side", None),
+        getattr(rec, "angular_reference", None),
     )
     if selected_view is not None:
         view = selected_view
@@ -6763,7 +6765,8 @@ _PMI_CORRIDOR_PRIORITY = PRIORITY.AUTHORED
 _PMI_SLOT = 10.0  # mm — slot size for PMI dim lines in the strip
 
 
-#: Dimension categories the IR admits but this renderer cannot draw TRUTHFULLY. `Dimension`
+#: Categories the generic linear renderer cannot draw truthfully. The separate angular
+#: candidate path admits explicit supported ray geometry via _angular_renderable. `Dimension`
 #: measures a straight projected path, so a record whose value is measured on some other
 #: basis renders as an annotation whose geometry contradicts its own label — a drawing that
 #: asserts something false (#1177). Measured on a 1:1 sheet, value against drawn length:
@@ -6797,6 +6800,21 @@ _MEASUREMENT_BASIS = {
     "curved_dist": "a distance along a curve",
     "oriented": "a distance along a stated direction",
 }
+
+
+def _angular_renderable(record) -> bool:
+    reference = getattr(record, "angular_reference", None)
+    return (
+        record.pmi_kind == "angular"
+        and reference is not None
+        and reference.principal_axis in ("X", "Y", "Z")
+        # Structured angle tolerances still need compiler-owned label composition.
+        # Retain a refusal until that path can state every authored term.
+        and all(
+            getattr(record, field, None) is None
+            for field in ("upper_tol", "lower_tol", "lower_bound", "upper_bound")
+        )
+    )
 
 
 def _authored_with_usable_references(record) -> bool:
@@ -6850,6 +6868,12 @@ def _record_unsupported_dimension_kind(ctx, rec):
     drawing.
     """
     basis = _MEASUREMENT_BASIS[rec.pmi_kind]
+    reason = (
+        "supported angular ink requires explicit coplanar rays in a principal view "
+        "and currently cannot compose structured angular tolerances"
+        if rec.pmi_kind == "angular"
+        else "this renderer measures only a straight projected path"
+    )
     source_id = getattr(rec, "source_id", "")
     # `error` for a source-bearing record, matching `_record_pmi_no_candidate` and the
     # three `lint_pmi_*` checks: in annotate mode a requirement that came from the AP242
@@ -6860,7 +6884,7 @@ def _record_unsupported_dimension_kind(ctx, rec):
         "error" if source_id else "warning",
         "dimension_kind_unsupported",
         f"authored {rec.pmi_kind} dimension {getattr(rec, 'label', '')!r} is not drawn: it "
-        f"states {basis}, and this renderer measures only a straight projected path",
+        f"states {basis}; {reason}",
         source=source_id,
         outcome_stage="validation",
     )
@@ -6879,7 +6903,7 @@ def _renderable_pmi_records(records):
         for r in records
         if _authored_with_usable_references(r)
         and r.pmi_kind in AUTHORED_DIMENSION_KINDS
-        and r.pmi_kind not in _UNRENDERABLE_DIMENSION_KINDS
+        and (r.pmi_kind not in _UNRENDERABLE_DIMENSION_KINDS or _angular_renderable(r))
     ]
 
 
@@ -6894,6 +6918,7 @@ def _unsupported_kind_records(records):
         if _authored_with_usable_references(r)
         and r.pmi_kind in AUTHORED_DIMENSION_KINDS
         and r.pmi_kind in _UNRENDERABLE_DIMENSION_KINDS
+        and not _angular_renderable(r)
     ]
 
 
@@ -7095,6 +7120,11 @@ def _pmi_place_one(dwg, spec, rec, *, ctx, trace=None):
         ctx=ctx,
         force=True,
         features={spec["name"]: rec},
+        naturals={spec["name"]: spec["natural"]} if "natural" in spec else None,
+        footprints={spec["name"]: spec["footprint"]} if "footprint" in spec else None,
+        valid_positions={spec["name"]: spec["valid_position"]}
+        if "valid_position" in spec
+        else None,
         priorities={spec["name"]: _PMI_CORRIDOR_PRIORITY},
         trace=trace,
         trace_label="pmi_fallback",
@@ -7138,6 +7168,9 @@ def _pmi_queue_options(dwg, ctx, options, ax, label, rec):
             priority=_PMI_CORRIDOR_PRIORITY,
             force=True,
             feature=rec,
+            natural=primary.get("natural"),
+            footprint=primary.get("footprint"),
+            valid_position=primary.get("valid_position"),
         ),
     )
     return True
@@ -7195,6 +7228,72 @@ def _pmi_front_linear(dwg, a, ctx, rec, ax, label, name, primary, secondary, cen
     return placed
 
 
+def _pmi_angular_specs(a, rec, name, draft):
+    reference = rec.angular_reference
+    axis = reference.principal_axis
+    view, to_page, zones = {
+        "X": ("side", lambda p: (a.proj.side_x(p[1]), a.proj.side_z(p[2])), a.sv_zones),
+        "Y": ("front", lambda p: (a.proj.front_x(p[0]), a.proj.front_z(p[2])), a.fv_zones),
+        "Z": ("plan", lambda p: (a.proj.plan_x(p[0]), a.proj.plan_y(p[1])), a.pv_zones),
+    }[axis]
+    ink = AngularInk(
+        to_page(reference.vertex),
+        to_page(reference.first),
+        to_page(reference.second),
+        rec.label,
+        draft,
+    )
+    options = []
+    for index in sorted(range(2), key=lambda i: -abs(ink.bisector[i])):
+        component = ink.bisector[index]
+        if abs(component) < 1e-6:
+            continue
+        side = (("left", "right"), ("below", "above"))[index][component > 0]
+        if rec.side is not None and rec.side != side:
+            continue
+        strip = getattr(zones, side)
+        if strip is None:
+            continue
+        lo, hi, inner = strip_free_span(strip)
+        natural = ink.vertex[index] + ink.minimum_radius * component
+        natural = max(natural, inner) if component > 0 else min(natural, inner)
+
+        def radius(pos, _index=index, _component=component):
+            return (pos - ink.vertex[_index]) / _component
+
+        def valid_position(pos, _radius=radius):
+            value = _radius(pos)
+            if value < ink.minimum_radius - 1e-9:
+                return False
+            x0, y0, x1, y1 = ink.footprint(max(ink.minimum_radius, value))
+            return (
+                x0 >= _MARGIN
+                and y0 >= _MARGIN
+                and x1 <= a.PAGE_W - _MARGIN
+                and y1 <= a.PAGE_H - _MARGIN
+            )
+
+        options.append(
+            {
+                "name": name,
+                "view": view,
+                "side": side,
+                "strip": strip,
+                "axis": "x" if index == 0 else "y",
+                "order": (_PMI_SUBCHAIN, ink.vertex[1 - index], name),
+                "natural": natural,
+                "valid_position": valid_position,
+                "build": lambda pos, _radius=radius: ink.build(
+                    max(ink.minimum_radius, _radius(pos))
+                ),
+                "footprint": lambda pos, _radius=radius: ink.footprint(
+                    max(ink.minimum_radius, _radius(pos))
+                ),
+            }
+        )
+    return options
+
+
 def _place_pmi_record(dwg, a, ctx, rec, idx, bore_cfg, draft) -> bool:
     """Place one PMI record; returns True when it was queued/placed on a strip.
 
@@ -7211,7 +7310,11 @@ def _place_pmi_record(dwg, a, ctx, rec, idx, bore_cfg, draft) -> bool:
     name_y = f"pmi_y_{idx}"
     name_d = f"pmi_d_{idx}"
 
-    if rec.pmi_kind in ("diameter", "radius"):
+    if rec.pmi_kind == "angular":
+        placed = _pmi_queue_options(
+            dwg, ctx, _pmi_angular_specs(a, rec, f"pmi_angle_{idx}", draft), ax, label, rec
+        )
+    elif rec.pmi_kind in ("diameter", "radius"):
         # Bore size: a diameter spans centroid ± value/2; a radius runs centroid → +value
         # (#1208). See `_bore_span_offsets`.
         info = _bore_info(rec)

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -54,6 +54,7 @@ from draftwright.annotations._common import (
 from draftwright.annotations.balloons import render_balloons
 from draftwright.annotations.from_model import (
     ladder_plan_for,
+    render_angular_dimensions,
     render_blends,
     render_boss_diameters,
     render_boss_heights,
@@ -262,6 +263,7 @@ _PASS_SEQUENCE: tuple[str, ...] = (
     # hole pattern (the pitch dim needs strip room the post-drain decoration slots lack)
     "slot_patterns",  # a through-slot ARRAY: same grouped callout + pitch, same pre-drain reason
     "through_steps",  # two section legs register with the shared corridor before its drain
+    "angles",
     "user_dims",  # finalize-only: pin/priority dims queue into the shared corridor
     "gdt",
     "pmi",
@@ -680,6 +682,9 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # Two transverse open-section legs, independently identified and corridor-placed.
         render_through_steps(dwg, _compiled, a, ctx=ctx)
 
+    def _s_angles():
+        render_angular_dimensions(dwg, _compiled, a, ctx=ctx)
+
     def _s_flats():
         # Machined-flat callouts (#148b): {across} A/F via a leader off each flat on round stock.
         # Planner-fed (#726): consumes the DimensionGroups so an authored tolerance renders.
@@ -909,6 +914,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
             "pocket_patterns": _s_pocket_patterns,
             "slot_patterns": _s_slot_patterns,
             "through_steps": _s_through_steps,
+            "angles": _s_angles,
             "off_axis_across": _s_off_axis_across,
             "envelope": _s_envelope,
             "detail_request": _s_detail_request,

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -54,6 +54,7 @@ from draftwright.annotations._common import (
 from draftwright.annotations.balloons import render_balloons
 from draftwright.annotations.from_model import (
     ladder_plan_for,
+    queue_step_detail,
     render_angular_dimensions,
     render_blends,
     render_boss_diameters,
@@ -164,7 +165,7 @@ def _planned_sections(a, model, feature_keys) -> tuple[SectionPlan, ...]:
     return tuple(plans)
 
 
-def _queue_authored_details(a, ctx) -> None:
+def _queue_authored_details(dwg, a, ctx, plan) -> None:
     """Lower semantic ``detail_view(..., around=feature)`` constraints to crop requests."""
 
     constraints = a.view_constraints
@@ -182,6 +183,20 @@ def _queue_authored_details(a, ctx) -> None:
         if not (isinstance(target, tuple) and len(target) == 2 and target[0] == "feature"):
             raise ValueError(f"detail {item.spec.name!r} has no semantic feature target")
         feature = target[1]
+        label = item.spec.name.removeprefix("detail_").upper()
+        factor = item.spec.scale_factor or 2.0
+        if queue_step_detail(
+            dwg,
+            plan,
+            feature,
+            a,
+            ctx=ctx,
+            view_name=item.spec.name,
+            label=label,
+            factor=factor,
+            source=item.source,
+        ):
+            continue
         origin = feature.frame.origin
         axis = feature.frame.axis
         view_for_axis: dict[
@@ -205,8 +220,6 @@ def _queue_authored_details(a, ctx) -> None:
         half = max(3.0, (max(sizes) if sizes else 6.0) * 0.75)
         first, second = crop_axes
         fi, si = "xyz".index(first), "xyz".index(second)
-        label = item.spec.name.removeprefix("detail_").upper()
-        factor = item.spec.scale_factor or 2.0
         ctx.detail_requests.append(
             DetailRequest(
                 axis=first,
@@ -862,7 +875,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # Resolve every queued enlarged-detail request (#307) — prismatic step bands and
         # crowded turned heads alike — through the one generic detailer, now that all
         # views and main-view annotations are placed (so the detail avoids them).
-        _queue_authored_details(a, ctx)
+        _queue_authored_details(dwg, a, ctx, _compiled)
         _resolve_details(dwg, a, ctx=ctx)
 
     def _s_title_block():
@@ -952,7 +965,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
 #: recorded by the pass that could not place the mark, which is the only place that knows WHY —
 #: which strip was full and who filled it. It is not the place that knows whether some LATER
 #: pass drew the measurement anyway.
-_WITHHOLDING_CODES = ("step_dim_withheld", "overall_dim_withheld")
+_WITHHOLDING_CODES = ("step_dim_withheld", "overall_dim_withheld", "step_dim_dropped")
 
 
 def _approved_per_measurement(plan) -> dict:

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -634,7 +634,7 @@ def _render_detail(
         _log.info("Detail %s skipped (non-finite scale required)", letter)
         return False
     if req.source_view not in dwg.views:
-        if req.keep_without_annotations:
+        if req.keep_without_annotations or req.view_name is not None:
             raise ValueError(
                 f"authored detail {letter!r} from {req.source} needs parent view "
                 f"{req.source_view!r}; add that principal view"
@@ -790,36 +790,26 @@ def _render_detail(
         return False
     dwg._set_view_coordinates(view_name, coords)
 
-    # Marker on the source orthographic view around the band + letter.
-    if req.source_view == "side":
-        zlo = req.cross_lo if req.cross_lo is not None else a.bb.min.Z
-        zhi = req.cross_hi if req.cross_hi is not None else a.bb.max.Z
-        corners = [dwg.at("side", a.bb.max.X, y, z) for y in (req.lo, req.hi) for z in (zlo, zhi)]
-        mx0, mx1 = min(p[0] for p in corners), max(p[0] for p in corners)
-        my0, my1 = min(p[1] for p in corners), max(p[1] for p in corners)
-    elif req.source_view == "plan":
-        corners = [
-            dwg.at("plan", x, y, a.bb.max.Z)
-            for x in (req.lo, req.hi)
-            for y in (
-                req.cross_lo if req.cross_lo is not None else a.bb.min.Y,
-                req.cross_hi if req.cross_hi is not None else a.bb.max.Y,
-            )
-        ]
-        mx0, mx1 = min(p[0] for p in corners), max(p[0] for p in corners)
-        my0, my1 = min(p[1] for p in corners), max(p[1] for p in corners)
-    else:
-        FX, FZ = a.proj.front_x, a.proj.front_z
-        if req.axis == "z":  # band runs along page-y
-            xlo = (
-                req.cross_lo if req.cross_axis == "x" and req.cross_lo is not None else a.bb.min.X
-            )
-            xhi = (
-                req.cross_hi if req.cross_axis == "x" and req.cross_hi is not None else a.bb.max.X
-            )
-            mx0, mx1, my0, my1 = FX(xlo), FX(xhi), FZ(req.lo), FZ(req.hi)
-        else:  # x band runs along page-x
-            mx0, mx1, my0, my1 = FX(req.lo), FX(req.hi), FZ(a.bb.min.Z), FZ(a.bb.max.Z)
+    # The marker uses the same two world-axis crop bands as the detail, on
+    # whichever principal camera supplied its profile.
+    axes = {"front": (0, 2), "side": (1, 2), "plan": (0, 1)}[req.source_view]
+    lower, upper = list(a.bb.min), list(a.bb.max)
+    axis_index = "xyz".index(req.axis)
+    lower[axis_index], upper[axis_index] = req.lo, req.hi
+    if req.cross_axis is not None:
+        cross_index = "xyz".index(req.cross_axis)
+        if req.cross_lo is not None:
+            lower[cross_index] = req.cross_lo
+        if req.cross_hi is not None:
+            upper[cross_index] = req.cross_hi
+    corners = []
+    for first in (lower[axes[0]], upper[axes[0]]):
+        for second in (lower[axes[1]], upper[axes[1]]):
+            point = list(a.bb.center())
+            point[axes[0]], point[axes[1]] = first, second
+            corners.append(dwg.at(req.source_view, *point))
+    mx0, mx1 = min(p[0] for p in corners), max(p[0] for p in corners)
+    my0, my1 = min(p[1] for p in corners), max(p[1] for p in corners)
     marker = Compound(
         children=[
             Edge.make_line(Vector(mx0, my0, 0), Vector(mx1, my0, 0)),
@@ -913,7 +903,7 @@ def _resolve_details(dwg, a: Analysis, *, ctx) -> None:
                 dwg.registry.reapply(hname, ident)
         if placed:
             used.add(letter)
-        elif req.keep_without_annotations:
+        elif req.keep_without_annotations or req.view_name is not None:
             raise ValueError(
                 f"authored detail {letter!r} from {req.source} is infeasible on this sheet; "
                 "its target, scale, or whole-view footprint was not relaxed"
@@ -1021,14 +1011,9 @@ def _request_prismatic_detail(dwg, a: Analysis, *, ctx, plan) -> None:
     dropped (a real bug the escalation routing fixes as a side effect).
 
     Prismatic only, by construction: `render_height_ladder` never emits this
-    escalation for a turned part (no `StepLevelFeature`). A crowded **Z-turned**
-    step-length chain has its own, separate drop in `_draw_step_chain`'s vertical
-    branch (`return 0`) — this function no longer accidentally, unreliably papers
-    over that with prismatic-semantics dims (wrong anchor/labeling for a turned
-    chain). That drop is now reported (a `step_dim_dropped` lint warning, #362);
-    still outstanding is a Z-turned-appropriate *detail* remedy, analogous to the
-    X-turned crowded-head block + `DetailRequest` this docstring's sibling,
-    `render_step_lengths`, already has.
+    escalation for a turned part (no `StepLevelFeature`). Turned shoulder recovery
+    uses the approved axial length through `queue_step_detail` and the shared
+    chain pass; it never substitutes a prismatic height-above-datum measurement.
 
     The redraw draws only the approved rungs the source-view spacing gate omitted,
     at the enlarged scale. The escalation carries those exact compiled objects; this

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -1341,6 +1341,7 @@ def _build_drawing_once(
                 getattr(feature, "dominant_axis", ""),
                 getattr(feature, "view", None),
                 getattr(feature, "side", None),
+                getattr(feature, "angular_reference", None),
             )
             if (
                 getattr(feature, "kind", None) != "authored_dimension"
@@ -1382,6 +1383,7 @@ def _build_drawing_once(
                         getattr(feature, "dominant_axis", ""),
                         view,
                         getattr(feature, "side", None),
+                        getattr(feature, "angular_reference", None),
                     )
                 if isinstance(view, str) and view in third_angle_view_names():
                     aspect_views.add(view)

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -2134,9 +2134,11 @@ def build_drawing(
                 )
             )
 
-        def _qualify_candidate(candidate, *, require_axial_coverage=False):
+        def _qualify_candidate(
+            candidate, *, require_axial_coverage=False, allow_recovery_detail=False
+        ):
             """Run cheap semantic gates before the one full acceptance lint."""
-            if _has_detail_view(candidate.views):
+            if _has_detail_view(candidate.views) and not allow_recovery_detail:
                 return (), (), "recovery_detail_retained"
             if require_axial_coverage:
                 assert latest_analysis is not None
@@ -2166,6 +2168,7 @@ def build_drawing(
             reason,
             fallback_views,
             require_axial_coverage,
+            allow_recovery_detail=False,
         ):
             """Try the bounded standard-page tail under one settled correction policy."""
             standard_pages = tuple(_PAGE_SIZES.items())
@@ -2210,6 +2213,7 @@ def build_drawing(
                 issues, blockers, rejection = _qualify_candidate(
                     larger,
                     require_axial_coverage=require_axial_coverage,
+                    allow_recovery_detail=allow_recovery_detail,
                 )
                 if rejection is None:
                     _record_attempt(
@@ -2317,27 +2321,31 @@ def build_drawing(
                 drawing = upscaled
                 settled_issues = upscaled_issues
                 replanned = True
-            elif page is None and any(
-                getattr(feature, "kind", None) == "authored_dimension"
-                and bool(getattr(feature, "source_id", ""))
-                for feature in getattr(drawing.model(), "features", ())
-            ):
-                # If the measured detail cannot be eliminated on the selected sheet, keep
-                # searching the bounded standard-page tail for externally authored dimensions.
-                # A generated detail is a conservative recovery for detected measurements, but
-                # it must not strand imported source-owned marks when the next sheet renders
-                # every one directly (GRM-03 PMI after inter-view clearance, #1262).
-                larger, larger_issues = _try_larger_standard_pages(
-                    original_page,
-                    include_iso=_include_iso,
-                    reason="page_escalation_after_detail",
-                    fallback_views=tuple(drawing.views),
-                    require_axial_coverage=False,
+            elif page is None:
+                _detail_issues, detail_blockers = _automatic_assessment(drawing)
+                has_source_dimensions = any(
+                    getattr(feature, "kind", None) == "authored_dimension"
+                    and bool(getattr(feature, "source_id", ""))
+                    for feature in getattr(drawing.model(), "features", ())
                 )
-                if larger is not None:
-                    drawing = larger
-                    settled_issues = larger_issues
-                    replanned = True
+                if detail_blockers or has_source_dimensions:
+                    # A detail may recover its own measurements while another required
+                    # mark remains unplaced. Try the existing bounded page tail in that
+                    # case too; retaining the detail is valid if the candidate passes
+                    # every structural and required-outcome gate. A complete detected
+                    # drawing does not spend a larger sheet just to eliminate its detail.
+                    larger, larger_issues = _try_larger_standard_pages(
+                        original_page,
+                        include_iso=_include_iso,
+                        reason="page_escalation_after_detail",
+                        fallback_views=tuple(drawing.views),
+                        require_axial_coverage=False,
+                        allow_recovery_detail=bool(detail_blockers),
+                    )
+                    if larger is not None:
+                        drawing = larger
+                        settled_issues = larger_issues
+                        replanned = True
 
         # #443/#1299: a pictorial view is useful context, but it cannot outrank the
         # dimensions or other required annotations needed to manufacture a part.

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -459,17 +459,22 @@ def _compose_anno_boxes(
         axis = getattr(feature, "dominant_axis", "")
         view_hint = getattr(feature, "view", None)
         side_hint = getattr(feature, "side", None)
-        if view_hint is None and side_hint is None:
+        angular_reference = getattr(feature, "angular_reference", None)
+        if view_hint is None and side_hint is None and angular_reference is None:
             if kind not in ("diameter", "radius", "angular") and axis == "Z":
                 _reserve("front", "left")
                 _reserve("front", "right")
             continue
-        target_view = authored_dimension_target_view(kind, axis, view_hint, side_hint)
+        target_view = authored_dimension_target_view(
+            kind, axis, view_hint, side_hint, angular_reference
+        )
         if target_view is None:
             continue
         sides: tuple[str, ...]
         if side_hint is not None:
             sides = (side_hint,)
+        elif angular_reference is not None:
+            sides = ("above", "below", "left", "right")
         elif kind in ("diameter", "radius") or axis == "X":
             sides = ("above", "below")
         elif axis == "Z":

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -17,10 +17,10 @@ from __future__ import annotations
 
 import logging
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from types import SimpleNamespace
 
-from build123d_drafting.helpers import format_drawing_scale
+from build123d_drafting.helpers import draft_preset, format_drawing_scale
 
 from draftwright._core import (
     _DIM_PAD,
@@ -49,15 +49,18 @@ from draftwright._core import (
     _table_metrics,
     _tag_sequence,
     _tb_width,
+    _text_size,
     _text_width,
     _tol_suffix,
     _wrap_rows,
 )
-from draftwright._geometry import _END_ON
+from draftwright._geometry import _END_ON, _fmt_angle
+from draftwright.angular_geometry import AngularGeometry, AngularStyle
+from draftwright.fonts import PLEX_MONO
 from draftwright.layout import fit_box
 from draftwright.model.callout import hole_callout_spec, hole_callout_suffix
-from draftwright.model.compiled import compile_dimensions
 from draftwright.model.ir import authored_dimension_target_view
+from draftwright.model.planner import angular_pattern_label, plan_dimensions
 from draftwright.view_plan import (
     ARRANGEMENTS,
     LayoutCandidate,
@@ -333,6 +336,26 @@ def _est_planned_bore_callout_width(
     return max_w
 
 
+@dataclass(frozen=True)
+class AngularReservation:
+    """Unscaled view-relative supports and once-measured paper-space typography."""
+
+    view: str
+    points: tuple[tuple[float, float], ...]
+    sector: str
+    text_size: tuple[float, float]
+    style: AngularStyle
+
+    def footprint(self, scale):
+        vertex, first, second = (
+            tuple(component * scale for component in point) for point in self.points
+        )
+        geometry = AngularGeometry(
+            vertex, first, second, self.text_size, self.style, sector=self.sector
+        )
+        return geometry.footprint(geometry.minimum_radius)
+
+
 @dataclass
 class StripDepths:
     """Annotation strip depths (page-mm) computed before view positions are fixed.
@@ -351,6 +374,7 @@ class StripDepths:
     sv_top: float = 0.0
     sv_bottom: float = 0.0
     sv_right: float = 0.0  # band outside the rightmost side view
+    angular: tuple[AngularReservation, ...] = ()
 
 
 def _measure_strips(
@@ -364,8 +388,8 @@ def _measure_strips(
 ) -> StripDepths:
     """Compute annotation strip depths from composed annotation boxes (Pass 1 of #131).
 
-    All annotation sizes are scale-independent because font_size is a fixed
-    page-mm constant, so there is no circularity with choose_scale().
+    Typography is measured once at its fixed paper size. Angular supports retain
+    their model-space extent so scale trials can evaluate their analytic boxes.
     *arrow_length* and *pad_around_text* should come from ``draft_preset(...)``.
     """
     return _footprint_from_boxes(
@@ -401,6 +425,7 @@ class AnnoBox:
 
     side: str
     depth: float
+    angular: AngularReservation | None = None
 
 
 def _compose_anno_boxes(
@@ -453,13 +478,47 @@ def _compose_anno_boxes(
         key = (view, side)
         authored_corridors[key] = authored_corridors.get(key, 0) + 1
 
+    def reserve_angle(reference, view, label):
+        draft = draft_preset(font_size=font_size, decimal_precision=1)
+        style = AngularStyle(
+            arrow_length=arrow_length,
+            extension_gap=draft.extension_gap,
+            pad_around_text=pad_around_text,
+            line_width=draft.line_width,
+        )
+        axes = {"plan": (0, 1), "front": (0, 2), "side": (1, 2)}[view]
+        centre = tuple(model.bbox.center())
+        points = tuple(
+            tuple(point[index] - centre[index] for index in axes)
+            for point in (reference.vertex, reference.first, reference.second)
+        )
+        measured = _text_size(label, font_size, PLEX_MONO, draft.font, draft.font_style)
+        boxes.append(
+            AnnoBox(
+                "angular", 0.0, AngularReservation(view, points, reference.sector, measured, style)
+            )
+        )
+
     if any(feature.kind == "angle" for feature in model.features):
-        # Reserve only approved angles: an authored omission must not keep
-        # phantom bands. The arc's extent can reach both neighbouring corridors.
-        for group in compile_dimensions(model).of_kind("angle"):
-            for _approved in group.dims:
-                for side in ("above", "below", "left", "right"):
-                    _reserve(group.view, side)
+        # Sizing reads planned content without executing the compiler: the same
+        # compose path also serves read-only inspection. Share the complete text
+        # formatter so small authored tolerances reserve their actual footprint.
+        # Each curved footprint grows only the sides it actually reaches.
+        for group in plan_dimensions(model):
+            if group.feature.kind != "angle":
+                continue
+            shared_label = angular_pattern_label(group)
+            for planned in group.dims:
+                if not planned.suppressed:
+                    parameter = planned.param
+                    reserve_angle(
+                        parameter.angular_reference,
+                        group.view,
+                        shared_label
+                        or _fmt_angle(
+                            parameter.value, planned.display_decimals, parameter.tolerance
+                        ),
+                    )
 
     for feature in model.features:
         if getattr(feature, "kind", None) != "authored_dimension":
@@ -479,11 +538,12 @@ def _compose_anno_boxes(
         )
         if target_view is None:
             continue
+        if angular_reference is not None:
+            reserve_angle(angular_reference, target_view, feature.label)
+            continue
         sides: tuple[str, ...]
         if side_hint is not None:
             sides = (side_hint,)
-        elif angular_reference is not None:
-            sides = ("above", "below", "left", "right")
         elif kind in ("diameter", "radius") or axis == "X":
             sides = ("above", "below")
         elif axis == "Z":
@@ -598,6 +658,7 @@ def _footprint_from_boxes(boxes: list[AnnoBox]) -> StripDepths:
         sv_top=deepest("side_above"),
         sv_bottom=deepest("side_below"),
         sv_right=deepest("side_right"),
+        angular=tuple(box.angular for box in boxes if box.angular is not None),
     )
 
 
@@ -1062,7 +1123,7 @@ def _compose_view_blocks(
         strips.right if (section and strips) else 0.0,
     )
 
-    return {
+    result = {
         "front": ViewBlock(
             fv_hw,
             fv_hh,
@@ -1087,6 +1148,17 @@ def _compose_view_blocks(
             bottom=strips.sv_bottom if strips else 0.0,
         ),
     }
+    for reservation in strips.angular if strips else ():
+        block = result[reservation.view]
+        x0, y0, x1, y1 = reservation.footprint(scale)
+        result[reservation.view] = replace(
+            block,
+            left=max(block.left, -x0 - block.hw),
+            right=max(block.right, x1 - block.hw),
+            bottom=max(block.bottom, -y0 - block.hh),
+            top=max(block.top, y1 - block.hh),
+        )
+    return result
 
 
 def _layout_geometry(

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -56,6 +56,7 @@ from draftwright._core import (
 from draftwright._geometry import _END_ON
 from draftwright.layout import fit_box
 from draftwright.model.callout import hole_callout_spec, hole_callout_suffix
+from draftwright.model.compiled import compile_dimensions
 from draftwright.model.ir import authored_dimension_target_view
 from draftwright.view_plan import (
     ARRANGEMENTS,
@@ -451,6 +452,14 @@ def _compose_anno_boxes(
     def _reserve(view: str, side: str) -> None:
         key = (view, side)
         authored_corridors[key] = authored_corridors.get(key, 0) + 1
+
+    if any(feature.kind == "angle" for feature in model.features):
+        # Reserve only approved angles: an authored omission must not keep
+        # phantom bands. The arc's extent can reach both neighbouring corridors.
+        for group in compile_dimensions(model).of_kind("angle"):
+            for _approved in group.dims:
+                for side in ("above", "below", "left", "right"):
+                    _reserve(group.view, side)
 
     for feature in model.features:
         if getattr(feature, "kind", None) != "authored_dimension":

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1372,6 +1372,9 @@ class Drawing:
                         item.axis,
                         item.discriminator,
                         item.location_member,
+                        item.angular_reference.measurement_key
+                        if item.angular_reference is not None
+                        else None,
                     )
                     for item in approved
                 )
@@ -1743,9 +1746,63 @@ class Drawing:
             return "above" if exterior[1] > (p1[1] + p2[1]) / 2 else "below"
         return "right" if exterior[0] > (p1[0] + p2[0]) / 2 else "left"
 
+    def _angular_dimension_plan(self, feature, options):
+        """Compile a referential angle edit with the model's existing decorations."""
+        from dataclasses import replace
+
+        from draftwright.model.compiled import compile_dimensions
+        from draftwright.model.ir import RequestedDimension
+
+        if options["param"] not in ("angle", "included.angle") or options.get("role") not in (
+            None,
+            "included",
+        ):
+            raise ValueError("angle exposes only the included.angle measurement")
+        extra = set(options) - {"param", "role", "view", "side", "name", "pin", "priority"}
+        if extra:
+            raise ValueError(
+                f"unsupported angular edit controls: {sorted(extra)}; declare content on Sheet"
+            )
+        model = self.model()
+        if model is None or not any(owner is feature for owner in model.features):
+            raise ValueError("angular edit must name an exact feature in the drawing model")
+        request = RequestedDimension(
+            feature,
+            "included.angle",
+            view=options.get("view"),
+            side=options.get("side"),
+        )
+        return compile_dimensions(
+            replace(model, authored_dimensions=(request,), requested_dimensions=())
+        )
+
     def _queue_dimension_intent(self, it, a, *, ctx, used_names=None) -> bool:
         """Queue a pinned/prioritized feature dimension into a shared corridor."""
         from draftwright.annotations._common import CorridorCandidate, register_corridor
+
+        if getattr(it.feature, "kind", None) == "angle":
+            from draftwright.annotations.from_model import render_angular_dimensions
+            from draftwright.model.compiled import FeatureRef
+
+            plan = self._angular_dimension_plan(it.feature, it.kwargs)
+            name = it.kwargs.get("name")
+            used_names = used_names if used_names is not None else set()
+            if name is None:
+                index = 0
+                while (name := f"dim_angle{index}") in self._registry or name in used_names:
+                    index += 1
+            used_names.add(name)
+            render_angular_dimensions(
+                self,
+                plan,
+                a,
+                ctx=ctx,
+                only={FeatureRef(it.feature)},
+                name=name,
+                pin=bool(it.kwargs.get("pin")),
+                priority=float(it.kwargs.get("priority") or 0.0),
+            )
+            return True
 
         side = it.kwargs.get("side")
         view = it.kwargs.get("view")
@@ -1927,6 +1984,35 @@ class Drawing:
                 )
             )
             return ""
+        if getattr(feature, "kind", None) == "angle":
+            options = dict(
+                param=param,
+                role=role,
+                side=side,
+                view=view,
+                name=name,
+                pin=pin,
+                priority=priority,
+                **kwargs,
+            )
+            self._angular_dimension_plan(feature, options)
+            if name is None:
+                index = 0
+                while (name := f"dim_angle{index}") in self._registry:
+                    index += 1
+            with self.deferred():
+                self.dimension(
+                    feature,
+                    param,
+                    role=role,
+                    side=side,
+                    view=view,
+                    name=name,
+                    pin=pin,
+                    priority=priority,
+                    **kwargs,
+                )
+            return name
         rec, view, p1, p2 = self._resolve_dimension_span(feature, param, role=role, view=view)
         side = self._resolve_dimension_side(feature, rec, view, p1, p2, side)
         from draftwright.model.compiled import DimensionId
@@ -2525,6 +2611,9 @@ class Drawing:
         dimension with a resolvable span and a corridor-side, not already claimed by a
         specialized route (``already_routed`` = ``len_ids | slot_ids | height_ladder_ids |
         step_position_ids``)."""
+        if routable and it.kind == "dimension" and getattr(it.feature, "kind", None) == "angle":
+            self._angular_dimension_plan(it.feature, it.kwargs)
+            return True
         if (
             not routable
             or it.kind != "dimension"

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -135,6 +135,7 @@ from draftwright.linting import (
     lint_through_step_coverage,
     pmi_stage_summary,
 )
+from draftwright.linting.angular import lint_angular_supports
 from draftwright.linting.issues import _collect_issue_aggregation, _current_issue_aggregation
 from draftwright.linting.quality import quality_components
 from draftwright.linting.section_recess_coverage import lint_section_recess_coverage
@@ -237,6 +238,9 @@ _GEOMETRY_AWARE_CODES = frozenset(
         "pocket_requirement_unverifiable",
         "missing_principal_dimension",
         "label_vs_measured",
+        "angular_label_vs_geometry",
+        "angular_geometry_mismatch",
+        "angular_support_unverifiable",
         "dim_inside_part",
         "callout_dropped",
         "location_ref_dropped",
@@ -3777,6 +3781,8 @@ class Drawing:
             _aggregation=aggregation,
         )
         working_part = self._working_part
+        if physical:
+            issues += lint_angular_supports(self.items)
         if working_part is not None and physical:
             # Reuse the single feature inventory from the build (#244) when present,
             # so lint does not re-detect holes/patterns/turned-steps; fall back to

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -135,7 +135,7 @@ from draftwright.linting import (
     lint_through_step_coverage,
     pmi_stage_summary,
 )
-from draftwright.linting.angular import lint_angular_supports
+from draftwright.linting.angular import lint_angular_supports, lint_profile_angle_coverage
 from draftwright.linting.issues import _collect_issue_aggregation, _current_issue_aggregation
 from draftwright.linting.quality import quality_components
 from draftwright.linting.section_recess_coverage import lint_section_recess_coverage
@@ -241,6 +241,7 @@ _GEOMETRY_AWARE_CODES = frozenset(
         "angular_label_vs_geometry",
         "angular_geometry_mismatch",
         "angular_support_unverifiable",
+        "angular_support_mismatch",
         "dim_inside_part",
         "callout_dropped",
         "location_ref_dropped",
@@ -1031,9 +1032,9 @@ class Drawing:
     def report(self) -> dict[str, object]:
         """Return the versioned machine-readable recognition and drawing report.
 
-        Schema version 2 projects accepted raw recognition occurrences, their exact run-local
+        Schema version 3 projects accepted raw recognition occurrences, their exact run-local
         consumer dispositions, final IR owners, recognition-owned semantic requirement outcomes,
-        and the existing structured lint summary.
+        profile-support requirements, and the existing structured lint summary.
         Report IDs are deterministic within this document only; they are not topology or durable
         feature identifiers. ``bounded-clear`` is not manufacturing readiness because recognition
         can miss geometry and material, process, finish, fit, and tolerance intent remains authored.
@@ -1065,6 +1066,8 @@ class Drawing:
             self._build.omissions,
             dimension_plan=dimension_plan,
             part=self._working_part,
+            evidence=evidence,
+            ownership=ownership,
         )
 
         with _reuse_report_requirements(self, requirement_outcomes, dimension_plan):
@@ -1753,11 +1756,18 @@ class Drawing:
         from draftwright.model.compiled import compile_dimensions
         from draftwright.model.ir import RequestedDimension
 
-        if options["param"] not in ("angle", "included.angle") or options.get("role") not in (
-            None,
-            "included",
-        ):
-            raise ValueError("angle exposes only the included.angle measurement")
+        parameters = feature.parameters()
+        matches = [
+            parameter
+            for parameter in parameters
+            if options["param"] == parameter.parameter_id
+            or (options["param"] == "angle" and len(parameters) == 1)
+        ]
+        if len(matches) != 1 or options.get("role") not in (None, "included"):
+            raise ValueError(
+                "angle edit needs one included-angle measurement: "
+                + ", ".join(parameter.parameter_id for parameter in parameters)
+            )
         extra = set(options) - {"param", "role", "view", "side", "name", "pin", "priority"}
         if extra:
             raise ValueError(
@@ -1768,7 +1778,7 @@ class Drawing:
             raise ValueError("angular edit must name an exact feature in the drawing model")
         request = RequestedDimension(
             feature,
-            "included.angle",
+            matches[0].parameter_id,
             view=options.get("view"),
             side=options.get("side"),
         )
@@ -3870,7 +3880,7 @@ class Drawing:
             _aggregation=aggregation,
         )
         working_part = self._working_part
-        if physical:
+        if physical and working_part is None:
             issues += lint_angular_supports(self.items)
         if working_part is not None and physical:
             # Reuse the single feature inventory from the build (#244) when present,
@@ -3923,6 +3933,20 @@ class Drawing:
                 prof_kw = {}
             if recognition is None:
                 recognition = self._build.ensure_recognition(working_part)
+            issues += lint_angular_supports(
+                self.items,
+                registry=self._registry,
+                evidence=self._build.recognition_evidence,
+                ownership=self._build.recognition_ownership,
+                to_page=self.at,
+            )
+            issues += lint_profile_angle_coverage(
+                self._build.recognition_evidence,
+                self._build.recognition_ownership,
+                getattr(self._part_model, "features", ()),
+                self._registry,
+                self._build.omissions,
+            )
             profiled_bores = list(recognition.double_d_bores)
             issues += lint_feature_coverage(
                 working_part,
@@ -4294,6 +4318,8 @@ class Drawing:
             omissions=self._build.omissions,
             issues=issues,
             part=self._working_part,
+            evidence=self._build.recognition_evidence,
+            ownership=self._build.recognition_ownership,
             # Fidelity asks whether what the drawing SAYS is true, so a drawing that says
             # nothing measurable has no answer rather than a perfect one.
             #

--- a/src/draftwright/inspection_contract.py
+++ b/src/draftwright/inspection_contract.py
@@ -11,12 +11,13 @@ import copy
 from importlib.metadata import version as distribution_version
 from typing import Any
 
+from quiddity.evidence import evidence_api_manifest
 from quiddity.inspection import inspection_api_manifest
 
 CONSUMER_INSPECTION_FORMAT = "draftwright-inspection-api"
 CONSUMER_INSPECTION_FORMAT_VERSION = 1
 SUPPORTED_INSPECTION_API_MAJOR = 1
-SUPPORTED_RECOGNISER_VERSION = "0.2.5"
+SUPPORTED_RECOGNISER_VERSION = "0.2.6"
 _DISTRIBUTION = "quiddity"
 _PROVIDER_FORMAT = "quiddity-inspection-api"
 _NAMESPACE = "quiddity.inspection"
@@ -190,6 +191,39 @@ def _require_equal(label: str, actual: object, expected: object) -> None:
         raise InspectionContractError(f"{label} mismatch: expected {expected!r}, got {actual!r}")
 
 
+def validate_profile_evidence_contract(package_manifest: dict[str, Any] | None = None) -> None:
+    """Check the released evidence surface consumed by face-profile drafting."""
+    package = evidence_api_manifest() if package_manifest is None else package_manifest
+    _require_equal("evidence format", package.get("format"), "quiddity-evidence-api")
+    _require_equal("evidence format version", package.get("format_version"), 1)
+    _require_equal(
+        "evidence package",
+        package.get("package"),
+        {"name": _DISTRIBUTION, "version": SUPPORTED_RECOGNISER_VERSION},
+    )
+    api = package.get("api")
+    if not isinstance(api, dict):
+        raise InspectionContractError("evidence api must be an object")
+    _require_equal("evidence API major", api.get("major"), 1)
+    _require_equal("evidence namespace", api.get("namespace"), "quiddity.evidence")
+    required = {
+        "RecognitionEvidence",
+        "PlanarOuterProfile",
+        "PlanarOuterProfileEvidence",
+        "ProfileLine",
+        "ProfileArc",
+        "RefusedPlanarOuterProfile",
+        "OuterProfileRefusalReason",
+    }
+    symbols = api.get("symbols")
+    if not isinstance(symbols, list) or not all(isinstance(symbol, str) for symbol in symbols):
+        raise InspectionContractError("evidence symbols must be a list of names")
+    if len(set(symbols)) != len(symbols) or not required.issubset(symbols):
+        raise InspectionContractError(
+            "required profile evidence symbols are missing or duplicated"
+        )
+
+
 def validate_inspection_contract(
     package_manifest: dict[str, Any] | None = None,
     declaration: dict[str, Any] | None = None,
@@ -241,3 +275,4 @@ def validate_inspection_contract(
             "contract": actual.get("contract"),
         }
         _require_equal(f"inspection symbol {name!r}", consumed, expected)
+    validate_profile_evidence_contract()

--- a/src/draftwright/linting/angular.py
+++ b/src/draftwright/linting/angular.py
@@ -1,0 +1,165 @@
+"""Independent checks of angular claims and their visible arc geometry."""
+
+from __future__ import annotations
+
+from math import atan2, degrees, hypot, isfinite, pi
+from statistics import median
+
+from build123d import GeomType
+
+from draftwright.linting.issues import LintIssue
+
+
+def is_angular_label(label: str) -> bool:
+    """Whether the displayed claim carries a degree marker, including authored ``deg``."""
+    return any(mark in label.lower() for mark in ("°", "deg"))
+
+
+def _has_witness_ink(edges, vertices, vertex, ray, radius):
+    """Require a visible tip at the arc and a radial extension beyond it."""
+    length = hypot(*ray)
+    unit = (ray[0] / length, ray[1] / length)
+
+    def coordinates(point):
+        x, y = point.X - vertex[0], point.Y - vertex[1]
+        return x * unit[0] + y * unit[1], x * unit[1] - y * unit[0]
+
+    tip = any(
+        abs(along - radius) <= 0.01 and abs(across) <= 0.01
+        for along, across in (coordinates(point.center()) for point in vertices)
+    )
+    boundaries = []
+    for edge in edges:
+        if edge.geom_type != GeomType.LINE:
+            continue
+        start, end = coordinates(edge.position_at(0)), coordinates(edge.position_at(1))
+        lo, hi = sorted((start[0], end[0]))
+        if (
+            abs(start[1] - end[1]) <= 0.01
+            and lo >= length - 0.01
+            and lo < radius - 0.01
+            and hi > radius + 0.01
+        ):
+            boundaries.append((start[1], lo, hi))
+    # A stroked extension has two parallel boundaries straddling the ray.
+    # Inspect that geometry rather than assuming the default pen width.
+    extension = any(
+        abs(offset) <= 0.01
+        or any(
+            abs(offset + other) <= 0.01 and abs(lo - low) <= 0.01 and abs(hi - high) <= 0.01
+            for other, low, high in boundaries
+        )
+        for offset, lo, hi in boundaries
+    )
+    return tip and extension
+
+
+def lint_angular_geometry(item, label_value):
+    """Compare degrees with the reference rays, then inspect the actual circular ink.
+
+    This never reads the renderer's ``measured_angle`` as the expected answer.
+    Correspondence between declared rays and physical part supports is a separate
+    evidence obligation, not something a correct arc on the page proves.
+    """
+    label = getattr(item, "label", "")
+    try:
+        first, vertex, second = item.angular_points
+        u = tuple(a - b for a, b in zip(first, vertex, strict=True))
+        v = tuple(a - b for a, b in zip(second, vertex, strict=True))
+        if len(u) != 2 or len(v) != 2 or not all(isfinite(c) for c in (*u, *v)):
+            raise ValueError("angular witnesses must be finite page-plane points")
+        if min(hypot(*u), hypot(*v)) <= 1e-9:
+            raise ValueError("angular witnesses must define two nonzero rays")
+        signed = atan2(u[0] * v[1] - u[1] * v[0], sum(a * b for a, b in zip(u, v, strict=True)))
+        angle = abs(signed)
+        if not 1e-9 < angle < pi - 1e-9:
+            raise ValueError("angular witnesses have no nondegenerate minor sector")
+    except (AttributeError, TypeError, ValueError) as exc:
+        return [
+            LintIssue(
+                severity="error",
+                code="angular_geometry_mismatch",
+                message=f"Angle {label!r} has unusable reference geometry: {exc}",
+            )
+        ]
+
+    findings = []
+    actual = degrees(angle)
+    if (
+        not is_angular_label(label)
+        or label_value is None
+        or not isfinite(label_value)
+        or abs(label_value - actual) > max(0.01, actual * 0.005)
+    ):
+        findings.append(
+            LintIssue(
+                severity="error",
+                code="angular_label_vs_geometry",
+                location=tuple(vertex),
+                message=f"Angle {label!r} does not agree with its reference rays ({actual:.6g} degrees)",
+            )
+        )
+
+    halves = set()
+    radii = []
+    escaped = False
+    try:
+        edges = item.edges()
+        for edge in edges:
+            if edge.geom_type != GeomType.CIRCLE:
+                continue
+            centre = edge.arc_center
+            if hypot(centre.X - vertex[0], centre.Y - vertex[1]) > 0.01:
+                continue
+            midpoint = edge.position_at(0.5)
+            ray = (midpoint.X - vertex[0], midpoint.Y - vertex[1])
+            offset = atan2(u[0] * ray[1] - u[1] * ray[0], u[0] * ray[0] + u[1] * ray[1])
+            offset = (offset * (1 if signed > 0 else -1)) % (2 * pi)
+            if offset > angle + 1e-6:
+                escaped = True
+            else:
+                halves.add(offset > angle / 2)
+                radii.append(edge.radius)
+        witness_ink = bool(radii) and all(
+            _has_witness_ink(edges, item.vertices(), vertex, ray, median(radii)) for ray in (u, v)
+        )
+    except (AttributeError, TypeError, ValueError, RuntimeError) as exc:
+        findings.append(
+            LintIssue(
+                severity="error",
+                code="angular_geometry_mismatch",
+                location=tuple(vertex),
+                message=f"Angle {label!r} has unreadable circular ink: {exc}",
+            )
+        )
+        return findings
+    if escaped or halves != {False, True} or not witness_ink:
+        findings.append(
+            LintIssue(
+                severity="error",
+                code="angular_geometry_mismatch",
+                location=tuple(vertex),
+                message=f"Angle {label!r} lacks circular shafts, arrow tips or extension lines "
+                "at both rays of its selected reference sector",
+            )
+        )
+    return findings
+
+
+def lint_angular_supports(items):
+    """Keep physical support assurance explicit until the provider contract exists.
+
+    Quiddity #579 requests body-owned outer-profile supports. An authored vertex
+    and two points cannot prove that such edges exist on the part, even if the
+    resulting annotation is internally consistent. Do not rescan topology here.
+    """
+    return [
+        LintIssue(
+            severity="warning",
+            code="angular_support_unverifiable",
+            message=f"Angle {item.label!r}: correspondence of the declared rays to physical "
+            "part supports is unavailable (Quiddity #579)",
+        )
+        for item in items
+        if getattr(item, "measured_angle", None) is not None
+    ]

--- a/src/draftwright/linting/angular.py
+++ b/src/draftwright/linting/angular.py
@@ -3,12 +3,19 @@
 from __future__ import annotations
 
 import re
-from math import atan2, degrees, hypot, isfinite, pi
+from dataclasses import dataclass
+from math import atan2, degrees, dist, fsum, hypot, isfinite, pi
 from statistics import median
+from types import SimpleNamespace
 
 from build123d import GeomType
 
 from draftwright.linting.issues import LintIssue
+from draftwright.profile_angles import (
+    ProfileAngle,
+    profile_angle_repetitions,
+    profile_angle_requirements,
+)
 
 
 def is_angular_label(label: str) -> bool:
@@ -16,7 +23,7 @@ def is_angular_label(label: str) -> bool:
     return any(mark in label.lower() for mark in ("°", "deg"))
 
 
-def _has_witness_ink(edges, vertices, vertex, ray, radius):
+def _has_witness_ink(edges, vertices, vertex, ray, radius, direction=1):
     """Require a visible tip at the arc and a radial extension beyond it."""
     length = hypot(*ray)
     unit = (ray[0] / length, ray[1] / length)
@@ -37,7 +44,7 @@ def _has_witness_ink(edges, vertices, vertex, ray, radius):
         lo, hi = sorted((start[0], end[0]))
         if (
             abs(start[1] - end[1]) <= 0.01
-            and lo >= length - 0.01
+            and lo >= direction * length - 0.01
             and lo < radius - 0.01
             and hi > radius + 0.01
         ):
@@ -71,6 +78,11 @@ def lint_angular_geometry(item, label_value):
             raise ValueError("angular witnesses must be finite page-plane points")
         if min(hypot(*u), hypot(*v)) <= 1e-9:
             raise ValueError("angular witnesses must define two nonzero rays")
+        sector = getattr(item, "angular_sector", "minor")
+        if sector not in ("minor", "opposite"):
+            raise ValueError("angular witnesses have an unsupported selected sector")
+        direction = -1 if sector == "opposite" else 1
+        u, v = tuple(direction * c for c in u), tuple(direction * c for c in v)
         signed = atan2(u[0] * v[1] - u[1] * v[0], sum(a * b for a, b in zip(u, v, strict=True)))
         angle = abs(signed)
         if not 1e-9 < angle < pi - 1e-9:
@@ -126,7 +138,8 @@ def lint_angular_geometry(item, label_value):
                 halves.add(offset > angle / 2)
                 radii.append(edge.radius)
         witness_ink = bool(radii) and all(
-            _has_witness_ink(edges, item.vertices(), vertex, ray, median(radii)) for ray in (u, v)
+            _has_witness_ink(edges, item.vertices(), vertex, ray, median(radii), direction)
+            for ray in (u, v)
         )
     except (AttributeError, TypeError, ValueError, RuntimeError) as exc:
         findings.append(
@@ -151,20 +164,390 @@ def lint_angular_geometry(item, label_value):
     return findings
 
 
-def lint_angular_supports(items):
-    """Keep physical support assurance explicit until the provider contract exists.
+def _difference(first, second):
+    return tuple(a - b for a, b in zip(first, second, strict=True))
 
-    Quiddity #579 requests body-owned outer-profile supports. An authored vertex
-    and two points cannot prove that such edges exist on the part, even if the
-    resulting annotation is internally consistent. Do not rescan topology here.
+
+def _cross(first, second):
+    return (
+        first[1] * second[2] - first[2] * second[1],
+        first[2] * second[0] - first[0] * second[2],
+        first[0] * second[1] - first[1] * second[0],
+    )
+
+
+def _dot(first, second):
+    return fsum(a * b for a, b in zip(first, second, strict=True))
+
+
+def _physical_corner(evidence, requirement):
+    """Reconstruct the corner from two exact borrowed edges, independently of IR.
+
+    The issued profile establishes adjacency and orientation. Actual edge endpoints
+    establish the intersection and finite witnesses; neither the adapter's vertex
+    nor the annotation's measured-angle metadata supplies the expected answer.
     """
-    return [
-        LintIssue(
-            severity="warning",
-            code="angular_support_unverifiable",
-            message=f"Angle {item.label!r}: correspondence of the declared rays to physical "
-            "part supports is unavailable (Quiddity #579)",
+    source = requirement.source
+    supports = source.profile.supports
+    first_index, second_index = requirement.first_index, requirement.second_index
+    next_index = (first_index + 1) % len(supports)
+    rounded = supports[next_index].kind == "arc"
+    if second_index != (next_index + int(rounded)) % len(supports):
+        raise ValueError("the bound supports are not adjacent profile sides")
+    physical = []
+    for index in (first_index, second_index):
+        support = supports[index]
+        if support.kind != "line":
+            raise ValueError("the bound angular support is not a straight line")
+        edge = evidence.profile_edge(source, index)
+        if edge.geom_type != GeomType.LINE:
+            raise ValueError("the borrowed angular support is not a straight edge")
+        endpoints = tuple(tuple(edge.position_at(t)) for t in (0, 1))
+        if dist(endpoints[0], support.start) > dist(endpoints[1], support.start):
+            endpoints = endpoints[::-1]
+        if dist(endpoints[0], support.start) > 1e-6 or dist(endpoints[1], support.end) > 1e-6:
+            raise ValueError("the issued support no longer agrees with its physical edge")
+        physical.append(endpoints)
+    (a, b), (c, d) = physical
+    u, v = _difference(b, a), _difference(d, c)
+    normal = _cross(u, v)
+    denominator = _dot(normal, normal)
+    if denominator <= 1e-16:
+        raise ValueError("the physical supports have no unique angular vertex")
+    station = _dot(_cross(_difference(c, a), v), normal) / denominator
+    vertex = tuple(p + station * direction for p, direction in zip(a, u, strict=True))
+    residual = _cross(_difference(vertex, c), v)
+    if hypot(*residual) / hypot(*v) > 1e-6:
+        raise ValueError("the physical supports do not intersect in one plane")
+    axis = max(range(3), key=lambda index: abs(normal[index]))
+    if any(abs(value) / hypot(*normal) > 1e-8 for i, value in enumerate(normal) if i != axis):
+        raise ValueError("the physical angle has no principal true-angle view")
+    witnesses = (b, c) if rounded else (a, d)
+    return ("side", "front", "plan")[axis], (witnesses[0], vertex, witnesses[1]), physical
+
+
+def _on_segment(point, endpoints):
+    first, second = endpoints
+    direction = _difference(second, first)
+    length_squared = _dot(direction, direction)
+    if length_squared <= 1e-16:
+        return False
+    station = _dot(_difference(point, first), direction) / length_squared
+    nearest = tuple(p + station * u for p, u in zip(first, direction, strict=True))
+    return -1e-8 <= station <= 1 + 1e-8 and dist(point, nearest) <= 1e-6
+
+
+def _declared_physical_corner(owner, evidence, view=None, *, reference=None):
+    """Check a declaration's model-space witnesses without inventing ownership.
+
+    Only a unique issued face-profile corner establishes this bounded proof.
+    The finite-edge check permits a witness part-way along a physical edge; a
+    collinear point floating beyond that edge is not a supported declaration.
+    """
+    reference = reference if reference is not None else getattr(owner, "angular_reference", None)
+    if reference is None:
+        return None
+    matches = []
+    for face in evidence.faces:
+        source = evidence.planar_outer_profile(face)
+        profile = getattr(source, "profile", None)
+        if profile is None:
+            continue
+        supports = profile.supports
+        for index, support in enumerate(supports):
+            if support.kind != "line":
+                continue
+            following = (index + 1) % len(supports)
+            if supports[following].kind == "arc":
+                following = (following + 1) % len(supports)
+            if supports[following].kind != "line":
+                continue
+            pair = SimpleNamespace(source=source, first_index=index, second_index=following)
+            try:
+                actual_view, expected, edges = _physical_corner(evidence, pair)
+            except (AttributeError, TypeError, ValueError, RuntimeError, IndexError):
+                continue  # This profile cannot establish the declared corner.
+            if (view is not None and actual_view != view) or dist(
+                reference.vertex, expected[1]
+            ) > 1e-6:
+                continue
+            if any(
+                _on_segment(reference.first, first) and _on_segment(reference.second, second)
+                for first, second in (edges, edges[::-1])
+            ):
+                matches.append(
+                    (pair, actual_view, (reference.first, reference.vertex, reference.second))
+                )
+    return matches[0] if len(matches) == 1 else None
+
+
+def _angular_references(owner):
+    if getattr(owner, "angular_reference", None) is None:
+        return ()
+    parameters = owner.parameters() if callable(getattr(owner, "parameters", None)) else ()
+    references = tuple(
+        (parameter.parameter_id, parameter.angular_reference)
+        for parameter in parameters
+        if getattr(parameter, "angular_reference", None) is not None
+    )
+    return references or (("included.angle", owner.angular_reference),)
+
+
+def _corner_key(requirement):
+    return id(requirement.source), requirement.first_index, requirement.second_index
+
+
+def _projected_angle(points):
+    first, vertex, second = points
+    u = tuple(a - b for a, b in zip(first, vertex, strict=True))
+    v = tuple(a - b for a, b in zip(second, vertex, strict=True))
+    return degrees(
+        abs(atan2(u[0] * v[1] - u[1] * v[0], sum(a * b for a, b in zip(u, v, strict=True))))
+    )
+
+
+def lint_angular_supports(items, *, registry=None, evidence=None, ownership=None, to_page=None):
+    """Check every claimed corner against physical supports, including quantity marks.
+
+    A quantity mark shows one representative but must account for distinct, equal
+    physical corners. Detected groups additionally need the provider-profile
+    repetition proof; authored groups must name one face's actual corners.
+    """
+    names = (
+        {} if registry is None else {id(registry.named(name)): name for name in registry.names()}
+    )
+    findings = []
+    repetitions = None
+    for item in items:
+        if getattr(item, "measured_angle", None) is None:
+            continue
+        name = names.get(id(item))
+        owner = registry.feature_of(name) if name is not None else None
+        references = dict(_angular_references(owner))
+        claims = registry.measurement_of(name) if name is not None else ()
+        parameters = tuple(claim.parameter for claim in claims)
+        if not claims and len(references) == 1:
+            parameters = tuple(references)
+        if (
+            not parameters
+            or len(set(parameters)) != len(parameters)
+            or any(claim.feature is not owner for claim in claims)
+            or any(parameter not in references for parameter in parameters)
+            or evidence is None
+            or to_page is None
+        ):
+            findings.append(
+                LintIssue(
+                    severity="warning",
+                    code="angular_support_unverifiable",
+                    message=f"Angle {item.label!r}: no unique same-run physical support binding",
+                )
+            )
+            continue
+        try:
+            expected_members = []
+            pairs = []
+            for parameter in parameters:
+                reference = references[parameter]
+                if ownership is None:
+                    declared = _declared_physical_corner(
+                        owner,
+                        evidence,
+                        registry.view_of(name),
+                        reference=reference,
+                    )
+                    if declared is None:
+                        raise LookupError("no unique declared physical corner")
+                    pair, view, expected = declared
+                else:
+                    bindings = [
+                        binding
+                        for binding in ownership.profile_angles
+                        if ownership.evidence is evidence
+                        and binding.feature is owner
+                        and binding.parameter_id == parameter
+                    ]
+                    if len(bindings) != 1:
+                        raise LookupError("no unique same-run physical support binding")
+                    pair = bindings[0].requirement
+                    view, expected, _edges = _physical_corner(evidence, pair)
+                if registry.view_of(name) != view:
+                    raise ValueError(f"the physical supports require the {view} true-angle view")
+                projected = tuple(tuple(to_page(view, *point)[:2]) for point in expected)
+                declared_points = tuple(
+                    tuple(to_page(view, *point)[:2])
+                    for point in (reference.first, reference.vertex, reference.second)
+                )
+                if not any(
+                    all(
+                        dist(a, b) <= 0.01 for a, b in zip(declared_points, candidate, strict=True)
+                    )
+                    for candidate in (projected, projected[::-1])
+                ):
+                    raise ValueError(
+                        "a member's declared witnesses differ from its physical supports"
+                    )
+                pairs.append(pair)
+                expected_members.append(projected)
+            actual = item.angular_points
+            if not any(
+                all(dist(a, b) <= 0.01 for a, b in zip(actual, candidate, strict=True))
+                for expected in expected_members
+                for candidate in (expected, expected[::-1])
+            ):
+                raise ValueError("the drawn vertex or witnesses differ from the physical supports")
+            quantity = re.match(r"^\s*([1-9]\d*)\s*×\s*", item.label)
+            if (int(quantity.group(1)) if quantity else 1) != len(expected_members):
+                raise ValueError(
+                    "the displayed quantity does not match the physical corner roster"
+                )
+            keys = {_corner_key(pair) for pair in pairs}
+            if len(keys) != len(pairs) or len({id(pair.source) for pair in pairs}) != 1:
+                raise ValueError("a quantity needs distinct corners on one physical face profile")
+            if any(
+                abs(_projected_angle(expected) - _projected_angle(actual)) > 1e-5
+                for expected in expected_members
+            ):
+                raise ValueError("the represented physical corners have different angles")
+            if len(pairs) > 1 and ownership is not None:
+                if repetitions is None:
+                    repetitions = profile_angle_repetitions(evidence)
+                if not any(
+                    keys == {_corner_key(member) for member in repetition.members}
+                    for repetition in repetitions
+                ):
+                    raise ValueError("the quantity has no proved physical profile repetition")
+        except LookupError as exc:
+            findings.append(
+                LintIssue(
+                    severity="warning",
+                    code="angular_support_unverifiable",
+                    message=f"Angle {item.label!r}: {exc}",
+                    measurement_ids=claims,
+                )
+            )
+        except (AttributeError, TypeError, ValueError, RuntimeError, IndexError) as exc:
+            findings.append(
+                LintIssue(
+                    severity="error",
+                    code="angular_support_mismatch",
+                    message=f"Angle {item.label!r}: {exc}",
+                    measurement_ids=claims,
+                )
+            )
+    return findings
+
+
+@dataclass(frozen=True)
+class ProfileAngleOutcome:
+    """One issued profile corner, even when its adapter or annotation is absent."""
+
+    source_profile: ProfileAngle
+    state: str
+    features: tuple = ()
+    parameter_id: str = "included.angle"
+
+
+def profile_angle_requirement_outcomes(evidence, ownership, features, registry, omissions=()):
+    """Count physical profile requirements independently of the final IR and ink.
+
+    Conversion-time bindings establish detected ownership. Declarations can
+    represent a unique physical corner without acquiring detected ownership.
+    A lost detected owner is missing even if stale annotation provenance survives.
+    """
+    bindings = (
+        ownership.profile_angles
+        if ownership is not None and ownership.evidence is evidence
+        else ()
+    )
+    declared = []
+    if ownership is None and evidence is not None:
+        for feature in features:
+            for parameter_id, reference in _angular_references(feature):
+                proof = _declared_physical_corner(feature, evidence, reference=reference)
+                if proof is not None:
+                    declared.append((feature, parameter_id, proof[0]))
+    outcomes = []
+    for requirement in profile_angle_requirements(evidence):
+        matches = [
+            binding
+            for binding in bindings
+            if binding.requirement.source is requirement.source
+            and binding.requirement.first_index == requirement.first_index
+            and binding.requirement.second_index == requirement.second_index
+        ]
+        owners = (matches[0].feature,) if len(matches) == 1 else ()
+        parameter_id = matches[0].parameter_id if len(matches) == 1 else "included.angle"
+        if ownership is None:
+            representations = [
+                (feature, parameter)
+                for feature, parameter, pair in declared
+                if pair.source is requirement.source
+                and pair.first_index == requirement.first_index
+                and pair.second_index == requirement.second_index
+            ]
+            owners = (representations[0][0],) if len(representations) == 1 else ()
+            if len(representations) == 1:
+                parameter_id = representations[0][1]
+        final = tuple(owner for owner in owners if any(owner is feature for feature in features))
+        state = "unverifiable"
+        if owners and not final:
+            state = "missing"
+        elif final:
+            (owner,) = final
+
+            def matches_id(identity):
+                return identity.feature is owner and identity.parameter == parameter_id
+
+            if any(
+                hasattr(registry.named(name), "angular_points")
+                and any(matches_id(identity) for identity in registry.measurement_of(name))
+                for name in registry.names()
+            ):
+                state = "placed"
+            elif any(
+                matches_id(identity)
+                for name in registry.names()
+                for identity in registry.satisfaction_of(name)
+            ):
+                state = "satisfied_by_structured_note"
+            elif any(
+                omission.feature is owner
+                and omission.parameter_id == parameter_id
+                and omission.authored
+                for omission in omissions
+            ):
+                state = "suppressed"
+            elif any(
+                matches_id(identity)
+                for issue in registry.issues
+                if issue.code == "angular_dimension_dropped"
+                for identity in issue.measurement_ids
+            ):
+                state = "dropped"
+            else:
+                state = "missing"
+        outcomes.append(ProfileAngleOutcome(requirement, state, final, parameter_id))
+    return outcomes
+
+
+def lint_profile_angle_coverage(evidence, ownership, features, registry, omissions=()):
+    """Expose missing or unbound profile angles, retaining authored omissions."""
+    findings = []
+    for outcome in profile_angle_requirement_outcomes(
+        evidence, ownership, features, registry, omissions
+    ):
+        if outcome.state in {"placed", "satisfied_by_structured_note", "dropped"}:
+            continue
+        requirement = outcome.source_profile
+        findings.append(
+            LintIssue(
+                severity="info" if outcome.state == "suppressed" else "warning",
+                code=f"angular_requirement_{outcome.state}",
+                message=(
+                    f"Outer-profile angle at {requirement.vertex}, supports "
+                    f"{requirement.first_index}/{requirement.second_index}: {outcome.state}"
+                ),
+            )
         )
-        for item in items
-        if getattr(item, "measured_angle", None) is not None
-    ]
+    return findings

--- a/src/draftwright/linting/angular.py
+++ b/src/draftwright/linting/angular.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from math import atan2, degrees, hypot, isfinite, pi
 from statistics import median
 
@@ -85,11 +86,15 @@ def lint_angular_geometry(item, label_value):
 
     findings = []
     actual = degrees(angle)
+    nominal = re.search(r"[+-]?\d+(?:\.(\d+))?\s*(?:°|deg)", label, re.IGNORECASE)
+    # Interpret the nominal at its displayed resolution. A fixed percentage
+    # both missed false precise claims and rejected correctly rounded small angles.
+    rounding = 0.5 * 10 ** -len(nominal.group(1) or "") if nominal else 0.0
     if (
         not is_angular_label(label)
         or label_value is None
         or not isfinite(label_value)
-        or abs(label_value - actual) > max(0.01, actual * 0.005)
+        or abs(label_value - actual) > rounding + 1e-8
     ):
         findings.append(
             LintIssue(

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -1850,12 +1850,11 @@ def _axial_covered_from_drawing(
         px, py, *_ = dwg.at(view, *pt)
         return float(px if horizontal else py)
 
-    # A crowded X-turned head or Y-turned side chain can be dimensioned in an
-    # enlarged detail view (#304/#307/#892), not the principal profile — so a
+    # A crowded turned chain can be dimensioned in an enlarged detail view,
+    # on every turning axis, rather than the principal profile — so a
     # shoulder counts as located when matched in EITHER source or detail view.
     views = [view for view in _turned_profile_views(prof.axis) if view in dwg.views]
-    if prof.axis in ("x", "y"):
-        views += sorted(v for v in dwg.views if v.startswith("detail_"))
+    views += sorted(v for v in dwg.views if v.startswith("detail_"))
     covered_steps: set[int] = set()
     for view in views:
         horizontal, _own_cross = _profile_projection(dwg, view, base, prof.axis)
@@ -1878,6 +1877,10 @@ def _axial_covered_from_drawing(
                 # step endpoint (so a non-contiguous profile's interior end face is a
                 # shoulder), and this branch should be unreachable — but a lint pass must
                 # never crash on an unguarded lookup, so skip rather than KeyError.
+                continue
+            if abs(chi - clo) < 1e-9:
+                # An end-on detail projects both shoulder stations onto one
+                # point. Coincident witnesses cannot establish an axial length.
                 continue
             for name, label, cs, cross_coords, owners in dims:
                 if not cs:

--- a/src/draftwright/linting/evidence.py
+++ b/src/draftwright/linting/evidence.py
@@ -315,6 +315,20 @@ def verify_measurement_claims(registry, plan) -> list[ClaimOutcome]:
         if not claims:
             continue
         numbers = rendered_numbers(registry.named(name))
+        shared_angular_labels = tuple(
+            group.shared_label
+            for group in getattr(plan, "groups", ())
+            if getattr(group, "feature_kind", None) == "angle"
+            and getattr(group, "shared_label", None)
+            and len(claims) == len(group.dims)
+            and all(
+                any(
+                    claim.feature is member.id.feature and claim.parameter == member.id.parameter
+                    for claim in claims
+                )
+                for member in group.dims
+            )
+        )
         for claim in claims:
             entries = approved.get(claim, ())
             parameter = str(getattr(claim, "parameter", claim))
@@ -325,8 +339,10 @@ def verify_measurement_claims(registry, plan) -> list[ClaimOutcome]:
                 and entry.rendered_label is not None
             )
             if angular_labels:
-                # An included angle has one complete compiler-owned label. A
-                # matching nominal alone cannot vouch for a missing tolerance.
+                # A quantity label must carry the entire compiler-approved member
+                # roster. Matching a nominal cannot vouch for a lost tolerance or
+                # a quantity whose other corner measurements disappeared.
+                angular_labels += shared_angular_labels
                 rendered = str(getattr(registry.named(name), "label", ""))
                 outcomes.append(
                     ClaimOutcome(

--- a/src/draftwright/linting/evidence.py
+++ b/src/draftwright/linting/evidence.py
@@ -318,6 +318,27 @@ def verify_measurement_claims(registry, plan) -> list[ClaimOutcome]:
         for claim in claims:
             entries = approved.get(claim, ())
             parameter = str(getattr(claim, "parameter", claim))
+            angular_labels = tuple(
+                entry.rendered_label
+                for entry in entries
+                if getattr(entry, "angular_reference", None) is not None
+                and entry.rendered_label is not None
+            )
+            if angular_labels:
+                # An included angle has one complete compiler-owned label. A
+                # matching nominal alone cannot vouch for a missing tolerance.
+                rendered = str(getattr(registry.named(name), "label", ""))
+                outcomes.append(
+                    ClaimOutcome(
+                        name,
+                        parameter,
+                        "confirmed" if rendered in angular_labels else "value_absent",
+                        angular_labels,
+                        rendered,
+                        measurement=claim,
+                    )
+                )
+                continue
             expected = tuple(entry.value_text for entry in entries)
             wanted = (
                 frozenset().union(*(_expected_numbers(entry) for entry in entries))

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -154,6 +154,7 @@ _UNDECIDED_INVENTORIES: dict[str, str] = {
 }
 
 _AUDITED_FAMILIES = (
+    "outer_profile_angles",
     "section_recesses",
     "angled_steps",
     "blends",
@@ -249,6 +250,7 @@ _FIDELITY_CODES = frozenset(
         "angular_label_vs_geometry",
         "angular_geometry_mismatch",
         "angular_support_unverifiable",
+        "angular_support_mismatch",
         "radius_leader_target_mismatch",
         "radius_leader_target_unverifiable",
         "diameter_leader_target_mismatch",
@@ -405,6 +407,7 @@ _STAGE_ROUTED_CODES = frozenset(
 #: individually, so the prefix register governs only the interpolating sites — it can never
 #: reclassify a code somebody spelled out.
 _UNSCORED_CODE_PREFIXES = (
+    "angular_requirement_",
     "blend_requirement_",
     "chamfer_requirement_",
     "channel_requirement_",
@@ -632,6 +635,8 @@ def _completeness_component(
     *,
     dimension_plan=None,
     part=None,
+    evidence=None,
+    ownership=None,
     requirement_outcomes: Mapping[str, tuple[Any, ...]] | None = None,
 ) -> dict:
     unrecognised = sum(issue.code == _UNRECOGNISED_GEOMETRY_CODE for issue in issues)
@@ -650,6 +655,8 @@ def _completeness_component(
             omissions,
             dimension_plan=dimension_plan,
             part=part,
+            evidence=evidence,
+            ownership=ownership,
         )
     )
 
@@ -740,6 +747,8 @@ def quality_components(
     has_asserted_content: bool,
     dimension_plan=None,
     part=None,
+    evidence=None,
+    ownership=None,
     requirement_outcomes: Mapping[str, tuple[Any, ...]] | None = None,
     _aggregation=None,
 ) -> dict:
@@ -776,6 +785,8 @@ def quality_components(
             issues,
             dimension_plan=dimension_plan,
             part=part,
+            evidence=evidence,
+            ownership=ownership,
             requirement_outcomes=requirement_outcomes,
         ),
         "restraint": {

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -246,6 +246,9 @@ _UNRECOGNISED_GEOMETRY_CODE = "unrecognised_defining_geometry"
 _FIDELITY_CODES = frozenset(
     {
         "label_vs_measured",
+        "angular_label_vs_geometry",
+        "angular_geometry_mismatch",
+        "angular_support_unverifiable",
         "radius_leader_target_mismatch",
         "radius_leader_target_unverifiable",
         "diameter_leader_target_mismatch",

--- a/src/draftwright/linting/requirements.py
+++ b/src/draftwright/linting/requirements.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from types import MappingProxyType
 from typing import Any
 
+from draftwright.linting.angular import profile_angle_requirement_outcomes
 from draftwright.linting.blend_coverage import blend_requirement_outcomes
 from draftwright.linting.chamfer_coverage import chamfer_requirement_outcomes
 from draftwright.linting.channel_coverage import channel_requirement_outcomes
@@ -44,12 +45,17 @@ def recognized_requirement_outcomes(
     *,
     dimension_plan=None,
     part=None,
+    evidence=None,
+    ownership=None,
 ) -> Mapping[str, tuple[Any, ...]]:
     """Return typed physical-requirement ledgers shared by lint and reports.
 
     The denominator is recognition-owned: callers may project or count these outcomes,
     but must not reconstruct physical requirements from final IR parameters.
     """
+
+    if evidence is not None and evidence.result is not recognition:
+        raise ValueError("requirement evidence and recognition must belong to the same run")
 
     outcomes: dict[str, list] = {
         "section_recesses": unsupported_section_recess_outcomes(recognition),
@@ -105,4 +111,8 @@ def recognized_requirement_outcomes(
         outcomes[
             "hole_patterns" if hole_outcome.source_kind == "hole_pattern" else "holes"
         ].append(hole_outcome)
+    if evidence is not None:
+        outcomes["outer_profile_angles"] = profile_angle_requirement_outcomes(
+            evidence, ownership, features, registry, omissions
+        )
     return MappingProxyType({family: tuple(items) for family, items in outcomes.items()})

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -206,6 +206,10 @@ def _label_reading(item, label: str) -> float | None:
     If another per-unit producer appears untagged it will report a large false discrepancy —
     loudly, as an error — which is the right failure mode for a missing tag.
     """
+    if getattr(item, "measured_angle", None) is not None:
+        # Repeated angles count corners; they never multiply the displayed
+        # degrees into a longer path. Read the actual label, not a value rider.
+        return _label_value(re.sub(r"^\s*[1-9]\d*\s*[×x]\s*", "", label))
     declared = getattr(item, "_dw_label_value", None)
     return float(declared) if declared is not None else _label_value(label)
 
@@ -1041,7 +1045,24 @@ def _label_centerline_overlap(dim_item, cl_item, box_cache=None, warned=None):
             else None
         )
 
-    return overlap((cl_min_x, cl_min_y, cl_max_x, cl_max_y))
+    result = overlap((cl_min_x, cl_min_y, cl_max_x, cl_max_y))
+    if result is None:
+        return None
+    # Circular helper strokes have no linear segment metadata. Their aggregate
+    # box includes the empty centre and the corners outside the ring. Check the
+    # rendered edges through the same geometric gate used for projected ink.
+    # Duck-typed items without inspectable edges keep the conservative fallback.
+    key = ("centerline_edges", id(cl_item))
+    token = _loc_token(cl_item)
+    hit = box_cache.get(key)
+    if hit is not None and hit[0] is cl_item and hit[1] == token:
+        edges = hit[2]
+    else:
+        edges = _view_edge_entries(cl_item, {})
+        box_cache[key] = (cl_item, token, edges)
+    if edges and not _edges_intersect_rect(edges, label_bbox):
+        return None
+    return result
 
 
 #: At or above this relative discrepancy a dimension does not merely round differently from

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -23,6 +23,8 @@ from draftwright._geometry import (
     _segment_clips_box,
     material_reentry_span,
 )
+from draftwright.linting.angular import is_angular_label as _is_angular_label
+from draftwright.linting.angular import lint_angular_geometry
 from draftwright.linting.ink_overlap import crossable_region, label_crossings, segments_of
 from draftwright.linting.issues import LintIssue, _IssueAggregation
 from draftwright.projection import _MATERIAL_PAGE_TOLERANCE
@@ -147,7 +149,10 @@ def is_dimension_like(item) -> bool:
     Deliberately narrow: ``measured_length`` is a plain attribute on the helper's dimension
     types, so this needs none of :func:`_label_bbox`'s raising-property discipline.
     """
-    return getattr(item, "measured_length", None) is not None
+    return (
+        getattr(item, "measured_length", None) is not None
+        or getattr(item, "measured_angle", None) is not None
+    )
 
 
 def _label_bbox(item, warned=None):
@@ -1039,17 +1044,6 @@ def _label_centerline_overlap(dim_item, cl_item, box_cache=None, warned=None):
     return overlap((cl_min_x, cl_min_y, cl_max_x, cl_max_y))
 
 
-#: Degree markers a dimension label may carry. ``°`` is what the engine and AP242 emit;
-#: ``deg`` is admitted because an authored label is free text.
-_DEGREE_MARKS = ("\u00b0", "deg")
-
-
-def _is_angular_label(label: str) -> bool:
-    """Whether *label* states an angle rather than a length."""
-    lowered = label.lower()
-    return any(mark in lowered for mark in _DEGREE_MARKS)
-
-
 #: At or above this relative discrepancy a dimension does not merely round differently from
 #: its geometry — it states something false, and the drawing asserts a measurement the part does
 #: not have. That is a different KIND of defect from everything else lint reports: an
@@ -1111,7 +1105,8 @@ def dimension_path_measurement(item, drawing_scale: float = 1.0):
     # so on the imported path this guard is inert and the renderer's category refusal is
     # the whole protection. An earlier version of this comment claimed the marker "survives
     # every path into lint", which is false. Tagging the annotation with its kind would fix
-    # that properly; it is not done here because nothing angular now reaches the renderer.
+    # that category independently. Supported angular ink now exposes measured_angle
+    # and angular_points, and is checked by lint_angular_geometry instead.
     #
     if measured is None or _is_angular_label(label):
         return None
@@ -1146,6 +1141,8 @@ def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0, box_cache=Non
     measurement = dimension_path_measurement(item, drawing_scale)
     # A repeat label is read as its producer declared it (#1153).
     label_val = _label_reading(item, label)
+    if getattr(item, "measured_angle", None) is not None:
+        issues.extend(lint_angular_geometry(item, label_val))
     if label_val is not None and measurement is not None:
         measured, item_scale = measurement
         effective_measured = measured / item_scale

--- a/src/draftwright/linting/suggest.py
+++ b/src/draftwright/linting/suggest.py
@@ -109,11 +109,22 @@ def _suggest_fix(issue, dwg) -> str | None:
         )
 
     if code == "step_dim_dropped":
-        # Steps too closely spaced to dimension at sheet scale (#41/#42).
+        # This code covers two different measurement families. Prismatic
+        # height ladders have automatic detail recovery; turned axial chains
+        # need an authored profile detail. Use provenance, not message wording.
+        kinds = {identity.feature.kind for identity in issue.measurement_ids}
+        if kinds == {"step_level"}:
+            return (
+                "# Recover crowded prismatic heights in an enlarged detail view:\n"
+                "dwg = build_drawing(part, detail_view=True)"
+            )
+        if kinds != {"step"}:
+            return None
         return (
-            "# Re-build with an enlarged detail view so the crowded shoulders are "
-            "dimensionable:\n"
-            "dwg = build_drawing(part, detail_view=True)"
+            "# In the declared Sheet script, target the affected step handle with an\n"
+            "# authored profile detail. Its scale must fit the available sheet space:\n"
+            'sheet.detail_view("A", around=shoulder).scale(3)\n'
+            "dwg = sheet.build()"
         )
 
     if code == "plate_thickness_dropped":

--- a/src/draftwright/model/__init__.py
+++ b/src/draftwright/model/__init__.py
@@ -61,6 +61,7 @@ from draftwright.model.declare import (
 from draftwright.model.detect import build_part_model, build_pmi_features
 from draftwright.model.ir import (
     AUTHORED_DIMENSION_KINDS,
+    AngularReference,
     AuthoredDimension,
     BlendFeature,
     BossFeature,
@@ -123,6 +124,7 @@ from draftwright.model.planner import (
 from draftwright.view_plan import UncoveredViewRequirement, ViewPlanIncomplete
 
 __all__ = [
+    "AngularReference",
     "AuthoredDimension",
     "AUTHORED_DIMENSION_KINDS",
     "BossFeature",

--- a/src/draftwright/model/__init__.py
+++ b/src/draftwright/model/__init__.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 from draftwright.model.declare import (
     angle,
+    angle_pattern,
     blend,
     boss,
     chamfer,
@@ -63,6 +64,7 @@ from draftwright.model.detect import build_part_model, build_pmi_features
 from draftwright.model.ir import (
     AUTHORED_DIMENSION_KINDS,
     AngleFeature,
+    AnglePatternFeature,
     AngularReference,
     AuthoredDimension,
     BlendFeature,
@@ -127,7 +129,9 @@ from draftwright.view_plan import UncoveredViewRequirement, ViewPlanIncomplete
 
 __all__ = [
     "AngleFeature",
+    "AnglePatternFeature",
     "angle",
+    "angle_pattern",
     "AngularReference",
     "AuthoredDimension",
     "AUTHORED_DIMENSION_KINDS",

--- a/src/draftwright/model/__init__.py
+++ b/src/draftwright/model/__init__.py
@@ -23,6 +23,7 @@ reads recognised geometry, by design (ground truth, not the plan).
 from __future__ import annotations
 
 from draftwright.model.declare import (
+    angle,
     blend,
     boss,
     chamfer,
@@ -61,6 +62,7 @@ from draftwright.model.declare import (
 from draftwright.model.detect import build_part_model, build_pmi_features
 from draftwright.model.ir import (
     AUTHORED_DIMENSION_KINDS,
+    AngleFeature,
     AngularReference,
     AuthoredDimension,
     BlendFeature,
@@ -124,6 +126,8 @@ from draftwright.model.planner import (
 from draftwright.view_plan import UncoveredViewRequirement, ViewPlanIncomplete
 
 __all__ = [
+    "AngleFeature",
+    "angle",
     "AngularReference",
     "AuthoredDimension",
     "AUTHORED_DIMENSION_KINDS",

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -50,11 +50,9 @@ completeness:
 from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
-from decimal import Decimal
-from math import isfinite
 from typing import Any, Literal
 
-from draftwright._geometry import _fmt
+from draftwright._geometry import _fmt, _fmt_angle
 from draftwright.model.ir import (
     AngularReference,
     EnvelopeFeature,
@@ -77,6 +75,7 @@ from draftwright.model.planner import (
     DimensionId,
     _decorated,
     _is_zero_step_position,
+    angular_pattern_label,
     authored_location_axis_omitted,
     authored_location_omitted,
     hole_location_parameter_id,
@@ -258,6 +257,13 @@ class ApprovedDimension:
     #: dimensional families keep their established parameter-id addressing.
     location_member: int | Literal["centre"] | None = None
     angular_reference: AngularReference | None = None
+    #: Other approved identities for the same physical measurement. This is
+    #: compiler-owned equivalence, never inferred from already printed numbers.
+    equivalent_ids: tuple[DimensionId, ...] = ()
+
+    @property
+    def measurement_ids(self) -> tuple[DimensionId, ...]:
+        return ((self.id,) if self.id is not None else ()) + self.equivalent_ids
 
     @property
     def parameter_id(self) -> str:
@@ -501,6 +507,9 @@ class ApprovedGroup:
     #: Optional authored strip intent.  The renderer turns this into an ordinary corridor
     #: candidate; coordinates remain solver-owned.
     side: str | None = None
+    #: Optional complete quantity presentation, alongside the independent
+    #: per-member approvals. Every member must be claimed by a shared mark.
+    shared_label: str | None = None
 
     def dim(self, *, kind: str | None = None, role: str | None = None):
         """The first approved dimension matching *kind* and/or *role*, or ``None``.
@@ -1576,29 +1585,6 @@ def _compile_slot_positions(model: PartModel) -> tuple[list[ApprovedDimension], 
     return approved, omissions
 
 
-def _angular_label(parameter, decimals) -> str | None:
-    if parameter.angular_reference is None:
-        return None
-    nominal = f"{_fmt(parameter.value, decimals)}°"
-    tolerance = parameter.tolerance
-    if tolerance is None:
-        return nominal
-
-    def magnitude(value):
-        if isinstance(value, bool) or not isinstance(value, (int, float)):
-            raise ValueError("angular tolerance must be a nonnegative degree magnitude")
-        if not isfinite(value) or value < 0:
-            raise ValueError("angular tolerance must be finite and nonnegative")
-        # Keep small authored deviations even when nominal display precision is
-        # coarse; formatting a nonzero tolerance as zero would change the claim.
-        return format(Decimal(str(value)), "f")
-
-    if isinstance(tolerance, tuple) and len(tolerance) == 2:
-        lower, upper = tolerance
-        return f"{nominal} +{magnitude(upper)}° -{magnitude(lower)}°"
-    return f"{nominal} ±{magnitude(tolerance)}°"
-
-
 def _compile_groups(planned) -> tuple[list[ApprovedGroup], list[Omission]]:
     """Every planned group, reduced to what the compiler approved, plus what it withheld.
 
@@ -1641,7 +1627,11 @@ def _compile_groups(planned) -> tuple[list[ApprovedGroup], list[Omission]]:
                 discriminator=pd.param.discriminator,
                 tolerance=pd.param.tolerance,
                 angular_reference=pd.param.angular_reference,
-                rendered_label=_angular_label(pd.param, pd.display_decimals),
+                rendered_label=(
+                    _fmt_angle(pd.param.value, pd.display_decimals, pd.param.tolerance)
+                    if pd.param.angular_reference is not None
+                    else None
+                ),
                 display_decimals=pd.display_decimals,
                 view=pd.view,
                 side=pd.side,
@@ -1667,6 +1657,7 @@ def _compile_groups(planned) -> tuple[list[ApprovedGroup], list[Omission]]:
                 facts=FeatureFacts(g.feature),
                 dims=approved,
                 side=g.side,
+                shared_label=angular_pattern_label(g),
             )
         )
     return out, omissions
@@ -1718,6 +1709,7 @@ def compile_dimensions(
     marked = _suppressed_dims(model, planned)
     ladders, omissions = _compile_step_ladders(model, marked)
     groups_out, group_omissions = _compile_groups(planned)
+    groups_out = _share_unique_outer_diameter(groups_out, planned)
     step_chain_approved = any(
         group.feature_kind == "step"
         and group.facts.frame.axis == "z"
@@ -1763,6 +1755,82 @@ def compile_dimensions(
             omissions, height_omissions, location_omissions, group_omissions
         ),
     )
+
+
+def _share_unique_outer_diameter(groups: list[ApprovedGroup], planned) -> list[ApprovedGroup]:
+    """Let a global OD carry one unique coaxial maximum band's approved identity.
+
+    A global OD has no axial station or body token. It can therefore stand for
+    a native external diameter only when exactly one band supplies
+    that maximum on its axis line. Equal disjoint bands, bores and decorated
+    diameters keep their own measurements. The native entry remains available
+    if the global OD does not land.
+    """
+    result = []
+    for group in groups:
+        od = group.dim(kind="diameter", role="od") if group.feature_kind == "rotational" else None
+        if od is None or od.tolerance is not None:
+            result.append(group)
+            continue
+        frame = group.facts.frame
+        axis = "xyz".find(frame.axis)
+        if axis < 0:
+            result.append(group)
+            continue
+        coaxial = [
+            (candidate, diameter)
+            for candidate in groups
+            if candidate.feature_kind in {"step", "boss"}
+            and candidate.facts.frame.axis == frame.axis
+            and all(
+                abs(candidate.facts.frame.origin[index] - frame.origin[index]) <= 1e-6
+                for index in range(3)
+                if index != axis
+            )
+            if (diameter := candidate.dim(kind="diameter")) is not None
+        ]
+        # Suppression changes what is printed, never whether another band makes
+        # the global OD ambiguous. Count the planner's complete geometry here.
+        physical = [
+            dimension.param.value
+            for candidate in planned
+            if candidate.feature_kind in {"step", "boss"}
+            and candidate.feature.frame.axis == frame.axis
+            and all(
+                abs(candidate.feature.frame.origin[index] - frame.origin[index]) <= 1e-6
+                for index in range(3)
+                if index != axis
+            )
+            for dimension in candidate.dims
+            if dimension.param.kind == "diameter"
+        ]
+        matches = [
+            (candidate, diameter)
+            for candidate, diameter in coaxial
+            if abs(diameter.value - od.value) <= 1e-6
+        ]
+        if (
+            len(matches) == 1
+            and sum(abs(value - od.value) <= 1e-6 for value in physical) == 1
+            and not any(value > od.value + 1e-6 for value in physical)
+        ):
+            candidate, diameter = matches[0]
+            if (
+                diameter.id is not None
+                and diameter.tolerance is None
+                and diameter.value_text == od.value_text
+                and candidate.facts.get("thread") is None
+                and candidate.facts.get("knurl") is None
+            ):
+                group = replace(
+                    group,
+                    dims=tuple(
+                        replace(entry, equivalent_ids=(diameter.id,)) if entry is od else entry
+                        for entry in group.dims
+                    ),
+                )
+        result.append(group)
+    return result
 
 
 def _dedupe_omissions(*sources: list[Omission]) -> tuple[Omission, ...]:

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -50,10 +50,13 @@ completeness:
 from __future__ import annotations
 
 from dataclasses import dataclass, field, replace
+from decimal import Decimal
+from math import isfinite
 from typing import Any, Literal
 
 from draftwright._geometry import _fmt
 from draftwright.model.ir import (
+    AngularReference,
     EnvelopeFeature,
     Feature,
     HoleFeature,
@@ -254,6 +257,7 @@ class ApprovedDimension:
     #: The declaration-local selector retained for location script emission. Other
     #: dimensional families keep their established parameter-id addressing.
     location_member: int | Literal["centre"] | None = None
+    angular_reference: AngularReference | None = None
 
     @property
     def parameter_id(self) -> str:
@@ -297,6 +301,7 @@ class ApprovedDimension:
 #: The compiler refuses anything absent from this table, so a new feature kind cannot leak
 #: measurements by default: it arrives with no facts at all until someone lists them.
 _FACTS: dict[str, tuple[str, ...]] = {
+    "angle": ("frame",),
     "hole": (
         "frame",
         "through",
@@ -1571,6 +1576,29 @@ def _compile_slot_positions(model: PartModel) -> tuple[list[ApprovedDimension], 
     return approved, omissions
 
 
+def _angular_label(parameter, decimals) -> str | None:
+    if parameter.angular_reference is None:
+        return None
+    nominal = f"{_fmt(parameter.value, decimals)}°"
+    tolerance = parameter.tolerance
+    if tolerance is None:
+        return nominal
+
+    def magnitude(value):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError("angular tolerance must be a nonnegative degree magnitude")
+        if not isfinite(value) or value < 0:
+            raise ValueError("angular tolerance must be finite and nonnegative")
+        # Keep small authored deviations even when nominal display precision is
+        # coarse; formatting a nonzero tolerance as zero would change the claim.
+        return format(Decimal(str(value)), "f")
+
+    if isinstance(tolerance, tuple) and len(tolerance) == 2:
+        lower, upper = tolerance
+        return f"{nominal} +{magnitude(upper)}° -{magnitude(lower)}°"
+    return f"{nominal} ±{magnitude(tolerance)}°"
+
+
 def _compile_groups(planned) -> tuple[list[ApprovedGroup], list[Omission]]:
     """Every planned group, reduced to what the compiler approved, plus what it withheld.
 
@@ -1612,6 +1640,8 @@ def _compile_groups(planned) -> tuple[list[ApprovedGroup], list[Omission]]:
                 role=pd.param.role,
                 discriminator=pd.param.discriminator,
                 tolerance=pd.param.tolerance,
+                angular_reference=pd.param.angular_reference,
+                rendered_label=_angular_label(pd.param, pd.display_decimals),
                 display_decimals=pd.display_decimals,
                 view=pd.view,
                 side=pd.side,

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -2440,6 +2440,8 @@ def measured_dimension(
     ``angular_reference`` supplies an explicit vertex and two ray witnesses in model space;
     it is an ``AngularReference`` or a mapping with the same fields. Its points populate
     empty ``ref_pts`` or must agree with the supplied ``(first, vertex, second)`` points.
+    Sheet-authored three-point angles use that same order automatically. Imported generic
+    reference stations do not establish this ordering and require an explicit reference.
     This retains angular meaning; it does not imply that the renderer supports the case."""
     _require_positive(value=value)
     dim_kind = str(kind).lower()
@@ -2447,6 +2449,15 @@ def measured_dimension(
         allowed = ", ".join(sorted(AUTHORED_DIMENSION_KINDS))
         raise ValueError(f"measured_dimension() kind must be one of: {allowed}")
     pts = tuple(_point3("ref_pts item", p) for p in ref_pts)
+    if (
+        dim_kind == "angular"
+        and angular_reference is None
+        and source == "sheet"
+        and not source_id
+        and len(pts) == 3
+        and not rendering_blockers
+    ):
+        angular_reference = AngularReference(vertex=pts[1], first=pts[0], second=pts[2])
     if angular_reference is not None:
         if isinstance(angular_reference, dict):
             angular_reference = AngularReference(**angular_reference)
@@ -2498,7 +2509,14 @@ def measured_dimension(
         unresolved_bore = dom == "?" and dim_kind in ("diameter", "radius") and bbox is not None
         if not (unresolved_import or unresolved_bore):
             raise ValueError("measured_dimension() dominant_axis must be X, Y, or Z")
-    validate_authored_dimension_placement(dim_kind, dom, view, side, owner="measured_dimension()")
+    validate_authored_dimension_placement(
+        dim_kind,
+        dom,
+        view,
+        side,
+        owner="measured_dimension()",
+        angular_reference=angular_reference,
+    )
     cylinder_axes = {reference.principal_axis for reference in cylinders}
     if cylinders and (len(cylinder_axes) != 1 or "?" in cylinder_axes):
         if not imported_blocked:

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -39,6 +39,7 @@ from draftwright._geometry import (
 )
 from draftwright.model.ir import (
     AUTHORED_DIMENSION_KINDS,
+    AngleFeature,
     AngularReference,
     AuthoredDimension,
     BlendFeature,
@@ -2401,6 +2402,16 @@ def _point3(name: str, p) -> Point:
     if len(vals) != 3:
         raise ValueError(f"measured_dimension() {name} must be a 3-tuple")
     return (vals[0], vals[1], vals[2])
+
+
+def angle(*, vertex, first, second, sector="minor", virtual_vertex=False) -> AngleFeature:
+    """Declare the included angle between two model-space rays, deriving its value.
+
+    Witness points identify geometry, not annotation positions. The reference
+    plane must admit a true-angle principal projection. A virtual vertex states
+    that the oriented supports meet only when extended.
+    """
+    return AngleFeature(AngularReference(vertex, first, second, sector, virtual_vertex))
 
 
 def measured_dimension(

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -39,6 +39,7 @@ from draftwright._geometry import (
 )
 from draftwright.model.ir import (
     AUTHORED_DIMENSION_KINDS,
+    AngularReference,
     AuthoredDimension,
     BlendFeature,
     BossFeature,
@@ -2424,6 +2425,7 @@ def measured_dimension(
     cylindrical_refs=(),
     view: str | None = None,
     side: str | None = None,
+    angular_reference=None,
 ) -> AuthoredDimension:
     """A pre-authored drafting dimension from explicit measured values — the IR constructor
     behind :meth:`Sheet.measured_dimension` (#704: extracted so ``build_drawing(model=…)``
@@ -2434,13 +2436,34 @@ def measured_dimension(
     are mutually exclusive with deviation tolerances. ``source_id`` preserves an external
     record identity; ordinary Sheet declarations leave it blank. ``lowering_blockers`` retains
     why an imported requirement could not safely enrich a canonical feature parameter;
-    ``rendering_blockers`` retains why its source geometry cannot truthfully form a witness."""
+    ``rendering_blockers`` retains why its source geometry cannot truthfully form a witness.
+    ``angular_reference`` supplies an explicit vertex and two ray witnesses in model space;
+    it is an ``AngularReference`` or a mapping with the same fields. Its points populate
+    empty ``ref_pts`` or must agree with the supplied ``(first, vertex, second)`` points.
+    This retains angular meaning; it does not imply that the renderer supports the case."""
     _require_positive(value=value)
     dim_kind = str(kind).lower()
     if dim_kind not in AUTHORED_DIMENSION_KINDS:
         allowed = ", ".join(sorted(AUTHORED_DIMENSION_KINDS))
         raise ValueError(f"measured_dimension() kind must be one of: {allowed}")
     pts = tuple(_point3("ref_pts item", p) for p in ref_pts)
+    if angular_reference is not None:
+        if isinstance(angular_reference, dict):
+            angular_reference = AngularReference(**angular_reference)
+        if not isinstance(angular_reference, AngularReference):
+            raise ValueError(
+                "measured_dimension() angular_reference must be a mapping or AngularReference"
+            )
+        if dim_kind != "angular":
+            raise ValueError("angular_reference requires an angular dimension")
+        angular_points = (
+            angular_reference.first,
+            angular_reference.vertex,
+            angular_reference.second,
+        )
+        if pts and pts != angular_points:
+            raise ValueError("angular ref_pts must agree with first, vertex, second")
+        pts = angular_points
     cylinders: list[CylindricalReference] = []
     for raw in cylindrical_refs:
         if isinstance(raw, CylindricalReference):
@@ -2533,4 +2556,5 @@ def measured_dimension(
         cylindrical_refs=tuple(cylinders),
         view=view,
         side=side,
+        angular_reference=angular_reference,
     )

--- a/src/draftwright/model/declare.py
+++ b/src/draftwright/model/declare.py
@@ -40,6 +40,7 @@ from draftwright._geometry import (
 from draftwright.model.ir import (
     AUTHORED_DIMENSION_KINDS,
     AngleFeature,
+    AnglePatternFeature,
     AngularReference,
     AuthoredDimension,
     BlendFeature,
@@ -2412,6 +2413,11 @@ def angle(*, vertex, first, second, sector="minor", virtual_vertex=False) -> Ang
     that the oriented supports meet only when extended.
     """
     return AngleFeature(AngularReference(vertex, first, second, sector, virtual_vertex))
+
+
+def angle_pattern(*members: AngularReference) -> AnglePatternFeature:
+    """Declare repeated corners while keeping every included angle addressable."""
+    return AnglePatternFeature(tuple(members))
 
 
 def measured_dimension(

--- a/src/draftwright/model/detect.py
+++ b/src/draftwright/model/detect.py
@@ -95,6 +95,9 @@ from draftwright._geometry import (
 from draftwright.model.declare import circular_blind_step, control_frame, datum
 from draftwright.model.ir import (
     AUTHORED_DIMENSION_KINDS,
+    AngleFeature,
+    AnglePatternFeature,
+    AngularReference,
     AuthoredDimension,
     BlendFeature,
     BossFeature,
@@ -137,6 +140,7 @@ from draftwright.oriented_slot_contract import (
     standalone_oriented_slots,
 )
 from draftwright.plate_correspondence import plate_owner_dependencies
+from draftwright.profile_angles import profile_angle_repetitions, profile_angle_requirements
 from draftwright.recognition_frame import (
     groove_owns_turned_step_band,
     require_unambiguous_groove_owner,
@@ -2643,6 +2647,48 @@ def build_part_model(
         features.append(
             RotationalFeature(frame=Frame((c.X, c.Y, c.Z), rot_axis), od=od, bores=tuple(bores))
         )
+
+    # Ordered face supports come from the same evidence acquisition as the
+    # recognised families. Their drafting requirements use the declared IR;
+    # source identity remains in the run-local ledger, outside that IR.
+    requirements = profile_angle_requirements(recognition_evidence)
+
+    def corner_key(requirement):
+        return id(requirement.source), requirement.first_index, requirement.second_index
+
+    by_key = {corner_key(requirement): requirement for requirement in requirements}
+    repeated = {}
+    for repetition in profile_angle_repetitions(recognition_evidence):
+        keys = tuple(corner_key(member) for member in repetition.members)
+        if any(key not in by_key or key in repeated for key in keys):
+            continue
+        for key in keys:
+            repeated[key] = keys
+    handled: set[tuple[int, int, int]] = set()
+    for requirement in requirements:
+        key = corner_key(requirement)
+        if key in handled:
+            continue
+        keys = repeated.get(key, (key,))
+        handled.update(keys)
+        angle_members = tuple(by_key[member_key] for member_key in keys)
+        references = tuple(
+            AngularReference(
+                vertex=member.vertex,
+                first=member.first,
+                second=member.second,
+                virtual_vertex=member.virtual_vertex,
+                sector="opposite",
+            )
+            for member in angle_members
+        )
+        feature = (
+            AnglePatternFeature(references) if len(references) > 1 else AngleFeature(references[0])
+        )
+        features.append(feature)
+        if ownership is not None:
+            for member, parameter in zip(angle_members, feature.parameters(), strict=True):
+                ownership.bind_profile_angle(member, feature, parameter_id=parameter.parameter_id)
 
     # STEP AP242 PMI — re-homed into drafting-concept IR where possible (#208).
     # Rendered directly by render_pmi; the planner adds nothing.

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -2898,8 +2898,10 @@ class RotationalFeature:
 class AngularReference:
     """Two oriented model-space rays bounding the non-reflex angular sector.
 
-    ``first`` and ``second`` are witness points on rays starting at ``vertex``.
-    Reversing their order reverses the plane normal, not the measured angle.
+    ``first`` and ``second`` are witness points on supports through ``vertex``.
+    ``minor`` selects the rays towards them; ``opposite`` extends both supports
+    through the vertex and selects the vertically opposite non-reflex sector.
+    Reversing witness order reverses the plane normal, not the measured angle.
     A virtual vertex explicitly describes intersecting extended supports; this
     declaration alone does not certify correspondence to physical part edges.
     No field describes annotation placement or an arc radius on the sheet.
@@ -2908,14 +2910,16 @@ class AngularReference:
     vertex: Point
     first: Point
     second: Point
-    sector: Literal["minor"] = "minor"
+    sector: Literal["minor", "opposite"] = "minor"
     virtual_vertex: bool = False
 
     def __post_init__(self) -> None:
         for name in ("vertex", "first", "second"):
             object.__setattr__(self, name, _finite_point3(name, getattr(self, name)))
-        if self.sector != "minor":
-            raise ValueError("angular reference supports only the minor (non-reflex) sector")
+        if self.sector not in ("minor", "opposite"):
+            raise ValueError(
+                "angular reference supports only minor or opposite non-reflex sectors"
+            )
         if type(self.virtual_vertex) is not bool:
             raise ValueError("angular reference virtual_vertex must be a bool")
         first, second = self.rays
@@ -2931,7 +2935,8 @@ class AngularReference:
             length = hypot(*ray)
             if not isfinite(length) or length <= 1e-9:
                 raise ValueError("angular reference needs two finite nonzero rays")
-            result.append((ray[0] / length, ray[1] / length, ray[2] / length))
+            sign = -1 if self.sector == "opposite" else 1
+            result.append((sign * ray[0] / length, sign * ray[1] / length, sign * ray[2] / length))
         return result[0], result[1]
 
     @staticmethod
@@ -3005,6 +3010,64 @@ class AngleFeature:
                 self.angular_reference.angle_degrees,
                 angular_reference=self.angular_reference,
             )
+        ]
+
+    def references(self) -> list[Datum]:
+        return []
+
+
+@dataclass(frozen=True)
+class AnglePatternFeature:
+    """Declared repeated corners, each with an independently addressable angle.
+
+    The member order is part of the declaration: omitting or tolerancing one
+    measurement does not remove or renumber members. Recognition may create
+    this form only after proving the physical profile repetition.
+    """
+
+    members: tuple[AngularReference, ...]
+    kind: ClassVar[str] = "angle"
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "members", tuple(self.members))
+        if len(self.members) < 2 or not all(
+            isinstance(member, AngularReference) for member in self.members
+        ):
+            raise ValueError("angle pattern requires at least two AngularReference members")
+        if len({member.vertex for member in self.members}) != len(self.members):
+            raise ValueError("angle pattern requires distinct corner references")
+        first = self.members[0]
+        if first.principal_axis == "?":
+            raise ValueError("angle pattern requires a true-angle principal projection")
+        axis = "XYZ".index(first.principal_axis)
+        if any(
+            member.principal_axis != first.principal_axis
+            or member.sector != first.sector
+            or abs(member.vertex[axis] - first.vertex[axis]) > 1e-6
+            or abs(member.angle_degrees - first.angle_degrees) > 1e-6
+            for member in self.members
+        ):
+            raise ValueError("angle pattern members must share a plane, sector and angle")
+
+    @property
+    def angular_reference(self) -> AngularReference:
+        """The first member establishes the common true-angle view."""
+        return self.members[0]
+
+    @property
+    def frame(self) -> Frame:
+        return Frame(self.angular_reference.vertex, self.angular_reference.principal_axis.lower())
+
+    def parameters(self) -> list[DimParameter]:
+        return [
+            DimParameter(
+                "angle",
+                "included",
+                member.angle_degrees,
+                discriminator=f"member{index + 1}",
+                angular_reference=member,
+            )
+            for index, member in enumerate(self.members)
         ]
 
     def references(self) -> list[Datum]:

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -78,13 +78,26 @@ def validate_authored_dimension_placement(
     side: str | None,
     *,
     owner: str,
+    angular_reference: AngularReference | None = None,
 ) -> None:
     """Reject a view/side pair for which the authored-dimension renderer has no candidate."""
     validate_placement_intent(view, side, owner=owner)
     if view is None and side is None:
         return
     valid_pairs: tuple[tuple[str, str], ...]
-    if dimension_kind in ("diameter", "radius"):
+    if dimension_kind == "angular" and angular_reference is not None:
+        axis = angular_reference.principal_axis
+        end_view = {"X": "side", "Y": "front", "Z": "plan"}.get(axis)
+        first, second = angular_reference.rays
+        bisector = tuple(a + b for a, b in zip(first, second, strict=True))
+        length = hypot(*bisector)
+        components = {"X": (1, 2), "Y": (0, 2), "Z": (0, 1)}.get(axis, ())
+        valid_pairs = tuple(
+            (end_view, (("left", "right"), ("below", "above"))[index][bisector[component] > 0])
+            for index, component in enumerate(components)
+            if end_view is not None and abs(bisector[component]) / length >= 1e-6
+        )
+    elif dimension_kind in ("diameter", "radius"):
         end_view = {"X": "side", "Y": "front", "Z": "plan"}.get(dominant_axis)
         valid_pairs = () if end_view is None else ((end_view, "above"), (end_view, "below"))
     else:
@@ -114,6 +127,7 @@ def authored_dimension_target_view(
     dominant_axis: str,
     view: str | None,
     side: str | None,
+    angular_reference: AngularReference | None = None,
 ) -> str | None:
     """Resolve the principal view selected by an explicit measured-dimension hint.
 
@@ -124,6 +138,8 @@ def authored_dimension_target_view(
     """
     if view is not None:
         return view
+    if dimension_kind == "angular" and angular_reference is not None:
+        return {"X": "side", "Y": "front", "Z": "plan"}.get(angular_reference.principal_axis)
     if side is None:
         return None
     if dimension_kind in ("diameter", "radius"):
@@ -3009,6 +3025,7 @@ class AuthoredDimension:
             self.view,
             self.side,
             owner="authored dimension",
+            angular_reference=self.angular_reference,
         )
 
     @property

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -2875,6 +2875,80 @@ class RotationalFeature:
 
 
 @dataclass(frozen=True)
+class AngularReference:
+    """Two oriented model-space rays bounding the non-reflex angular sector.
+
+    ``first`` and ``second`` are witness points on rays starting at ``vertex``.
+    Reversing their order reverses the plane normal, not the measured angle.
+    A virtual vertex explicitly describes intersecting extended supports; this
+    declaration alone does not certify correspondence to physical part edges.
+    No field describes annotation placement or an arc radius on the sheet.
+    """
+
+    vertex: Point
+    first: Point
+    second: Point
+    sector: Literal["minor"] = "minor"
+    virtual_vertex: bool = False
+
+    def __post_init__(self) -> None:
+        for name in ("vertex", "first", "second"):
+            object.__setattr__(self, name, _finite_point3(name, getattr(self, name)))
+        if self.sector != "minor":
+            raise ValueError("angular reference supports only the minor (non-reflex) sector")
+        if type(self.virtual_vertex) is not bool:
+            raise ValueError("angular reference virtual_vertex must be a bool")
+        first, second = self.rays
+        cross = self._cross(first, second)
+        if hypot(*cross) <= 1e-9:
+            raise ValueError("angular reference rays must not be parallel or collinear")
+
+    @property
+    def rays(self) -> tuple[Point, Point]:
+        result = []
+        for point in (self.first, self.second):
+            ray = tuple(p - v for p, v in zip(point, self.vertex, strict=True))
+            length = hypot(*ray)
+            if not isfinite(length) or length <= 1e-9:
+                raise ValueError("angular reference needs two finite nonzero rays")
+            result.append((ray[0] / length, ray[1] / length, ray[2] / length))
+        return result[0], result[1]
+
+    @staticmethod
+    def _cross(first: Point, second: Point) -> Point:
+        x, y, z = first
+        u, v, w = second
+        return y * w - z * v, z * u - x * w, x * v - y * u
+
+    @property
+    def normal(self) -> Point:
+        cross = self._cross(*self.rays)
+        length = hypot(*cross)
+        return cross[0] / length, cross[1] / length, cross[2] / length
+
+    @property
+    def angle_degrees(self) -> float:
+        first, second = self.rays
+        return (
+            atan2(
+                hypot(*self._cross(first, second)),
+                sum(a * b for a, b in zip(first, second, strict=True)),
+            )
+            * 180
+            / pi
+        )
+
+    @property
+    def principal_axis(self) -> str:
+        """Normal axis of a true-angle principal projection, or ``?`` if oblique."""
+        normal = self.normal
+        dominant = max(range(3), key=lambda index: abs(normal[index]))
+        if any(abs(normal[index]) > 1e-6 for index in range(3) if index != dominant):
+            return "?"
+        return "XYZ"[dominant]
+
+
+@dataclass(frozen=True)
 class AuthoredDimension:
     """A pre-authored drafting dimension imported from an external semantic source.
 
@@ -2917,9 +2991,18 @@ class AuthoredDimension:
     # they are not page coordinates and do not bypass placement solving (ADR 2 (was 0012/0014)).
     view: str | None = None
     side: str | None = None
+    angular_reference: AngularReference | None = None
     kind: ClassVar[str] = "authored_dimension"
 
     def __post_init__(self) -> None:
+        if self.angular_reference is not None:
+            if self.dimension_kind != "angular":
+                raise ValueError("angular_reference requires an angular dimension")
+            if not isinstance(self.angular_reference, AngularReference):
+                raise ValueError("angular_reference must be an AngularReference")
+            reference = self.angular_reference
+            if self.ref_pts != (reference.first, reference.vertex, reference.second):
+                raise ValueError("angular ref_pts must agree with first, vertex, second")
         validate_authored_dimension_placement(
             self.dimension_kind,
             self.dominant_axis,

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -375,6 +375,7 @@ DimensionParameterId = Literal[
     "groove.diameter",
     "groove.length",
     "height.length",
+    "included.angle",
     "od.diameter",
     "oriented_slot_length.length",
     "oriented_slot_width.length",
@@ -453,6 +454,9 @@ class DimParameter:
     # (ADR 4 (was 0016) identity, tier 2). Today's sole instance is a grid pattern's two pitches
     # (``"row"`` / ``"col"``). ``None`` wherever role + kind already identify the thing.
     discriminator: str | None = None
+    # Angular geometry travels with the approved measurement, not through the
+    # structural feature facts where suppression could be bypassed.
+    angular_reference: AngularReference | None = None
 
     @property
     def parameter_id(self) -> ParameterId:
@@ -2962,6 +2966,49 @@ class AngularReference:
         if any(abs(normal[index]) > 1e-6 for index in range(3) if index != dominant):
             return "?"
         return "XYZ"[dominant]
+
+    @property
+    def measurement_key(self) -> tuple:
+        """Referenced geometry and sector, invariant under witness-order reversal."""
+        return (
+            self.vertex,
+            tuple(sorted((self.first, self.second))),
+            self.sector,
+            self.virtual_vertex,
+        )
+
+
+@dataclass(frozen=True)
+class AngleFeature:
+    """One included-angle requirement derived from explicit oriented supports."""
+
+    angular_reference: AngularReference
+    kind: ClassVar[str] = "angle"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.angular_reference, AngularReference):
+            raise ValueError("angle requires an AngularReference")
+        if self.angular_reference.principal_axis == "?":
+            raise ValueError(
+                "angle requires a true-angle principal projection; oblique is unsupported"
+            )
+
+    @property
+    def frame(self) -> Frame:
+        return Frame(self.angular_reference.vertex, self.angular_reference.principal_axis.lower())
+
+    def parameters(self) -> list[DimParameter]:
+        return [
+            DimParameter(
+                "angle",
+                "included",
+                self.angular_reference.angle_degrees,
+                angular_reference=self.angular_reference,
+            )
+        ]
+
+    def references(self) -> list[Datum]:
+        return []
 
 
 @dataclass(frozen=True)

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -33,6 +33,7 @@ from draftwright._geometry import _EDGE_ON, _END_ON, HoleRef
 from draftwright.model.ir import (
     PLACEMENT_SIDES,
     PLACEMENT_VIEWS,
+    AngleFeature,
     BlendFeature,
     ChamferFeature,
     ChannelFeature,
@@ -57,6 +58,7 @@ from draftwright.model.ir import (
     SlotFeature,
     SlotPatternFeature,
     StepLevelFeature,
+    validate_authored_dimension_placement,
 )
 from draftwright.view_plan import (
     UncoveredViewRequirement,
@@ -81,6 +83,7 @@ def _is_zero_step_position(value: float) -> bool:
 
 # How each (role, kind) is drawn. Defaults keep the table small.
 _CONVENTION = {
+    ("included", "angle"): "angular",
     ("step", "length"): "chain",
     ("step", "diameter"): "leader",
     ("bore", "diameter"): "leader",
@@ -156,7 +159,7 @@ class PlannedDimension:
     a feature emits datum-referenced params."""
 
     param: DimParameter
-    convention: str  # "chain" | "ordinate" | "leader" | "linear" | "pitch"
+    convention: str  # "chain" | "ordinate" | "leader" | "linear" | "pitch" | "angular"
     suppressed: bool = False
     reason: str | None = None
     datum: Datum | None = None
@@ -1180,6 +1183,21 @@ def _check_intent_policy_conflicts(model: PartModel) -> None:
 def _group_placement(feature: Feature, dims: list[PlannedDimension], planned_views=None):
     """Resolve one view/side for a compound group, or reject an unrenderable intent."""
     approved = [pd for pd in dims if not pd.suppressed]
+
+    if isinstance(feature, AngleFeature):
+        for pd in approved:
+            validate_authored_dimension_placement(
+                "angular",
+                feature.frame.axis.upper(),
+                pd.view,
+                pd.side,
+                owner="angle",
+                angular_reference=feature.angular_reference,
+            )
+        sides = {pd.side for pd in approved if pd.side is not None}
+        if len(sides) > 1:
+            raise ValueError("conflicting placement intent for one included angle")
+        return _group_view(feature, planned_views), next(iter(sides), None)
 
     # An envelope group is a feature-level compiler container, not one compound mark:
     # width, depth, and height are independent dimensions which intentionally scatter

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -29,11 +29,12 @@ from __future__ import annotations
 from dataclasses import dataclass, replace
 from typing import Any, Literal
 
-from draftwright._geometry import _EDGE_ON, _END_ON, HoleRef
+from draftwright._geometry import _EDGE_ON, _END_ON, HoleRef, _fmt_angle
 from draftwright.model.ir import (
     PLACEMENT_SIDES,
     PLACEMENT_VIEWS,
     AngleFeature,
+    AnglePatternFeature,
     BlendFeature,
     ChamferFeature,
     ChannelFeature,
@@ -1184,7 +1185,7 @@ def _group_placement(feature: Feature, dims: list[PlannedDimension], planned_vie
     """Resolve one view/side for a compound group, or reject an unrenderable intent."""
     approved = [pd for pd in dims if not pd.suppressed]
 
-    if isinstance(feature, AngleFeature):
+    if isinstance(feature, AngleFeature | AnglePatternFeature):
         for pd in approved:
             validate_authored_dimension_placement(
                 "angular",
@@ -1192,8 +1193,10 @@ def _group_placement(feature: Feature, dims: list[PlannedDimension], planned_vie
                 pd.view,
                 pd.side,
                 owner="angle",
-                angular_reference=feature.angular_reference,
+                angular_reference=pd.param.angular_reference,
             )
+        if isinstance(feature, AnglePatternFeature):
+            return _group_view(feature, planned_views), None
         sides = {pd.side for pd in approved if pd.side is not None}
         if len(sides) > 1:
             raise ValueError("conflicting placement intent for one included angle")
@@ -1635,6 +1638,25 @@ def _uncovered_location_requirements(
                 )
             )
     return uncovered
+
+
+def angular_pattern_label(group: DimensionGroup) -> str | None:
+    """Approve a quantity label only for a complete, uniformly decorated pattern.
+
+    Partial authored sets and member-specific formatting remain individual
+    measurements. Their original parameter IDs and references are unchanged.
+    Composition shares this pure decision without executing the compiler.
+    """
+    if not isinstance(group.feature, AnglePatternFeature):
+        return None
+    dimensions = group.dims
+    if len(dimensions) != len(group.feature.members) or any(d.suppressed for d in dimensions):
+        return None
+    labels = {_fmt_angle(d.param.value, d.display_decimals, d.param.tolerance) for d in dimensions}
+    routes = {(d.view, d.side) for d in dimensions}
+    if len(labels) != 1 or len(routes) != 1:
+        return None
+    return f"{len(dimensions)}× {next(iter(labels))}"
 
 
 def plan_dimensions(model: PartModel, *, planned_views=None) -> list[DimensionGroup]:

--- a/src/draftwright/profile_angles.py
+++ b/src/draftwright/profile_angles.py
@@ -1,0 +1,310 @@
+"""Drafting requirements projected from the provider's ordered outer profiles.
+
+The provider owns topology, adjacency and body identity. This module chooses
+which of its face profiles to dimension and extends their supplied straight
+supports; it never traverses part topology or creates recognition occurrences.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import cos, dist, fsum, pi, sin
+from typing import TYPE_CHECKING
+
+from quiddity import BoltCircle, Chamfer, PolygonalBoss, PolygonalStock
+from quiddity.evidence import (
+    FaceRef,
+    FeatureRef,
+    PlanarOuterProfileEvidence,
+    ProfileArc,
+    ProfileLine,
+)
+
+if TYPE_CHECKING:
+    from build123d import Edge
+
+
+def _sub(a, b):
+    return tuple(x - y for x, y in zip(a, b, strict=True))
+
+
+def _dot(a, b):
+    return fsum(x * y for x, y in zip(a, b, strict=True))
+
+
+def _cross(a, b):
+    return a[1] * b[2] - a[2] * b[1], a[2] * b[0] - a[0] * b[2], a[0] * b[1] - a[1] * b[0]
+
+
+@dataclass(frozen=True)
+class ProfileAngle:
+    """One same-run support pair, separate from its eventual IR owner."""
+
+    source: PlanarOuterProfileEvidence
+    first_index: int
+    second_index: int
+    vertex: tuple[float, float, float]
+    first: tuple[float, float, float]
+    second: tuple[float, float, float]
+    virtual_vertex: bool
+
+
+def _corners(source):
+    supports = source.profile.supports
+    normal = source.profile.normal
+    for index, first in enumerate(supports):
+        if type(first) is not ProfileLine:
+            continue
+        next_index = (index + 1) % len(supports)
+        transition = supports[next_index]
+        rounded = type(transition) is ProfileArc
+        if rounded:
+            next_index = (next_index + 1) % len(supports)
+        second = supports[next_index]
+        if type(second) is not ProfileLine:
+            continue
+        u, v = first.direction, second.direction
+        turn = _dot(_cross(u, v), normal)
+        # Straight continuations have no corner. Orthogonal corners need no
+        # automatic angle label; an author can still request one explicitly.
+        if turn <= 1e-8 or abs(_dot(u, v)) <= 1e-8:
+            continue
+        distance = _dot(_cross(_sub(second.start, first.end), v), normal) / turn
+        vertex = tuple(p + distance * d for p, d in zip(first.end, u, strict=True))
+        along_second = _dot(_sub(vertex, second.start), v)
+        reconstructed = tuple(p + along_second * d for p, d in zip(second.start, v, strict=True))
+        if dist(vertex, reconstructed) > 1e-6:
+            continue
+        if rounded:
+            # A rounded convex corner extends the preceding line forward and
+            # the following line backward. An arbitrary line/arc/line sequence
+            # with its intersection elsewhere does not establish that corner.
+            if distance <= 1e-6 or along_second >= -1e-6:
+                continue
+            # Both finite lines must be tangent to the supplied circular join.
+            if abs(_dot(u, _sub(first.end, transition.center))) > 1e-6:
+                continue
+            if abs(_dot(v, _sub(second.start, transition.center))) > 1e-6:
+                continue
+            witnesses = first.end, second.start
+        else:
+            if dist(vertex, first.end) > 1e-6 or first.end != second.start:
+                continue
+            witnesses = first.start, second.end
+        yield ProfileAngle(source, index, next_index, vertex, *witnesses, rounded)
+
+
+def _profile_callout_definitions(evidence):
+    """Issued faces/edges whose existing callout defines the profile angles.
+
+    This reads the provider's cached face profiles, not part topology. A shared
+    numerical angle or projected location cannot establish this relationship.
+    """
+    definitions = []
+    for occurrence in evidence.features:
+        record = evidence.record(occurrence)
+        if not isinstance(record, (Chamfer, PolygonalStock, PolygonalBoss)):
+            continue
+        if isinstance(record, Chamfer) and record.turned:
+            continue  # no planar bevel-face authority for a conical treatment
+        faces = (
+            evidence.defining_faces(occurrence)
+            if isinstance(record, Chamfer)
+            else evidence.constituent_faces(occurrence)
+        )
+        edges: list[Edge] = []
+        for face in faces:
+            source = evidence.planar_outer_profile(face)
+            if type(source) is PlanarOuterProfileEvidence:
+                edges.extend(
+                    evidence.profile_edge(source, index)
+                    for index in range(len(source.profile.supports))
+                )
+        definitions.append((record, faces, edges))
+    return definitions
+
+
+def _standalone_corners(source, evidence, definitions):
+    """Keep angles not already defined by an exact same-body feature callout."""
+    edges = None
+    bevel_supports: set[int] = set()
+    for record, faces, defining_edges in definitions:
+        if (
+            not faces
+            or not faces <= source.body_faces
+            or abs(source.profile.normal["xyz".index(record.axis)]) < 1 - 1e-8
+        ):
+            continue
+        if edges is None:
+            edges = tuple(
+                evidence.profile_edge(source, index)
+                for index in range(len(source.profile.supports))
+            )
+        shared = {
+            index
+            for index, edge in enumerate(edges)
+            if any(edge.is_same(defining) for defining in defining_edges)
+        }
+        if isinstance(record, (PolygonalStock, PolygonalBoss)):
+            if (
+                len(edges) == record.side_count
+                and all(type(support) is ProfileLine for support in source.profile.supports)
+                and (source.face in faces or len(shared) == len(edges))
+            ):
+                return  # the regular-polygon callout defines the complete corner ring
+        else:
+            bevel_supports.update(shared)
+    for corner in _corners(source):
+        if corner.virtual_vertex or not bevel_supports.intersection(
+            (corner.first_index, corner.second_index)
+        ):
+            yield corner
+
+
+def profile_angle_requirements(evidence) -> tuple[ProfileAngle, ...]:
+    """Choose non-right corners on the foremost camera-facing profile per body/view.
+
+    This is a bounded face-profile drafting policy, not a claim that a face's
+    outer wire is the stock envelope. Inner wires never supply corners. Tied
+    coplanar faces stay distinct, as do equal-valued corners and separate bodies.
+    Angles already defined by an issued chamfer or regular-polygon callout do
+    not create duplicate automatic requirements; explicit angles remain valid.
+    Back faces are not a second copy of the view's requirements. The standard
+    cameras face the part from +X (side), -Y (front) and +Z (plan).
+    """
+    if evidence is None:
+        return ()
+    candidates: dict[tuple[frozenset[FaceRef], int], list[PlanarOuterProfileEvidence]] = {}
+    for face in evidence.faces:
+        source = evidence.planar_outer_profile(face)
+        if type(source) is not PlanarOuterProfileEvidence:
+            continue
+        profile = source.profile
+        if profile.schema_version != 1 or profile.boundary_kind != "outer":
+            raise ValueError("unsupported planar outer-profile schema")
+        axis = max(range(3), key=lambda index: abs(profile.normal[index]))
+        camera_side = -1 if axis == 1 else 1
+        if camera_side * profile.normal[axis] < 1 - 1e-8 or any(
+            abs(component) > 1e-8
+            for index, component in enumerate(profile.normal)
+            if index != axis
+        ):
+            continue
+        candidates.setdefault((source.body_faces, axis), []).append(source)
+    definitions = _profile_callout_definitions(evidence)
+    selected = []
+    for (_body, axis), profiles in candidates.items():
+        camera_side = -1 if axis == 1 else 1
+        foremost = max(camera_side * source.profile.origin[axis] for source in profiles)
+        for source in profiles:
+            if abs(camera_side * source.profile.origin[axis] - foremost) <= 1e-6:
+                selected.extend(_standalone_corners(source, evidence, definitions))
+    # Ordering controls presentation only. The binding retains the issued
+    # profile and its support indices; numerical sorting establishes no owner.
+    return tuple(sorted(selected, key=lambda angle: (angle.vertex, angle.first, angle.second)))
+
+
+@dataclass(frozen=True)
+class ProfileAngleRepetition:
+    """Angles carried by one verified rotation of a same-body bolt-circle pattern.
+
+    This is run-local drafting evidence, not IR. It never establishes a new
+    recognition occurrence or groups measurements merely because values agree.
+    """
+
+    pattern: BoltCircle
+    members: tuple[ProfileAngle, ...]
+
+
+def profile_angle_repetitions(evidence) -> tuple[ProfileAngleRepetition, ...]:
+    """Prove repeated-angle presentations using an already recognised rotation.
+
+    Every pattern member must belong to the profile's exact body, and the entire
+    ordered outer profile must map to itself under that rotation, including arc
+    centres, radii and sweeps. A shared numerical angle or partial resemblance
+    supplies no repetition authority. Unproved corners remain individual.
+    """
+    if evidence is None:
+        return ()
+    by_profile: dict[int, list[ProfileAngle]] = {}
+    for requirement in profile_angle_requirements(evidence):
+        by_profile.setdefault(id(requirement.source), []).append(requirement)
+    refs_by_record: dict[int, list[FeatureRef]] = {}
+    for occurrence in evidence.features:
+        refs_by_record.setdefault(id(evidence.record(occurrence)), []).append(occurrence)
+    repeated = []
+    for requirements in by_profile.values():
+        source = requirements[0].source
+        profile = source.profile
+        supports = profile.supports
+        for pattern in evidence.result.hole_patterns:
+            if not isinstance(pattern, BoltCircle):
+                continue
+            count = len(pattern.holes)
+            if count < 3 or len(supports) % count:
+                continue
+            owned = True
+            for hole in pattern.holes:
+                refs = refs_by_record.get(id(hole), [])
+                if len(refs) != 1 or abs(_dot(hole.axis, profile.normal)) < 1 - 1e-8:
+                    owned = False
+                    break
+                faces = evidence.constituent_faces(refs[0])
+                if not faces or not faces <= source.body_faces:
+                    owned = False
+                    break
+            if not owned:
+                continue
+            # The recognised bolt-circle axis intersects this profile's plane.
+            # This allows a through pattern to support either cap of its body.
+            normal = profile.normal
+            along = _dot(_sub(profile.origin, pattern.center), normal)
+            centre = tuple(p + along * n for p, n in zip(pattern.center, normal, strict=True))
+            theta = 2 * pi / count
+
+            def rotate(point):
+                delta = _sub(point, centre)
+                crossed = _cross(normal, delta)
+                axial = _dot(normal, delta)
+                return tuple(
+                    c + d * cos(theta) + cross * sin(theta) + n * axial * (1 - cos(theta))
+                    for c, d, cross, n in zip(centre, delta, crossed, normal, strict=True)
+                )
+
+            shift = len(supports) // count
+            for index, support in enumerate(supports):
+                target = supports[(index + shift) % len(supports)]
+                if type(support) is not type(target):
+                    break
+                if (
+                    max(
+                        dist(rotate(support.start), target.start),
+                        dist(rotate(support.end), target.end),
+                    )
+                    > 1e-6
+                ):
+                    break
+                if isinstance(support, ProfileArc) and (
+                    not isinstance(target, ProfileArc)
+                    or dist(rotate(support.center), target.center) > 1e-6
+                    or abs(support.radius - target.radius) > 1e-6
+                    or abs(support.sweep - target.sweep) > 1e-6
+                ):
+                    break
+            else:
+                by_index = {item.first_index: item for item in requirements}
+                remaining = set(by_index)
+                while remaining:
+                    first = min(remaining)
+                    indices = tuple(
+                        (first + member * shift) % len(supports) for member in range(count)
+                    )
+                    if not set(indices) <= remaining:
+                        remaining.remove(first)
+                        continue
+                    repeated.append(
+                        ProfileAngleRepetition(pattern, tuple(by_index[i] for i in indices))
+                    )
+                    remaining.difference_update(indices)
+                break  # One proved complete pattern supplies this profile's presentation.
+    return tuple(repeated)

--- a/src/draftwright/recognition_ownership.py
+++ b/src/draftwright/recognition_ownership.py
@@ -16,6 +16,7 @@ from quiddity.evidence import FeatureRef, RecognitionEvidence
 
 from draftwright.blend_contract import blend_provider_key
 from draftwright.oriented_slot_contract import standalone_oriented_slots
+from draftwright.profile_angles import ProfileAngle
 from draftwright.recogniser_policy import (
     OwnerlessDisposition,
     ownerless_occurrence_policy,
@@ -391,6 +392,15 @@ def _policy_outcomes(evidence: RecognitionEvidence) -> tuple[OccurrencePolicyOut
 
 
 @dataclass(frozen=True)
+class ProfileAngleBinding:
+    """A drafting requirement's exact provider support pair and final IR owner."""
+
+    requirement: ProfileAngle
+    feature: object
+    parameter_id: str = "included.angle"
+
+
+@dataclass(frozen=True)
 class RecognitionOwnership:
     """Immutable run-local ownership ledger paired with one evidence authority."""
 
@@ -401,6 +411,7 @@ class RecognitionOwnership:
     expected_conditional: tuple[FeatureRef, ...]
     bindings: tuple[OccurrenceBinding, ...]
     policy_outcomes: tuple[OccurrencePolicyOutcome, ...]
+    profile_angles: tuple[ProfileAngleBinding, ...] = ()
 
     @property
     def owner_expected_occurrences(self) -> tuple[FeatureRef, ...]:
@@ -529,6 +540,7 @@ class RecognitionOwnershipBuilder:
             record = evidence.record(occurrence)
             self._by_record_identity.setdefault(id(record), []).append((occurrence, record))
         self._bindings: list[OccurrenceBinding] = []
+        self._profile_angles: list[ProfileAngleBinding] = []
         expected_ids = {
             id(occurrence)
             for occurrence in (
@@ -565,6 +577,31 @@ class RecognitionOwnershipBuilder:
             )
             raise ValueError(f"recognition record {reason}")
         return matches[0]
+
+    def bind_profile_angle(
+        self, requirement: ProfileAngle, feature: object, *, parameter_id="included.angle"
+    ) -> None:
+        """Bind at conversion, validating the source against this run's authority."""
+        for index in (requirement.first_index, requirement.second_index):
+            self.evidence.profile_edge(requirement.source, index)
+        if getattr(feature, "kind", None) != "angle":
+            raise ValueError("profile angle binding requires an angular IR owner")
+        parameters = getattr(feature, "parameters", None)
+        if not callable(parameters) or not any(
+            p.parameter_id == parameter_id for p in parameters()
+        ):
+            raise ValueError("profile angle binding requires an addressable member")
+        if any(
+            (binding.feature is feature and binding.parameter_id == parameter_id)
+            or (
+                binding.requirement.source is requirement.source
+                and binding.requirement.first_index == requirement.first_index
+                and binding.requirement.second_index == requirement.second_index
+            )
+            for binding in self._profile_angles
+        ):
+            raise ValueError("profile angle or IR feature already has an owner")
+        self._profile_angles.append(ProfileAngleBinding(requirement, feature, parameter_id))
 
     def bind(
         self,
@@ -887,6 +924,26 @@ class RecognitionOwnershipBuilder:
     ) -> None:
         """Follow one explicit IR-lowering lineage without reconstructing correspondence."""
 
+        profile_matches = [
+            binding for binding in self._profile_angles if binding.feature is source
+        ]
+        if profile_matches and len(replacements) == 1 and source_member_groups is None:
+            replacement = replacements[0]
+            if getattr(replacement, "kind", None) != "angle":
+                raise ValueError("a lowered profile angle requires an angular IR owner")
+            if any(
+                binding.feature is replacement and binding.feature is not source
+                for binding in self._profile_angles
+            ):
+                raise ValueError("lowered IR feature already owns a profile angle")
+            self._profile_angles = [
+                ProfileAngleBinding(binding.requirement, replacement)
+                if binding.feature is source
+                else binding
+                for binding in self._profile_angles
+            ]
+        # An absent or ambiguous replacement leaves the expected owner in the
+        # ledger. Final-model accounting reports that loss; no new join is guessed.
         matches = [
             index
             for index, binding in enumerate(self._bindings)
@@ -1012,4 +1069,5 @@ class RecognitionOwnershipBuilder:
             expected_conditional=self._expected_conditional,
             bindings=tuple(self._bindings),
             policy_outcomes=self._policy_outcomes,
+            profile_angles=tuple(self._profile_angles),
         )

--- a/src/draftwright/registry.py
+++ b/src/draftwright/registry.py
@@ -119,6 +119,14 @@ class AnnotationRegistry:
         ids: tuple = self._anno_measurement.get(name, ())
         return ids
 
+    def has_measurement(self, identity) -> bool:
+        """Whether a live mark carries this exact feature/parameter identity."""
+        return identity is not None and any(
+            recorded.feature is identity.feature and recorded.parameter == identity.parameter
+            for name in self._named
+            for recorded in self.measurement_of(name)
+        )
+
     def satisfaction_of(self, name) -> tuple:
         """The ``DimensionId`` requirements *name* satisfies as structured note authority.
 

--- a/src/draftwright/reporting.py
+++ b/src/draftwright/reporting.py
@@ -18,10 +18,11 @@ if TYPE_CHECKING:
     from quiddity.evidence import RecognitionEvidence
 
     from draftwright.model import PartModel
+    from draftwright.profile_angles import ProfileAngle
     from draftwright.recognition_ownership import RecognitionOwnership
 
 REPORT_SCHEMA = "draftwright-report"
-REPORT_SCHEMA_VERSION = 2
+REPORT_SCHEMA_VERSION = 3
 _DISPOSITIONS = (
     "represented",
     "absorbed",
@@ -194,6 +195,7 @@ def _annotation_names(index: _AnnotationIndex, outcome: object) -> list[str]:
 def _requirements(
     *,
     evidence: RecognitionEvidence,
+    ownership: RecognitionOwnership,
     model: PartModel,
     occurrences: list[dict[str, Any]],
     registry: object,
@@ -203,6 +205,8 @@ def _requirements(
     requirement_outcomes: Mapping[str, tuple[Any, ...]] | None = None,
 ) -> tuple[list[dict[str, Any]], dict[str, list[str]], set[str]]:
     """Project the recognition-owned semantic denominator exactly once."""
+
+    from draftwright.profile_angles import profile_angle_requirements
 
     if requirement_outcomes is None:
         from draftwright.linting.requirements import recognized_requirement_outcomes
@@ -214,6 +218,25 @@ def _requirements(
             omissions,
             dimension_plan=dimension_plan,
             part=part,
+            evidence=evidence,
+            ownership=ownership,
+        )
+
+    expected_profiles = Counter(
+        (id(item.source), item.first_index, item.second_index)
+        for item in profile_angle_requirements(evidence)
+    )
+    reported_profiles = Counter(
+        (
+            id(item.source_profile.source),
+            item.source_profile.first_index,
+            item.source_profile.second_index,
+        )
+        for item in requirement_outcomes.get("outer_profile_angles", ())
+    )
+    if reported_profiles != expected_profiles:
+        raise ReportUnavailableError(
+            "profile requirement ledger differs from the issued denominator"
         )
 
     occurrence_ids: dict[int, tuple[object, str]] = {}
@@ -232,6 +255,8 @@ def _requirements(
     requirements: list[dict[str, Any]] = []
     by_occurrence: dict[str, list[str]] = {key: [] for key in occurrences_by_id}
     inapplicable_occurrences: set[str] = set()
+    profile_ids: dict[int, str] = {}
+    support_ids: dict[tuple[int, int], str] = {}
 
     for family, outcomes in requirement_outcomes.items():
         for outcome in outcomes:
@@ -241,7 +266,36 @@ def _requirements(
                     f"recognized requirement family {family!r} has invalid state {state!r}"
                 )
             source_records = _outcome_records(outcome)
-            if not source_records:
+            profile: ProfileAngle | None = getattr(outcome, "source_profile", None)
+            profile_source = None
+            if profile is not None:
+                if family != "outer_profile_angles" or source_records:
+                    raise ReportUnavailableError(
+                        "profile requirement has conflicting source kinds"
+                    )
+                source = profile.source
+                try:
+                    if evidence.planar_outer_profile(source.face) is not source:
+                        raise ValueError("profile does not belong to this evidence run")
+                    for index in (profile.first_index, profile.second_index):
+                        evidence.profile_edge(source, index)
+                except (AttributeError, TypeError, ValueError, IndexError) as exc:
+                    raise ReportUnavailableError(
+                        "profile requirement has no exact issued source"
+                    ) from exc
+                # Allocate document IDs on first use; no opaque reference or
+                # provider topology/support index is serialized.
+                profile_id = profile_ids.setdefault(id(source), f"profile:{len(profile_ids) + 1}")
+                pair_ids = [
+                    support_ids.setdefault((id(source), index), f"support:{len(support_ids) + 1}")
+                    for index in (profile.first_index, profile.second_index)
+                ]
+                profile_source = {
+                    "kind": "planar_outer_profile",
+                    "profile_id": profile_id,
+                    "support_ids": pair_ids,
+                }
+            if not source_records and profile_source is None:
                 raise ReportUnavailableError(
                     f"recognized requirement family {family!r} has no exact source records"
                 )
@@ -282,6 +336,17 @@ def _requirements(
                 },
                 key=owner_order.__getitem__,
             )
+            if profile_source is not None:
+                final_owners = _feature_ids(model)
+                owner_ids = []
+                for feature in getattr(outcome, "features", ()):
+                    matched = final_owners.get(id(feature))
+                    if matched is None or matched[0] is not feature:
+                        raise ReportUnavailableError(
+                            "profile requirement has a non-final IR owner"
+                        )
+                    owner_ids.append(matched[1]["id"])
+                owner_ids.sort(key=owner_order.__getitem__)
             annotations = _annotation_names(annotation_index, outcome)
             representation = getattr(outcome, "representation", None)
             representation_reason = getattr(outcome, "representation_reason", None)
@@ -307,6 +372,11 @@ def _requirements(
                         "annotations": annotations,
                         "representation": representation,
                         "representation_reason": representation_reason,
+                        **(
+                            {"profile_source": profile_source}
+                            if profile_source is not None
+                            else {}
+                        ),
                     }
                 )
                 for occurrence_id in source_ids:
@@ -355,7 +425,7 @@ def validate_report_inputs(
     if evidence is None or ownership is None or ownership.evidence is not evidence:
         raise ReportUnavailableError(
             "accepted occurrence ownership is unavailable for this drawing; "
-            "raw automatic recognition is required by report schema version 2"
+            "raw automatic recognition is required by report schema version 3"
         )
     if model is None:
         raise ReportUnavailableError("the drawing has no final IR model")
@@ -440,6 +510,7 @@ def project_occurrences(
     if registry is not None:
         requirements, by_occurrence, inapplicable = _requirements(
             evidence=evidence,
+            ownership=ownership,
             model=model,
             occurrences=projected,
             registry=registry,
@@ -486,7 +557,7 @@ def drawing_report(
     part: object | None = None,
     requirement_outcomes: Mapping[str, tuple[Any, ...]] | None = None,
 ) -> dict[str, object]:
-    """Build the strict schema-v2 report for one raw automatic drawing.
+    """Build the strict schema-v3 report for one raw automatic drawing.
 
     ``bounded-clear`` means only that this report found no known occurrence, semantic
     requirement, or lint blocker. It is deliberately not manufacturing readiness: recognition
@@ -523,9 +594,10 @@ def drawing_report(
         "source": _source(source),
         "outputs": {},
         "recognition": {
-            "coverage": "accepted-occurrences",
+            "coverage": "accepted-occurrences-and-profile-requirements",
             "identity_scope": "report-local",
             "occurrences": occurrences,
+            "owners": [owner for _feature, owner in _feature_ids(model).values()],
             "requirements": requirements,
             "summary": summary,
         },

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -63,6 +63,7 @@ from draftwright.builder import _coerce_model, build_drawing, detect_part_model
 from draftwright.compose import _est_table_size
 from draftwright.fits import fit_class
 from draftwright.model import DimensionParameterId, Feature
+from draftwright.model import angle as _angle
 from draftwright.model import blend as _blend
 from draftwright.model import boss as _boss
 from draftwright.model import chamfer as _chamfer
@@ -1754,6 +1755,16 @@ class Sheet:
         open-to-terminal run length and shared-ridge midpoint.  The form is explicit-only:
         a detached face or cutter cannot prove the paired material-removal topology."""
         self._features.append(_paired_ramp_step(**kw))
+        return _Params(self, len(self._features) - 1)
+
+    def angle(self, **kw) -> _Params:
+        """Declare an included angle from vertex/first/second model-space points.
+
+        The value is derived from those rays. Select ``included.angle`` with
+        ``dimension()`` and use the usual tolerance, omission and placement controls.
+        No number or annotation radius is authored.
+        """
+        self._features.append(_angle(**kw))
         return _Params(self, len(self._features) - 1)
 
     def circular_blind_step(self, **kw) -> _Params:

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -64,6 +64,7 @@ from draftwright.compose import _est_table_size
 from draftwright.fits import fit_class
 from draftwright.model import DimensionParameterId, Feature
 from draftwright.model import angle as _angle
+from draftwright.model import angle_pattern as _angle_pattern
 from draftwright.model import blend as _blend
 from draftwright.model import boss as _boss
 from draftwright.model import chamfer as _chamfer
@@ -547,9 +548,20 @@ class _Dim(_Nameable):
     ) -> _Dim:
         """A ± tolerance on this dimension: symmetric ``.tolerance(0.05)`` (→ ``±0.05``) or a
         limit pair ``.tolerance(0.0, 0.1)`` (→ ``+0.1 -0.0``). ``on`` picks the parameter for
-        a multi-dim feature — a step's ``"length"`` (default) vs its ``"diameter"`` (OD).
+        a multi-dim feature — a step's ``"length"`` (default) vs its ``"diameter"`` (OD),
+        or its canonical parameter id such as ``"step.length"``.
         ``source`` / ``source_ids`` retain provenance on generated imported requirements."""
-        self._sheet._tolerances[(self._token, on or self._kind)] = _tolerance_decoration(
+        parameters = self._sheet._features[self._i].parameters()
+        target = on or self._kind
+        exact = [parameter for parameter in parameters if parameter.parameter_id == target]
+        if len(exact) == 1:
+            target = exact[0].kind
+        if sum(parameter.kind == target for parameter in parameters) != 1:
+            raise ValueError(
+                f"on={on!r} must name one parameter of this feature; "
+                f"choose from {sorted(parameter.parameter_id for parameter in parameters)}"
+            )
+        self._sheet._tolerances[(self._token, target)] = _tolerance_decoration(
             lo, hi, source=source, source_ids=source_ids
         )
         return self
@@ -1765,6 +1777,16 @@ class Sheet:
         No number or annotation radius is authored.
         """
         self._features.append(_angle(**kw))
+        return _Params(self, len(self._features) - 1)
+
+    def angle_pattern(self, *members) -> _Params:
+        """Declare repeated AngularReference corners with independent member IDs.
+
+        The parameters are ``included.angle.member1``, ``member2``, etc. An
+        authored omission retains the other member identities; tolerances may
+        target one full parameter ID or the whole included-angle family.
+        """
+        self._features.append(_angle_pattern(*members))
         return _Params(self, len(self._features) - 1)
 
     def circular_blind_step(self, **kw) -> _Params:

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -1496,6 +1496,9 @@ class Sheet:
         ray witness, with optional ``virtual_vertex=True`` for extended supports.
         Its only supported sector is the non-reflex ``"minor"`` sector. Supply it as an
         ``AngularReference`` or mapping; empty ``ref_pts`` are filled from that reference.
+        A Sheet-authored angle with exactly three ``ref_pts`` uses the order
+        ``(first, vertex, second)``. Generic imported PMI stations require an explicit
+        angular reference; their order cannot be inferred from the point count.
         Geometric intent is preserved even when angular rendering is unavailable.
         Delegates to :func:`draftwright.model.declare.measured_dimension` (#704), so
         ``build_drawing(model=…)`` callers can author the same feature without the façade.

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -1470,6 +1470,7 @@ class Sheet:
         cylindrical_refs=(),
         view: str | None = None,
         side: str | None = None,
+        angular_reference=None,
     ) -> _Params:
         """Declare a drafting dimension from explicit **measured** values.
 
@@ -1491,6 +1492,11 @@ class Sheet:
         ``rendering_blockers`` carries the source-geometry reason it cannot be drawn truthfully.
         ``view``/``side`` select a supported semantic corridor while leaving its actual
         position to the normal placement solve.
+        ``angular_reference`` names a model-space ``vertex``, ``first`` and ``second``
+        ray witness, with optional ``virtual_vertex=True`` for extended supports.
+        Its only supported sector is the non-reflex ``"minor"`` sector. Supply it as an
+        ``AngularReference`` or mapping; empty ``ref_pts`` are filled from that reference.
+        Geometric intent is preserved even when angular rendering is unavailable.
         Delegates to :func:`draftwright.model.declare.measured_dimension` (#704), so
         ``build_drawing(model=…)`` callers can author the same feature without the façade.
         """
@@ -1516,6 +1522,7 @@ class Sheet:
                 cylindrical_refs=cylindrical_refs,
                 view=view,
                 side=side,
+                angular_reference=angular_reference,
             )
         )
         # A handle like every other declaration verb (#922). A measured dimension carries its

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -489,24 +489,31 @@ def _member_slot_str(m) -> str:
 
 
 def _measured_dimension_line(f) -> str:
+    angular = getattr(f, "angular_reference", None)
+    number = repr if angular is not None else _n
+    reference_points = (
+        repr((angular.first, angular.vertex, angular.second))
+        if angular is not None
+        else _pts_arg(f.ref_pts)
+    )
     kw = [
         f"kind={f.dimension_kind!r}",
-        f"value={_n(f.value)}",
+        f"value={number(f.value)}",
         f"label={f.label!r}",
         f"dominant_axis={f.dominant_axis!r}",
-        f"ref_pts={_pts_arg(f.ref_pts)}",
+        f"ref_pts={reference_points}",
         f"ref_bbox={_bbox_arg(f.ref_bbox)}",
         f"at={_pt(f.frame.origin)}",
         f"axis={f.frame.axis!r}",
     ]
     if f.upper_tol is not None:
-        kw.append(f"upper_tol={_n(f.upper_tol)}")
+        kw.append(f"upper_tol={number(f.upper_tol)}")
     if f.lower_tol is not None:
-        kw.append(f"lower_tol={_n(f.lower_tol)}")
+        kw.append(f"lower_tol={number(f.lower_tol)}")
     if f.lower_bound is not None:
-        kw.append(f"lower_bound={_n(f.lower_bound)}")
+        kw.append(f"lower_bound={number(f.lower_bound)}")
     if f.upper_bound is not None:
-        kw.append(f"upper_bound={_n(f.upper_bound)}")
+        kw.append(f"upper_bound={number(f.upper_bound)}")
     if f.source != "sheet":
         kw.append(f"source={f.source!r}")
     if f.source_kind is not None and f.source_kind != f.dimension_kind:
@@ -519,6 +526,16 @@ def _measured_dimension_line(f) -> str:
         kw.append(f"rendering_blockers={f.rendering_blockers!r}")
     if getattr(f, "cylindrical_refs", ()):
         kw.append(f"cylindrical_refs={_cylindrical_refs_arg(f.cylindrical_refs)}")
+    if angular is not None:
+        # Preserve full point precision: short angular rays amplify coordinate rounding.
+        reference = {
+            "vertex": angular.vertex,
+            "first": angular.first,
+            "second": angular.second,
+            "sector": angular.sector,
+            "virtual_vertex": angular.virtual_vertex,
+        }
+        kw.append(f"angular_reference={reference!r}")
     if getattr(f, "view", None) is not None:
         kw.append(f"view={f.view!r}")
     if getattr(f, "side", None) is not None:

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -982,6 +982,13 @@ def _feature_line(
             f'sheet.fillet(axis="{f.axis}", radius={_n(f.radius)}, '
             f"at={_pt(f.frame.origin)}{turned})"
         )
+    if k == "angle":
+        reference = f.angular_reference
+        return (
+            f"sheet.angle(vertex={reference.vertex!r}, first={reference.first!r}, "
+            f"second={reference.second!r}, sector={reference.sector!r}, "
+            f"virtual_vertex={reference.virtual_vertex!r})"
+        )
     if k == "paired_ramp_step":
         return (
             f'sheet.paired_ramp_step(axis="{f.axis}", angle={_n(f.angle)}, '
@@ -1788,6 +1795,7 @@ def _feature_block(
                     line += f".fit({tolerance.code!r}{show})"
 
             if f.kind in (
+                "angle",
                 "through_step",
                 "pad",
                 "rectangular_blind_slot",

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -983,6 +983,8 @@ def _feature_line(
             f"at={_pt(f.frame.origin)}{turned})"
         )
     if k == "angle":
+        if members := getattr(f, "members", ()):
+            return "sheet.angle_pattern(" + ", ".join(repr(member) for member in members) + ")"
         reference = f.angular_reference
         return (
             f"sheet.angle(vertex={reference.vertex!r}, first={reference.first!r}, "
@@ -1766,7 +1768,7 @@ def _feature_block(
                 # The broad tolerance still belongs on recess diameters; the role-specific fit
                 # then wins only on the bore. Preserve that public fluent ordering exactly.
                 tolerances = (broad_tolerance, role_tolerance)
-            for tolerance in tolerances:
+            for tolerance in () if f.kind in ("step", "boss") else tolerances:
                 if isinstance(tolerance, ToleranceDecoration | int | float | tuple):
                     value = (
                         tolerance.value
@@ -1795,6 +1797,8 @@ def _feature_block(
                     line += f".fit({tolerance.code!r}{show})"
 
             if f.kind in (
+                "step",
+                "boss",
                 "angle",
                 "through_step",
                 "pad",
@@ -1817,6 +1821,10 @@ def _feature_block(
                         tolerance = (decorations or {}).get((f, parameter.kind, parameter.role))
                     if tolerance is None:
                         tolerance = (decorations or {}).get((f, parameter.kind))
+                    if isinstance(tolerance, FitClass) and f.kind in ("step", "boss"):
+                        show = "" if tolerance.show == "class" else f", show={tolerance.show!r}"
+                        line += f".fit({tolerance.code!r}{show})"
+                        continue
                     if not isinstance(tolerance, ToleranceDecoration | int | float | tuple):
                         continue
                     value = (
@@ -2100,6 +2108,8 @@ def emit_sheet_script(
     # generated file uses, and a missing entry is a NameError on the first line that runs
     # (#957 review; pocket/slot patterns were emitting unrunnable scripts).
     model_imports = set()
+    if any(f.kind == "angle" and getattr(f, "members", ()) for f in model.features):
+        model_imports.add("AngularReference")
     if any(f.kind in ("hole", "pattern") for f in model.features):
         model_imports.add("hole")
     if any(

--- a/tests/refactor_golden/grooved_shaft.json
+++ b/tests/refactor_golden/grooved_shaft.json
@@ -15,37 +15,6 @@
     },
     {
       "geom_bbox": [
-        112.9,
-        50.0,
-        113.1,
-        120.0
-      ],
-      "label": "",
-      "label_bbox": null,
-      "name": "centerline_side",
-      "type": "Centerline",
-      "view": "side"
-    },
-    {
-      "geom_bbox": [
-        54.0,
-        55.0,
-        62.0,
-        115.1
-      ],
-      "label": "60",
-      "label_bbox": [
-        58.9,
-        83.4,
-        61.1,
-        86.6
-      ],
-      "name": "dim_height",
-      "type": "Dimension",
-      "view": "front"
-    },
-    {
-      "geom_bbox": [
         30.0,
         119.0,
         50.1,
@@ -64,17 +33,71 @@
     },
     {
       "geom_bbox": [
+        15.9,
+        60.4,
+        30.0,
+        62.6
+      ],
+      "label": "\u00f820",
+      "label_bbox": [
+        15.9,
+        60.4,
+        21.0,
+        62.6
+      ],
+      "name": "m_dia_z0",
+      "type": "Leader",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        15.9,
+        83.9,
+        30.0,
+        86.1
+      ],
+      "label": "\u00f820",
+      "label_bbox": [
+        15.9,
+        83.9,
+        21.0,
+        86.1
+      ],
+      "name": "m_dia_z1",
+      "type": "Leader",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        15.9,
+        107.4,
+        30.0,
+        109.6
+      ],
+      "label": "\u00f820",
+      "label_bbox": [
+        15.9,
+        107.4,
+        21.0,
+        109.6
+      ],
+      "name": "m_dia_z2",
+      "type": "Leader",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
         40.0,
-        70.0,
-        88.9,
-        86.8
+        68.9,
+        88.4,
+        71.1
       ],
       "label": "4 WIDE \u00d7 \u00f814",
       "label_bbox": [
-        67.6,
-        84.5,
-        88.9,
-        86.8
+        67.0,
+        68.9,
+        88.4,
+        71.1
       ],
       "name": "m_groove_z0",
       "type": "Leader",
@@ -83,16 +106,16 @@
     {
       "geom_bbox": [
         40.0,
-        100.0,
-        79.0,
-        126.7
+        98.9,
+        88.3,
+        101.1
       ],
       "label": "4 WIDE \u00d7 \u00f816",
       "label_bbox": [
-        57.7,
-        124.4,
-        79.0,
-        126.7
+        67.0,
+        98.9,
+        88.3,
+        101.1
       ],
       "name": "m_groove_z1",
       "type": "Leader",
@@ -100,16 +123,70 @@
     },
     {
       "geom_bbox": [
-        202.8,
+        52.0,
+        55.0,
+        63.0,
+        68.1
+      ],
+      "label": "13",
+      "label_bbox": [
+        59.9,
+        59.9,
+        62.1,
+        63.1
+      ],
+      "name": "m_steplen0",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        52.0,
+        72.0,
+        63.0,
+        98.1
+      ],
+      "label": "26",
+      "label_bbox": [
+        59.9,
+        83.4,
+        62.1,
+        86.6
+      ],
+      "name": "m_steplen1",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        52.0,
+        102.0,
+        63.0,
+        115.1
+      ],
+      "label": "13",
+      "label_bbox": [
+        59.9,
+        106.9,
+        62.1,
+        110.1
+      ],
+      "name": "m_steplen2",
+      "type": "Dimension",
+      "view": "front"
+    },
+    {
+      "geom_bbox": [
+        166.3,
         86.3,
-        227.2,
+        190.7,
         89.0
       ],
       "label": "ISO VIEW (NTS)",
       "label_bbox": [
-        202.8,
+        166.3,
         86.3,
-        227.2,
+        190.7,
         89.0
       ],
       "name": "note_iso_nts",
@@ -130,19 +207,8 @@
       "view": null
     }
   ],
-  "build_issues": [
-    [
-      "error",
-      "plan_incomplete",
-      "the automatically planned sheet drops 1 required annotation outcome(s) (step_dim_dropped)"
-    ],
-    [
-      "warning",
-      "step_dim_dropped",
-      "step-length chain dropped: turned shoulders too closely spaced to dimension at this scale (use a detail view)"
-    ]
-  ],
-  "item_count": 8,
+  "build_issues": [],
+  "item_count": 12,
   "page": [
     297.0,
     210.0
@@ -155,9 +221,9 @@
       115.0
     ],
     "iso": [
-      202.0,
+      165.5,
       93.7,
-      228.0,
+      191.5,
       172.3
     ],
     "plan": [
@@ -165,12 +231,6 @@
       135.0,
       50.0,
       155.0
-    ],
-    "side": [
-      103.0,
-      55.0,
-      123.0,
-      115.0
     ]
   }
 }

--- a/tests/test_add_dimension.py
+++ b/tests/test_add_dimension.py
@@ -1236,6 +1236,7 @@ class TestEveryFeatureVerbIsNameable:
     #: the API the way the first version's six-verb parametrization did.
     _CALLS: dict = {
         "angle": dict(vertex=(0, 0, 0), first=(10, 0, 0), second=(0, 10, 0)),
+        "angle_pattern": {},
         "hole": dict(diameter=6, at=(0, 0, 0), axis="z"),
         "double_d_bore": dict(
             major_diameter=10,
@@ -1394,6 +1395,13 @@ class TestEveryFeatureVerbIsNameable:
                     bbox_min=(-40.0, -25.0, -4.0),
                     bbox_max=(40.0, 25.0, 4.0),
                 )
+            )
+        if verb == "angle_pattern":
+            from draftwright.model import AngularReference
+
+            return sheet.angle_pattern(
+                AngularReference((0, 0, 0), (10, 0, 0), (0, 10, 0)),
+                AngularReference((20, 0, 0), (30, 0, 0), (20, 10, 0)),
             )
         if verb.endswith("pattern"):
             member = {

--- a/tests/test_add_dimension.py
+++ b/tests/test_add_dimension.py
@@ -1235,6 +1235,7 @@ class TestEveryFeatureVerbIsNameable:
     #: with no entry FAILS rather than being skipped, so the table cannot silently fall behind
     #: the API the way the first version's six-verb parametrization did.
     _CALLS: dict = {
+        "angle": dict(vertex=(0, 0, 0), first=(10, 0, 0), second=(0, 10, 0)),
         "hole": dict(diameter=6, at=(0, 0, 0), axis="z"),
         "double_d_bore": dict(
             major_diameter=10,

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -1121,6 +1121,7 @@ class TestTheBoundaryIsLoadBearing:
                         break
 
         assert sorted(by_contract["plan"]) == [
+            "render_angular_dimensions",
             "render_blends",
             "render_boss_diameters",
             "render_boss_heights",

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -88,6 +88,8 @@ _LAYERS: dict[str, int] = {
     # Shared pure Plate-record/final-IR correspondence predicates. Both model assembly and
     # completeness lint consume them without either layer importing the other.
     "plate_correspondence": 0,
+    "profile_angles": 0,
+    "angular_geometry": 0,
     "recogniser_policy": 0,
     # Consumer-owned public record schema versions, shared by the report projector and the
     # rank-7 cross-repository validator without either leaf depending on the validator.
@@ -464,6 +466,7 @@ def test_classifier_is_binding_aware_and_context_correct(tmp_path):
 # ── model/ IR-waist guards (original #584 WP2 — kept; add the relative-import rejection) ──
 
 _MODEL_MAY_IMPORT = {
+    "profile_angles",
     "_geometry",
     "blend_contract",
     "fits",

--- a/tests/test_inspection_contract.py
+++ b/tests/test_inspection_contract.py
@@ -9,14 +9,34 @@ from pathlib import Path
 
 import pytest
 import quiddity.inspection as inspection
+from quiddity.evidence import evidence_api_manifest
 
 from draftwright.inspection_contract import (
     InspectionContractError,
     consumer_inspection_declaration,
     validate_inspection_contract,
+    validate_profile_evidence_contract,
 )
 
 ROOT = Path(__file__).parents[1]
+
+
+@pytest.mark.parametrize(
+    "symbol",
+    [
+        "PlanarOuterProfile",
+        "PlanarOuterProfileEvidence",
+        "ProfileLine",
+        "ProfileArc",
+        "RefusedPlanarOuterProfile",
+    ],
+)
+def test_missing_released_profile_evidence_is_refused(symbol):
+    manifest = evidence_api_manifest()
+    assert symbol in manifest["api"]["symbols"]
+    manifest["api"]["symbols"].remove(symbol)
+    with pytest.raises(InspectionContractError, match="profile evidence symbols"):
+        validate_profile_evidence_contract(manifest)
 
 
 def _manifest() -> dict:
@@ -26,7 +46,7 @@ def _manifest() -> dict:
 def test_installed_pypi_wheel_satisfies_the_inspection_contract() -> None:
     distribution = importlib.metadata.distribution("quiddity")
 
-    assert distribution.version == "0.2.5"
+    assert distribution.version == "0.2.6"
     assert distribution.read_text("direct_url.json") is None
     assert (
         Path(inspect.getfile(inspection.inspection_api_manifest))

--- a/tests/test_issue_1143_hole_completeness.py
+++ b/tests/test_issue_1143_hole_completeness.py
@@ -265,6 +265,7 @@ def test_pattern_and_central_bore_have_a_complete_recognition_owned_ledger():
     assert completeness["audited_score"] == 1.0
     assert completeness["requirements"] == completeness["placed"] == 10
     assert completeness["by_family"] == {
+        "outer_profile_angles": 0,
         "section_recesses": 0,
         "blends": 0,
         "chamfers": 0,

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -430,6 +430,29 @@ def test_segmented_centerline_diagnostic_ignores_only_the_empty_aabb_triangle():
     )
 
 
+@pytest.mark.parametrize("moved", (False, True))
+def test_circular_centerline_lint_uses_the_ring_not_its_enclosing_square(moved):
+    from build123d import Location
+    from build123d_drafting import CenterlineCircle
+
+    from draftwright.linting.structural import _label_centerline_overlap
+
+    ring = CenterlineCircle((0, 0), 40)
+    assert not ring.segments  # circular strokes exercise the rendered-ink fallback
+    cache = {}
+    interior = SimpleNamespace(label="CLEAR", label_bbox=(-2, -2, 2, 2))
+    corner = SimpleNamespace(label="CLEAR", label_bbox=(15, 15, 19, 19))
+    crossing = SimpleNamespace(label="HIT", label_bbox=(17, -3, 23, 3))
+    assert _label_centerline_overlap(interior, ring, cache) is None
+    assert _label_centerline_overlap(corner, ring, cache) is None
+    assert _label_centerline_overlap(crossing, ring, cache) is not None
+    if moved:
+        # A persisted cache must follow a public in-place location change.
+        ring.locate(Location((20, 0, 0)))
+        assert _label_centerline_overlap(interior, ring, cache) is not None
+        assert _label_centerline_overlap(crossing, ring, cache) is None
+
+
 def test_centerline_warning_tolerance_uses_the_actual_colliding_component():
     from draftwright.linting.structural import _label_centerline_overlap
 

--- a/tests/test_issue_1176_quality_fidelity.py
+++ b/tests/test_issue_1176_quality_fidelity.py
@@ -367,9 +367,8 @@ class TestFidelityIsAboutFalsehoodNotAbsence:
         assert code not in _FIDELITY_CODES
 
     def test_an_unsupported_dimension_does_not_lower_fidelity(self):
-        # #1207 refuses to draw an angular dimension rather than drawing it as a linear
-        # one. Nothing false reaches the sheet, so fidelity is intact; the content is
-        # missing, which is a different axis.
+        # Generic imported stations do not establish angular rays (#1504). Nothing
+        # false reaches the sheet; the content is missing, which is a different axis.
         sheet = Sheet(Box(115, 50, 68), title="T", number="T-1", page="A2", scale=1)
         sheet.measured_dimension(
             kind="angular",
@@ -377,6 +376,7 @@ class TestFidelityIsAboutFalsehoodNotAbsence:
             label="60°",
             dominant_axis="y",
             ref_pts=((0, -25, 0), (0, -9, 0), (0, -13.619, 8)),
+            source="ap242_pmi",
         )
         sheet.authored_dimensions()
         summary = sheet.build().lint_summary()

--- a/tests/test_issue_1177_angular_dimensions.py
+++ b/tests/test_issue_1177_angular_dimensions.py
@@ -10,9 +10,9 @@ Two defects in one line. The drawing asserted a length where the author stated a
 and the check that exists to catch a wrong value was itself comparing degrees to
 millimetres — so it reported a units mismatch as an axis swap.
 
-The issue's minimal contract allows either rendering a genuine angular dimension or
-failing loudly as unsupported *before* producing the misleading annotation. This refuses,
-and says so.
+The original safety fix refused angular rendering. #1504 now draws supported
+Sheet-authored three-point angles; imported generic stations remain unsupported
+unless their angular reference geometry is established explicitly.
 
 NOT because the primitives are missing — an earlier version of this docstring claimed the
 rendering library "has no angular primitive at all", and that is false twice over:
@@ -29,6 +29,7 @@ legitimate AP242 file unreadable.
 
 from __future__ import annotations
 
+from math import atan2, degrees
 from types import SimpleNamespace
 
 import pytest
@@ -53,7 +54,7 @@ _DOVETAIL = ((0, -25, 0), (0, -9, 0), (0, -13.619, 8))
 _RENDERABLE = frozenset({"linear", "thickness", "diameter", "radius"})
 
 
-def _sheet_with_angular():
+def _sheet_with_angular(source="ap242_pmi"):
     sheet = Sheet(Box(115, 50, 68), title="T", number="T-1")
     sheet.measured_dimension(
         kind="angular",
@@ -61,6 +62,7 @@ def _sheet_with_angular():
         label="60°",
         dominant_axis="y",
         ref_pts=_DOVETAIL,
+        source=source,
     )
     sheet.authored_dimensions()
     return sheet
@@ -70,7 +72,7 @@ class TestTheDrawingNoLongerAssertsALengthForAnAngle:
     def test_no_linear_dimension_is_drawn_for_an_angular_declaration(self):
         # The reported reproduction. Before: `pmi_y_0`, a `Dimension` with
         # `measured_length=16.0` carrying the label '60°'.
-        drawing = _sheet_with_angular().build()
+        drawing = _sheet_with_angular(source="sheet").build()
         drawn = [
             name
             for name, annotation in drawing.iter_annotations()
@@ -78,11 +80,17 @@ class TestTheDrawingNoLongerAssertsALengthForAnAngle:
             and "60" in str(getattr(annotation, "label", ""))
         ]
         assert drawn == [], f"an angular declaration was drawn as a linear dimension: {drawn}"
+        angular = [
+            item for _, item in drawing.iter_annotations() if hasattr(item, "measured_angle")
+        ]
+        assert len(angular) == 1
+        # The source coordinates round the slanted leg to 4.619mm.
+        assert angular[0].measured_angle == pytest.approx(degrees(atan2(8, 4.619)))
 
     def test_the_omission_is_reported_rather_than_silent(self):
         # "Fail loudly as unsupported" — the alternative the issue permits. Refusing
         # without saying so would trade a wrong drawing for a quietly incomplete one.
-        drawing = _sheet_with_angular().build()
+        drawing = _sheet_with_angular(source="ap242_pmi").build()
         reported = [i for i in drawing.lint() if i.code == "dimension_kind_unsupported"]
         assert reported, "the angular dimension vanished with no diagnostic"
         assert "angular" in reported[0].message
@@ -100,7 +108,7 @@ class TestTheDrawingNoLongerAssertsALengthForAnAngle:
         # a fact about the renderer, not a reason to declare the page unusable.
         from draftwright.linting.issues import is_placement_drop
 
-        drawing = _sheet_with_angular().build()
+        drawing = _sheet_with_angular(source="ap242_pmi").build()
         refusals = [i for i in drawing.lint() if i.code == "dimension_kind_unsupported"]
         assert refusals
         assert not any(is_placement_drop(i) for i in refusals)

--- a/tests/test_issue_1215_no_approved_tolerance_is_dropped.py
+++ b/tests/test_issue_1215_no_approved_tolerance_is_dropped.py
@@ -255,7 +255,7 @@ def _rendered_text(registry, name) -> str:
 
 
 def _missing(text: str, approved) -> list[str]:
-    """The suffixes *text* owes and does not carry — counted, not searched for.
+    """The complete angular labels or linear suffixes *text* owes, counted per claim.
 
     ONE OCCURRENCE PER APPROVED ID. Every predicate before this one asked "does the label
     contain a tolerance", and each was green over a live drop:
@@ -282,7 +282,12 @@ def _missing(text: str, approved) -> list[str]:
     guessed — which is also the ADR 4 (was 0016 Amdt 1) shape: compare to the compiler, not to a
     pattern.
     """
-    want = Counter(_tol_suffix(dim.tolerance, _DRAFT) for dim in approved)
+    want = Counter(
+        dim.final_label
+        if dim.angular_reference is not None
+        else _tol_suffix(dim.tolerance, _DRAFT)
+        for dim in approved
+    )
     return [f"{n}x{sfx!r}" for sfx, n in sorted(want.items()) if text.count(sfx) < n]
 
 

--- a/tests/test_issue_1299_page_escalation.py
+++ b/tests/test_issue_1299_page_escalation.py
@@ -39,8 +39,9 @@ def _five_step_grm_profile():
 def test_incomplete_same_page_tries_larger_scales_before_spending_the_sheet():
     # #1338: larger scales on the selected sheet are still the first recovery lever. With
     # external text clearance included in view blocks (#1262), this synthetic detected model's
-    # overall-height dimension no longer fits beside the end view on A4, so both bounded scale
-    # candidates are rejected before the workflow spends the ISO and advances to A3.
+    # overall-height dimension no longer fits beside the end view on A4. At 10:1 the
+    # native shoulder chain is incomplete, so its earlier coverage gate rejects the
+    # proposal. Both scales fail before the workflow spends the ISO and advances to A3.
     drawing = build_drawing(_five_step_grm_profile(), pmi="off")
 
     assert (drawing.page_w, drawing.page_h) == (420.0, 297.0)
@@ -67,7 +68,7 @@ def test_incomplete_same_page_tries_larger_scales_before_spending_the_sheet():
             (297.0, 210.0),
             "rejected",
             "scale_escalation_on_selected_page",
-            "structural_error",
+            "axial_coverage_incomplete",
         ),
         ((297.0, 210.0), "rejected", "remove_optional_iso", "axial_coverage_incomplete"),
         ((420.0, 297.0), "complete", "page_escalation_after_optional_iso", None),
@@ -308,7 +309,7 @@ def test_unrelated_drop_on_a_typed_owner_does_not_borrow_its_source(monkeypatch)
 
 
 def test_complete_detail_drawing_stays_on_its_original_page(monkeypatch):
-    """#1299 does not broaden recovery beyond incomplete axial/source-owned plans."""
+    """A complete detected drawing does not spend a larger sheet to remove a detail."""
 
     class FakeDrawing:
         def __init__(self, *, page, scale, include_iso, detail):

--- a/tests/test_issue_1334_prevent_ink.py
+++ b/tests/test_issue_1334_prevent_ink.py
@@ -1,10 +1,14 @@
 """Candidate prevention: dimension ink blocks peer labels before commit (#1334)."""
 
+from types import SimpleNamespace
+
+import pytest
+from build123d import Edge
 from build123d_drafting.helpers import Draft
 
 from draftwright._core import _dim
 from draftwright._geometry import _boxes_overlap
-from draftwright.annotations._common import prevent_dimension_label_ink
+from draftwright.annotations._common import prevent_dimension_label_ink, view_label_clearance
 from draftwright.linting.ink_overlap import (
     MIN_CROSSING_MM,
     crossable_region,
@@ -26,6 +30,27 @@ def _short_chain():
             _dim((22.5, 0.0, 0.0), (32.5, 0.0, 0.0), "above", 11.0, draft, label="2"),
         ),
     ]
+
+
+@pytest.mark.parametrize("pin", (False, True))
+def test_part_edge_through_a_single_short_label_uses_the_far_tier(pin):
+    draft = Draft(font_size=3.0, arrow_length=2.7, line_width=0.1)
+    natural = _dim((20, 20, 0), (20, 23, 0), "right", 11, draft, label="3")
+    edge = Edge.make_line((29, 21.5, 0), (34, 21.5, 0))
+    clear = view_label_clearance(SimpleNamespace(views={"front": (edge,)}), "front")
+    assert not clear(natural.label_bbox)
+    [(name, selected)] = prevent_dimension_label_ink(
+        [("short", natural)],
+        page=(0, 0, 100, 100),
+        perpendicular_step=7,
+        label_clear=clear,
+        immutable={"short"} if pin else (),
+    )
+    assert name == "short" and selected.label == "3"
+    assert clear(selected.label_bbox) is not pin
+    assert (selected is natural) is pin
+    assert selected._dw_spec.p1 == natural._dw_spec.p1
+    assert selected._dw_spec.p2 == natural._dw_spec.p2
 
 
 def _connected_mixed_chain():

--- a/tests/test_issue_1372_groove_completeness_evidence.py
+++ b/tests/test_issue_1372_groove_completeness_evidence.py
@@ -676,11 +676,11 @@ def test_deleting_groove_declaration_cannot_shrink_quality_denominator() -> None
     assert complete_quality["requirements"] == sparse_quality["requirements"] == 6
     assert complete_quality["by_family"]["grooves"] == 2
     assert complete_quality["by_family"]["turned_steps"] == 4
-    # One part-global OD cannot satisfy both equal outer bands: the groove callout is placed,
-    # both step lengths are explicit drops, and both native band diameters are genuinely missing.
-    assert complete_quality["placed"] == 2
-    assert complete_quality["dropped"] == 2
-    assert complete_quality["missing"] == 2
+    # Each outer band now retains its own length and diameter claims. The global
+    # OD does not stand in for either independent diameter when its mark is lost.
+    assert complete_quality["placed"] == 6
+    assert complete_quality["dropped"] == 0
+    assert complete_quality["missing"] == 0
     assert sparse_quality["unverifiable"] == 6
-    assert complete_quality["audited_score"] == pytest.approx(1 / 3)
+    assert complete_quality["audited_score"] == 1.0
     assert sparse_quality["audited_score"] == 0.0

--- a/tests/test_issue_1374_turned_step_completeness_evidence.py
+++ b/tests/test_issue_1374_turned_step_completeness_evidence.py
@@ -226,7 +226,7 @@ def test_equal_lengths_share_ink_but_keep_every_measurement_identity() -> None:
     assert {measurement.feature.length for measurement in measurements} == {10.0}
 
 
-def test_largest_band_od_can_use_exact_rotational_od_representation() -> None:
+def test_largest_band_identity_is_carried_by_its_exact_rotational_od_mark() -> None:
     from draftwright import build_drawing
     from draftwright.linting.turned_step_coverage import turned_step_requirement_outcomes
     from draftwright.model.compiled import compile_dimensions
@@ -247,8 +247,11 @@ def test_largest_band_od_can_use_exact_rotational_od_representation() -> None:
     )
 
     assert maximum.state == "placed"
-    assert maximum.representation_feature.kind == "rotational"
-    assert maximum.representation_parameter == "od.diameter"
+    assert maximum.representation_feature is maximum.features[0]
+    assert maximum.representation_parameter == "step.diameter"
+    identities = drawing.registry.measurement_of("dim_od")
+    assert {identity.parameter for identity in identities} == {"od.diameter", "step.diameter"}
+    assert any(identity.feature is maximum.features[0] for identity in identities)
 
 
 @pytest.mark.parametrize("framed", [False, True])

--- a/tests/test_issue_1438_report_projection.py
+++ b/tests/test_issue_1438_report_projection.py
@@ -22,7 +22,7 @@ from draftwright import reporting as reporting_module
 from draftwright.linting import requirements as requirement_module
 from draftwright.registry import AnnotationRegistry
 
-_SCHEMA_PATH = Path(__file__).parents[1] / "docs/reference/draftwright-report-v2.schema.json"
+_SCHEMA_PATH = Path(__file__).parents[1] / "docs/reference/draftwright-report-v3.schema.json"
 _EVALUATION_FIXTURES = Path(__file__).parent / "fixtures" / "evaluation"
 
 
@@ -66,7 +66,7 @@ def _coincident_body_local_evidence_part():
     return Compound(children=[stepped_block(), stepped_block()])
 
 
-def test_raw_report_has_the_closed_v2_shape_and_exact_owner() -> None:
+def test_raw_report_has_the_closed_v3_shape_and_exact_owner() -> None:
     drawing = build_drawing(_through_step_part())
 
     report = drawing.report()
@@ -82,14 +82,14 @@ def test_raw_report_has_the_closed_v2_shape_and_exact_owner() -> None:
         "lint",
     }
     assert report["schema"] == "draftwright-report"
-    assert report["schema_version"] == 2
+    assert report["schema_version"] == 3
     assert report["status"] == "bounded-clear"
     assert set(report["producer"]) == {"draftwright", "quiddity"}
     assert report["source"] == {"kind": "build123d", "name": None}
     assert report["outputs"] == {}
 
     recognition = report["recognition"]
-    assert recognition["coverage"] == "accepted-occurrences"
+    assert recognition["coverage"] == "accepted-occurrences-and-profile-requirements"
     assert recognition["identity_scope"] == "report-local"
     (occurrence,) = recognition["occurrences"]
     assert occurrence == {
@@ -273,9 +273,7 @@ def test_report_requirement_projection_matches_typed_family_ledgers(fixture: str
     counts = Counter(requirement["state"] for requirement in requirements)
     completeness = report["lint"]["quality"]["completeness"]
     occurrence_ids = {occurrence["id"] for occurrence in recognition["occurrences"]}
-    owner_ids = {
-        owner["id"] for occurrence in recognition["occurrences"] for owner in occurrence["owners"]
-    }
+    owner_ids = {owner["id"] for owner in recognition["owners"]}
 
     assert len(requirements) == completeness["requirements"]
     assert all(
@@ -859,7 +857,7 @@ def test_report_projection_does_not_change_visual_output(tmp_path) -> None:
 def test_documented_schema_has_the_same_closed_top_level() -> None:
     schema = _schema()
 
-    assert schema["$id"].endswith("draftwright-report-v2.schema.json")
+    assert schema["$id"].endswith("draftwright-report-v3.schema.json")
     assert schema["additionalProperties"] is False
     assert set(schema["required"]) == {
         "schema",

--- a/tests/test_issue_1460_step_inspection.py
+++ b/tests/test_issue_1460_step_inspection.py
@@ -44,6 +44,7 @@ _SCHEMA_PATH = (
 # `view_plan` are absent because the shared one-run detect seam sizes a page and plans dimensions
 # while detecting; the pinned set below covers those.
 _FORBIDDEN_STAGES = (
+    "draftwright.model.compiled",
     "draftwright.projection",
     "draftwright.export",
     "draftwright.repair",
@@ -63,6 +64,8 @@ _EXPECTED_ENGINE_MODULES = frozenset(
         "draftwright._geometry",
         "draftwright._pmi_part21",
         "draftwright.analysis",
+        "draftwright.angular_geometry",  # pure sizing footprints, no compiled plan
+        "draftwright.profile_angles",  # pure projection of issued profile supports
         "draftwright.blend_contract",
         "draftwright.oriented_slot_contract",
         "draftwright.section_recess_contract",  # pure validated pattern projection during detect

--- a/tests/test_issue_1466_semantic_sides.py
+++ b/tests/test_issue_1466_semantic_sides.py
@@ -32,6 +32,13 @@ def grm04_scripts(tmp_path_factory):
         formats=(),
     )
     source = Path(path).read_text(encoding="utf-8")
+    # Keep this authored collision case focused on hole/location dimensions.
+    # The newly detected profile angles change packing enough to clear its
+    # original crossing before the side edit. Omit their dimension requests
+    # explicitly on both sides of the comparison, retaining their declarations.
+    angle_requests = [line for line in source.splitlines() if '"included.angle")' in line]
+    assert len(angle_requests) == 2
+    source = "\n".join(line for line in source.splitlines() if line not in angle_requests)
     assert source.count('"bore.diameter")') == 2
     assert source.count('"height.length")') == 1
     edited = source.replace('"bore.diameter")', '"bore.diameter", side="left")')

--- a/tests/test_issue_1485_curved_pockets.py
+++ b/tests/test_issue_1485_curved_pockets.py
@@ -218,9 +218,10 @@ def test_repeated_curved_pockets_keep_one_group_and_every_original_occurrence(tm
     drawing = build_drawing(part)
     recognition = drawing.recognition()
     assert len(recognition.section_recesses) == 3
-    # Released 0.2.3 repeats this exact assertion. Keep the aggregate intact while
-    # projecting one physical group, and retain all three source occurrence identities.
-    first, second = recognition.section_recess_patterns
+    # The released aggregate now emits this physical group once. Keep the
+    # consumer's exact-duplicate guard exercised with an equal-valued copy.
+    (first,) = recognition.section_recess_patterns
+    second = replace(first)
     assert first == second and first is not second
     from draftwright.section_recess_contract import distinct_section_recess_patterns
 

--- a/tests/test_issue_1504_angle_patterns.py
+++ b/tests/test_issue_1504_angle_patterns.py
@@ -1,0 +1,219 @@
+"""A quantity angle retains every independently editable corner measurement."""
+
+from dataclasses import replace
+from math import sqrt
+
+import pytest
+from build123d import Polygon, extrude
+
+from draftwright import Sheet
+from draftwright.linting.angular import profile_angle_requirement_outcomes
+from draftwright.linting.evidence import verify_measurement_claims
+from draftwright.model import AngularReference, angle_pattern
+from draftwright.model.compiled import compile_dimensions
+from draftwright.registry import AnnotationRegistry
+from draftwright.sheet_emit import emit_sheet_script
+
+
+@pytest.fixture(scope="module")
+def triangle():
+    points = ((0, 0, 3), (30, 0, 3), (15, 15 * sqrt(3), 3))
+    references = tuple(
+        AngularReference(point, points[(i + 1) % 3], points[(i + 2) % 3], sector="opposite")
+        for i, point in enumerate(points)
+    )
+    part = extrude(Polygon(*(point[:2] for point in points), align=None), amount=3)
+    return part, references
+
+
+def _sheet(triangle, *, omitted=None, tolerance=None):
+    part, references = triangle
+    sheet = Sheet(part, page="A2", scale=1)
+    handle = sheet.angle_pattern(*references)
+    if tolerance:
+        handle.tolerance(0.05, on=tolerance)
+    for parameter in handle.dimension_ids():
+        if parameter != omitted:
+            sheet.dimension(handle, parameter)
+    return sheet, handle
+
+
+def test_pattern_members_keep_referential_values_and_distinct_ids(triangle):
+    _, references = triangle
+    pattern = angle_pattern(*references)
+    parameters = pattern.parameters()
+    assert [p.parameter_id for p in parameters] == [
+        "included.angle.member1",
+        "included.angle.member2",
+        "included.angle.member3",
+    ]
+    assert [p.value for p in parameters] == pytest.approx([60, 60, 60])
+    assert tuple(p.angular_reference for p in parameters) == references
+
+
+@pytest.mark.parametrize("case", ("singleton", "duplicate", "different-angle", "different-plane"))
+def test_pattern_rejects_incoherent_members(triangle, case):
+    _, references = triangle
+    if case == "singleton":
+        references = references[:1]
+    elif case == "duplicate":
+        references = (references[0], references[0])
+    elif case == "different-angle":
+        references = (references[0], replace(references[1], second=(15, 15, 3)))
+    else:
+        moved = references[1]
+        references = (
+            references[0],
+            replace(
+                moved,
+                **{
+                    field: (getattr(moved, field)[0], getattr(moved, field)[1], 5)
+                    for field in ("vertex", "first", "second")
+                },
+            ),
+        )
+    with pytest.raises(ValueError):
+        angle_pattern(*references)
+
+
+@pytest.mark.parametrize("case", ("complete", "uniform-tolerance", "member-tolerance", "omitted"))
+def test_quantity_approval_never_hides_a_member_omission_or_tolerance(triangle, case):
+    sheet, _ = _sheet(
+        triangle,
+        omitted="included.angle.member2" if case == "omitted" else None,
+        tolerance={
+            "uniform-tolerance": "included",
+            "member-tolerance": "included.angle.member2",
+        }.get(case),
+    )
+    plan = compile_dimensions(sheet.model())
+    (group,) = plan.of_kind("angle")
+    expected = {"complete": "3× 60°", "uniform-tolerance": "3× 60° ±0.05°"}.get(case)
+    assert group.shared_label == expected
+    assert len(group.dims) == (2 if case == "omitted" else 3)
+    if case == "omitted":
+        assert [p.id.parameter for p in group.dims] == [
+            "included.angle.member1",
+            "included.angle.member3",
+        ]
+    if case == "member-tolerance":
+        assert [p.final_label for p in group.dims] == ["60°", "60° ±0.05°", "60°"]
+    drawing = sheet.build()
+    marks = [
+        (n, item) for n, item in drawing.iter_annotations() if hasattr(item, "measured_angle")
+    ]
+    assert len(marks) == (1 if expected else len(group.dims))
+    assert sorted(
+        identity.parameter
+        for name, _ in marks
+        for identity in drawing.registry.measurement_of(name)
+    ) == sorted(p.id.parameter for p in group.dims)
+    assert not [
+        finding
+        for finding in drawing.lint(physical=True)
+        if finding.code
+        in {"claimed_value_absent", "angular_label_vs_geometry", "angular_geometry_mismatch"}
+        or finding.code.startswith("angular_support_")
+    ]
+    outcomes = profile_angle_requirement_outcomes(
+        drawing.recognition_evidence(),
+        None,
+        drawing.model().features,
+        drawing.registry,
+        plan.diagnostics,
+    )
+    assert len(outcomes) == 3
+    assert sorted(outcome.state for outcome in outcomes) == (
+        ["placed", "placed", "suppressed"] if case == "omitted" else ["placed"] * 3
+    )
+
+
+@pytest.mark.parametrize("deferred", (False, True))
+def test_individual_pattern_member_can_be_replaced_through_the_shared_edit_path(
+    triangle, deferred
+):
+    sheet, _ = _sheet(triangle, tolerance="included.angle.member2")
+    drawing = sheet.build()
+    owner = drawing.model().features[0]
+    member = "included.angle.member2"
+    existing = next(
+        name
+        for name in drawing.annotations_of(owner)
+        if any(identity.parameter == member for identity in drawing.registry.measurement_of(name))
+    )
+    drawing.remove(existing)
+    if deferred:
+        with drawing.deferred():
+            drawing.dimension(owner, member, name="edited_member", priority=2)
+    else:
+        assert (
+            drawing.dimension(owner, member, name="edited_member", priority=2) == "edited_member"
+        )
+    mark = drawing.registry.named("edited_member")
+    assert mark.label == "60° ±0.05°"
+    (identity,) = drawing.registry.measurement_of("edited_member")
+    assert identity.feature is owner and identity.parameter == member
+    outcomes = verify_measurement_claims(drawing.registry, compile_dimensions(drawing.model()))
+    assert outcomes and all(outcome.state == "confirmed" for outcome in outcomes)
+
+
+def test_pattern_member_side_preferences_split_the_quantity_without_retargeting(triangle):
+    sheet = Sheet(triangle[0], page="A2", scale=1)
+    handle = sheet.angle_pattern(*triangle[1])
+    sides = ("left", "right", "above")
+    for parameter, side in zip(handle.dimension_ids(), sides, strict=True):
+        sheet.dimension(handle, parameter, side=side)
+    (group,) = compile_dimensions(sheet.model()).of_kind("angle")
+    assert group.shared_label is None
+    assert tuple(dim.side for dim in group.dims) == sides
+    drawing = sheet.build()
+    assert len(drawing.annotations_of(drawing.model().features[0])) == 3
+
+
+@pytest.fixture(scope="module")
+def built_pattern(triangle):
+    sheet, _ = _sheet(triangle)
+    return sheet, sheet.build()
+
+
+@pytest.mark.parametrize(
+    "corruption", ("quantity", "nominal", "missing-member", "duplicate-member")
+)
+def test_quantity_claim_requires_the_complete_approved_roster(built_pattern, corruption):
+    sheet, drawing = built_pattern
+    ((name, mark),) = [
+        (n, item) for n, item in drawing.iter_annotations() if hasattr(item, "measured_angle")
+    ]
+    plan = compile_dimensions(sheet.model())
+    claims = drawing.registry.measurement_of(name)
+    assert len(claims) == 3
+    original = mark.label
+    registry = AnnotationRegistry()
+    try:
+        if corruption == "quantity":
+            mark.label = "4× 60°"
+        elif corruption == "nominal":
+            mark.label = "3× 99°"
+        elif corruption == "missing-member":
+            claims = claims[:2]
+        else:
+            claims = (claims[0], claims[0], claims[2])
+        registry.add(mark, name, "plan", measurement=claims)
+        outcomes = verify_measurement_claims(registry, plan)
+        assert outcomes and all(outcome.state == "value_absent" for outcome in outcomes)
+    finally:
+        mark.label = original
+
+
+def test_pattern_round_trips_all_members_and_member_specific_tolerance(triangle, tmp_path):
+    sheet, _ = _sheet(triangle, tolerance="included.angle.member2")
+    source = emit_sheet_script(
+        sheet.model(), "part", str(tmp_path / "pattern"), title="T", number="N", formats=("svg",)
+    )
+    namespace = {"part": triangle[0]}
+    exec(source, namespace)
+    original = compile_dimensions(sheet.model()).of_kind("angle")[0]
+    replayed = compile_dimensions(namespace["sheet"].model()).of_kind("angle")[0]
+    assert [(d.id.parameter, d.angular_reference, d.final_label) for d in replayed.dims] == [
+        (d.id.parameter, d.angular_reference, d.final_label) for d in original.dims
+    ]

--- a/tests/test_issue_1504_angular_references.py
+++ b/tests/test_issue_1504_angular_references.py
@@ -1,0 +1,105 @@
+"""Angular intent must retain oriented rays before it can earn rendered ink (#1504)."""
+
+from dataclasses import replace
+from math import cos, radians, sin
+
+import pytest
+from build123d import Box
+
+from draftwright import Sheet
+from draftwright.model import AngularReference, measured_dimension
+from draftwright.sheet_emit import _measured_dimension_line
+
+
+@pytest.mark.parametrize("angle", (12.850620352742, 30, 60, 90, 120, 179))
+@pytest.mark.parametrize("length", (0.001, 1, 1000))
+def test_reference_measures_the_selected_rays_in_degrees(angle, length):
+    reference = AngularReference(
+        vertex=(4, -3, 2),
+        first=(4 + length, -3, 2),
+        second=(4 + length * cos(radians(angle)), -3 + length * sin(radians(angle)), 2),
+    )
+    assert reference.angle_degrees == pytest.approx(angle, abs=1e-8)
+    assert reference.principal_axis == "Z"
+    reversed_rays = replace(reference, first=reference.second, second=reference.first)
+    assert reversed_rays.angle_degrees == pytest.approx(angle, abs=1e-8)
+    assert reversed_rays.normal == pytest.approx(tuple(-v for v in reference.normal))
+
+
+@pytest.mark.parametrize(
+    ("changes", "message"),
+    [
+        ({"first": (0, 0, 0)}, "nonzero rays"),
+        ({"second": (2, 0, 0)}, "parallel or collinear"),
+        ({"second": (-2, 0, 0)}, "parallel or collinear"),
+        ({"vertex": (float("nan"), 0, 0)}, "finite 3-vector"),
+        ({"second": (0, float("inf"), 0)}, "finite 3-vector"),
+        ({"first": (1, 0)}, "finite 3-vector"),
+        ({"sector": "major"}, "non-reflex"),
+        ({"sector": "supplementary"}, "non-reflex"),
+        ({"virtual_vertex": "yes"}, "must be a bool"),
+    ],
+)
+def test_ambiguous_or_degenerate_references_are_refused(changes, message):
+    valid = dict(vertex=(0, 0, 0), first=(1, 0, 0), second=(0, 1, 0))
+    assert AngularReference(**valid).angle_degrees == 90
+    with pytest.raises(ValueError, match=message):
+        AngularReference(**(valid | changes))
+
+
+def test_oblique_plane_is_not_misidentified_as_a_principal_projection():
+    reference = AngularReference((0, 0, 0), (1, 1, 0), (0, 0, 1))
+    assert reference.angle_degrees == 90
+    assert reference.principal_axis == "?"
+
+
+def test_explicit_reference_survives_executed_sheet_emission():
+    # Short rays would lose their angle if the emitter rounded these points to 3dp.
+    reference = AngularReference(
+        vertex=(0, 0, 0),
+        first=(0.000123456789, 0, 0),
+        second=(0.0000617283945, 0.000106916715543, 0),
+        virtual_vertex=True,
+    )
+    original = measured_dimension(
+        kind="angular",
+        value=60,
+        label="60°",
+        dominant_axis="z",
+        ref_pts=(),
+        angular_reference=reference,
+        upper_tol=0.000123456789,
+        lower_tol=-0.000234567891,
+    )
+    line = _measured_dimension_line(original)
+    sheet = Sheet(Box(10, 10, 2))
+    sheet.authored_dimensions()
+    namespace = {"sheet": sheet}
+    exec("handle = " + line, namespace)
+    replayed = sheet.model().features[0]
+    assert replayed.angular_reference == reference
+    assert replayed.ref_pts == (reference.first, reference.vertex, reference.second)
+    assert replayed.upper_tol == original.upper_tol and replayed.lower_tol == original.lower_tol
+    assert replayed.angular_reference.angle_degrees == reference.angle_degrees
+
+
+def test_reference_cannot_disagree_with_generic_stations_or_dimension_kind():
+    reference = AngularReference((0, 0, 0), (1, 0, 0), (0, 1, 0))
+    arguments = dict(
+        kind="angular",
+        value=90,
+        label="90°",
+        dominant_axis="z",
+        ref_pts=(),
+        angular_reference=reference,
+    )
+    valid = measured_dimension(**arguments)
+    assert valid.angular_reference == reference
+    with pytest.raises(ValueError, match="ref_pts must agree"):
+        measured_dimension(**(arguments | {"ref_pts": ((0, 0, 0), (3, 0, 0))}))
+    with pytest.raises(ValueError, match="requires an angular dimension"):
+        measured_dimension(**(arguments | {"kind": "linear"}))
+    with pytest.raises(ValueError, match="requires an angular dimension"):
+        replace(valid, dimension_kind="linear")
+    with pytest.raises(ValueError, match="ref_pts must agree"):
+        replace(valid, ref_pts=((0, 0, 0), (3, 0, 0)))

--- a/tests/test_issue_1504_angular_references.py
+++ b/tests/test_issue_1504_angular_references.py
@@ -103,3 +103,23 @@ def test_reference_cannot_disagree_with_generic_stations_or_dimension_kind():
         replace(valid, dimension_kind="linear")
     with pytest.raises(ValueError, match="ref_pts must agree"):
         replace(valid, ref_pts=((0, 0, 0), (3, 0, 0)))
+
+
+@pytest.mark.parametrize(
+    ("view", "side"), [("front", "above"), ("plan", "left"), ("plan", "below")]
+)
+def test_hints_cannot_change_the_reference_plane_or_angular_sector(view, side):
+    reference = AngularReference((0, 0, 0), (1, 0, 0), (0, 1, 0))
+    arguments = dict(
+        kind="angular",
+        value=90,
+        label="90°",
+        dominant_axis="z",
+        ref_pts=(),
+        angular_reference=reference,
+    )
+    assert (
+        measured_dimension(**arguments, view="plan", side="right").angular_reference == reference
+    )
+    with pytest.raises(ValueError, match="cannot render"):
+        measured_dimension(**arguments, view=view, side=side)

--- a/tests/test_issue_1504_angular_references.py
+++ b/tests/test_issue_1504_angular_references.py
@@ -13,17 +13,20 @@ from draftwright.sheet_emit import _measured_dimension_line
 
 @pytest.mark.parametrize("angle", (12.850620352742, 30, 60, 90, 120, 179))
 @pytest.mark.parametrize("length", (0.001, 1, 1000))
-def test_reference_measures_the_selected_rays_in_degrees(angle, length):
+@pytest.mark.parametrize("sector", ("minor", "opposite"))
+def test_reference_measures_the_selected_rays_in_degrees(angle, length, sector):
     reference = AngularReference(
         vertex=(4, -3, 2),
         first=(4 + length, -3, 2),
         second=(4 + length * cos(radians(angle)), -3 + length * sin(radians(angle)), 2),
+        sector=sector,
     )
     assert reference.angle_degrees == pytest.approx(angle, abs=1e-8)
     assert reference.principal_axis == "Z"
     reversed_rays = replace(reference, first=reference.second, second=reference.first)
     assert reversed_rays.angle_degrees == pytest.approx(angle, abs=1e-8)
     assert reversed_rays.normal == pytest.approx(tuple(-v for v in reference.normal))
+    assert reference.rays[0][0] == (1 if sector == "minor" else -1)
 
 
 @pytest.mark.parametrize(
@@ -53,13 +56,15 @@ def test_oblique_plane_is_not_misidentified_as_a_principal_projection():
     assert reference.principal_axis == "?"
 
 
-def test_explicit_reference_survives_executed_sheet_emission():
+@pytest.mark.parametrize("sector", ("minor", "opposite"))
+def test_explicit_reference_survives_executed_sheet_emission(sector):
     # Short rays would lose their angle if the emitter rounded these points to 3dp.
     reference = AngularReference(
         vertex=(0, 0, 0),
         first=(0.000123456789, 0, 0),
         second=(0.0000617283945, 0.000106916715543, 0),
         virtual_vertex=True,
+        sector=sector,
     )
     original = measured_dimension(
         kind="angular",

--- a/tests/test_issue_1504_angular_rendering.py
+++ b/tests/test_issue_1504_angular_rendering.py
@@ -176,12 +176,17 @@ def test_lint_rejects_visible_ink_rotated_away_from_its_reference_sector(sector)
         if issue.code == "angular_geometry_mismatch"
     ]
     vertex = annotation.angular_points[1]
+    reference_points = annotation.angular_points
     old_box = annotation.bounding_box()
     wrong_sector = annotation.rotate(Axis((*vertex, 0), (0, 0, 1)), 180)
     assert wrong_sector.bounding_box().center() != old_box.center()
     # Deliberately replace only visible ink. Trusting the renderer's value or
     # reference metadata alone would still report a correct 60-degree angle.
-    annotation.wrapped = wrong_sector.wrapped
+    # A rotated shape can carry the rotation in its root location (build123d
+    # 0.11). Nest it in a fresh compound so only the visible ink rotates.
+    annotation.wrapped = Compound(children=[wrong_sector]).wrapped
+    assert annotation.angular_points == reference_points
+    assert annotation.bounding_box().center() == wrong_sector.bounding_box().center()
     assert annotation.measured_angle == pytest.approx(60)
     assert [
         issue

--- a/tests/test_issue_1504_angular_rendering.py
+++ b/tests/test_issue_1504_angular_rendering.py
@@ -1,0 +1,267 @@
+"""Angular placement must preserve a true projected angle and expose missing authority."""
+
+import json
+from copy import copy
+from math import cos, radians, sin
+from types import SimpleNamespace
+
+import pytest
+from build123d import Axis, Compound, Edge, GeomType, Location, Polygon, Rot, Vertex, extrude
+
+from draftwright import Sheet, build_drawing
+from draftwright.annotations.angular import AngularInk
+from draftwright.linting.angular import lint_angular_geometry
+from draftwright.model import AngularReference
+
+
+def _angle_sheet(angle=60, rotation=(0, 0, 0), **options):
+    end = (30 * cos(radians(angle)), 30 * sin(radians(angle)))
+    part = extrude(Polygon((0, 0), (30, 0), end, align=None), amount=3)
+    transform = Rot(*rotation)
+    points = ((0, 0, 3), (15, 0, 3), (end[0] / 2, end[1] / 2, 3))
+    vertex, first, second = [tuple((transform * Vertex(*point)).center()) for point in points]
+    reference = AngularReference(vertex, first, second)
+    part = transform * part
+    sheet = Sheet(part, **options)
+    sheet.measured_dimension(
+        kind="angular",
+        value=angle,
+        label=f"{angle}°",
+        dominant_axis="z",
+        ref_pts=(),
+        angular_reference=reference,
+    )
+    sheet.authored_dimensions()
+    return sheet, part, reference
+
+
+def _angle_annotation(drawing):
+    annotations = [
+        (name, item)
+        for name, item in drawing.iter_annotations()
+        if hasattr(item, "measured_angle")
+    ]
+    assert len(annotations) == 1, "one angular requirement must reach one visible mark"
+    return annotations[0]
+
+
+@pytest.fixture(scope="module")
+def drawing_draft():
+    sheet, _, _ = _angle_sheet()
+    return sheet.build().draft
+
+
+@pytest.mark.parametrize(
+    ("rotation", "view"), [((0, 0, 0), "plan"), ((0, 90, 0), "side"), ((90, 0, 0), "front")]
+)
+@pytest.mark.parametrize("angle", (60, 120))
+@pytest.mark.parametrize("scale", (1, 2))
+def test_declared_angles_use_true_views_at_each_scale(rotation, view, angle, scale):
+    sheet, _, reference = _angle_sheet(angle, rotation, scale=scale)
+    drawing = sheet.build()
+    name, annotation = _angle_annotation(drawing)
+    assert drawing.view_of(name) == view
+    assert annotation.measured_angle == pytest.approx(angle)
+    assert getattr(annotation, "measured_length", None) is None
+    assert annotation.angular_points[1] == pytest.approx(drawing.at(view, *reference.vertex)[:2])
+    assert any(edge.geom_type == GeomType.CIRCLE for edge in annotation.edges())
+    assert not [
+        issue
+        for issue in drawing.lint(physical=False)
+        if issue.code
+        in {
+            "angular_geometry_mismatch",
+            "angular_label_vs_geometry",
+            "label_vs_measured",
+            "dimension_kind_unsupported",
+            "annotation_out_of_bounds",
+        }
+    ]
+    assert [issue for issue in drawing.lint() if issue.code == "angular_support_unverifiable"]
+
+
+def test_angular_intent_enters_the_shared_corridor_trace(tmp_path):
+    sheet, part, _ = _angle_sheet()
+    output = tmp_path / "angular"
+    drawing = build_drawing(part, model=sheet.model(), scale=1, out=str(output), trace=True)
+    name, _ = _angle_annotation(drawing)
+    data = json.loads(output.with_suffix(".trace.json").read_text())
+    assert any(
+        candidate["name"] == name for solve in data["solves"] for candidate in solve["candidates"]
+    )
+    fidelity = drawing.lint_summary()["quality"]["fidelity"]
+    assert fidelity["by_code"]["angular_support_unverifiable"] == 1
+    assert fidelity["score"] < 1
+
+
+def test_insufficient_arc_clearance_is_a_reported_drop_not_a_render_exception():
+    sheet, part, _ = _angle_sheet(0.25, scale=1, scale_policy="permissive")
+    assert min(part.bounding_box().size) > 0.1, "do not hit the projected-geometry guard"
+    drawing = sheet.build()
+    assert not [item for _, item in drawing.iter_annotations() if hasattr(item, "measured_angle")]
+    assert [issue for issue in drawing.lint(physical=False) if issue.code == "pmi_dropped"]
+    assert not [
+        issue
+        for issue in drawing.lint(physical=False)
+        if issue.code == "dimension_kind_unsupported"
+    ]
+
+
+@pytest.mark.parametrize("wrong_label", ("120°", "60 mm", "60"))
+def test_angular_lint_catches_a_changed_label_without_using_the_renderer_value(wrong_label):
+    sheet, _, _ = _angle_sheet()
+    drawing = sheet.build()
+    _, annotation = _angle_annotation(drawing)
+    assert not [
+        issue
+        for issue in drawing.lint(physical=False)
+        if issue.code == "angular_label_vs_geometry"
+    ]
+    annotation.label = wrong_label
+    findings = drawing.lint(physical=False)
+    assert [issue for issue in findings if issue.code == "angular_label_vs_geometry"]
+    assert not [issue for issue in findings if issue.code == "label_vs_measured"]
+    assert drawing.lint_summary()["quality"]["fidelity"]["by_code"]["angular_label_vs_geometry"]
+
+
+def test_moved_angular_metadata_tracks_its_visible_geometry():
+    sheet, _, _ = _angle_sheet()
+    drawing = sheet.build()
+    _, annotation = _angle_annotation(drawing)
+    original = annotation.label_bbox
+    annotation.location = Location((7, 11, 0))
+    assert annotation.label_bbox == pytest.approx(
+        tuple(v + delta for v, delta in zip(original, (7, 11, 7, 11), strict=True))
+    )
+    assert not [
+        issue for issue in drawing.lint(physical=False) if issue.code.startswith("angular_")
+    ]
+
+
+def test_lint_rejects_visible_ink_rotated_away_from_its_reference_sector():
+    sheet, _, _ = _angle_sheet()
+    drawing = sheet.build()
+    _, annotation = _angle_annotation(drawing)
+    assert not [
+        issue
+        for issue in drawing.lint(physical=False)
+        if issue.code == "angular_geometry_mismatch"
+    ]
+    vertex = annotation.angular_points[1]
+    old_box = annotation.bounding_box()
+    wrong_sector = annotation.rotate(Axis((*vertex, 0), (0, 0, 1)), 180)
+    assert wrong_sector.bounding_box().center() != old_box.center()
+    # Deliberately replace only visible ink. Trusting the renderer's value or
+    # reference metadata alone would still report a correct 60-degree angle.
+    annotation.wrapped = wrong_sector.wrapped
+    assert annotation.measured_angle == pytest.approx(60)
+    assert [
+        issue
+        for issue in drawing.lint(physical=False)
+        if issue.code == "angular_geometry_mismatch"
+    ]
+    assert drawing.lint_summary()["quality"]["fidelity"]["by_code"]["angular_geometry_mismatch"]
+
+
+@pytest.mark.parametrize("angle", (12.85062, 60, 120, 175))
+@pytest.mark.parametrize("extra_radius", (0, 15))
+@pytest.mark.parametrize("rotation", (0, 90, 180, 270))
+def test_radius_dependent_footprint_contains_real_ink(
+    angle, extra_radius, rotation, drawing_draft
+):
+    # Probe the primitive, not the planner's prediction, so an under-sized
+    # footprint cannot make both sides of this check agree by construction.
+    ink = AngularInk(
+        (0, 0),
+        (15 * cos(radians(rotation)), 15 * sin(radians(rotation))),
+        (15 * cos(radians(angle + rotation)), 15 * sin(radians(angle + rotation))),
+        f"{angle}°",
+        drawing_draft,
+    )
+    radius = ink.minimum_radius + extra_radius
+    annotation = ink.build(radius)
+    predicted = ink.footprint(radius)
+    actual = annotation.bounding_box()
+    assert predicted[0] <= actual.min.X and predicted[1] <= actual.min.Y
+    assert predicted[2] >= actual.max.X and predicted[3] >= actual.max.Y
+    assert annotation.label == f"{angle}°"
+    assert lint_angular_geometry(annotation, angle) == []
+
+
+@pytest.mark.parametrize("missing", ("arrows", "extensions"))
+def test_lint_requires_visible_arrows_and_extensions(missing, drawing_draft):
+    ink = AngularInk((0, 0), (15, 0), (7.5, 15 * sin(radians(60))), "60°", drawing_draft)
+    annotation = ink.build(ink.minimum_radius)
+    assert lint_angular_geometry(annotation, 60) == []
+    if missing == "arrows":
+        children = [
+            Edge.make_circle(ink.minimum_radius, start_angle=10, end_angle=20),
+            Edge.make_circle(ink.minimum_radius, start_angle=40, end_angle=50),
+            annotation.children[2],
+        ]
+    else:
+        children = [annotation.children[0], annotation.children[1], annotation.children[3]]
+    original_edges = len(annotation.edges())
+    annotation.wrapped = Compound(children=children).wrapped
+    assert len(annotation.edges()) < original_edges
+    assert annotation.measured_angle == pytest.approx(60)
+    assert [
+        finding
+        for finding in lint_angular_geometry(annotation, 60)
+        if finding.code == "angular_geometry_mismatch"
+    ]
+
+
+@pytest.mark.parametrize("line_width", (0.1, 0.25, 0.35, 0.5, 1))
+def test_angular_lint_accepts_the_actual_extension_stroke_width(line_width, drawing_draft):
+    draft = copy(drawing_draft)
+    draft.line_width = line_width
+    ink = AngularInk((0, 0), (15, 0), (7.5, 15 * sin(radians(60))), "60°", draft)
+    annotation = ink.build(ink.minimum_radius)
+    assert annotation.edges()
+    assert lint_angular_geometry(annotation, 60) == []
+
+
+def test_reversing_witness_order_preserves_ink_and_independent_angular_reading(drawing_draft):
+    first, second = (15, 0), (7.5, 15 * sin(radians(60)))
+    forward = AngularInk((0, 0), first, second, "60°", drawing_draft)
+    reverse = AngularInk((0, 0), second, first, "60°", drawing_draft)
+    forward_ink, reverse_ink = [ink.build(ink.minimum_radius) for ink in (forward, reverse)]
+    assert reverse_ink.label_bbox == pytest.approx(forward_ink.label_bbox)
+    assert reverse_ink.measured_angle == pytest.approx(forward_ink.measured_angle)
+    swapped_metadata = SimpleNamespace(
+        label="60°",
+        angular_points=forward_ink.angular_points[::-1],
+        edges=forward_ink.edges,
+        vertices=forward_ink.vertices,
+    )
+    assert lint_angular_geometry(reverse_ink, 60) == []
+    assert lint_angular_geometry(swapped_metadata, 60) == []
+
+
+@pytest.mark.parametrize(
+    "points",
+    [
+        ((float("nan"), 0), (0, 0), (0, 1)),
+        ((0, 0), (0, 0), (0, 1)),
+        ((1, 0), (0, 0), (-1, 0)),
+        ((1, 0, 0), (0, 0, 0), (0, 1, 0)),
+    ],
+)
+def test_unusable_angular_witnesses_are_findings_not_clean_or_exceptions(points):
+    item = SimpleNamespace(label="90°", angular_points=points)
+    assert [
+        finding
+        for finding in lint_angular_geometry(item, 90)
+        if finding.code == "angular_geometry_mismatch"
+    ]
+
+
+def test_unreadable_angular_ink_is_a_finding():
+    def unreadable():
+        raise RuntimeError("circular geometry unavailable")
+
+    item = SimpleNamespace(label="90°", angular_points=((1, 0), (0, 0), (0, 1)), edges=unreadable)
+    findings = lint_angular_geometry(item, 90)
+    assert len(findings) == 1 and findings[0].code == "angular_geometry_mismatch"
+    assert "circular geometry unavailable" in findings[0].message

--- a/tests/test_issue_1504_angular_rendering.py
+++ b/tests/test_issue_1504_angular_rendering.py
@@ -265,3 +265,23 @@ def test_unreadable_angular_ink_is_a_finding():
     findings = lint_angular_geometry(item, 90)
     assert len(findings) == 1 and findings[0].code == "angular_geometry_mismatch"
     assert "circular geometry unavailable" in findings[0].message
+
+
+@pytest.mark.parametrize(
+    ("angle", "label", "displayed", "matches"),
+    [(60.04, "60.00°", 60.0, False), (1.04, "1.0°", 1.0, True), (60.04, "60.04°", 60.04, True)],
+)
+def test_angular_label_check_respects_the_displayed_precision(
+    angle, label, displayed, matches, drawing_draft
+):
+    ink = AngularInk(
+        (0, 0), (15, 0), (15 * cos(radians(angle)), 15 * sin(radians(angle))), label, drawing_draft
+    )
+    annotation = ink.build(ink.minimum_radius)
+    assert annotation.measured_angle == pytest.approx(angle)
+    incorrect = [
+        finding
+        for finding in lint_angular_geometry(annotation, displayed)
+        if finding.code == "angular_label_vs_geometry"
+    ]
+    assert bool(incorrect) is not matches

--- a/tests/test_issue_1504_angular_rendering.py
+++ b/tests/test_issue_1504_angular_rendering.py
@@ -14,13 +14,13 @@ from draftwright.linting.angular import lint_angular_geometry
 from draftwright.model import AngularReference
 
 
-def _angle_sheet(angle=60, rotation=(0, 0, 0), **options):
+def _angle_sheet(angle=60, rotation=(0, 0, 0), *, sector="minor", **options):
     end = (30 * cos(radians(angle)), 30 * sin(radians(angle)))
     part = extrude(Polygon((0, 0), (30, 0), end, align=None), amount=3)
     transform = Rot(*rotation)
     points = ((0, 0, 3), (15, 0, 3), (end[0] / 2, end[1] / 2, 3))
     vertex, first, second = [tuple((transform * Vertex(*point)).center()) for point in points]
-    reference = AngularReference(vertex, first, second)
+    reference = AngularReference(vertex, first, second, sector=sector)
     part = transform * part
     sheet = Sheet(part, **options)
     sheet.measured_dimension(
@@ -56,8 +56,9 @@ def drawing_draft():
 )
 @pytest.mark.parametrize("angle", (60, 120))
 @pytest.mark.parametrize("scale", (1, 2))
-def test_declared_angles_use_true_views_at_each_scale(rotation, view, angle, scale):
-    sheet, _, reference = _angle_sheet(angle, rotation, scale=scale)
+@pytest.mark.parametrize("sector", ("minor", "opposite"))
+def test_declared_angles_use_true_views_at_each_scale(rotation, view, angle, scale, sector):
+    sheet, _, reference = _angle_sheet(angle, rotation, scale=scale, sector=sector)
     drawing = sheet.build()
     name, annotation = _angle_annotation(drawing)
     assert drawing.view_of(name) == view
@@ -77,7 +78,7 @@ def test_declared_angles_use_true_views_at_each_scale(rotation, view, angle, sca
             "annotation_out_of_bounds",
         }
     ]
-    assert [issue for issue in drawing.lint() if issue.code == "angular_support_unverifiable"]
+    assert not [issue for issue in drawing.lint() if issue.code.startswith("angular_support_")]
 
 
 def test_angular_intent_enters_the_shared_corridor_trace(tmp_path):
@@ -90,8 +91,34 @@ def test_angular_intent_enters_the_shared_corridor_trace(tmp_path):
         candidate["name"] == name for solve in data["solves"] for candidate in solve["candidates"]
     )
     fidelity = drawing.lint_summary()["quality"]["fidelity"]
-    assert fidelity["by_code"]["angular_support_unverifiable"] == 1
-    assert fidelity["score"] < 1
+    assert fidelity["by_code"].get("angular_support_unverifiable", 0) == 0
+    assert fidelity["score"] == 1
+
+
+def test_compaction_only_considers_the_current_candidate_set(monkeypatch):
+    from draftwright.annotations import _common
+
+    place = _common.place_strip_candidates
+    checked = []
+
+    def outside_batch():
+        pytest.fail("a retry must not compact an annotation outside its candidate set")
+
+    def with_shared_options(drawing, strip, view, axis, candidates, tier, **kwargs):
+        # Corridor retries share option maps with the original batch, while
+        # their candidate list contains only the unplaced remainder.
+        assert "already_placed_angle" not in {name for name, _build in candidates}
+        kwargs["compact_candidates"] = {
+            **(kwargs.get("compact_candidates") or {}),
+            "already_placed_angle": outside_batch,
+        }
+        checked.append(bool(candidates))
+        return place(drawing, strip, view, axis, candidates, tier, **kwargs)
+
+    monkeypatch.setattr(_common, "place_strip_candidates", with_shared_options)
+    sheet, _, _ = _angle_sheet()
+    _angle_annotation(sheet.build())
+    assert any(checked)
 
 
 def test_insufficient_arc_clearance_is_a_reported_drop_not_a_render_exception():
@@ -138,8 +165,9 @@ def test_moved_angular_metadata_tracks_its_visible_geometry():
     ]
 
 
-def test_lint_rejects_visible_ink_rotated_away_from_its_reference_sector():
-    sheet, _, _ = _angle_sheet()
+@pytest.mark.parametrize("sector", ("minor", "opposite"))
+def test_lint_rejects_visible_ink_rotated_away_from_its_reference_sector(sector):
+    sheet, _, _ = _angle_sheet(sector=sector)
     drawing = sheet.build()
     _, annotation = _angle_annotation(drawing)
     assert not [
@@ -166,8 +194,9 @@ def test_lint_rejects_visible_ink_rotated_away_from_its_reference_sector():
 @pytest.mark.parametrize("angle", (12.85062, 60, 120, 175))
 @pytest.mark.parametrize("extra_radius", (0, 15))
 @pytest.mark.parametrize("rotation", (0, 90, 180, 270))
+@pytest.mark.parametrize("sector", ("minor", "opposite"))
 def test_radius_dependent_footprint_contains_real_ink(
-    angle, extra_radius, rotation, drawing_draft
+    angle, extra_radius, rotation, drawing_draft, sector
 ):
     # Probe the primitive, not the planner's prediction, so an under-sized
     # footprint cannot make both sides of this check agree by construction.
@@ -177,6 +206,7 @@ def test_radius_dependent_footprint_contains_real_ink(
         (15 * cos(radians(angle + rotation)), 15 * sin(radians(angle + rotation))),
         f"{angle}°",
         drawing_draft,
+        sector=sector,
     )
     radius = ink.minimum_radius + extra_radius
     annotation = ink.build(radius)

--- a/tests/test_issue_1504_canonical_angles.py
+++ b/tests/test_issue_1504_canonical_angles.py
@@ -1,0 +1,248 @@
+"""An angle is a named compiled measurement, including tolerances and omissions."""
+
+from dataclasses import replace
+from math import cos, radians, sin, sqrt
+
+import pytest
+from build123d import Polygon, extrude
+
+from draftwright import Sheet, build_drawing
+from draftwright.audit import compare_measurements
+from draftwright.model import AngularReference, angle
+from draftwright.model.compiled import compile_dimensions
+from draftwright.sheet_emit import emit_sheet_script
+
+
+@pytest.fixture(scope="module")
+def angle_part():
+    return extrude(Polygon((0, 0), (30, 0), (15, 15 * sqrt(3)), align=None), amount=3)
+
+
+def _declared(part, tolerance=None, *, scale=1):
+    sheet = Sheet(part, scale=scale)
+    handle = sheet.angle(vertex=(0, 0, 3), first=(15, 0, 3), second=(7.5, 7.5 * sqrt(3), 3))
+    if tolerance is not None:
+        handle.tolerance(*tolerance, on="included.angle")
+    sheet.dimension(handle, "included.angle")
+    return sheet, handle
+
+
+def _approved(model):
+    return [entry for group in compile_dimensions(model).of_kind("angle") for entry in group.dims]
+
+
+@pytest.mark.parametrize(
+    ("tolerance", "label"),
+    [
+        (None, "60°"),
+        ((0.05,), "60° ±0.05°"),
+        ((0.0, 0.1), "60° +0.1° -0.0°"),
+        ((0.000000123,), "60° ±0.000000123°"),
+    ],
+)
+@pytest.mark.parametrize("scale", (None, 1))
+def test_canonical_angle_and_complete_tolerance_reach_the_same_mark(
+    angle_part, tolerance, label, scale
+):
+    sheet, handle = _declared(angle_part, tolerance, scale=scale)
+    assert handle.dimension_ids() == ("included.angle",)
+    (entry,) = _approved(sheet.model())
+    assert entry.value == pytest.approx(60)
+    assert entry.final_label == label and entry.angular_reference is not None
+    drawing = sheet.build()
+    marks = [
+        (name, item)
+        for name, item in drawing.iter_annotations()
+        if hasattr(item, "measured_angle")
+    ]
+    assert len(marks) == 1 and marks[0][1].label == label
+    (identity,) = drawing.registry.measurement_of(marks[0][0])
+    assert identity.parameter == "included.angle" and identity.feature is entry.id.feature
+    assert compare_measurements(drawing, drawing)["status"] == "preserved"
+
+
+def test_omission_removes_angular_ink_and_reports_a_lost_named_measurement(angle_part):
+    sheet, _ = _declared(angle_part)
+    model = sheet.model()
+    assert len(_approved(model)) == 1
+    omitted = replace(model, authored_dimensions=())
+    assert _approved(omitted) == []
+    plan = compile_dimensions(omitted)
+    assert any(
+        item.parameter_id == "included.angle" and "authored" in item.reason
+        for item in plan.diagnostics
+    )
+    before, after = [build_drawing(angle_part, model=value, scale=1) for value in (model, omitted)]
+    comparison = compare_measurements(before, after)
+    assert comparison["status"] == "changed"
+    assert [item["parameter_id"] for item in comparison["lost"]] == ["included.angle"]
+    assert not [item for _, item in after.iter_annotations() if hasattr(item, "measured_angle")]
+
+
+def test_script_executes_with_exact_references_and_small_tolerances(angle_part, tmp_path):
+    sheet, _ = _declared(angle_part, (0.000000123,))
+    source = emit_sheet_script(
+        sheet.model(), "part", str(tmp_path / "angle"), title="T", number="N", formats=("svg",)
+    )
+    namespace = {"part": angle_part}
+    exec(source, namespace)
+    (original,) = _approved(sheet.model())
+    (replayed,) = _approved(namespace["sheet"].model())
+    assert replayed.angular_reference == original.angular_reference
+    assert replayed.final_label == original.final_label
+    assert (tmp_path / "angle.svg").is_file()
+
+
+def test_equal_valued_support_substitution_is_not_reported_preserved(angle_part):
+    sheet, _ = _declared(angle_part)
+    old = sheet.model()
+    owner = old.features[0]
+    reference = owner.angular_reference
+    moved = replace(reference, vertex=(3, 0, 3), first=(18, 0, 3), second=(10.5, 7.5 * sqrt(3), 3))
+    replacement = replace(owner, angular_reference=moved)
+    new = replace(
+        old,
+        features=(replacement,),
+        authored_dimensions=tuple(
+            replace(request, feature=replacement) for request in old.authored_dimensions
+        ),
+    )
+    assert _approved(old)[0].value == _approved(new)[0].value
+    before, after = [build_drawing(angle_part, model=model, scale=1) for model in (old, new)]
+    comparison = compare_measurements(before, after, feature_pairs=((owner, replacement),))
+    assert comparison["status"] == "changed" and comparison["changed"]
+
+
+def test_angular_options_cannot_choose_a_distorted_view_or_opposite_sector(angle_part):
+    sheet, handle = _declared(angle_part)
+    assert sheet.validate_dimension(handle, "included.angle", view="plan", side="right")[
+        "supported"
+    ]
+    assert not sheet.validate_dimension(handle, "included.angle", view="front")["supported"]
+    assert not sheet.validate_dimension(handle, "included.angle", side="left")["supported"]
+
+
+def test_canonical_oblique_angle_is_refused_before_it_can_select_an_apparent_view():
+    reference = AngularReference((0, 0, 0), (1, 1, 0), (0, 0, 1))
+    assert reference.principal_axis == "?"
+    with pytest.raises(ValueError, match="oblique is unsupported"):
+        angle(vertex=reference.vertex, first=reference.first, second=reference.second)
+
+
+@pytest.mark.parametrize(
+    ("deferred", "pin", "priority"), ((False, True, 2), (True, True, 2), (True, False, 3))
+)
+def test_live_and_deferred_edits_preserve_the_compiled_angle_and_pin(
+    angle_part, tmp_path, deferred, pin, priority
+):
+    sheet, _ = _declared(angle_part, (0.05,))
+    drawing = build_drawing(
+        angle_part, model=sheet.model(), scale=1, trace=True, out=str(tmp_path / "edit")
+    )
+    owner = drawing.model().features[0]
+    before = drawing.measurement_snapshot()
+    drawing.drop(owner)
+    assert not drawing.annotations_of(owner)
+    if deferred:
+        with drawing.deferred():
+            drawing.dimension(
+                owner, "included.angle", name="edited_angle", pin=pin, priority=priority
+            )
+    else:
+        assert (
+            drawing.dimension(
+                owner, "included.angle", name="edited_angle", pin=pin, priority=priority
+            )
+            == "edited_angle"
+        )
+    assert drawing.registry.is_pinned("edited_angle") is pin
+    assert drawing.registry.named("edited_angle").label == "60° ±0.05°"
+    assert compare_measurements(before, drawing)["status"] == "preserved"
+    candidates = [
+        candidate
+        for solve in drawing.solve_trace.solves
+        for candidate in solve["candidates"]
+        if candidate["name"] == "edited_angle"
+    ]
+    assert candidates and all(candidate["anchored"] is pin for candidate in candidates)
+    assert all(
+        candidate["priority"] == (max(priority, 100) if pin else priority)
+        for candidate in candidates
+    )
+
+
+def test_omitting_an_approved_angular_tolerance_is_not_a_confirmed_claim(angle_part):
+    sheet, _ = _declared(angle_part, (0.05,))
+    drawing = sheet.build()
+    assert not [finding for finding in drawing.lint() if finding.code == "claimed_value_absent"]
+    mark = drawing.registry.named("m_angle_0")
+    assert mark.label == "60° ±0.05°"
+    mark.label = "60°"
+    assert mark.measured_angle == pytest.approx(60)
+    assert [finding for finding in drawing.lint() if finding.code == "claimed_value_absent"]
+    assert drawing.measurement_snapshot().unknown
+
+
+@pytest.mark.parametrize(
+    ("options", "message"),
+    [
+        ({"param": "length"}, "included.angle"),
+        ({"view": "front"}, "cannot render"),
+        ({"side": "left"}, "cannot render"),
+        ({"label": "120°"}, "unsupported angular edit controls"),
+    ],
+)
+def test_angular_edits_refuse_wrong_measurements_views_and_raw_content(
+    angle_part, options, message
+):
+    sheet, _ = _declared(angle_part)
+    drawing = sheet.build()
+    owner = drawing.model().features[0]
+    arguments = {"param": "included.angle", **options}
+    before = drawing.measurement_snapshot()
+    with pytest.raises(ValueError, match=message):
+        drawing.dimension(owner, **arguments)
+    assert compare_measurements(before, drawing)["status"] == "preserved"
+
+
+def test_an_equal_valued_foreign_angle_does_not_acquire_edit_authority(angle_part):
+    sheet, _ = _declared(angle_part)
+    drawing = sheet.build()
+    owner = drawing.model().features[0]
+    foreign = replace(owner)
+    assert owner == foreign and owner is not foreign
+    with pytest.raises(ValueError, match="exact feature"):
+        drawing.dimension(foreign, "included.angle")
+
+
+@pytest.mark.parametrize("tolerance", (-0.1, float("inf"), float("nan")))
+def test_invalid_angular_tolerances_fail_before_ink(angle_part, tolerance):
+    sheet, _ = _declared(angle_part, (tolerance,))
+    with pytest.raises(ValueError, match="angular tolerance"):
+        compile_dimensions(sheet.model())
+
+
+def test_unplaceable_canonical_angle_reports_its_measurement_identity():
+    theta = radians(0.25)
+    part = extrude(
+        Polygon((0, 0), (30, 0), (30 * cos(theta), 30 * sin(theta)), align=None), amount=3
+    )
+    assert min(part.bounding_box().size) > 0.1
+    sheet = Sheet(part, scale=1, scale_policy="permissive")
+    handle = sheet.angle(
+        vertex=(0, 0, 3), first=(15, 0, 3), second=(15 * cos(theta), 15 * sin(theta), 3)
+    )
+    sheet.dimension(handle, "included.angle")
+    assert len(_approved(sheet.model())) == 1
+    drawing = sheet.build()
+    findings = [
+        finding
+        for finding in drawing.lint(physical=False)
+        if finding.code == "angular_dimension_dropped"
+    ]
+    assert findings and any(
+        key.parameter == "included.angle" and key.feature is drawing.model().features[0]
+        for finding in findings
+        for key in finding.measurement_ids
+    )
+    assert not [item for _, item in drawing.iter_annotations() if hasattr(item, "measured_angle")]

--- a/tests/test_issue_1504_canonical_angles.py
+++ b/tests/test_issue_1504_canonical_angles.py
@@ -1,15 +1,26 @@
 """An angle is a named compiled measurement, including tolerances and omissions."""
 
+import json
 from dataclasses import replace
-from math import cos, radians, sin, sqrt
+from math import acos, cos, dist, pi, radians, sin, sqrt, tan
+from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
-from build123d import Polygon, extrude
+from build123d import Axis, Cylinder, GeomType, Polygon, Pos, extrude, fillet
+from jsonschema import ValidationError
+from jsonschema.validators import validator_for
 
-from draftwright import Sheet, build_drawing
+from draftwright import ReportUnavailableError, Sheet, build_drawing
 from draftwright.audit import compare_measurements
+from draftwright.linting.angular import (
+    lint_angular_supports,
+    profile_angle_requirement_outcomes,
+)
 from draftwright.model import AngularReference, angle
 from draftwright.model.compiled import compile_dimensions
+from draftwright.profile_angles import profile_angle_repetitions
+from draftwright.reporting import drawing_report
 from draftwright.sheet_emit import emit_sheet_script
 
 
@@ -18,9 +29,11 @@ def angle_part():
     return extrude(Polygon((0, 0), (30, 0), (15, 15 * sqrt(3)), align=None), amount=3)
 
 
-def _declared(part, tolerance=None, *, scale=1):
+def _declared(part, tolerance=None, *, scale=1, sector="minor"):
     sheet = Sheet(part, scale=scale)
-    handle = sheet.angle(vertex=(0, 0, 3), first=(15, 0, 3), second=(7.5, 7.5 * sqrt(3), 3))
+    handle = sheet.angle(
+        vertex=(0, 0, 3), first=(15, 0, 3), second=(7.5, 7.5 * sqrt(3), 3), sector=sector
+    )
     if tolerance is not None:
         handle.tolerance(*tolerance, on="included.angle")
     sheet.dimension(handle, "included.angle")
@@ -41,10 +54,11 @@ def _approved(model):
     ],
 )
 @pytest.mark.parametrize("scale", (None, 1))
+@pytest.mark.parametrize("sector", ("minor", "opposite"))
 def test_canonical_angle_and_complete_tolerance_reach_the_same_mark(
-    angle_part, tolerance, label, scale
+    angle_part, tolerance, label, scale, sector
 ):
-    sheet, handle = _declared(angle_part, tolerance, scale=scale)
+    sheet, handle = _declared(angle_part, tolerance, scale=scale, sector=sector)
     assert handle.dimension_ids() == ("included.angle",)
     (entry,) = _approved(sheet.model())
     assert entry.value == pytest.approx(60)
@@ -79,8 +93,9 @@ def test_omission_removes_angular_ink_and_reports_a_lost_named_measurement(angle
     assert not [item for _, item in after.iter_annotations() if hasattr(item, "measured_angle")]
 
 
-def test_script_executes_with_exact_references_and_small_tolerances(angle_part, tmp_path):
-    sheet, _ = _declared(angle_part, (0.000000123,))
+@pytest.mark.parametrize("sector", ("minor", "opposite"))
+def test_script_executes_with_exact_references_and_small_tolerances(angle_part, tmp_path, sector):
+    sheet, _ = _declared(angle_part, (0.000000123,), sector=sector)
     source = emit_sheet_script(
         sheet.model(), "part", str(tmp_path / "angle"), title="T", number="N", formats=("svg",)
     )
@@ -90,6 +105,12 @@ def test_script_executes_with_exact_references_and_small_tolerances(angle_part, 
     (replayed,) = _approved(namespace["sheet"].model())
     assert replayed.angular_reference == original.angular_reference
     assert replayed.final_label == original.final_label
+    marks = [
+        item
+        for _, item in namespace["drawing"].iter_annotations()
+        if hasattr(item, "measured_angle")
+    ]
+    assert len(marks) == 1 and marks[0].label == original.final_label
     assert (tmp_path / "angle.svg").is_file()
 
 
@@ -169,6 +190,23 @@ def test_live_and_deferred_edits_preserve_the_compiled_angle_and_pin(
         candidate["priority"] == (max(priority, 100) if pin else priority)
         for candidate in candidates
     )
+    if pin:
+        label = drawing.registry.named("edited_angle").label_bbox
+        positions = [
+            (stage["axis"], item.get("strip_pos", item["pos"]), stage["span"])
+            for solve in drawing.solve_trace.solves
+            for stage in solve["passes"]
+            for item in stage["placed"]
+            if item["name"] == "edited_angle"
+        ]
+        assert positions
+        for axis, position, span in positions:
+            index = 0 if axis == "x" else 1
+            centre = (label[index] + label[index + 2]) / 2
+            assert centre == pytest.approx(position)
+            # A pin cannot be recovered at a compact position outside the
+            # chosen strip merely because its smaller ink happens to be clear.
+            assert span[0] - 1e-6 <= centre <= span[1] + 1e-6
 
 
 def test_omitting_an_approved_angular_tolerance_is_not_a_confirmed_claim(angle_part):
@@ -181,6 +219,88 @@ def test_omitting_an_approved_angular_tolerance_is_not_a_confirmed_claim(angle_p
     assert mark.measured_angle == pytest.approx(60)
     assert [finding for finding in drawing.lint() if finding.code == "claimed_value_absent"]
     assert drawing.measurement_snapshot().unknown
+
+
+@pytest.mark.parametrize("corruption", ("floating-witnesses", "wrong-vertex"))
+def test_declared_rays_do_not_prove_their_own_physical_supports(angle_part, corruption):
+    sheet, _ = _declared(angle_part)
+    model = sheet.model()
+    owner = model.features[0]
+    reference = owner.angular_reference
+    if corruption == "floating-witnesses":
+        reference = replace(reference, first=(45, 0, 3), second=(22.5, 22.5 * sqrt(3), 3))
+    else:
+        reference = AngularReference(
+            *(
+                tuple(x + offset for x, offset in zip(point, (5, 5, 0), strict=True))
+                for point in (reference.vertex, reference.first, reference.second)
+            )
+        )
+    changed = replace(owner, angular_reference=reference)
+    model = replace(
+        model,
+        features=(changed,),
+        authored_dimensions=tuple(
+            replace(request, feature=changed) for request in model.authored_dimensions
+        ),
+    )
+    drawing = build_drawing(angle_part, model=model, scale=1)
+    assert drawing.registry.named("m_angle_0").label == "60°"
+    issues = drawing.lint()
+    assert not [issue for issue in issues if issue.code == "angular_geometry_mismatch"]
+    assert [issue.code for issue in issues if issue.code.startswith("angular_support_")] == [
+        "angular_support_unverifiable"
+    ]
+    assert drawing.lint_summary()["quality"]["fidelity"]["score"] < 1
+
+
+@pytest.mark.parametrize("case", ("valid", "omitted", "duplicate", "floating", "absent"))
+def test_declared_angle_coverage_requires_a_unique_finite_physical_corner(angle_part, case):
+    sheet, _ = _declared(angle_part)
+    drawing = sheet.build()
+    assert drawing.recognition_ownership() is None
+    evidence = drawing.recognition_evidence()
+    model = drawing.model()
+    owner = model.features[0]
+    features, omissions = model.features, ()
+    if case == "duplicate":
+        features = (*features, replace(owner))
+    elif case == "floating":
+        features = (
+            replace(
+                owner,
+                angular_reference=replace(
+                    owner.angular_reference, first=(45, 0, 3), second=(22.5, 22.5 * sqrt(3), 3)
+                ),
+            ),
+        )
+    elif case == "absent":
+        features = ()
+    elif case == "omitted":
+        for name in tuple(drawing.annotations_of(owner)):
+            drawing.remove(name)
+        omissions = (SimpleNamespace(feature=owner, parameter_id="included.angle", authored=True),)
+    outcomes = profile_angle_requirement_outcomes(
+        evidence, None, features, drawing.registry, omissions
+    )
+    assert len(outcomes) == 3, "all physical corners remain, including undeclared corners"
+    (corner,) = [
+        outcome for outcome in outcomes if dist(outcome.source_profile.vertex, (0, 0, 3)) < 1e-6
+    ]
+    assert (
+        corner.state
+        == {
+            "valid": "placed",
+            "omitted": "suppressed",
+            "duplicate": "unverifiable",
+            "floating": "unverifiable",
+            "absent": "unverifiable",
+        }[case]
+    )
+    assert sum(outcome.state == "unverifiable" for outcome in outcomes) == (
+        2 if case in {"valid", "omitted"} else 3
+    )
+    assert drawing.recognition_ownership() is None, "physical critique must not invent ownership"
 
 
 @pytest.mark.parametrize(
@@ -246,3 +366,398 @@ def test_unplaceable_canonical_angle_reports_its_measurement_identity():
         for key in finding.measurement_ids
     )
     assert not [item for _, item in drawing.iter_annotations() if hasattr(item, "measured_angle")]
+
+
+@pytest.fixture(scope="module")
+def rounded_flange_drawings():
+    vertices = tuple(
+        (
+            (60 if index % 2 == 0 else 40) * cos(pi / 6 + index * pi / 3),
+            (60 if index % 2 == 0 else 40) * sin(pi / 6 + index * pi / 3),
+            3,
+        )
+        for index in range(6)
+    )
+    part = extrude(Polygon(*(point[:2] for point in vertices), align=None), amount=6)
+    angles = []
+    for index, vertex in enumerate(vertices):
+        radius = 3 if index % 2 == 0 else 8
+        edge = min(
+            part.edges().filter_by(Axis.Z), key=lambda item: dist(tuple(item.center()), vertex)
+        )
+        assert dist(tuple(edge.center()), vertex) < 1e-6
+        part = fillet(edge, radius)
+        rays = [
+            tuple((p - v) / dist(point, vertex) for p, v in zip(point, vertex, strict=True))
+            for point in (vertices[index - 1], vertices[(index + 1) % 6])
+        ]
+        included = acos(sum(a * b for a, b in zip(*rays, strict=True)))
+        tangent = radius / tan(included / 2)
+        points = [tuple(v + tangent * u for v, u in zip(vertex, ray, strict=True)) for ray in rays]
+        angles.append(
+            angle(
+                vertex=(*vertex[:2], 6),
+                first=(*points[0][:2], 6),
+                second=(*points[1][:2], 6),
+                virtual_vertex=True,
+                sector="opposite",
+            )
+        )
+    for index in range(3):
+        theta = pi / 6 + index * 2 * pi / 3
+        part -= Pos(20 * cos(theta), 20 * sin(theta), 3) * Cylinder(3, 12)
+    cap = part.faces().filter_by(GeomType.PLANE).sort_by(Axis.Z)[-1]
+    assert len(cap.outer_wire().edges()) == 12
+    assert len(cap.inner_wires()) == 3
+    options = dict(scale=1, scale_policy="permissive", page="A2")
+    after = build_drawing(part, **options)
+    detected = tuple(feature for feature in after.model().features if feature.kind == "angle")
+    assert len(detected) == 2
+    detected_references = tuple(
+        parameter.angular_reference for feature in detected for parameter in feature.parameters()
+    )
+    assert len(detected_references) == len(angles) == 6
+    for authored in angles:
+        expected = authored.angular_reference
+        actual = min(
+            detected_references, key=lambda reference: dist(reference.vertex, expected.vertex)
+        )
+        assert actual.vertex == pytest.approx(expected.vertex)
+        assert actual.virtual_vertex and actual.sector == expected.sector
+        for point in (expected.first, expected.second):
+            assert min(dist(point, actual.first), dist(point, actual.second)) < 1e-6
+    model = replace(
+        after.model(),
+        features=tuple(feature for feature in after.model().features if feature.kind != "angle"),
+    )
+    before = build_drawing(part, model=model, **options)
+    return before, after, detected
+
+
+def test_rounded_flange_keeps_all_six_corner_angles_and_existing_claims(rounded_flange_drawings):
+    before, after, angles = rounded_flange_drawings
+    # Independent construction: the alternating turns sum to 720 degrees.
+    expected = (2 * 180 / pi * acos(2 / sqrt(7)), 240 - 2 * 180 / pi * acos(2 / sqrt(7)))
+    assert sorted(
+        parameter.value for item in angles for parameter in item.parameters()
+    ) == pytest.approx(sorted(expected * 3))
+    for feature in angles:
+        marks = [
+            item
+            for item in after.annotations_of(feature).values()
+            if hasattr(item, "measured_angle")
+        ]
+        assert len(marks) == 1
+        assert marks[0].label.startswith("3× ")
+        assert marks[0].arc_radius < 40, "a corner dimension must not expand across the whole part"
+    old = {(id(c.owner), c.parameter): c.meaning for c in before.measurement_snapshot().claims}
+    new = {(id(c.owner), c.parameter): c.meaning for c in after.measurement_snapshot().claims}
+    assert old and {kind for _owner, kind in old} >= {"bore.diameter", "blend.radius"}
+    assert all(new.get(key) == value for key, value in old.items())
+    assert not [issue for issue in after.lint(physical=False) if issue.code.startswith("angular_")]
+
+
+def test_detected_rounded_angles_have_same_run_support_ownership(rounded_flange_drawings):
+    _before, drawing, angles = rounded_flange_drawings
+    evidence = drawing.recognition_evidence()
+    bindings = drawing.recognition_ownership().profile_angles
+    assert len(bindings) == sum(len(feature.parameters()) for feature in angles) == 6
+    for feature in angles:
+        for parameter in feature.parameters():
+            (binding,) = [
+                binding
+                for binding in bindings
+                if binding.feature is feature and binding.parameter_id == parameter.parameter_id
+            ]
+            source = binding.requirement
+            assert evidence.planar_outer_profile(source.source.face) is source.source
+            reference = parameter.angular_reference
+            assert source.vertex == reference.vertex and source.virtual_vertex
+            for index, point in (
+                (source.first_index, reference.first),
+                (source.second_index, reference.second),
+            ):
+                edge = evidence.profile_edge(source.source, index)
+                assert min(dist(point, tuple(edge.position_at(t))) for t in (0, 1)) < 1e-6
+    assert not [issue for issue in drawing.lint() if issue.code.startswith("angular_support_")]
+    repetitions = profile_angle_repetitions(evidence)
+    assert len(repetitions) == 2
+    assert [len(group.members) for group in repetitions] == [3, 3]
+    assert {
+        (member.source.face, member.first_index, member.second_index)
+        for group in repetitions
+        for member in group.members
+    } == {
+        (
+            binding.requirement.source.face,
+            binding.requirement.first_index,
+            binding.requirement.second_index,
+        )
+        for binding in bindings
+    }
+
+
+def test_a_self_consistent_angle_moved_off_its_part_supports_is_contradicted(
+    rounded_flange_drawings, monkeypatch
+):
+    _before, drawing, angles = rounded_flange_drawings
+    name, mark = next(iter(drawing.annotations_of(angles[0]).items()))
+    monkeypatch.setattr(mark, "location", mark.location * Pos(5, 0, 0))
+    issues = drawing.lint()
+    assert not [issue for issue in issues if issue.code == "angular_geometry_mismatch"]
+    mismatches = [issue for issue in issues if issue.code == "angular_support_mismatch"]
+    assert len(mismatches) == 1
+    assert mismatches[0].measurement_ids == drawing.registry.measurement_of(name)
+    assert (
+        drawing.lint_summary()["quality"]["fidelity"]["by_code"]["angular_support_mismatch"] == 1
+    )
+
+
+@pytest.mark.parametrize("corruption", ("absent-owner", "equal-copy", "absent-binding"))
+def test_profile_denominator_survives_lost_ir_or_conversion_binding(
+    rounded_flange_drawings, corruption
+):
+    _before, drawing, angles = rounded_flange_drawings
+    ownership = drawing.recognition_ownership()
+    features = drawing.model().features
+    if corruption == "absent-binding":
+        ownership = replace(ownership, profile_angles=())
+    else:
+        features = tuple(
+            replace(feature) if corruption == "equal-copy" and feature is angles[0] else feature
+            for feature in features
+            if corruption != "absent-owner" or feature is not angles[0]
+        )
+    outcomes = profile_angle_requirement_outcomes(
+        drawing.recognition_evidence(), ownership, features, drawing.registry
+    )
+    assert len(outcomes) == 6, "IR removal cannot shrink the six physical corner requirements"
+    assert sum(item.state == "placed" for item in outcomes) == (
+        0 if corruption == "absent-binding" else 3
+    )
+    assert sum(item.state == "unverifiable" for item in outcomes) == (
+        6 if corruption == "absent-binding" else 0
+    )
+    assert sum(item.state == "missing" for item in outcomes) == (
+        0 if corruption == "absent-binding" else 3
+    )
+
+
+def test_removing_an_angle_reduces_coverage_and_keeps_its_profile_source_in_report(
+    rounded_flange_drawings,
+):
+    _before, drawing, angles = rounded_flange_drawings
+    before = drawing.lint_summary()["quality"]["completeness"]
+    assert before["by_family"]["outer_profile_angles"] == 6
+    name = next(iter(drawing.annotations_of(angles[0])))
+    saved_registry, saved_items = drawing.registry.snapshot(), list(drawing.items)
+    drawing.remove(name)
+    try:
+        after = drawing.lint_summary()["quality"]["completeness"]
+        assert after["requirements"] == before["requirements"]
+        assert after["placed"] == before["placed"] - 3
+        assert after["missing"] == before["missing"] + 3
+        assert [
+            issue.code for issue in drawing.lint() if issue.code.startswith("angular_requirement_")
+        ] == ["angular_requirement_missing"] * 3
+        report = drawing.report()
+        rows = [
+            row
+            for row in report["recognition"]["requirements"]
+            if row["family"] == "outer_profile_angles"
+        ]
+        assert len(rows) == 6 and sum(row["state"] == "missing" for row in rows) == 3
+        assert all(row["occurrence_ids"] == [] and len(row["owner_ids"]) == 1 for row in rows)
+        assert all(row["profile_source"]["kind"] == "planar_outer_profile" for row in rows)
+        assert (
+            len(
+                {
+                    (
+                        row["profile_source"]["profile_id"],
+                        tuple(row["profile_source"]["support_ids"]),
+                    )
+                    for row in rows
+                }
+            )
+            == 6
+        )
+        schema = json.loads(
+            (
+                Path(__file__).parents[1] / "docs/reference/draftwright-report-v3.schema.json"
+            ).read_text()
+        )
+        validator_for(schema).check_schema(schema)
+        validator = validator_for(schema)(schema)
+        validator.validate(report)
+        # A profile requirement cannot masquerade as an accepted occurrence,
+        # and losing its source cannot produce a valid empty-source requirement.
+        original = dict(rows[0])
+        for malformed in (
+            {key: value for key, value in original.items() if key != "profile_source"},
+            {**original, "occurrence_ids": ["invented:1"]},
+            {
+                **original,
+                "profile_source": {
+                    **original["profile_source"],
+                    "support_ids": ["support:1", "support:1"],
+                },
+            },
+        ):
+            rows[0].clear()
+            rows[0].update(malformed)
+            with pytest.raises(ValidationError):
+                validator.validate(report)
+        rows[0].clear()
+        rows[0].update(original)
+    finally:
+        drawing.registry.restore(saved_registry)
+        drawing.items[:] = saved_items
+
+
+@pytest.mark.parametrize("corruption", ("missing-requirement", "unissued-source-copy"))
+def test_report_refuses_a_shrunken_or_foreign_profile_denominator(
+    rounded_flange_drawings, corruption
+):
+    from draftwright.linting.requirements import recognized_requirement_outcomes
+
+    _before, drawing, _angles = rounded_flange_drawings
+    evidence, ownership, model = (
+        drawing.recognition_evidence(),
+        drawing.recognition_ownership(),
+        drawing.model(),
+    )
+    outcomes = dict(
+        recognized_requirement_outcomes(
+            evidence.result,
+            model.features,
+            drawing.registry,
+            (),
+            evidence=evidence,
+            ownership=ownership,
+        )
+    )
+    corners = outcomes["outer_profile_angles"]
+    assert len(corners) == 6
+    if corruption == "missing-requirement":
+        outcomes["outer_profile_angles"] = corners[1:]
+    else:
+        requirement = corners[0].source_profile
+        source = requirement.source
+        unissued = SimpleNamespace(
+            face=source.face, profile=source.profile, body_faces=source.body_faces
+        )
+        copied = replace(requirement, source=unissued)
+        outcomes["outer_profile_angles"] = (
+            replace(corners[0], source_profile=copied),
+            *corners[1:],
+        )
+    with pytest.raises(ReportUnavailableError, match="profile requirement ledger"):
+        drawing_report(
+            evidence=evidence,
+            ownership=ownership,
+            model=model,
+            lint={},
+            source=None,
+            registry=drawing.registry,
+            requirement_outcomes=outcomes,
+        )
+
+
+@pytest.mark.parametrize(
+    "corruption",
+    (
+        "same-value-corner",
+        "absent-authority",
+        "physical-edge",
+        "equal-copy-owner",
+        "unshown-member",
+        "absent-repetition",
+    ),
+)
+def test_angular_support_proof_requires_the_exact_binding_and_actual_edges(
+    rounded_flange_drawings, monkeypatch, corruption
+):
+    _before, drawing, angles = rounded_flange_drawings
+    ownership = drawing.recognition_ownership()
+    evidence = drawing.recognition_evidence()
+    registry = drawing.registry
+    binding = next(entry for entry in ownership.profile_angles if entry.feature is angles[0])
+    mark = next(iter(drawing.annotations_of(angles[0]).values()))
+    assert len(ownership.profile_angles) == 6
+    code = "angular_support_mismatch"
+    if corruption == "unshown-member":
+        binding = next(
+            entry
+            for entry in ownership.profile_angles
+            if entry.feature is angles[0]
+            and dist(drawing.at("plan", *entry.requirement.vertex)[:2], mark.angular_points[1]) > 1
+        )
+    if corruption == "same-value-corner":
+        other = next(
+            entry
+            for entry in ownership.profile_angles
+            if entry.feature is binding.feature and entry.parameter_id != binding.parameter_id
+        )
+        ownership = replace(
+            ownership,
+            profile_angles=tuple(
+                replace(entry, requirement=other.requirement) if entry is binding else entry
+                for entry in ownership.profile_angles
+            ),
+        )
+    elif corruption == "absent-authority":
+        evidence = None
+        code = "angular_support_unverifiable"
+    elif corruption == "equal-copy-owner":
+        from draftwright.registry import AnnotationRegistry
+
+        registry = AnnotationRegistry()
+        registry.add(mark, "copy", "plan", feature=replace(binding.feature))
+        code = "angular_support_unverifiable"
+    elif corruption == "absent-repetition":
+        monkeypatch.setattr("draftwright.linting.angular.profile_angle_repetitions", lambda _: ())
+    else:
+        physical_edge = type(evidence).profile_edge
+
+        def wrong_edge(self, source, index):
+            if source is binding.requirement.source and index == binding.requirement.first_index:
+                index = binding.requirement.second_index
+            return physical_edge(self, source, index)
+
+        monkeypatch.setattr(type(evidence), "profile_edge", wrong_edge)
+    issues = lint_angular_supports(
+        [mark],
+        registry=registry,
+        evidence=evidence,
+        ownership=ownership,
+        to_page=drawing.at,
+    )
+    assert [issue.code for issue in issues] == [code]
+
+
+def test_compact_angle_cannot_move_its_label_onto_a_fixed_note(angle_part):
+    sheet, _handle = _declared(angle_part, sector="opposite")
+    drawing = sheet.build()
+    owner = drawing.model().features[0]
+    original = next(iter(drawing.annotations_of(owner).values()))
+    box = original.label_bbox
+    centre = ((box[0] + box[2]) / 2, (box[1] + box[3]) / 2)
+    drawing.drop(owner)
+    note = drawing.note("KEEP CLEAR", centre, view="plan")
+    fixed = drawing.registry.named(note).bounding_box()
+    assert fixed.min.X < centre[0] < fixed.max.X and fixed.min.Y < centre[1] < fixed.max.Y
+    name = drawing.dimension(owner, "included.angle")
+    rebuilt = drawing.registry.named(name)
+    if rebuilt is None:
+        assert any(
+            issue.code == "angular_dimension_dropped"
+            and any(identity.feature is owner for identity in issue.measurement_ids)
+            for issue in drawing.lint(physical=False)
+        )
+        return
+    label = rebuilt.label_bbox
+    assert rebuilt.arc_radius > original.arc_radius
+    overlap = min(label[2], fixed.max.X) > max(label[0], fixed.min.X) and min(
+        label[3], fixed.max.Y
+    ) > max(label[1], fixed.min.Y)
+    assert not overlap

--- a/tests/test_issue_1504_profile_angles.py
+++ b/tests/test_issue_1504_profile_angles.py
@@ -1,0 +1,185 @@
+"""Released profile evidence supplies angle requirements without merging bodies."""
+
+from dataclasses import replace
+from math import cos, dist, pi, sin
+from types import SimpleNamespace
+
+import pytest
+from build123d import (
+    Axis,
+    Box,
+    Compound,
+    Cylinder,
+    Polygon,
+    Pos,
+    RegularPolygon,
+    Rot,
+    extrude,
+    fillet,
+)
+from quiddity.evidence import ProfileLine, build_recognition_evidence
+
+from draftwright import Sheet
+from draftwright.model import AngularReference, angle
+from draftwright.profile_angles import profile_angle_repetitions, profile_angle_requirements
+from draftwright.recognition_ownership import RecognitionOwnershipBuilder
+
+
+@pytest.fixture(scope="module", params=[(0, 0, 0), (90, 0, 0), (0, 90, 0)])
+def profile_evidence(request):
+    outline = RegularPolygon(30, 3)
+    ring = extrude(outline - RegularPolygon(8, 3), amount=4)
+    assert len(ring.solids()) == 1
+    part = Rot(*request.param) * Compound(
+        children=[ring, Pos(100, 0, 0) * ring, Pos(200, 0, 0) * Box(20, 20, 4)]
+    )
+    assert len(part.solids()) == 3
+    evidence = build_recognition_evidence(part)
+    return evidence, profile_angle_requirements(evidence)
+
+
+def test_sharp_profiles_keep_distinct_bodies_and_exclude_inner_wires(profile_evidence):
+    evidence, requirements = profile_evidence
+    assert len(requirements) == 6
+    assert len({item.source.body_faces for item in requirements}) == 2
+    assert len({item.source.face for item in requirements}) == 2
+    for item in requirements:
+        normal = item.source.profile.normal
+        axis = max(range(3), key=lambda index: abs(normal[index]))
+        assert normal[axis] == pytest.approx((1, -1, 1)[axis])
+        assert item.source.profile.inner_loop_count == 1
+        assert len(item.source.profile.supports) == 3
+        assert not item.virtual_vertex
+        assert AngularReference(
+            item.vertex, item.first, item.second
+        ).angle_degrees == pytest.approx(60)
+        for index, point in ((item.first_index, item.first), (item.second_index, item.second)):
+            support = item.source.profile.supports[index]
+            assert type(support) is ProfileLine
+            edge = evidence.profile_edge(item.source, index)
+            endpoints = [tuple(edge.position_at(t)) for t in (0, 1)]
+            assert min(dist(point, endpoint) for endpoint in endpoints) < 1e-6
+            assert min(dist(item.vertex, endpoint) for endpoint in endpoints) < 1e-6
+
+
+def test_profile_binding_retains_exact_supports_and_rejects_foreign_authority(profile_evidence):
+    evidence, requirements = profile_evidence
+    assert len(requirements) == 6
+    ledger = RecognitionOwnershipBuilder(evidence)
+    item = requirements[0]
+    feature = angle(vertex=item.vertex, first=item.first, second=item.second, sector="opposite")
+    ledger.bind_profile_angle(item, feature)
+    (binding,) = ledger.snapshot().profile_angles
+    assert binding.requirement is item and binding.feature is feature
+    with pytest.raises(ValueError, match="already has an owner"):
+        ledger.bind_profile_angle(item, replace(feature))
+    replacement = replace(feature)
+    ledger.remap_feature(feature, (replacement,))
+    (remapped,) = ledger.snapshot().profile_angles
+    assert remapped.requirement is item and remapped.feature is replacement
+    ledger.remap_feature(replace(replacement), (feature,))
+    assert ledger.snapshot().profile_angles[0].feature is replacement
+    foreign = build_recognition_evidence(Box(10, 10, 2))
+    with pytest.raises(ValueError):
+        RecognitionOwnershipBuilder(foreign).bind_profile_angle(item, feature)
+
+
+def test_absent_profile_authority_does_not_fabricate_requirements():
+    assert profile_angle_requirements(None) == ()
+    assert profile_angle_repetitions(None) == ()
+
+
+@pytest.fixture(scope="module")
+def chamfer_and_unrelated_equal_corners():
+    part = extrude(
+        Polygon((-45, -30), (45, -30), (45, 18), (33, 30), (0, 30), (-45, -15), align=None),
+        amount=20,
+    )
+    evidence = build_recognition_evidence(part)
+    assert len(evidence.result.chamfers) == 1
+    assert evidence.result.chamfers[0].leg1 == 12
+    return part, evidence
+
+
+def test_only_the_chamfers_actual_shared_edges_define_automatic_angles(
+    chamfer_and_unrelated_equal_corners,
+):
+    _, evidence = chamfer_and_unrelated_equal_corners
+    # With no feature definitions, the same supplied profile has four 135° corners.
+    profiles_only = SimpleNamespace(
+        features=(), faces=evidence.faces, planar_outer_profile=evidence.planar_outer_profile
+    )
+    all_corners = profile_angle_requirements(profiles_only)
+    assert len(all_corners) == 4
+    assert all(
+        AngularReference(c.vertex, c.first, c.second).angle_degrees == pytest.approx(135)
+        for c in all_corners
+    )
+    remaining = profile_angle_requirements(evidence)
+    assert {corner.vertex for corner in remaining} == {(-45, -15, 20), (0, 30, 20)}
+
+
+@pytest.mark.parametrize("kind", ("chamfer", "regular-polygon"))
+def test_an_explicit_angle_remains_available_when_a_feature_callout_already_defines_it(
+    chamfer_and_unrelated_equal_corners, kind
+):
+    if kind == "chamfer":
+        part, _ = chamfer_and_unrelated_equal_corners
+        vertex, first, second = (33, 30, 20), (0, 30, 20), (39, 24, 20)
+        label = "135° ±0.05°"
+    else:
+        part = extrude(RegularPolygon(20, 6), amount=30)
+        vertex, first, second = (
+            (20, 0, 30),
+            (10, 20 * sin(pi / 3), 30),
+            (10, -20 * sin(pi / 3), 30),
+        )
+        label = "120° ±0.05°"
+    sheet = Sheet(part, page="A2", scale=1)
+    handle = sheet.angle(vertex=vertex, first=first, second=second, sector="opposite")
+    handle.tolerance(0.05, on="included.angle")
+    sheet.dimension(handle, "included.angle")
+    drawing = sheet.build()
+    (mark,) = [item for _, item in drawing.iter_annotations() if hasattr(item, "measured_angle")]
+    assert mark.label == label
+    assert not [issue for issue in drawing.lint() if issue.code.startswith("angular_support_")]
+
+
+@pytest.fixture(scope="module", params=[False, True])
+def repeated_profile_evidence(request):
+    part = extrude(RegularPolygon(30, 3), amount=4)
+    vertices = [tuple(edge.center()) for edge in part.edges().filter_by(Axis.Z)]
+    for index, vertex in enumerate(vertices):
+        edge = min(
+            part.edges().filter_by(Axis.Z), key=lambda item: dist(tuple(item.center()), vertex)
+        )
+        part = fillet(edge, 3 if request.param and index == 0 else 2)
+    plain = Pos(0, 0, 20) * part
+    for index in range(3):
+        theta = index * 2 * pi / 3
+        part -= Pos(10 * cos(theta), 10 * sin(theta), 2) * Cylinder(2, 8)
+    compound = Compound(children=[part, plain])
+    assert len(compound.solids()) == 2
+    evidence = build_recognition_evidence(compound)
+    assert len(evidence.result.hole_patterns) == 1
+    requirements = profile_angle_requirements(evidence)
+    assert len(requirements) == 6
+    assert all(
+        AngularReference(item.vertex, item.first, item.second).angle_degrees == pytest.approx(60)
+        for item in requirements
+    ), "changing one fillet must leave all six angle values equal"
+    return evidence, request.param
+
+
+def test_repetition_requires_the_whole_profile_and_same_body_pattern(repeated_profile_evidence):
+    evidence, broken_rotation = repeated_profile_evidence
+    repetitions = profile_angle_repetitions(evidence)
+    if broken_rotation:
+        assert repetitions == (), "equal angles cannot hide a non-repeating rounded profile"
+    else:
+        assert len(repetitions) == 1, "the unpatterned second body cannot borrow the first pattern"
+        (group,) = repetitions
+        assert group.pattern is evidence.result.hole_patterns[0]
+        assert len(group.members) == 3
+        assert len({member.first_index for member in group.members}) == 3
+        assert all(member.vertex[2] == pytest.approx(4) for member in group.members)

--- a/tests/test_issue_1505_diameter_coverage.py
+++ b/tests/test_issue_1505_diameter_coverage.py
@@ -1,0 +1,156 @@
+"""A hole's equal diameter cannot erase a physical shoulder or boss measurement."""
+
+from dataclasses import replace
+
+import pytest
+from build123d import Box, Compound, Cylinder, Pos
+
+from draftwright import build_drawing
+from draftwright.model import PartModel, rotational, step
+from draftwright.model.compiled import compile_dimensions
+from draftwright.model.ir import RequestedDimension
+
+
+@pytest.fixture(scope="module", params=("shoulders", "boss"))
+def equal_diameter_drawing(request):
+    if request.param == "shoulders":
+        lower = Pos(0, 0, -14) * Cylinder(36, 22) + Pos(0, 0, -1.5) * Cylinder(20, 3)
+        upper = Pos(0, 0, 14) * Cylinder(36, 22) + Pos(0, 0, 1.5) * Cylinder(20, 3)
+        flange = Box(120, 110, 6) - Cylinder(20, 12)
+        part = Compound(children=[lower, upper, flange])
+        assert len(part.solids()) == 3
+        kind, diameter, count = "step", 40, 2
+    else:
+        part = Box(100, 60, 10) - Pos(-30, 0, 0) * Cylinder(10, 20)
+        part += Pos(30, 0, 10) * Cylinder(10, 10)
+        assert len(part.solids()) == 1
+        kind, diameter, count = "boss", 20, 1
+    drawing = build_drawing(part, page="A2", scale=1, scale_policy="permissive")
+    owners = [
+        feature
+        for feature in drawing.model().features
+        if feature.kind == kind and feature.diameter == pytest.approx(diameter)
+    ]
+    assert len(owners) == count
+    holes = [
+        feature
+        for feature in drawing.model().features
+        if feature.kind == "hole" and feature.diameter == pytest.approx(diameter)
+    ]
+    assert len(holes) == 1, "the independent equal-diameter hole must actually be recognised"
+    return drawing, owners, holes[0]
+
+
+@pytest.mark.parametrize("mode", ("automatic", "deferred"))
+def test_equal_bore_and_external_diameters_keep_separate_measurement_coverage(
+    equal_diameter_drawing, mode
+):
+    drawing, owners, hole = equal_diameter_drawing
+    hole_names = {
+        name
+        for name in drawing.registry.names()
+        for identity in drawing.registry.measurement_of(name)
+        if identity.feature is hole and identity.parameter == "bore.diameter"
+    }
+    assert hole_names, "the independent equal-diameter hole must be printed"
+    saved_registry, saved_items = drawing.registry.snapshot(), list(drawing.items)
+    try:
+        if mode == "deferred":
+            # The hole is committed before this edit. Automatic leader queuing
+            # can otherwise defer it until after the external-diameter pass.
+            existing = {
+                name
+                for name in drawing.registry.names()
+                for identity in drawing.registry.measurement_of(name)
+                if any(identity.feature is owner for owner in owners)
+                and identity.parameter.endswith(".diameter")
+            }
+            assert existing and existing.isdisjoint(hole_names)
+            for name in existing:
+                drawing.remove(name)
+            with drawing.deferred():
+                for owner in owners:
+                    drawing.callout(owner)
+        for owner in owners:
+            names = {
+                name
+                for name in drawing.registry.names()
+                for identity in drawing.registry.measurement_of(name)
+                if identity.feature is owner and identity.parameter == f"{owner.kind}.diameter"
+            }
+            assert names and names.isdisjoint(hole_names)
+        report = drawing.report()
+        assert not [
+            row
+            for row in report["recognition"]["requirements"]
+            if row["family"] == "turned_steps" and row["state"] != "placed"
+        ]
+    finally:
+        drawing.registry.restore(saved_registry)
+        drawing.items[:] = saved_items
+
+
+def test_equal_external_diameters_remain_independently_removable(equal_diameter_drawing):
+    drawing, owners, hole = equal_diameter_drawing
+    saved_registry, saved_items = drawing.registry.snapshot(), list(drawing.items)
+    try:
+        names_by_owner = [
+            {
+                name
+                for name in drawing.registry.names()
+                for identity in drawing.registry.measurement_of(name)
+                if identity.feature is owner and identity.parameter == f"{owner.kind}.diameter"
+            }
+            for owner in owners
+        ]
+        assert all(len(names) == 1 for names in names_by_owner)
+        assert len(set.union(*names_by_owner)) == len(owners), (
+            "equal diameters on distinct shoulders cannot become one unowned mark"
+        )
+        removed = drawing.drop(owners[0])
+        assert names_by_owner[0] <= set(removed)
+        assert not names_by_owner[0] & set(drawing.registry.names())
+        assert all(names <= set(drawing.registry.names()) for names in names_by_owner[1:])
+        assert any(
+            identity.feature is hole and identity.parameter == "bore.diameter"
+            for name in drawing.registry.names()
+            for identity in drawing.registry.measurement_of(name)
+        )
+    finally:
+        drawing.registry.restore(saved_registry)
+        drawing.items[:] = saved_items
+
+
+@pytest.fixture(scope="module")
+def diameter_model():
+    band = step(diameter=30, length=40, at=(0, 0, 0), axis="z")
+    body = rotational(od=30, at=(0, 0, 0), axis="z")
+    return PartModel(Cylinder(15, 40).bounding_box(), "z", features=[band, body])
+
+
+@pytest.mark.parametrize("case", ("unique", "offset", "equal-peer", "hidden-peer", "tolerance"))
+def test_global_od_reuse_requires_one_undecorated_band_on_the_same_axis(diameter_model, case):
+    model = replace(diameter_model, features=list(diameter_model.features))
+    band, body = model.features
+    if case == "offset":
+        model.features[0] = replace(band, frame=replace(band.frame, origin=(2, 0, 0)))
+    elif case in {"equal-peer", "hidden-peer"}:
+        peer = step(diameter=30, length=10, at=(0, 0, 40), axis="z")
+        model.features.append(peer)
+        if case == "hidden-peer":
+            model.authored_dimensions = (
+                RequestedDimension(band, "step.diameter"),
+                RequestedDimension(body, "od.diameter"),
+            )
+    elif case == "tolerance":
+        model.decorations = {(band, "diameter"): 0.1}
+    plan = compile_dimensions(model)
+    (group,) = plan.of_kind("rotational")
+    od = group.dim(kind="diameter", role="od")
+    assert od is not None
+    if case == "unique":
+        assert len(od.measurement_ids) == 2
+        assert od.equivalent_ids[0].feature is band
+        assert od.equivalent_ids[0].parameter == "step.diameter"
+    else:
+        assert od.equivalent_ids == (), "unrelated or decorated facts cannot borrow a global OD"

--- a/tests/test_issue_1505_short_axial_chains.py
+++ b/tests/test_issue_1505_short_axial_chains.py
@@ -1,0 +1,303 @@
+"""Short shoulders must not erase neighbouring axial measurements (#1505)."""
+
+from collections import Counter
+
+import pytest
+from build123d import Cylinder, Pos, Rot
+
+from draftwright import Sheet
+from draftwright.model.compiled import compile_dimensions
+from draftwright.sheet_emit import emit_sheet_script
+
+
+@pytest.fixture(scope="module", params=(False, True), ids=("two-step", "symmetric-flange"))
+def axial_chain(request):
+    intervals = [(72, -25, -3, "lower"), (40, -3, 0, "lower")]
+    if request.param:
+        intervals.extend([(96, 0, 6, "flange"), (40, 6, 9, "upper"), (72, 9, 31, "upper")])
+    solids = [Pos(0, 0, (lo + hi) / 2) * Cylinder(d / 2, hi - lo) for d, lo, hi, _ in intervals]
+    part = solids[0].fuse(*solids[1:])
+    sheet = Sheet(part, page="A3", scale=1, scale_policy="permissive")
+    sheet.authored_dimensions()
+    for diameter, lo, hi, group in intervals:
+        handle = sheet.step(
+            diameter=diameter,
+            length=hi - lo,
+            at=(0, 0, (lo + hi) / 2),
+            axis="z",
+            profile_group=group,
+        )
+        sheet.dimension(handle, "step.length")
+        sheet.dimension(handle, "step.diameter")
+    return sheet.build(), intervals
+
+
+def test_every_authored_shoulder_has_its_own_value_supports_and_identity(axial_chain):
+    drawing, intervals = axial_chain
+    marks = [
+        (name, item)
+        for name, item in drawing.iter_annotations()
+        if any(
+            identity.parameter == "step.length"
+            for identity in drawing.registry.measurement_of(name)
+        )
+    ]
+    assert Counter(item.label for _, item in marks) == Counter(
+        str(hi - lo) for _, lo, hi, _ in intervals
+    )
+    spans = []
+    for name, item in marks:
+        (identity,) = drawing.registry.measurement_of(name)
+        lo, hi = sorted(point[2] for point in identity.feature.span)
+        spans.append((lo, hi))
+        view = drawing.registry.view_of(name)
+        expected = sorted(drawing.at(view, 0, 0, z)[1] for z in (lo, hi))
+        # Read the rendered horizontal extension strokes, not the renderer's
+        # nominal length metadata. Both physical shoulder stations must survive.
+        extensions = [
+            first[1]
+            for first, second in item.segments
+            if abs(first[1] - second[1]) < 1e-6 and abs(first[0] - second[0]) > 1
+        ]
+        assert all(
+            any(abs(station - actual) < 1e-6 for actual in extensions) for station in expected
+        )
+    assert Counter(spans) == Counter((lo, hi) for _, lo, hi, _ in intervals)
+    problems = {
+        "step_dim_dropped",
+        "axial_length_missing",
+        "plan_incomplete",
+        "annotation_overlap",
+        "annotation_ink_overlap",
+        "view_annotation_overlap",
+        "dim_label_vs_geometry",
+    }
+    assert not [issue for issue in drawing.lint() if issue.code in problems]
+
+
+def _shoulder_detail_sheet(axis="z", *, omitted=None, factor=3):
+    rotation = {"x": Rot(0, 90, 0), "y": Rot(-90, 0, 0), "z": Rot(0, 0, 0)}[axis]
+    origin = (60, 40, 20)
+    part = (
+        Pos(*origin)
+        * rotation
+        * (Pos(0, 0, -14) * Cylinder(15, 22) + Pos(0, 0, -1.5) * Cylinder(10, 3))
+    )
+    sheet = Sheet(part, page="A2", scale=1, scale_policy="permissive")
+    for diameter, station, length in ((30, -14, 22), (20, -1.5, 3)):
+        position = tuple(
+            value + (station if i == "xyz".index(axis) else 0) for i, value in enumerate(origin)
+        )
+        handle = sheet.step(diameter=diameter, length=length, at=position, axis=axis)
+        handle.tolerance(0.2, on="length")
+        for parameter in ("step.length", "step.diameter"):
+            if length != 3 or parameter != omitted:
+                sheet.dimension(handle, parameter)
+    sheet.detail_view("A", around=handle).scale(factor)
+    return sheet
+
+
+@pytest.fixture(scope="module", params=("x", "y", "z"))
+def shoulder_detail(request):
+    axis = request.param
+    sheet = _shoulder_detail_sheet(axis)
+    plan = compile_dimensions(sheet.model())
+    (approved,) = [
+        group.dim(kind="length")
+        for group in plan.of_kind("step")
+        if group.dim(kind="length").value == 3
+    ]
+    assert approved.tolerance is not None, "the detail must preserve a real approved tolerance"
+    return sheet.build(), approved, axis, sheet.view_constraints
+
+
+def test_semantic_shoulder_detail_keeps_profile_scale_tolerance_and_supports(shoulder_detail):
+    drawing, approved, axis, _constraints = shoulder_detail
+    ((name, mark),) = [
+        (name, mark)
+        for name, mark in drawing.iter_annotations()
+        if drawing.view_of(name) == "detail_a"
+    ]
+    assert mark.label == "3 ±0.2"
+    (identity,) = drawing.registry.measurement_of(name)
+    assert identity.feature is approved.id.feature and identity.parameter == "step.length"
+    points = [drawing.at("detail_a", *point) for point in approved.span]
+    coordinate = 1 if axis == "z" else 0
+    stations = sorted(point[coordinate] for point in points)
+    assert stations[1] - stations[0] == pytest.approx(9)
+    strokes = [
+        first[coordinate]
+        for first, second in mark.segments
+        if abs(first[coordinate] - second[coordinate]) < 1e-6
+        and abs(first[1 - coordinate] - second[1 - coordinate]) > 1
+    ]
+    assert all(any(abs(station - stroke) < 1e-6 for stroke in strokes) for station in stations)
+    parent = "side" if axis == "y" else "front"
+    parent_stations = sorted(drawing.at(parent, *point)[coordinate] for point in approved.span)
+    marker = drawing.registry.named("detail_marker_A").bounding_box()
+    assert (tuple(marker.min)[coordinate], tuple(marker.max)[coordinate]) == pytest.approx(
+        parent_stations
+    )
+    assert not [issue for issue in drawing.lint() if issue.severity != "info"]
+
+
+def test_shoulder_detail_round_trips_as_editable_intent(shoulder_detail, tmp_path):
+    drawing, _approved, _axis, constraints = shoulder_detail
+    source = emit_sheet_script(
+        drawing.model(),
+        "part",
+        str(tmp_path / "shoulder"),
+        title="T",
+        number="N",
+        page="A2",
+        scale=1,
+        scale_policy="permissive",
+        view_constraints=constraints,
+        formats=("svg",),
+    )
+    namespace = {"part": drawing.working_part}
+    exec(source, namespace)
+    replayed = namespace["drawing"]
+    assert "detail_a" in replayed.views
+    assert replayed.registry.named("detail_a_steplen0").label == "3 ±0.2"
+
+    def claims(value):
+        return Counter(
+            (identity.parameter, identity.feature.frame, identity.feature.span, mark.label)
+            for name, mark in value.iter_annotations()
+            for identity in value.registry.measurement_of(name)
+        )
+
+    assert claims(drawing) == claims(replayed)
+    assert not [issue for issue in replayed.lint() if issue.severity != "info"]
+    assert (tmp_path / "shoulder.svg").is_file()
+
+
+@pytest.mark.parametrize("omitted", ("step.length", "step.diameter"))
+def test_shoulder_detail_does_not_reconstruct_omitted_content(omitted):
+    drawing = _shoulder_detail_sheet(omitted=omitted).build()
+    assert "detail_a" in drawing.views
+    measurements = [
+        identity.parameter
+        for name in drawing.registry.names()
+        if drawing.view_of(name) == "detail_a"
+        for identity in drawing.registry.measurement_of(name)
+    ]
+    assert measurements == ([] if omitted == "step.length" else ["step.length"])
+
+
+@pytest.mark.parametrize("failure", ("no-ink", "no-room"))
+def test_authored_shoulder_detail_refuses_unfulfilled_recovery(monkeypatch, failure):
+    from draftwright.annotations import from_model
+
+    redraws = []
+    if failure == "no-ink":
+        original = from_model._draw_step_chain
+
+        def decline_detail(dwg, view, *args, **kwargs):
+            if view == "detail_a":
+                redraws.append(view)
+                return 0
+            return original(dwg, view, *args, **kwargs)
+
+        monkeypatch.setattr(from_model, "_draw_step_chain", decline_detail)
+    sheet = _shoulder_detail_sheet(factor=1000 if failure == "no-room" else 3)
+    with pytest.raises(ValueError, match="authored detail.*not relaxed"):
+        sheet.build()
+    assert redraws == (["detail_a"] if failure == "no-ink" else [])
+
+
+@pytest.mark.parametrize("unresolved_neighbour", (False, True))
+def test_detail_retracts_only_recovered_main_view_length_drops(monkeypatch, unresolved_neighbour):
+    from draftwright.annotations import from_model
+
+    original = from_model._draw_step_chain
+    refused = []
+
+    def decline_main(dwg, view, segments, *args, ctx, **kwargs):
+        if view == "front":
+            kept = []
+            for segment in segments:
+                if segment.value == 3 or unresolved_neighbour:
+                    refused.extend(segment.measurements)
+                    ctx.record_issue(
+                        "warning",
+                        "step_dim_dropped",
+                        "main-view placement refused",
+                        measurement=segment.measurements,
+                    )
+                else:
+                    kept.append(segment)
+            segments = kept
+        return original(dwg, view, segments, *args, ctx=ctx, **kwargs)
+
+    monkeypatch.setattr(from_model, "_draw_step_chain", decline_main)
+    drawing = _shoulder_detail_sheet().build()
+    assert len(refused) == (2 if unresolved_neighbour else 1)
+    assert drawing.registry.named("detail_a_steplen0").label == "3 ±0.2"
+    remaining = [issue for issue in drawing.lint() if issue.code == "step_dim_dropped"]
+    assert len(remaining) == int(unresolved_neighbour)
+    assert all(
+        identity.feature.length == 22 for issue in remaining for identity in issue.measurement_ids
+    )
+    if remaining:
+        from draftwright.linting import _suggest_fix
+
+        suggestion = _suggest_fix(remaining[0], drawing)
+        assert 'sheet.detail_view("A", around=shoulder).scale(3)' in suggestion
+        assert "detail_view=True" not in suggestion
+
+
+def test_naturally_off_page_z_shoulders_are_recovered_and_read_from_details(monkeypatch):
+    part = Pos(0, 0, -14) * Cylinder(15, 22) + Pos(0, 0, -1.5) * Cylinder(10, 3)
+    sheet = Sheet(part, page="A4", scale=1, scale_policy="permissive").authored_dimensions()
+    # Pin a whole view through the public semantic surface. Its geometry fits,
+    # while its shoulder labels naturally exceed the remaining page margin.
+    sheet.view("front").pin((260, 125))
+    handles = []
+    for diameter, station, length in ((30, -14, 22), (20, -1.5, 3)):
+        handle = sheet.step(
+            diameter=diameter,
+            length=length,
+            at=(0, 0, station),
+            axis="z",
+            profile_group="profile",
+        )
+        handle.tolerance(0.2, on="length")
+        sheet.dimension(handle, "step.length")
+        handles.append(handle)
+    cramped = sheet.build()
+    assert not any(cramped.measurement_keys(name) for name in cramped.annotations())
+    drops = [issue for issue in cramped.lint() if issue.code == "step_dim_dropped"]
+    assert len(drops) == 2 and all("off the drawable page" in issue.message for issue in drops)
+
+    for label, handle in zip(("A", "B"), handles, strict=True):
+        sheet.detail_view(label, around=handle).scale(3)
+    recovered = sheet.build()
+    assert Counter(
+        mark.label
+        for name, mark in recovered.iter_annotations()
+        if recovered.measurement_keys(name)
+    ) == Counter({"22 ±0.2": 1, "3 ±0.2": 1})
+    assert not [
+        issue
+        for issue in recovered.lint()
+        if issue.code in {"step_dim_dropped", "axial_length_missing", "annotation_ink_overlap"}
+    ]
+
+    # An end-on projection must not certify every shoulder from one coincident
+    # endpoint. Preserve the drawn geometry while corrupting only that projection.
+    project = recovered.at
+    witness = recovered.get_annotation("detail_b_steplen0")._dw_spec
+    assert witness.p1[0] == witness.p2[0]
+    with monkeypatch.context() as patch:
+        patch.setattr(
+            recovered,
+            "at",
+            lambda view, x, y, z: (
+                witness.p1 if view.startswith("detail_") else project(view, x, y, z)
+            ),
+        )
+        assert any(issue.code == "axial_length_missing" for issue in recovered.lint())
+    recovered.remove("detail_b_steplen0")
+    assert any(issue.code == "axial_length_missing" for issue in recovered.lint())

--- a/tests/test_issue_740_leader_assignment.py
+++ b/tests/test_issue_740_leader_assignment.py
@@ -44,7 +44,7 @@ def test_late_joint_assignment_stays_scoped_to_the_post_drain_adapters():
 
     assert call_sites("from_model.py") | call_sites("holes.py") == {
         ("from_model.py", "render_diameters", False),
-        ("from_model.py", "_render_typed_diameter_leaders", True),
+        ("from_model.py", "_render_diameter_leaders", True),
         ("from_model.py", "render_chamfers", True),
         ("from_model.py", "_render_radius_callouts", True),
         ("from_model.py", "render_circular_blind_steps", True),

--- a/tests/test_issue_909_sloped_profile.py
+++ b/tests/test_issue_909_sloped_profile.py
@@ -23,8 +23,29 @@ def test_touching_lower_ledges_do_not_hide_the_case_studys_raised_pad():
     assert recognise_rectangular_pads(part) == [RaisedPad(-15.5, 15.5, 8.0, 24.7, 13.0, 20.0)]
 
 
-def test_case_study_pad_reaches_the_drawing_with_complete_owned_footprint():
+def test_case_study_pad_reaches_the_drawing_with_complete_owned_footprint(monkeypatch):
+    import draftwright.builder as builder
+
+    build_once = builder._build_drawing_once
+    attempts = []
+
+    def capture_attempt(*args, **kwargs):
+        candidate = build_once(*args, **kwargs)
+        attempts.append(candidate)
+        return candidate
+
+    monkeypatch.setattr(builder, "_build_drawing_once", capture_attempt)
     drawing = build_drawing(_ISSUE_909)
+    # The angle and location requirements exceed the selected A4 corridor even
+    # after the height detail succeeds. Recovery must keep searching for the
+    # still-missing shoulder, rather than treating any detail as completion.
+    cramped = attempts[0]
+    assert (cramped.page_w, cramped.page_h) == (297, 210)
+    assert "detail_a" in cramped.views
+    assert any(issue.code == "step_position_dropped" for issue in cramped.lint())
+    assert (drawing.page_w, drawing.page_h) == (420, 297)
+    assert drawing.scale_decision["status"] == "automatic_replanned"
+    assert drawing.scale_decision["attempts"][-1]["reason"] == "page_escalation_after_detail"
     source = RaisedPad(-15.5, 15.5, 8.0, 24.7, 13.0, 20.0)
 
     recognition = drawing.recognition()
@@ -70,7 +91,27 @@ def test_case_study_pad_reaches_the_drawing_with_complete_owned_footprint():
     assert main_labels == Counter({"21": 1})
     assert detail_labels == Counter({"26": 1})
     assert not main_labels & detail_labels
-    assert drawing.lint() == []
+    shoulder = drawing.get_annotation("dim_shoulder_y0")
+    assert shoulder.label == "21"
+    assert drawing.measurement_keys("dim_shoulder_y0") == [
+        {
+            "feature": feature_key(
+                next(f for f in drawing.model().features if f.kind == "step_level")
+            ),
+            "parameter_id": "step_position.length",
+        }
+    ]
+    assert Counter(
+        annotation.label
+        for _, annotation in drawing.iter_annotations()
+        if hasattr(annotation, "measured_angle")
+    ) == Counter({"51.1°": 1, "128.9°": 1})
+    # An angle label over a blank region inside the view extents is legitimate;
+    # every diagnostic must describe that informational condition only.
+    assert all(
+        issue.severity == "info" and issue.code == "view_annotation_inside_extents"
+        for issue in drawing.lint()
+    )
 
 
 def test_case_study_detail_rungs_keep_their_compiled_measurement_identity():

--- a/tests/test_issue_955_height_contingency.py
+++ b/tests/test_issue_955_height_contingency.py
@@ -140,7 +140,19 @@ def test_an_unrelated_planner_suppression_still_withholds_height():
 
 
 @pytest.mark.timeout(120)
-def test_a_dropped_chain_releases_the_height_and_clears_the_planner_omission():
+def test_a_dropped_chain_releases_the_height_and_clears_the_planner_omission(monkeypatch):
+    from draftwright.annotations import from_model
+
+    draw_chain = from_model._draw_step_chain
+
+    def starved_chain(dwg, view, segs, name, **kwargs):
+        # #1505 recovers this part's naturally short shoulder. Exercise the
+        # contingency with an actually unavailable chain lane instead: use the
+        # real page guard and keep its measurement-specific drop reporting.
+        kwargs["profile_bounds"] = (dwg.page_w, 0, dwg.page_w, dwg.page_h)
+        return draw_chain(dwg, view, segs, name, **kwargs)
+
+    monkeypatch.setattr(from_model, "_draw_step_chain", starved_chain)
     drawing = build_drawing(_crowded_grooved_shaft(), number="X")
     labels = {
         label
@@ -152,7 +164,7 @@ def test_a_dropped_chain_releases_the_height_and_clears_the_planner_omission():
     assert "60" in labels
     assert "dim_height" in drawing.annotations()
     assert codes.get("axial_length_missing", 0) == 0
-    assert codes.get("step_dim_dropped") == 1
+    assert codes.get("step_dim_dropped") == 2
     assert not [row for row in drawing.suppressions() if row["parameter_id"] == "height.length"]
 
 

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -31,6 +31,7 @@ from draftwright.drawing import analyse_cylinders
 from draftwright.export import _export_shape
 from draftwright.linting import LintIssue
 from draftwright.make_drawing import lint_feature_coverage
+from draftwright.model import DimensionId
 
 _skip_011 = pytest.mark.skipif(B123D_GE_011, reason=SKIP_011)
 
@@ -874,12 +875,13 @@ class TestGrooveCallout:
         assert dwg.get_annotation(names[0]).label == _groove_label(4, 16)
         # A groove's width is axial → it reads in a profile view (axis in-plane), not down it.
         assert dwg.view_of(names[0]) == "front"
-        # This fixture IS incomplete, and says so since #1250: the groove floor is a step
-        # level whose span the page cannot carry, so `step_dim_dropped` is a required
-        # placement failure and `plan_incomplete` summarises it at error severity. Asserting
-        # the exact set rather than filtering it out keeps the known loss visible here — the
-        # test is about which view the groove label reads in, not about completeness.
-        assert {i.code for i in dwg.lint() if i.severity == "error"} == {"plan_incomplete"}
+        # The shoulder recovery keeps both outer bands independently dimensioned.
+        assert sorted(
+            item.label for name, item in dwg.iter_annotations() if name.startswith("m_steplen")
+        ) == ["18", "18"]
+        completeness = dwg.lint_summary()["quality"]["completeness"]
+        assert completeness["requirements"] == completeness["placed"] == 6
+        assert not [issue for issue in dwg.lint() if issue.severity == "error"]
 
     def test_groove_floor_diameter_is_not_double_dimensioned(self):
         # The groove floor band's two walls read as shoulders, so recognise_turned_steps
@@ -9491,15 +9493,22 @@ class TestTurnedDiameters:
         assert y_diameters == {"ø25", "ø31", "ø42"}
         # #890: each queued radial leader retains its own StepFeature provenance;
         # a lazy generator previously captured the final loop iteration's owner.
-        steps_by_diameter = {}
-        for step in steps:
-            steps_by_diameter.setdefault(step.diameter, []).append(step)
+        diameter_owners = [
+            feature for feature in dwg.model().features if feature.kind in {"step", "boss"}
+        ]
+        assert len(diameter_owners) == 8
         for name in (n for n in dwg.annotations() if n.startswith("m_dia_y")):
             ann = dwg.get_annotation(name)
             owner = dwg.registry.feature_of(name)
             diameter = float(ann.label.removeprefix("ø"))
-            matches = steps_by_diameter[diameter]
-            assert owner is (matches[0] if len(matches) == 1 else None)
+            matches = [feature for feature in diameter_owners if feature.diameter == diameter]
+            assert any(owner is match for match in matches)
+            (identity,) = dwg.registry.measurement_of(name)
+            assert identity.feature is owner and identity.parameter == f"{owner.kind}.diameter"
+        assert all(
+            dwg.registry.has_measurement(DimensionId(owner, f"{owner.kind}.diameter"))
+            for owner in diameter_owners
+        )
 
         self._assert_y_diameter_leaders_clear_holes(dwg)
         step_labels = {dwg.get_annotation(n).label for n in dwg.annotations() if "steplen" in n}
@@ -9951,9 +9960,9 @@ class TestTurnedDiameters:
             assert "50" not in labels, f"{axis}: OD double-dimensioned as envelope"
             assert [i for i in dwg.lint() if i.severity != "info"] == []
 
-    def test_unfittable_row_skips_without_crashing(self, monkeypatch):
-        # When the labels do not fit the row, both solvers return None; the pass
-        # must skip gracefully, not crash the whole build on a None unpack.
+    def test_unfittable_row_recovers_diameters_without_crashing(self, monkeypatch):
+        # A failed row must reach the shared leader solve without crashing on
+        # a None unpack. Both physical diameter requirements remain covered.
         import sys
 
         # render_diameters looks the strip solvers up in its own module's namespace
@@ -9962,7 +9971,10 @@ class TestTurnedDiameters:
         monkeypatch.setattr(m, "_solve_strip_ys", lambda *a, **k: None)
         monkeypatch.setattr(m, "_greedy_strip_ys", lambda *a, **k: None)
         dwg = build_drawing(_x_stepped_shaft())  # must not raise
-        assert not any(n.startswith("m_dia") for n in dwg.annotations())
+        marks = [(name, item) for name, item in dwg.iter_annotations() if name.startswith("m_dia")]
+        assert {item.label for _, item in marks} == {"ø30", "ø16"}
+        assert all(dwg.registry.measurement_of(name) for name, _ in marks)
+        assert not [issue for issue in dwg.lint() if issue.code == "feature_not_dimensioned"]
 
     def test_nested_band_under_silhouette_gets_a_callout(self):
         # #298: a narrow ø6 external band sits under the ø30 flange silhouette, so
@@ -9982,10 +9994,9 @@ class TestTurnedDiameters:
         assert dwg.lint_summary()["by_code"].get("feature_not_dimensioned", 0) == 0
 
     def test_diameter_row_places_what_fits_not_all_or_nothing(self):
-        # #298 hardening: on a part too small to fit every ø callout in the row, the
-        # placer keeps the significant ODs and drops only the smallest — never the whole
-        # row (the pre-fix all-or-nothing dropped all three). The finest band honestly
-        # surfaces as feature_not_dimensioned.
+        # #298/#1505: a partial row retains the ODs that fit and sends the
+        # remaining band to the shared leader solve. No measurement disappears
+        # merely because the first presentation ran out of capacity.
         from build123d import Align
 
         def cyl(r, h, z):
@@ -9995,9 +10006,18 @@ class TestTurnedDiameters:
         part = Rotation(0, 90, 0) * (cyl(3, 0.5, 0.0) + cyl(5, 1.7, 0.5) + cyl(4, 2.0, 2.2))
         dwg = build_drawing(part)
         labels = {o.label for n, o in dwg.iter_annotations() if n.startswith("m_dia")}
-        assert {"ø10", "ø8"} <= labels  # the significant ODs survive, not dropped wholesale
-        undim = {i.message.split()[2] for i in dwg.lint() if i.code == "feature_not_dimensioned"}
-        assert "ø6" in undim  # only the finest band falls to honest lint
+        assert {"ø10", "ø8", "ø6"} <= labels
+        assert not [issue for issue in dwg.lint() if issue.code == "feature_not_dimensioned"]
+        for feature in dwg.model().features:
+            if feature.kind not in {"step", "boss"}:
+                continue
+            matches = [
+                name
+                for name, _ in dwg.iter_annotations()
+                for identity in dwg.registry.measurement_of(name)
+                if identity.feature is feature and identity.parameter.endswith(".diameter")
+            ]
+            assert len(matches) == 1, "each physical diameter has exactly one owning mark"
 
     def test_leader_tip_on_the_edge_centred_on_the_feature_length(self, x_shaft_dwg):
         # The ø leader lands on the step's silhouette EDGE — a full radius off the
@@ -10053,26 +10073,33 @@ class TestTurnedDiameters:
         )
         assert abs(tip_x - origin_x) < 1e-6, "ø6 boss leader should anchor at its frame origin"
 
-    def test_shared_diameter_leader_centres_on_the_longest_disjoint_run(self):
-        # A ⌀ shared by DISJOINT, UNEQUAL steps (⌀20 len-5 · ⌀30 · ⌀20 len-20):
-        # the callout must centre on the LONGEST ⌀20 run (the prominent feature),
-        # not the first step in feature order — the short left run the pre-#794
-        # frame-origin anchor picked — nor the convex-hull midpoint, which falls
-        # in the ⌀30 gap, off any silhouette. This is the ONE case #794 changes:
-        # a single detected step's origin is already its own midpoint, so only a
-        # shared, unequal, disjoint ⌀ exercises the fix (fails on origin/main).
+    def test_equal_diameter_leaders_keep_each_disjoint_runs_own_support(self):
+        # The same diameter on two disjoint, unequal runs is independently
+        # editable. Each arrow must land on its own band's midpoint, never
+        # the convex-hull midpoint in the intervening larger-diameter band.
         part = (
             Cylinder(10, 5)
             + Pos(0, 0, 7.5) * Cylinder(15, 10)
             + Pos(0, 0, 22.5) * Cylinder(10, 20)
         )
         dwg = build_drawing(part, number="X")
-        o = next(o for n, o in dwg.iter_annotations() if str(getattr(o, "label", "")) == "ø20")
-        on_long = dwg.at("front", 0, 0, 22.5)[1]  # longest ⌀20 run (z 12.5..32.5) midpoint
-        on_short = dwg.at("front", 0, 0, 0)[1]  # short ⌀20 run (z -2.5..2.5) midpoint
-        in_gap = dwg.at("front", 0, 0, 7.5)[1]  # ⌀30 gap midpoint
-        assert abs(o.tip[1] - on_long) < 1e-6, "ø20 not centred on the longest run"
-        assert abs(o.tip[1] - on_short) > 1e-6 and abs(o.tip[1] - in_gap) > 1e-6
+        marks = [
+            (name, item)
+            for name, item in dwg.iter_annotations()
+            if str(getattr(item, "label", "")) == "ø20"
+        ]
+        assert len(marks) == 2
+        on_long = dwg.at("front", 0, 0, 22.5)[1]
+        on_short = dwg.at("front", 0, 0, 0)[1]
+        in_gap = dwg.at("front", 0, 0, 7.5)[1]
+        assert sorted(item.tip[1] for _, item in marks) == pytest.approx(
+            sorted((on_short, on_long))
+        )
+        for name, item in marks:
+            owner = dwg.registry.feature_of(name)
+            assert owner is not None
+            assert item.tip[1] == pytest.approx(dwg.at("front", *owner.frame.origin)[1])
+            assert abs(item.tip[1] - in_gap) > 1e-6
 
     def test_z_column_leader_lands_on_the_left_edge(self):
         # Cover the Z-turned column placer too (mirror of the X row): its tips sit

--- a/tests/test_parameter_id.py
+++ b/tests/test_parameter_id.py
@@ -70,6 +70,12 @@ def _plan(feature):
 # uniqueness is only stressed by a feature emitting its full parameter set.
 _SAMPLES: dict[str, ir.Feature] = {
     "AngleFeature": ir.AngleFeature(ir.AngularReference((0, 0, 0), (10, 0, 0), (0, 10, 0))),
+    "AnglePatternFeature": ir.AnglePatternFeature(
+        (
+            ir.AngularReference((0, 0, 0), (10, 0, 0), (0, 10, 0)),
+            ir.AngularReference((20, 0, 0), (30, 0, 0), (20, 10, 0)),
+        )
+    ),
     "HoleFeature": ir.HoleFeature(
         _F,
         8.0,
@@ -269,6 +275,10 @@ _SAMPLES: dict[str, ir.Feature] = {
 # intent aimed at it, silently.
 _SAMPLE_BINDINGS = {
     "AngleFeature": (("included.angle", 90.0),),
+    "AnglePatternFeature": (
+        ("included.angle.member1", 90.0),
+        ("included.angle.member2", 90.0),
+    ),
     "HoleFeature": (
         ("bore.diameter", 8.0),
         ("bore.depth", 10.0),

--- a/tests/test_parameter_id.py
+++ b/tests/test_parameter_id.py
@@ -69,6 +69,7 @@ def _plan(feature):
 # One MAXIMAL instance per feature type — every optional parameter populated, since
 # uniqueness is only stressed by a feature emitting its full parameter set.
 _SAMPLES: dict[str, ir.Feature] = {
+    "AngleFeature": ir.AngleFeature(ir.AngularReference((0, 0, 0), (10, 0, 0), (0, 10, 0))),
     "HoleFeature": ir.HoleFeature(
         _F,
         8.0,
@@ -267,6 +268,7 @@ _SAMPLES: dict[str, ir.Feature] = {
 # Re-blessing is a deliberate act — an id moving to a different quantity breaks every
 # intent aimed at it, silently.
 _SAMPLE_BINDINGS = {
+    "AngleFeature": (("included.angle", 90.0),),
     "HoleFeature": (
         ("bore.diameter", 8.0),
         ("bore.depth", 10.0),

--- a/tests/test_private_test_attr_reads.py
+++ b/tests/test_private_test_attr_reads.py
@@ -69,6 +69,7 @@ _DRAWING_PRIVATES: frozenset[str] = frozenset(
         "_add_shapes",
         "_add_view",
         "_analysis",
+        "_angular_dimension_plan",
         "_ann_box_cache",
         "_attach_part_model",
         "_attach_solve_trace",

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -159,7 +159,7 @@ def test_section_recess_family_covers_the_published_geometry_and_occurrence_cont
     assert not retired & package.keys()
     assert not retired & consumer.keys()
     family = package["section-recesses"]
-    assert INSTALLED_PACKAGE_VERSION == "0.2.5"
+    assert INSTALLED_PACKAGE_VERSION == "0.2.6"
     assert family["introduced_in"] == "0.2.0"
     assert family["census_output"] == "RecognitionResult.section_recesses"
     expected_fields = {

--- a/tests/test_refactor_golden.py
+++ b/tests/test_refactor_golden.py
@@ -56,6 +56,11 @@ labels identical, page identical, one build issue ADDED and none removed. The dr
 get worse; the report got honest, which is the one direction a completeness gate must not
 mistake for a regression.
 
+#1505 re-baselines only `grooved_shaft` after native shoulder recovery: the three
+13/26/13 mm links replace the inactive 60 mm fallback, and the redundant side view
+is omitted. All ten audited groove/shoulder requirements are placed, with each
+outer diameter retaining its own claim. The baseline now guards those recovered marks.
+
 Re-bless the recorded baseline (advances the footprint ratchet — do it deliberately):
     DRAFTWRIGHT_UPDATE_GOLDEN=1 uv run pytest tests/test_refactor_golden.py
 """

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,12 +1,28 @@
 """Unit tests for AnnotationRegistry — the single owner of annotation identity,
 ownership, pins, and build issues (#138 / ADR 1 (was 0005), Step 2)."""
 
+from types import SimpleNamespace
+
 import pytest
 
 from draftwright.registry import AnnotationRegistry
 
 # Pure unit tests — no OCC builds — so they join the build-light `smoke` set (#153).
 pytestmark = pytest.mark.smoke
+
+
+def test_measurement_presence_requires_the_live_exact_owner_and_parameter():
+    owner = SimpleNamespace(diameter=40)
+    identity = SimpleNamespace(feature=owner, parameter="step.diameter")
+    registry = AnnotationRegistry()
+    registry.add(object(), "diameter", "front", measurement=identity)
+    assert registry.has_measurement(identity)
+    assert not registry.has_measurement(
+        SimpleNamespace(feature=SimpleNamespace(diameter=40), parameter="step.diameter")
+    )
+    assert not registry.has_measurement(SimpleNamespace(feature=owner, parameter="step.length"))
+    registry.remove("diameter")
+    assert not registry.has_measurement(identity)
 
 
 def test_add_records_name_and_view():

--- a/tests/test_render_seam.py
+++ b/tests/test_render_seam.py
@@ -9,6 +9,7 @@ callouts is covered by the hole-callout tests in `test_make_drawing`; the test-o
 
 import math
 
+import pytest
 from build123d import Box, Cylinder, Pos
 
 from draftwright.annotations.from_model import hole_callout_spec
@@ -182,12 +183,13 @@ class TestStepChainDrop:
     Must NOT emit an Escalation(kind='step') (that is the prismatic-detail consumer,
     wrong semantics for a turned chain)."""
 
-    def _stub_dwg(self):
-        from types import SimpleNamespace
+    def _stub_dwg(self, page_width):
+        from build123d_drafting.helpers import Draft
 
         class _Dwg:
             def __init__(s):
-                s.draft = SimpleNamespace(font_size=3.0, pad_around_text=0.5)
+                s.draft = Draft(font_size=3.0, pad_around_text=0.5)
+                s.page_w, s.page_h = page_width, 100.0
                 s.issues = []
                 # NOTE: deliberately no _escalations — if the code tried to append a
                 # step Escalation it would AttributeError, so a clean run proves it doesn't.
@@ -195,52 +197,57 @@ class TestStepChainDrop:
             def view_bounds(s, view):
                 return (0.0, 0.0, 100.0, 100.0)
 
+            def iter_annotations(s):
+                return iter(())
+
             def _record_build_issue(s, sev, code, msg):
                 s.issues.append((sev, code, msg))
 
         return _Dwg()
 
-    def test_crowded_vertical_chain_records_the_drop(self):
+    @pytest.mark.parametrize("page_width, expected", ((100, 0), (200, 1)))
+    def test_off_page_chain_members_report_only_their_own_drops(self, page_width, expected):
         from types import SimpleNamespace
 
         from draftwright.annotations._common import PlacementContext
         from draftwright.annotations.from_model import _draw_step_chain
         from draftwright.registry import AnnotationRegistry
 
-        dwg = self._stub_dwg()
+        dwg = self._stub_dwg(page_width)
         # The drop lint routes through the ctx's registry now (#639), not the drawing.
-        ctx = PlacementContext(registry=AnnotationRegistry())
-        # Vertical (chain-to-the-right) segs whose shoulder Ys are 0.1 mm apart —
-        # far below tier_step (= font_size + 2*pad = 4). Values differ so the
-        # uniform-collapse path is not taken. The chain is dropped whole.
+        ctx = PlacementContext(registry=AnnotationRegistry(), items=[])
+        # The upper member is always off-page. A narrow page also loses the
+        # lower member; sufficient lateral space must preserve it (#1505).
         segs = [
             SimpleNamespace(
-                pa=(80.0, 10.0, 0),
-                pb=(80.0, 10.1, 0),
-                value=5.0,
+                pa=(80.0, 20.0, 0),
+                pb=(80.0, 42.0, 0),
+                value=22.0,
                 tolerance=None,
                 measurements=("step-a",),
                 label=None,
-                value_text="5",
+                value_text="22",
                 display_decimals=None,
             ),
             SimpleNamespace(
-                pa=(80.0, 10.1, 0),
-                pb=(80.0, 10.2, 0),
-                value=8.0,
+                pa=(80.0, 42.0, 0),
+                pb=(80.0, 105.0, 0),
+                value=63.0,
                 tolerance=None,
                 measurements=("step-b",),
                 label=None,
-                value_text="8",
+                value_text="63",
                 display_decimals=None,
             ),
         ]
         placed = _draw_step_chain(dwg, "front", segs, "m_steplen", ctx=ctx)
-        assert placed == 0
+        assert placed == expected == len(ctx.items)
         codes = [i.code for i in ctx.registry.issues]
         assert "step_dim_dropped" in codes, "silent drop no longer allowed (#362)"
-        drop = next(i for i in ctx.registry.issues if i.code == "step_dim_dropped")
-        assert drop.measurement_ids == ("step-a", "step-b")
+        drops = [i for i in ctx.registry.issues if i.code == "step_dim_dropped"]
+        assert [identity for drop in drops for identity in drop.measurement_ids] == (
+            ["step-b"] if expected else ["step-a", "step-b"]
+        )
         assert ctx.escalations == []  # _record_step_chain_drop records lint only, no Escalation
 
 

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -2925,6 +2925,7 @@ def _route_of(value: str) -> str:
 #: serialises it and the generated script reconstructs it (#973 r3). No `"untested"` route
 #: either; #948 closed the last of them.
 _KIND_MIRROR_COVERAGE = {
+    "angle": "declared",
     "hole": "corpus",
     "pattern": "corpus",
     "boss": "corpus",
@@ -3092,6 +3093,8 @@ def _declared_models():
         "external spur gear"
     ]()
     yield "external_spur_gear", gear, "sheet.external_spur_gear("
+    _part, angle = TestTheDeclaredModelMatchesTheDetectedOne._declared_corpus()["angle"]()
+    yield "angle", angle, "sheet.angle("
 
 
 def _declarable_kinds() -> set[str]:
@@ -3431,6 +3434,7 @@ _ROUTES = tuple(_ROUTE_OBLIGATIONS)
 #: reads it; the route decides which corpus must contain the kind, and is validated against
 #: `_ROUTES`. Fail-closed against the IR itself, so a new kind cannot arrive unclassified.
 _FIDELITY_ROUTE = {
+    "angle": ("declared", "included angle with explicit rays and tolerance"),
     # Detected: reachable by emitting a model the detectors built from a part.
     "hole": ("detected", "plate+hole, and as a pattern member"),
     "pattern": ("detected", "hole pattern (linear) and grid pattern"),
@@ -3804,6 +3808,14 @@ class TestTheDeclaredModelMatchesTheDetectedOne:
 
         from draftwright import Sheet
 
+        def angle():
+            part = Box(40, 20, 10)
+            sheet = Sheet(part, title="T", number="N")
+            handle = sheet.angle(vertex=(0, 0, 5), first=(10, 0, 5), second=(0, 10, 5))
+            handle.tolerance(0.05, on="included.angle")
+            sheet.dimension(handle, "included.angle")
+            return part, sheet.model()
+
         def measured_dimension():
             part = Box(40, 20, 10)
             sheet = Sheet(part, title="T", number="N").auto_dimensions()
@@ -3908,6 +3920,7 @@ class TestTheDeclaredModelMatchesTheDetectedOne:
             return part, dataclasses.replace(model, features=[*model.features, datum])
 
         return {
+            "angle": angle,
             "control frame": control_frame,
             "datum feature": datum_ref,
             "external spur gear": external_spur_gear,

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -1840,6 +1840,12 @@ class TestCli:
         assert (tmp_path / "g.pdf").exists()  # #702: Sheet.export defaults to PDF
 
 
+def _angular_profile():
+    # Scalene stock has independent corner angles, unlike a regular HEX callout
+    # or chamfer, whose geometry already defines the incident angles.
+    return extrude(Polygon((0, 0), (50, 0), (13, 30), align=None), amount=8)
+
+
 def _chamfered_corner(op, size):
     """A plate with ONE vertical corner edge chamfered or filleted — `op` is build123d's
     `chamfer` or `fillet`. Same edge selection the per-kind emit tests use, so the corpus
@@ -1974,11 +1980,12 @@ class TestRoundTripParity:
 
         Signature parity alone would also be satisfied by two identically BLANK drawings, so
         this pins the content on both sides as well.
-        This shaft's shoulders sit 4 mm apart, which fails the legibility gate, which drops the
-        whole step chain. #955 recovers the overall height from a compiler-approved contingency
-        while retaining the specific chain-drop diagnostic; direct and generated-script builds
-        must make that same runtime selection."""
+        The 4 mm groove previously caused the whole step chain to drop, activating the
+        overall-height contingency. Shoulder recovery now preserves the native lengths;
+        direct and generated-script builds must make the same runtime selection."""
         from build123d import Align
+
+        from draftwright.model import DimensionId
 
         shaft = Cylinder(12, 60, align=(Align.CENTER, Align.CENTER, Align.MIN))
         shaft -= Pos(0, 0, 30) * (
@@ -1994,14 +2001,20 @@ class TestRoundTripParity:
             assert any(n.startswith("m_groove") for n in names), (which, names)
             assert "4 WIDE × ø18" in labels, (which, labels)
             assert "ø24" in labels, (which, labels)
-            assert "dim_height" in names, (which, names)
-            assert "60" in labels, (which, labels)
+            assert sorted(
+                item.label for name, item in dwg.iter_annotations() if name.startswith("m_steplen")
+            ) == ["26", "30"], (which, labels)
+            assert "dim_height" not in names, "the complete chain needs no fallback"
             codes = dwg.lint_summary()["by_code"]
             assert codes.get("axial_length_missing", 0) == 0, (which, codes)
-            assert codes.get("step_dim_dropped") == 1, (which, codes)
-            assert not [
-                row for row in dwg.suppressions() if row["parameter_id"] == "height.length"
-            ], (which, dwg.suppressions())
+            assert codes.get("step_dim_dropped", 0) == 0, (which, codes)
+            steps = [feature for feature in dwg.model().features if feature.kind == "step"]
+            assert len(steps) == 2
+            assert all(
+                dwg.registry.has_measurement(DimensionId(step, parameter.parameter_id))
+                for step in steps
+                for parameter in step.parameters()
+            ), (which, steps)
 
     def test_pocket_pattern_parity(self, tmp_path, monkeypatch):
         """#957 review: the emitted script named `pocket` without importing it, so a
@@ -2556,6 +2569,7 @@ class TestTheDimensionMirror:
             "boss": Box(80, 60, 12) + Pos(0, 0, 12) * Cylinder(10, 8),
             "polygonal boss": _polygonal_boss_plate(),
             "polygonal stock": _polygonal_stock(),
+            "outer angles": _angular_profile(),
             # Turned parts joined the corpus with #945: `rotational` gained a declarative
             # verb, so they mirror their dimensions instead of falling back. Contiguous on
             # purpose — a disconnected profile is a separate, unrelated defect (#943).
@@ -2603,6 +2617,7 @@ class TestTheDimensionMirror:
     #: only an envelope) and "slot" (detected a pocket) until #947's review counted them.
     _EXPECTED_KINDS = {
         "plate+hole": {"hole"},
+        "outer angles": {"angle"},
         # The mounting lugs are solid material pierced by bores, not pockets. The
         # dedicated pocket and pad fixtures exercise those two mirror paths.
         "flange (no envelope feature)": {"boss", "hole", "pattern", "step"},
@@ -2925,7 +2940,7 @@ def _route_of(value: str) -> str:
 #: serialises it and the generated script reconstructs it (#973 r3). No `"untested"` route
 #: either; #948 closed the last of them.
 _KIND_MIRROR_COVERAGE = {
-    "angle": "declared",
+    "angle": "corpus",
     "hole": "corpus",
     "pattern": "corpus",
     "boss": "corpus",
@@ -3434,7 +3449,10 @@ _ROUTES = tuple(_ROUTE_OBLIGATIONS)
 #: reads it; the route decides which corpus must contain the kind, and is validated against
 #: `_ROUTES`. Fail-closed against the IR itself, so a new kind cannot arrive unclassified.
 _FIDELITY_ROUTE = {
-    "angle": ("declared", "included angle with explicit rays and tolerance"),
+    "angle": (
+        "detected",
+        "outer-profile included angles; declared rays and tolerances also tested",
+    ),
     # Detected: reachable by emitting a model the detectors built from a part.
     "hole": ("detected", "plate+hole, and as a pattern member"),
     "pattern": ("detected", "hole pattern (linear) and grid pattern"),
@@ -3677,9 +3695,8 @@ class TestTheDeclaredModelMatchesTheDetectedOne:
             - Pos(20, 0, 0) * Cylinder(4, 40)
             - Pos(60, 0, 0) * Cylinder(4, 40),
             "pocket pattern": rows(Box(10, 12, 6), z=7),
-            # Grid variants. They do NOT round-trip — #969 transposes the array — so they
-            # carry a strict xfail rather than sitting outside the corpus, which keeps the
-            # DESIRED equality as the assertion and still executes the grid emit branches.
+            # Both grid families remain in the round-trip corpus; the independent
+            # member-order check retains a strict xfail for the slot-grid mismatch.
             "pocket grid": grid(Box(12, 14, 6), z=7),
             "slot grid": grid(Box(24, 8, 40), z=0),
             # GRID variants. The linear ones above leave the grid branches of
@@ -3704,6 +3721,7 @@ class TestTheDeclaredModelMatchesTheDetectedOne:
             "boss": Box(80, 60, 12) + Pos(0, 0, 12) * Cylinder(10, 8),
             "polygonal boss": _polygonal_boss_plate(),
             "polygonal stock": _polygonal_stock(),
+            "outer angles": _angular_profile(),
             "turned shaft": Cylinder(15, 20) + Pos(0, 0, 17.5) * Cylinder(10, 15),
             "stepped": Box(40, 12, 40) - Pos(10, 0, 20) * Box(20, 12, 20),
             # The machined kinds. Excused in the first two cuts as carrying "no position to
@@ -3740,9 +3758,8 @@ class TestTheDeclaredModelMatchesTheDetectedOne:
     #: two fixtures most likely to regress. #969's second defect (recognition projecting onto
     #: its own plane basis) was live underneath one of these markers (Codex review of #970).
     _KNOWN_BAD_ORDER = {
-        "pocket grid": "#883 — per-member identity: detection enumerates a grid by column, "
+        "slot grid": "#883 — per-member identity: detection enumerates a grid by column, "
         "declaration by row. Same members, same places, different tuple order.",
-        "slot grid": "#883 — as pocket grid",
     }
 
     def _order_cases(_corpus=_corpus, _bad=_KNOWN_BAD_ORDER):  # noqa: N805 — class-body
@@ -3761,6 +3778,7 @@ class TestTheDeclaredModelMatchesTheDetectedOne:
     #: exists for, repeated here because this corpus made the same mistake (#967 review).
     _EXPECTED_KINDS = {
         "underside pocket": {"pocket"},
+        "outer angles": {"angle"},
         "top pocket": {"pocket"},
         "slot": {"slot"},
         "pocket pattern": {"pocket_pattern"},

--- a/tests/test_sheet_identity_invariant.py
+++ b/tests/test_sheet_identity_invariant.py
@@ -250,6 +250,7 @@ _SCENARIOS = {
 #: how a guard stops guarding.
 _SAME_PATH_AS_ENVELOPE = {
     "angle",
+    "angle_pattern",
     "add",
     "double_d_bore",
     "measured_dimension",

--- a/tests/test_sheet_identity_invariant.py
+++ b/tests/test_sheet_identity_invariant.py
@@ -249,6 +249,7 @@ _SCENARIOS = {
 #: against the source rather than taking it on trust: an exemption list nobody verifies is
 #: how a guard stops guarding.
 _SAME_PATH_AS_ENVELOPE = {
+    "angle",
     "add",
     "double_d_bore",
     "measured_dimension",

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -309,6 +309,23 @@ class TestCalloutRendering:
 
 
 class TestSheetTolerance:
+    @pytest.mark.parametrize("kind", ("step", "boss"))
+    def test_canonical_diameter_tolerance_targets_keep_source_and_reject_unknown_ids(self, kind):
+        sheet = Sheet(Cylinder(10, 20))
+        handle = (
+            sheet.step(diameter=20, length=20, at=(0, 0, 0), axis="z")
+            if kind == "step"
+            else sheet.diameter(diameter=20, at=(0, 0, 0), axis="z")
+        )
+        handle.tolerance(0.2, on=f"{kind}.diameter", source="authored", source_ids=("diameter-1",))
+        sheet.dimension(handle, f"{kind}.diameter")
+        model = sheet.model()
+        feature = model.features[0]
+        tolerance = model.decorations[(feature, "diameter")]
+        assert tolerance.value == 0.2 and tolerance.source_ids == ("diameter-1",)
+        with pytest.raises(ValueError, match="must name one parameter"):
+            handle.tolerance(0.2, on="unknown.length")
+
     @staticmethod
     def _stepped_shaft():
         # a genuine 2-diameter turned shaft: distinct shoulders → both a step chain and ⌀ leaders

--- a/uv.lock
+++ b/uv.lock
@@ -750,7 +750,7 @@ requires-dist = [
     { name = "numpy", specifier = ">=1.24" },
     { name = "pillow", specifier = ">=10" },
     { name = "pypdfium2", specifier = ">=4" },
-    { name = "quiddity", specifier = "==0.2.5" },
+    { name = "quiddity", specifier = "==0.2.6" },
     { name = "reportlab", specifier = ">=4.0" },
     { name = "steputils", specifier = "==0.1" },
     { name = "svglib", specifier = ">=1.5" },
@@ -2579,15 +2579,15 @@ wheels = [
 
 [[package]]
 name = "quiddity"
-version = "0.2.5"
+version = "0.2.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/22/d7/9a3a7686941c3147aad406abc36b4cb5b97887d47960a5e4a37eb2ca431b/quiddity-0.2.5.tar.gz", hash = "sha256:dc2f36d8848f2a6553e82b88e2b382c6024d43d7c51579d9b8b36d024cce64da", size = 14857329, upload-time = "2026-09-07T13:04:10.854Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/08/14ff956ac24f5811e4289dc9dd7dc6587479d86ec494b6953a1b6414caf6/quiddity-0.2.6.tar.gz", hash = "sha256:5ae79af9cffe0c5f03f5c1750391759040b9efbc9359bf9f1af3769aaf30316d", size = 14879390, upload-time = "2026-09-07T17:06:58.315Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f1/a2/ea9de2a6d389bd67cad2391e15045b8563d31666fb8306f1cd521e3ea546/quiddity-0.2.5-py3-none-any.whl", hash = "sha256:22d91ebc85624dbb56203ba5540b2c3c9ae7ba82bdea32d7536fe4391ad59997", size = 517010, upload-time = "2026-09-07T13:04:08.574Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ad/2bb920c90af85f98f8907705da8439723d6296d409c6975a1e211a7d7642/quiddity-0.2.6-py3-none-any.whl", hash = "sha256:b08a405da6eaf5fcfe48f2fdea452630c71b4b46b3ac7aca2c6ecc3430940a45", size = 526044, upload-time = "2026-09-07T17:06:56.733Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -7,9 +7,6 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
-[manifest]
-constraints = [{ name = "cadquery-ocp-novtk", specifier = "!=7.9.3.1.1" }]
-
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"
@@ -709,8 +706,10 @@ dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
     { name = "build123d-drafting-helpers" },
+    { name = "cadquery-ocp-novtk", marker = "python_full_version >= '3.13'" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "ocp-gordon" },
     { name = "pillow" },
     { name = "pypdfium2" },
     { name = "quiddity" },
@@ -747,7 +746,9 @@ requires-dist = [
     { name = "build123d", marker = "python_full_version < '3.13'", specifier = ">=0.9.0,<0.11" },
     { name = "build123d", marker = "python_full_version >= '3.13'", specifier = ">=0.11,<0.12" },
     { name = "build123d-drafting-helpers", specifier = ">=0.14.2" },
+    { name = "cadquery-ocp-novtk", marker = "python_full_version >= '3.13'", specifier = "!=7.9.3.1.1" },
     { name = "numpy", specifier = ">=1.24" },
+    { name = "ocp-gordon", specifier = "<0.3" },
     { name = "pillow", specifier = ">=10" },
     { name = "pypdfium2", specifier = ">=4" },
     { name = "quiddity", specifier = "==0.2.6" },


### PR DESCRIPTION
## Symptom and evidence

STC618 had no general angular dimensions, and its short 3 mm shoulders caused neighbouring 22 mm length dimensions to disappear. This change adds editable angular measurements and repeated outside-profile angle groups, and recovers short shoulder extension-line dimensions through the shared placement and semantic detail routes.

- Construction-authored sharp/rounded profiles and two-step/symmetric-flange fixtures reproduce the contracts without requiring a customer file.
- The private STC618 manual canary now shows `3× 85.7°`, `3× 154.3°`, and both 22+3 mm shoulder chains. All 39 requirements in audited recognised families are placed, with no warning/error findings. This is partial recognised-family coverage, not proof of whole-part completeness; bosses remain unscored.
- SVG, DXF, PDF and PNG were exported; the PNG was visually inspected. DXF read-back matches each angle's four exported arc edges by centre, radius and endpoints; the DXF audit is clear.
- Named mutations demonstrate failures for shared-edge ownership, unrelated equal-angle grouping, candidate-pool isolation, incomplete-detail page recovery, Z-detail coverage and collapsed end-on projections. Additional angular, ownership and shoulder mutations are recorded in the implementation review evidence.

Closes #1504. Closes #1505.

A fresh installed-wheel check exposed an OCP import failure: `ocp_gordon` 0.3 requires OCP 8, incompatible with the supported build123d/OCP 7 stacks. Published dependency metadata now caps Gordon below 0.3 and carries the existing broken-macOS-wheel exclusion. Corrected clean Python 3.12 and 3.14 wheel installs both completed the STC618 semantic assertions and all four exports. All 126 external locked package records are unchanged.

CI fixture correction: build123d 0.11 stores rotation in the root location, so the visible-ink corruption fixture also moved its reference metadata. The fixture now nests the rotated geometry in a fresh compound and asserts unchanged reference points plus changed visible geometry. All 113 angular-rendering tests pass on Python 3.14; disabling the production sector-ink guard makes both corruption cases fail. No production code changed. Both corrected cases also pass on Python 3.13, and the full Python 3.12 preflight is green. The corrected commit passed the complete required CI matrix.

## Contract and scope

- Adopt released Quiddity 0.2.6 profile evidence. Select adjacent, body-owned outer-profile supports; rounded corners retain explicit virtual intersections. Recognised chamfer and regular-polygon definitions exclude only their physically evidenced redundant automatic angles.
- Carry canonical angles and per-member angle-pattern identities through detection, declaration, discovery, compilation, generated scripts, live/deferred edits, tolerances, omission and physical critique. Group repetition requires a recognised same-body rotation and a complete matching profile.
- Place bounded angular candidates through the shared solve. Authors select meaning, supported sides, priority and pins. They do not place annotation coordinates.
- Preserve independently placeable shoulder lengths and diameter ownership. Semantic step details work on X/Y/Z and retain measurement identities. A detail drawing with another required drop can continue the bounded page search; a complete detected detail does not spend a larger sheet merely to remove its detail.
- Report angle outcomes through report schema v3, with unchanged explicit coverage limits.

ADR review: ADR 1 retains one inventory and compiler path; ADR 2 retains bounded shared placement and scale-before-sheet recovery; ADR 3 consumes issued provider evidence without topology rescans; ADR 4 keeps canonical identities, authored omission and executable script parity; ADR 5 keeps independent physical critique, truthful drops and mutation-tested guards. No ADR text changes.

Outside this slice: general oblique/reflex angles, arbitrary geometric pattern discovery, automatic removal of principal views, whole-part recognition completeness and removal of the valid bolt-circle furniture.

## Validation

- N/A: separate `scripts/pr-check --quick`; the successful full gate includes its smoke subset and all static checks.
- [x] `UV_PYTHON=3.12 scripts/pr-check --full`: 7,672 passed, two skipped, 13 expected failures; 95.92% combined coverage and 94% changed-line coverage (93% required).
- [x] Named guard mutations observed failing; mutations that failed for the wrong precondition were discarded and corrected.
- [x] Automatic, declared, generated-script and supported edit paths exercised.
- [x] Recognition, repeated-lint, import-boundary and inspection guards passed in the full suite.
- [x] Required real-part canary passed locally; SVG/DXF export and fixed measurement/occurrence checks.
- [x] Local slow integration suite (unchanged production source): 46 passed, two expected failures in 218 seconds (`uv run --python 3.12 pytest tests/ -m slow -n auto --dist load`, exit 0).
- [x] Required remote CI and Codecov project check passed on `bdb8b75f083923d8fe0999b6181a4bb6309907ae`; merged as `b3db97b2e9ca001d84452d3c4ecc5158c56062a1`.

The final full gate validates commit `bdb8b75f083923d8fe0999b6181a4bb6309907ae` and completed in 389 seconds. The real-part canary completed in 17 seconds. The installed-wheel and slow integration results apply to the same production source and dependency metadata; the final correction changes only the angular corruption fixture. Static checks, the lock check, sdist/wheel build and clean Python 3.12/3.14 installed-wheel checks are complete. Google-style author review covered design, correctness, complexity, tests, naming and documentation against all five ADRs. Substantive findings were corrected and the affected guards rerun, including deliberate mutations. All required remote checks passed and the PR merged. The non-required Codecov patch check remains advisory: 1,317 changed executable lines include 76 unhit lines and 64 partially covered branch lines, giving 94.23% line-hit coverage (above the explicit 93% gate) and 89.37% fully covered lines (below Codecov’s automatic 94.65% patch target). No coverage thresholds were lowered. The canonical CI XML reproduces both numbers; independent semantic guard mutations and the release canaries are recorded above.

## Stop check

- [x] No two consecutive review rounds invalidated the same core association strategy; exact provider ownership remains the boundary.
- [x] The missing upstream profile contract was raised separately and is now supplied by Quiddity 0.2.6.

## Contributor License Agreement

- [ ] Maintainer contribution; CLA acknowledgement retained for final PR review.
