### PR TITLE
Keep overall dimensions when turned step chains are incomplete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -478,6 +478,10 @@
 
 ### Fixed
 
+- Overall height and envelope width remain dimensioned when approved turned-step lengths
+  cover only part of the respective extent. Redundancy suppression now requires adjoining
+  measurements on one profile to reach both overall endpoints; STC618 retains its missing
+  62 mm height (#1509).
 - Non-1:1 orthographic and isometric projection now scales extracted solids about the world
   origin, matching the view-coordinate mapper and solver zones. Solids carrying a non-zero
   build123d `Location` no longer shift their silhouette away from dimensions and callouts.

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -1049,6 +1049,54 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
     return approved, omissions
 
 
+def _step_chain_covers_extent(
+    model: PartModel, groups: list[ApprovedGroup], axis: Literal["x", "z"]
+) -> bool:
+    """Require adjoining approved measurements between both overall ends of one profile."""
+    axis_index = "xyz".index(axis)
+    intervals: dict[tuple[tuple[float, ...], object], list[tuple[float, float]]] = {}
+    step_profiles = set()
+    for group in groups:
+        if group.feature_kind not in ("step", "groove") or group.facts.frame.axis != axis:
+            continue
+        length = group.dim(kind="length")
+        if length is None:
+            continue
+        feature = resolve_feature(group.ref)
+        frame = group.facts.frame
+        key = (
+            tuple(
+                round(float(value), 6) for i, value in enumerate(frame.origin) if i != axis_index
+            ),
+            feature.profile or feature.profile_group,
+        )
+        if group.feature_kind == "step":
+            if length.span is None:
+                continue
+            lo, hi = sorted(float(point[axis_index]) for point in length.span)
+            step_profiles.add(key)
+        else:
+            centre = float(frame.origin[axis_index])
+            lo, hi = centre - length.value / 2, centre + length.value / 2
+        intervals.setdefault(key, []).append((lo, hi))
+
+    # Emitted declarations round supports to 0.001 mm. Keep that numerical seam
+    # tolerance, but do not join different bodies or merely overlapping spans:
+    # 0..40 and 20..60 do not tell the reader the overall length.
+    tolerance = 1e-3 + 1e-9
+    bb: Any = model.bbox
+    for key in step_profiles:
+        reachable = [float(tuple(bb.min)[axis_index])]
+        for lo, hi in sorted(intervals[key]):
+            if any(abs(lo - station) <= tolerance for station in reachable):
+                reachable.append(hi)
+        if any(
+            abs(station - float(tuple(bb.max)[axis_index])) <= tolerance for station in reachable
+        ):
+            return True
+    return False
+
+
 def _compile_overall_height(
     model: PartModel, marked, *, planned, include_overall: bool, step_chain_approved: bool
 ) -> tuple[ApprovedLadder | None, ApprovedContingency | None, list[Omission]]:
@@ -1585,7 +1633,9 @@ def _compile_slot_positions(model: PartModel) -> tuple[list[ApprovedDimension], 
     return approved, omissions
 
 
-def _compile_groups(planned) -> tuple[list[ApprovedGroup], list[Omission]]:
+def _compile_groups(
+    planned, *, restore_width: bool = False
+) -> tuple[list[ApprovedGroup], list[Omission]]:
     """Every planned group, reduced to what the compiler approved, plus what it withheld.
 
     The general path all remaining renderers migrate onto: same per-feature shape they
@@ -1602,6 +1652,17 @@ def _compile_groups(planned) -> tuple[list[ApprovedGroup], list[Omission]]:
     out: list[ApprovedGroup] = []
     omissions: list[Omission] = []
     for g in planned:
+        # The planner's X-chain redundancy decision precedes chain approval.
+        # Restore only that reason, preserving authored and unrelated omissions.
+        dims = tuple(
+            replace(pd, suppressed=False, reason=None)
+            if restore_width
+            and isinstance(g.feature, EnvelopeFeature)
+            and pd.param.parameter_id == "width.length"
+            and pd.reason == "X-turned (step-length chain conveys the length)"
+            else pd
+            for pd in g.dims
+        )
         omissions.extend(
             Omission(
                 g.feature,
@@ -1610,7 +1671,7 @@ def _compile_groups(planned) -> tuple[list[ApprovedGroup], list[Omission]]:
                 pd.reason or "suppressed",
                 conveyed_by=pd.conveyed_by,
             )
-            for pd in g.dims
+            for pd in dims
             if pd.suppressed
         )
         approved = tuple(
@@ -1636,7 +1697,7 @@ def _compile_groups(planned) -> tuple[list[ApprovedGroup], list[Omission]]:
                 view=pd.view,
                 side=pd.side,
             )
-            for pd in g.dims
+            for pd in dims
             if not pd.suppressed
             # A datum-coincident shoulder is not a zero-valued dimension the general group
             # may keep after the dedicated ladder rejected its identical endpoints. It is
@@ -1709,13 +1770,10 @@ def compile_dimensions(
     marked = _suppressed_dims(model, planned)
     ladders, omissions = _compile_step_ladders(model, marked)
     groups_out, group_omissions = _compile_groups(planned)
+    if model.orientation == "x" and not _step_chain_covers_extent(model, groups_out, "x"):
+        groups_out, group_omissions = _compile_groups(planned, restore_width=True)
     groups_out = _share_unique_outer_diameter(groups_out, planned)
-    step_chain_approved = any(
-        group.feature_kind == "step"
-        and group.facts.frame.axis == "z"
-        and group.dim(kind="length") is not None
-        for group in groups_out
-    )
+    step_chain_approved = _step_chain_covers_extent(model, groups_out, "z")
     overall, contingency, height_omissions = _compile_overall_height(
         model,
         marked,

--- a/tests/test_overall_height_coverage.py
+++ b/tests/test_overall_height_coverage.py
@@ -1,0 +1,199 @@
+"""An incomplete axial chain cannot substitute for the overall extent (#1509)."""
+
+from dataclasses import replace
+
+import pytest
+from build123d import Box, Cylinder, Pos
+
+from draftwright import Sheet
+from draftwright.model.compiled import compile_dimensions
+from draftwright.model.declare import _envelope_from_bbox
+from draftwright.model.ir import Frame, GrooveFeature, PartModel, RequestedDimension, StepFeature
+from draftwright.sheet_emit import emit_sheet_script
+
+
+def _step(lo, hi, *, group="shaft", x=0):
+    return StepFeature(
+        Frame((x, 0, (lo + hi) / 2), "z"),
+        length=hi - lo,
+        diameter=24,
+        span=((x, 0, lo), (x, 0, hi)),
+        profile_group=group,
+    )
+
+
+@pytest.mark.parametrize("axis", ("x", "z"))
+@pytest.mark.parametrize(
+    "steps,grooves,complete",
+    [
+        ([_step(-25, -3), _step(-3, 3), _step(3, 25)], [], False),
+        ([_step(-31, -3), _step(3, 31)], [], False),
+        ([_step(-31, 10), _step(-10, 31)], [], False),
+        ([_step(-31, 0), _step(0, 31, group="other")], [], False),
+        ([_step(-31, 0), _step(0, 31, x=30)], [], False),
+        ([_step(0, 31), _step(-31, 0)], [], True),
+        (
+            [_step(-31, -3), _step(3, 31)],
+            [GrooveFeature(Frame((0, 0, 0), "z"), "z", 6, 18, profile_group="shaft")],
+            True,
+        ),
+        (
+            [_step(-31, -3), _step(3, 31)],
+            [GrooveFeature(Frame((0, 0, 0), "z"), "z", 6, 18, profile_group="other")],
+            False,
+        ),
+    ],
+    ids=(
+        "end-caps",
+        "internal-gap",
+        "overlap",
+        "other-body",
+        "other-axis-line",
+        "complete-reversed",
+        "groove-bridge",
+        "foreign-groove",
+    ),
+)
+def test_only_connected_approved_spans_can_replace_overall_extent(steps, grooves, complete, axis):
+    if axis == "x":
+        steps = [
+            replace(
+                step,
+                frame=Frame(tuple(reversed(step.frame.origin)), "x"),
+                span=tuple(tuple(reversed(point)) for point in step.span),
+            )
+            for step in steps
+        ]
+        grooves = [
+            replace(groove, frame=Frame(tuple(reversed(groove.frame.origin)), "x"), axis="x")
+            for groove in grooves
+        ]
+    bb = Box(*((62, 80, 100) if axis == "x" else (100, 80, 62))).bounding_box()
+    model = PartModel(bb, axis, [*steps, *grooves, _envelope_from_bbox(bb)])
+    plan = compile_dimensions(model)
+    assert len(plan.of_kind("step")) == len(steps)
+    assert all(group.dim(kind="length") is not None for group in plan.of_kind("step"))
+    if axis == "z":
+        assert (plan.contingency("step_length") is not None) is complete
+        height = plan.ladder("overall_height")
+        dimension = height.rungs[0] if height is not None else None
+    else:
+        dimension = next(
+            (
+                dim
+                for group in plan.of_kind("envelope")
+                for dim in group.dims
+                if dim.id.parameter == "width.length"
+            ),
+            None,
+        )
+    assert (dimension is None) is complete
+    if dimension is not None:
+        assert dimension.value == pytest.approx(62)
+        assert [point["xyz".index(axis)] for point in dimension.span] == pytest.approx([-31, 31])
+        parameter = "height.length" if axis == "z" else "width.length"
+        assert not [row for row in plan.diagnostics if row.parameter_id == parameter]
+
+
+def test_incomplete_x_chain_does_not_override_an_authored_width_omission():
+    bb = Box(62, 30, 20).bounding_box()
+    step = StepFeature(Frame((0, 0, 0), "x"), 50, 20, ((-25, 0, 0), (25, 0, 0)))
+    model = PartModel(
+        bb,
+        "x",
+        [step, _envelope_from_bbox(bb)],
+        authored_dimensions=(RequestedDimension(step, "step.length"),),
+    )
+    plan = compile_dimensions(model)
+    assert plan.of_kind("step")[0].dim(kind="length").value == 50
+    assert not [
+        dim
+        for group in plan.of_kind("envelope")
+        for dim in group.dims
+        if dim.id.parameter == "width.length"
+    ]
+    omissions = [row for row in plan.diagnostics if row.parameter_id == "width.length"]
+    assert len(omissions) == 1 and omissions[0].authored
+
+
+@pytest.fixture(scope="module")
+def partial_chain_drawing():
+    intervals = [(37, -31, -25), (36, -25, -3), (35, -3, 3), (34, 3, 25), (33, 25, 31)]
+    solids = [Pos(0, 0, (lo + hi) / 2) * Cylinder(radius, hi - lo) for radius, lo, hi in intervals]
+    part = solids[0].fuse(*solids[1:])
+    sheet = Sheet(part, page="A3", scale=1)
+    sheet.authored_dimensions()
+    for radius, lo, hi in intervals:
+        handle = sheet.step(
+            diameter=2 * radius,
+            length=hi - lo,
+            at=(0, 0, (lo + hi) / 2),
+            axis="z",
+            profile_group="shaft",
+        )
+        sheet.dimension(handle, "step.diameter")
+        if lo >= -25 and hi <= 25:
+            sheet.dimension(handle, "step.length")
+    sheet.dimension(sheet.envelope(), "height.length")
+    assert part.bounding_box().size.Z == pytest.approx(62)
+    drawing = sheet.build()
+    plan = compile_dimensions(drawing.model())
+    lengths = [g.dim(kind="length") for g in plan.of_kind("step")]
+    assert sum(dim.value for dim in lengths if dim is not None) == 50
+    return drawing
+
+
+def test_partial_chain_places_overall_with_physical_end_supports(partial_chain_drawing):
+    drawing = partial_chain_drawing
+    marks = [
+        (name, mark)
+        for name, mark in drawing.iter_annotations()
+        if any(mid.parameter == "height.length" for mid in drawing.registry.measurement_of(name))
+    ]
+    assert len(marks) == 1
+    name, mark = marks[0]
+    assert mark.label == "62"
+    view = drawing.registry.view_of(name)
+    stations = [drawing.at(view, 0, 0, z)[1] for z in (-31, 31)]
+    extensions = [
+        first[1]
+        for first, second in mark.segments
+        if abs(first[1] - second[1]) < 1e-6 and abs(first[0] - second[0]) > 1
+    ]
+    assert all(any(abs(station - actual) < 1e-6 for actual in extensions) for station in stations)
+    assert (
+        sum(
+            any(mid.parameter == "step.length" for mid in drawing.registry.measurement_of(n))
+            for n in drawing.annotations()
+        )
+        == 3
+    )
+    assert drawing.lint() == drawing.lint()
+    # An overall extent must not claim to locate the two omitted end shoulders.
+    assert [issue.code for issue in drawing.lint() if issue.severity != "info"] == [
+        "axial_length_missing"
+    ]
+
+
+def test_partial_chain_overall_survives_generated_script(partial_chain_drawing, tmp_path):
+    original = partial_chain_drawing
+    source = emit_sheet_script(
+        original.model(),
+        "part",
+        str(tmp_path / "replay"),
+        title="T",
+        number="N",
+        page="A3",
+        scale=1,
+        formats=("svg",),
+    )
+    namespace = {"part": original.working_part}
+    exec(source, namespace)
+    replay = namespace["drawing"]
+    assert replay.registry.named("dim_height").label == "62"
+    assert any(
+        mid.parameter == "height.length" for mid in replay.registry.measurement_of("dim_height")
+    )
+    assert [issue.code for issue in replay.lint() if issue.severity != "info"] == [
+        "axial_length_missing"
+    ]


### PR DESCRIPTION
## Symptom and evidence

STC618 is 62 mm tall, but its four approved shoulder lengths cover only -25..25 mm. The compiler treated any approved Z step as a complete chain and suppressed the overall height. The same premature decision affected automatic X-axis envelope width.

Require adjoining approved measurements on one physical profile to reach both overall endpoints before suppressing the extent. Groove widths can bridge a chain only with matching ownership. Existing complete-chain behavior and authored omissions remain intact. X width is restored through the shared group compiler only for its canonical chain-redundancy reason; Z height uses the existing approved ladder and contingency.

The fixed public STC618 build prints 62 at both physical end supports, preserves all 21 prior dimensional annotations (labels and parameter lists), and has no warning/error lint. A horizontal synthetic shaft also prints 62 and preserves it through generated Sheet code. No customer STEP is added to the repository.

## Contract and scope

- ADR 1: content approval stays in the compiler and one engine.
- ADR 2: ordinary dimension and height-ladder placement; no raw-coordinate annotations.
- ADR 3: consume existing profile ownership; no recognition changes or extra scans.
- ADR 4: authored omissions and generated-script semantics are guarded; runtime contingency release is unchanged.
- ADR 5: verify physical end supports and retained identities; deliberately omitted shoulders/end diameters remain reported.
- Scope: the existing Z-height and X-envelope-width chain suppression rules. No general dimension-network inference or new envelope-width IR.

## Validation

- [x] `scripts/pr-check --quick`
- [x] `scripts/pr-check --full` on final code: 7,688 passed, 5 skipped, 13 expected failures; 95.92% total coverage and 97.2% changed-line coverage.
- [x] Five targeted mutations, each matched once and failed named assertions: old any-step rule, disabled X restoration, ignored authored omission, ignored profile ownership, overlapping spans treated as adjoining.
- [x] Python 3.12 targeted regression/contingency tests: 28 passed.
- [x] Automatic STC618 build, declared drawings, generated scripts, and repeated lint checked.
- [x] Real-part canary on final code: 1 passed (11.95 seconds build/audit/export test).

Review used Google's design/functionality/complexity/tests checklist and all five live ADRs. This is author review, not an independent approval. Final author review found no unresolved blocking findings within this contract; required hosted CI remains the merge gate.

## Stop check

- [x] No two consecutive review rounds invalidated the same core association strategy.
- [x] No new upstream prerequisite or ADR change is needed.

Closes #1509.

## Contributor License Agreement

- [x] I have read the [CLA](https://github.com/pzfreo/draftwright/blob/main/CLA.md) and agree to it. Submitted for the repository owner.
