### PR TITLE
fix: retain approved boss heights on turned profiles

### DIFF
--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1769,7 +1769,7 @@ def render_diameters(dwg, plan, a, *, ctx, only=None) -> int:
                     pd.id for gp in feature_groups for pd in gp.dims if pd.kind == "diameter"
                 )
                 jobs.append((name, "front", vb, label, candidates, mids))
-                covered_by_name[name] = (dia,)
+                covered_by_name[name] = dia
             placed += place_machined_leader_jobs(
                 dwg,
                 a,
@@ -1778,9 +1778,13 @@ def render_diameters(dwg, plan, a, *, ctx, only=None) -> int:
                 drop_code="diameter_dropped",
                 ctx=ctx,
                 geom_clear=True,
-                joint=True,
-                covers_diameters_by_name=covered_by_name,
             )
+            # Internal concentric-circle leaders legitimately exit the outer
+            # silhouette, like bore callouts. Retain their diameter coverage.
+            for name, dia in covered_by_name.items():
+                ann = ctx.registry.named(name)
+                if ann is not None:
+                    ann.covers_diameters = (dia,)
     # #798: a ⌀ leader the row/column solve sent DIAGONALLY into the body — cutting
     # the silhouette, or an end feature whose diagonal merely grazes it — is re-routed
     # to the clear side (the margin the feature sits at). Auto-pass only: the finalize
@@ -2183,7 +2187,6 @@ def place_machined_leader_jobs(
     joint=False,
     expand_lanes=True,
     source_ids_by_name=None,
-    covers_diameters_by_name=None,
 ) -> int:
     """Lower every machined callout to the one shared ``FeatureLeaderJob`` path.
 
@@ -2193,7 +2196,6 @@ def place_machined_leader_jobs(
     """
 
     source_ids_by_name = source_ids_by_name or {}
-    covers_diameters_by_name = covers_diameters_by_name or {}
     late_inventory = joint and getattr(ctx, "feature_leaders", None) is not None
     feature_jobs = []
     for name, view, silhouette, label, raw_candidates, measurement in jobs:
@@ -2230,18 +2232,8 @@ def place_machined_leader_jobs(
                         feature,
                     )
 
-        def _build(
-            tip,
-            elbow,
-            _feature,
-            *,
-            _label=label,
-            _covers=tuple(covers_diameters_by_name.get(name, ())),
-        ):
-            leader = Leader(tip=(tip[0], tip[1], 0), elbow=elbow, label=_label, draft=dwg.draft)
-            if _covers:
-                leader.covers_diameters = _covers
-            return leader
+        def _build(tip, elbow, _feature, *, _label=label):
+            return Leader(tip=(tip[0], tip[1], 0), elbow=elbow, label=_label, draft=dwg.draft)
 
         label_width, label_height = _text_size(
             str(label),

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1769,7 +1769,7 @@ def render_diameters(dwg, plan, a, *, ctx, only=None) -> int:
                     pd.id for gp in feature_groups for pd in gp.dims if pd.kind == "diameter"
                 )
                 jobs.append((name, "front", vb, label, candidates, mids))
-                covered_by_name[name] = dia
+                covered_by_name[name] = (dia,)
             placed += place_machined_leader_jobs(
                 dwg,
                 a,
@@ -1778,19 +1778,16 @@ def render_diameters(dwg, plan, a, *, ctx, only=None) -> int:
                 drop_code="diameter_dropped",
                 ctx=ctx,
                 geom_clear=True,
+                joint=True,
+                covers_diameters_by_name=covered_by_name,
             )
-            # Internal concentric-circle leaders legitimately exit the outer
-            # silhouette, like bore callouts. Retain their diameter coverage.
-            for name, dia in covered_by_name.items():
-                ann = ctx.registry.named(name)
-                if ann is not None:
-                    ann.covers_diameters = (dia,)
     # #798: a ⌀ leader the row/column solve sent DIAGONALLY into the body — cutting
     # the silhouette, or an end feature whose diagonal merely grazes it — is re-routed
     # to the clear side (the margin the feature sits at). Auto-pass only: the finalize
     # (only=) path replays recorded verbs and must not disturb pinned user dims.
     if only is None:
-        _reroute_crossing_diameters(dwg, ctx=ctx)
+        # Rerouting must see the principal dimensions that registered before this pass.
+        ctx.post_drain.append(lambda: _reroute_crossing_diameters(dwg, ctx=ctx))
     return placed
 
 
@@ -2186,6 +2183,7 @@ def place_machined_leader_jobs(
     joint=False,
     expand_lanes=True,
     source_ids_by_name=None,
+    covers_diameters_by_name=None,
 ) -> int:
     """Lower every machined callout to the one shared ``FeatureLeaderJob`` path.
 
@@ -2195,6 +2193,7 @@ def place_machined_leader_jobs(
     """
 
     source_ids_by_name = source_ids_by_name or {}
+    covers_diameters_by_name = covers_diameters_by_name or {}
     late_inventory = joint and getattr(ctx, "feature_leaders", None) is not None
     feature_jobs = []
     for name, view, silhouette, label, raw_candidates, measurement in jobs:
@@ -2231,8 +2230,18 @@ def place_machined_leader_jobs(
                         feature,
                     )
 
-        def _build(tip, elbow, _feature, *, _label=label):
-            return Leader(tip=(tip[0], tip[1], 0), elbow=elbow, label=_label, draft=dwg.draft)
+        def _build(
+            tip,
+            elbow,
+            _feature,
+            *,
+            _label=label,
+            _covers=tuple(covers_diameters_by_name.get(name, ())),
+        ):
+            leader = Leader(tip=(tip[0], tip[1], 0), elbow=elbow, label=_label, draft=dwg.draft)
+            if _covers:
+                leader.covers_diameters = _covers
+            return leader
 
         label_width, label_height = _text_size(
             str(label),
@@ -4123,9 +4132,7 @@ def render_polygonal_stock(dwg, plan, a, *, ctx) -> int:
 
 
 def render_boss_heights(dwg, plan, a, *, ctx) -> int:
-    """Queue prismatic boss heights and polygonal-stock lengths in a profile corridor."""
-    if a.is_rotational or a.profiles:
-        return 0
+    """Queue approved boss heights and polygonal-stock lengths in a profile corridor."""
     tier = dwg.draft.font_size + 2 * dwg.draft.pad_around_text
     specs = {
         "z": ("front", "right", a.fv_zones.right, "x"),

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -444,6 +444,14 @@ def _compose_anno_boxes(
     n_boss_h = _n_right_strip_boss_heights(model)
     # FV right dim ladder + the boss heights that share the strip with it
     boxes = [AnnoBox("right", _est_right_strip_depth(n_steps, n_boss_h))]
+    if any(
+        feature.kind in ("boss", "step") and feature.frame.axis == "y"
+        for feature in model.features
+    ):
+        # The end-on radial fan needs clearance alongside the overall-height slot.
+        # This is a minimum band; deeper ladder/bore reservations still win by max.
+        radial_reach = font_size + 6 * pad_around_text
+        boxes.append(AnnoBox("right", _est_right_strip_depth(0) + radial_reach))
     requests = (
         model.authored_dimensions
         if model.authored_dimensions is not None

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -96,13 +96,9 @@ def _n_right_strip_boss_heights(model) -> int:
     declared path (#1022) removed that accident — a declared model that states a boss but no
     height ladder reserved one slot, needed two, and the height was dropped silently.
 
-    Mirrors ``render_boss_heights``' own guards: a turned model (any declared step) renders no
-    boss heights at all, and only the Z-axis ones land right — X/Y bosses go to the *above*
-    strips.  A rotational part that declares a Z boss over-reserves by one slot; that is the
-    conservative direction, and the same call the authored-Z-dim branch below makes.
+    Z-axis boss heights share this corridor even when a turned step chain is present.
+    X/Y heights reserve their profile-view above strips in ``_compose_anno_boxes``.
     """
-    if any(getattr(f, "kind", None) == "step" for f in model.features):
-        return 0
     occupants = [
         f
         for f in model.features
@@ -596,6 +592,37 @@ def _compose_anno_boxes(
             # in-plane ordinates, one in each strip.
             _reserve(view, "above")
             _reserve(view, "right")
+
+    # Axial boss sizes occupy the same profile corridors on detected and declared parts.
+    # Include them before view packing; a turned chain does not convey its end caps.
+    axial_corridors = set()
+    axial_features = [
+        feature
+        for feature in model.features
+        if feature.kind in ("boss", "polygonal_boss", "polygonal_stock")
+        and feature.frame.axis in ("x", "y")
+    ]
+    for group in plan_dimensions(model) if axial_features else ():
+        feature = group.feature
+        if feature.kind not in ("boss", "polygonal_boss", "polygonal_stock"):
+            continue
+        if feature.frame.axis not in ("x", "y"):
+            continue
+        view = "front" if feature.frame.axis == "x" else "side"
+        for dimension in group.dims:
+            if not dimension.suppressed and dimension.param.role in (
+                "boss_height",
+                "stock_length",
+            ):
+                _reserve(view, "above")
+                axial_corridors.add(view)
+    # The existing axial step chain already consumes one row in these corridors.
+    for view in sorted(axial_corridors):
+        axis = "x" if view == "front" else "y"
+        if any(
+            feature.kind == "step" and feature.frame.axis == axis for feature in model.features
+        ):
+            _reserve(view, "above")
 
     slot = _SLOT_DIM_STEP + _STRIP_SPACING
     # Front and plan occupy disjoint vertical ranges, so their left/right tiers are

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -3985,9 +3985,7 @@ class Drawing:
                 issues += lint_claimed_representations(self._registry, dimension_plan)
             else:
                 dimension_plan = None
-            # Turned bosses/bands remain in the OD + axial-step policy; this check is
-            # specifically for a prismatic boss's independent projection height.
-            if model is not None and (a is None or (not a.is_rotational and not a.profiles)):
+            if model is not None:
                 issues += lint_boss_height_coverage(
                     working_part,
                     self,

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -79,6 +79,7 @@ from draftwright.model.planner import (
     _extent_can_convey,
     _is_zero_step_position,
     _request_for,
+    _selected_chain_covers_extent,
     angular_pattern_label,
     authored_location_axis_omitted,
     authored_location_omitted,
@@ -1056,49 +1057,16 @@ def _compile_step_ladders(model: PartModel, marked) -> tuple[list[ApprovedLadder
 def _step_chain_covers_extent(
     model: PartModel, groups: list[ApprovedGroup], axis: Literal["x", "z"]
 ) -> bool:
-    """Require adjoining approved measurements between both overall ends of one profile."""
-    axis_index = "xyz".index(axis)
-    intervals: dict[tuple[tuple[float, ...], object], list[tuple[float, float]]] = {}
-    step_profiles = set()
-    for group in groups:
-        if group.feature_kind not in ("step", "groove") or group.facts.frame.axis != axis:
-            continue
-        length = group.dim(kind="length")
-        if length is None:
-            continue
-        feature = resolve_feature(group.ref)
-        frame = group.facts.frame
-        key = (
-            tuple(
-                round(float(value), 6) for i, value in enumerate(frame.origin) if i != axis_index
-            ),
-            feature.profile or feature.profile_group,
-        )
-        if group.feature_kind == "step":
-            if length.span is None:
-                continue
-            lo, hi = sorted(float(point[axis_index]) for point in length.span)
-            step_profiles.add(key)
-        else:
-            centre = float(frame.origin[axis_index])
-            lo, hi = centre - length.value / 2, centre + length.value / 2
-        intervals.setdefault(key, []).append((lo, hi))
-
-    # Emitted declarations round supports to 0.001 mm. Keep that numerical seam
-    # tolerance, but do not join different bodies or merely overlapping spans:
-    # 0..40 and 20..60 do not tell the reader the overall length.
-    tolerance = 1e-3 + 1e-9
-    bb: Any = model.bbox
-    for key in step_profiles:
-        reachable = [float(tuple(bb.min)[axis_index])]
-        for lo, hi in sorted(intervals[key]):
-            if any(abs(lo - station) <= tolerance for station in reachable):
-                reachable.append(hi)
-        if any(
-            abs(station - float(tuple(bb.max)[axis_index])) <= tolerance for station in reachable
-        ):
-            return True
-    return False
+    return _selected_chain_covers_extent(
+        model,
+        [
+            (resolve_feature(group.ref), length)
+            for group in groups
+            if group.feature_kind in ("step", "groove")
+            and (length := group.dim(kind="length")) is not None
+        ],
+        axis,
+    )
 
 
 def _compile_overall_height(

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -72,9 +72,13 @@ from draftwright.model.ir import (
 )
 from draftwright.model.planner import (
     _AUTHORED_OMISSION,
+    _CONSOLIDATED,
     DimensionId,
+    _authored_for,
     _decorated,
+    _extent_can_convey,
     _is_zero_step_position,
+    _request_for,
     angular_pattern_label,
     authored_location_axis_omitted,
     authored_location_omitted,
@@ -1633,6 +1637,19 @@ def _compile_slot_positions(model: PartModel) -> tuple[list[ApprovedDimension], 
     return approved, omissions
 
 
+def _dimension_witness_span(feature, parameter):
+    """Carry a boss's axial stations at its cylindrical silhouette, even without a diameter mark."""
+    span = parameter.span
+    if feature.kind != "boss" or parameter.parameter_id != "boss_height.length" or span is None:
+        return span
+    radial = 0 if feature.frame.axis == "z" else 2
+    rim = feature.frame.origin[radial] + feature.diameter / 2
+    return tuple(
+        tuple(rim if index == radial else value for index, value in enumerate(point))
+        for point in span
+    )
+
+
 def _compile_groups(
     planned, *, restore_width: bool = False
 ) -> tuple[list[ApprovedGroup], list[Omission]]:
@@ -1681,7 +1698,7 @@ def _compile_groups(
                 # the boundary instead of implying a nullable state renderers cannot handle.
                 value_text=_fmt(pd.param.value, pd.display_decimals),
                 value=float(pd.param.value),
-                span=pd.param.span,
+                span=_dimension_witness_span(g.feature, pd.param),
                 ref=FeatureRef(g.feature),
                 kind=pd.param.kind,
                 role=pd.param.role,
@@ -1795,6 +1812,9 @@ def compile_dimensions(
                 omission.feature is overall_feature and omission.parameter_id == "height.length"
             )
         ]
+    groups_out, group_omissions = _consolidate_boss_heights(
+        model, planned, groups_out, group_omissions, overall
+    )
     if overall is not None:
         ladders.append(overall)
     locations, location_omissions = _compile_locations(model)
@@ -1813,6 +1833,78 @@ def compile_dimensions(
             omissions, height_omissions, location_omissions, group_omissions
         ),
     )
+
+
+def _consolidate_boss_heights(model, planned, groups, omissions, overall):
+    """Reconcile boss heights with active extent owners, including synthetic and restored ones."""
+    owners = [
+        dimension
+        for group in groups
+        if group.feature_kind == "envelope"
+        for dimension in group.dims
+        if dimension.kind == "length" and dimension.role in ("width", "depth")
+    ]
+    if overall is not None:
+        owners.extend(overall.rungs)
+    extents = []
+    for owner in owners:
+        assert owner.id is not None
+        extent = replace(
+            next(
+                parameter
+                for parameter in owner.id.feature.parameters()
+                if parameter.parameter_id == owner.id.parameter
+            ),
+            value=owner.value,
+            span=owner.span,
+        )
+        extents.append((extent, owner.id))
+    shared = {}
+    for group in planned:
+        if group.feature.kind != "boss":
+            continue
+        for dimension in group.dims:
+            parameter = dimension.param
+            if (
+                parameter.parameter_id != "boss_height.length"
+                or _request_for(model, group.feature, parameter) is not None
+                or _authored_for(model, group.feature, parameter) is not None
+            ):
+                continue
+            for extent, owner_id in extents:
+                if _extent_can_convey(extent, parameter):
+                    shared[DimensionId(group.feature, parameter.parameter_id)] = (
+                        parameter,
+                        owner_id,
+                    )
+                    break
+    if not shared:
+        return groups, omissions
+    retained = []
+    for group in groups:
+        dims = tuple(dimension for dimension in group.dims if dimension.id not in shared)
+        if dims:
+            retained.append(replace(group, dims=dims))
+    updated = []
+    recorded = set()
+    for omission in omissions:
+        identity = _dim_id(omission.feature, omission.parameter_id)
+        if identity in shared:
+            omission = replace(omission, conveyed_by=shared[identity][1])
+            recorded.add(identity)
+        updated.append(omission)
+    for identity, (parameter, owner_id) in shared.items():
+        if identity not in recorded:
+            updated.append(
+                Omission(
+                    identity.feature,
+                    identity.parameter,
+                    parameter.value,
+                    _CONSOLIDATED,
+                    conveyed_by=owner_id,
+                )
+            )
+    return retained, updated
 
 
 def _share_unique_outer_diameter(groups: list[ApprovedGroup], planned) -> list[ApprovedGroup]:

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -1693,7 +1693,9 @@ def _selected_chain_covers_extent(model, selected, axis) -> bool:
 
 def _restore_uncovered_x_extent(model, groups):
     """Settle X-width ownership after the complete selected chain is known, before sizing."""
-    if model.orientation != "x" or _selected_chain_covers_extent(
+    if model.orientation != "x" or not any(group.feature.kind == "envelope" for group in groups):
+        return groups
+    if _selected_chain_covers_extent(
         model,
         [
             (group.feature, dimension.param)

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -1649,6 +1649,99 @@ def angular_pattern_label(group: DimensionGroup) -> str | None:
     return f"{len(dimensions)}× {next(iter(labels))}"
 
 
+def _selected_chain_covers_extent(model, selected, axis) -> bool:
+    """Require adjoining approved measurements between both overall ends of one profile."""
+    axis_index = "xyz".index(axis)
+    intervals: dict[tuple[tuple[float, ...], object], list[tuple[float, float]]] = {}
+    step_profiles = set()
+    for feature, length in selected:
+        if feature.kind not in ("step", "groove") or feature.frame.axis != axis:
+            continue
+        frame = feature.frame
+        key = (
+            tuple(
+                round(float(value), 6) for i, value in enumerate(frame.origin) if i != axis_index
+            ),
+            feature.profile or feature.profile_group,
+        )
+        if feature.kind == "step":
+            if length.span is None:
+                continue
+            lo, hi = sorted(float(point[axis_index]) for point in length.span)
+            step_profiles.add(key)
+        else:
+            centre = float(frame.origin[axis_index])
+            lo, hi = centre - length.value / 2, centre + length.value / 2
+        intervals.setdefault(key, []).append((lo, hi))
+
+    # Emitted declarations round supports to 0.001 mm. Keep that numerical seam
+    # tolerance, but do not join different bodies or merely overlapping spans:
+    # 0..40 and 20..60 do not tell the reader the overall length.
+    tolerance = 1e-3 + 1e-9
+    bb = model.bbox
+    for key in step_profiles:
+        reachable = [float(tuple(bb.min)[axis_index])]
+        for lo, hi in sorted(intervals[key]):
+            if any(abs(lo - station) <= tolerance for station in reachable):
+                reachable.append(hi)
+        if any(
+            abs(station - float(tuple(bb.max)[axis_index])) <= tolerance for station in reachable
+        ):
+            return True
+    return False
+
+
+def _restore_uncovered_x_extent(model, groups):
+    """Settle X-width ownership after the complete selected chain is known, before sizing."""
+    if model.orientation != "x" or _selected_chain_covers_extent(
+        model,
+        [
+            (group.feature, dimension.param)
+            for group in groups
+            if group.feature.kind in ("step", "groove")
+            for dimension in group.dims
+            if not dimension.suppressed and dimension.param.kind == "length"
+        ],
+        "x",
+    ):
+        return groups
+    restored = []
+    widths = []
+    for group in groups:
+        dimensions = []
+        for dimension in group.dims:
+            if group.feature.kind == "envelope" and dimension.param.parameter_id == "width.length":
+                if dimension.reason == "X-turned (step-length chain conveys the length)":
+                    dimension = replace(dimension, suppressed=False, reason=None)
+                if not dimension.suppressed:
+                    widths.append((dimension.param, DimensionId(group.feature, "width.length")))
+            dimensions.append(dimension)
+        restored.append(replace(group, units=_addressable(group.feature, dimensions)))
+    result = []
+    for group in restored:
+        dimensions = []
+        for dimension in group.dims:
+            parameter = dimension.param
+            if (
+                group.feature.kind == "boss"
+                and parameter.parameter_id == "boss_height.length"
+                and _request_for(model, group.feature, parameter) is None
+                and _authored_for(model, group.feature, parameter) is None
+            ):
+                for extent, owner in widths:
+                    if _extent_can_convey(extent, parameter):
+                        dimension = replace(
+                            dimension,
+                            suppressed=True,
+                            reason=dimension.reason if dimension.suppressed else _CONSOLIDATED,
+                            conveyed_by=owner,
+                        )
+                        break
+            dimensions.append(dimension)
+        result.append(replace(group, units=_addressable(group.feature, dimensions)))
+    return result
+
+
 def plan_dimensions(model: PartModel, *, planned_views=None) -> list[DimensionGroup]:
     """Plan each feature's parameters into one `DimensionGroup` (anchor + single
     view + planned dims, each carrying its render intent — convention, model-level
@@ -1715,18 +1808,25 @@ def plan_dimensions(model: PartModel, *, planned_views=None) -> list[DimensionGr
                 )
             )
         if dims:
-            selected_view, selected_side = _group_placement(feature, dims, planned_views)
             groups.append(
                 DimensionGroup(
                     feature=feature,
-                    # Preserve a total internal record while collecting every uncovered
-                    # identity below.  The exception prevents this preferred fallback from
-                    # crossing the planner boundary when it is not actually selected.
-                    view=selected_view or _preferred_group_view(feature),
+                    view=_preferred_group_view(feature),
                     units=_addressable(feature, dims),
-                    side=selected_side,
                 )
             )
+    groups = _restore_uncovered_x_extent(model, groups)
+    for index, group in enumerate(groups):
+        # Validate the final content: a consolidated height must not reject a
+        # supported end-on view requested for the remaining diameter.
+        selected_view, selected_side = _group_placement(
+            group.feature, list(group.dims), planned_views
+        )
+        groups[index] = replace(
+            group,
+            view=selected_view or _preferred_group_view(group.feature),
+            side=selected_side,
+        )
     if planned_views is not None:
         uncovered = _uncovered_group_requirements(model, groups, planned_views)
         uncovered.extend(_uncovered_location_requirements(model, planned_views))

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -474,6 +474,17 @@ def polygonal_stock_conveys_height(model: PartModel) -> bool:
     return any(f.kind == "polygonal_stock" for f in model.features)
 
 
+def _extent_can_convey(extent: DimParameter, parameter: DimParameter) -> bool:
+    """An overall extent may replace an untoleranced local measurement of the same planes.
+
+    A tolerance on the owner is acceptable; a toleranced local requirement stays explicit.
+    Owner availability is decided by the caller, not by geometric coincidence.
+    """
+    return parameter.tolerance is None and _same_support_planes(
+        _support_planes(extent), _support_planes(parameter)
+    )
+
+
 def rotational_od_conveys_height(model: PartModel) -> bool:
     """An X/Y rotational OD conveys the overall height, so it is not drawn separately."""
     rot = next((f for f in model.features if f.kind == "rotational"), None)
@@ -586,30 +597,9 @@ def _consolidated_owner(model: PartModel, feature: Feature, param: DimParameter)
         if envelope.kind != "envelope":
             continue
         for extent in envelope.parameters():
-            if not _same_support_planes(_support_planes(extent), planes):
+            if not _extent_can_convey(extent, param):
                 continue
             if not _owner_drawn(model, envelope, extent):
-                continue
-            if param.tolerance is not None:
-                # A toleranced dimension and an untoleranced one are not the same
-                # requirement, so the overall extent cannot state this fact on its behalf.
-                # Consolidating anyway DELETED a ±0.05 the author had written, silently and
-                # with nothing in lint (#1154 review) — the one case where the feature-local
-                # dimension is the one a machinist needs.
-                #
-                # ASYMMETRIC, and about the YIELDER alone. A tolerance on the OWNER is not a
-                # problem — it is the same two faces, so it is the same requirement and one
-                # dimension states it. The first cut refused whenever the two DIFFERED, which
-                # brought the duplicate `8` back for anyone who toleranced the overall
-                # thickness: this issue's own defect, re-opened by its fix (review r2).
-                #
-                # The correction then went one step too far and admitted "equal tolerances on
-                # both sides", on the premise that the receiving extent states the same
-                # requirement. It does not, ever: measured, an envelope decoration is not
-                # rendered on any axis, while `render_boss_heights` appends `_tol_suffix`, so
-                # a boss height toleranced identically to its envelope lost its ± anyway
-                # (review r3). Whether the owner happens to print a tolerance is not this
-                # rule's business — a toleranced measurement is simply never handed over.
                 continue
             return DimensionId(envelope, extent.parameter_id)
     return None

--- a/tests/test_declared_recognition_gate.py
+++ b/tests/test_declared_recognition_gate.py
@@ -333,9 +333,8 @@ def test_only_the_bosses_that_land_right_are_counted(declare, expected, why):
     assert _n_right_strip_boss_heights(model) == expected, why
 
 
-def test_a_turned_model_reserves_no_boss_height_slots():
-    """``render_boss_heights`` returns early for a turned part, so reserving for one there
-    would be dead page space."""
+def test_a_turned_model_without_bosses_reserves_no_boss_height_slots():
+    """A declared step chain without bosses needs no additional boss-height slots."""
     a, b, c = _turned_shaft_parts()
     sheet = Sheet(a + b + c).auto_dimensions()
     sheet.step(a)

--- a/tests/test_issue_1511_turned_boss_heights.py
+++ b/tests/test_issue_1511_turned_boss_heights.py
@@ -1,0 +1,287 @@
+"""Approved end-cap heights survive alongside a turned profile (#1511)."""
+
+from dataclasses import replace
+
+import pytest
+from build123d import Align, Compound, Cylinder, Pos, Rot
+
+from draftwright import build_drawing
+from draftwright.builder import detect_part_model
+from draftwright.model.compiled import compile_dimensions
+from draftwright.model.ir import RequestedDimension
+from draftwright.sheet_emit import emit_sheet_script
+
+
+@pytest.fixture(scope="module", params=("x", "y", "z"))
+def capped_shaft(request):
+    axis = request.param
+    align = (Align.CENTER, Align.CENTER, Align.MIN)
+    shaft = Cylinder(18, 25, align=align) + Pos(0, 0, 25) * Cylinder(16, 25, align=align)
+    rotation = {"x": Rot(0, 90, 0), "y": Rot(-90, 0, 0), "z": Rot(0, 0, 0)}[axis]
+    part = rotation * Compound(
+        children=[
+            shaft,
+            Pos(0, 0, -6) * Cylinder(20, 6, align=align),
+            Pos(0, 0, 50) * Cylinder(20, 6, align=align),
+        ]
+    )
+    drawing = build_drawing(part, page="A3", scale=1, scale_policy="strict")
+    plan = compile_dimensions(drawing.model())
+    assert len(plan.of_kind("step")) == 2
+    heights = [group.dim(role="boss_height", kind="length") for group in plan.of_kind("boss")]
+    assert len(heights) == 2 and all(height.value == 6 for height in heights)
+    assert all(group.facts.frame.axis == axis for group in plan.of_kind("boss"))
+    return part, drawing, heights, axis
+
+
+def test_cap_heights_have_their_own_claims_and_physical_supports(capped_shaft):
+    _part, drawing, heights, axis = capped_shaft
+    for height in heights:
+        marks = [
+            (name, mark)
+            for name, mark in drawing.iter_annotations()
+            if height.id in drawing.registry.measurement_of(name)
+        ]
+        assert len(marks) == 1
+        name, mark = marks[0]
+        assert mark.label == "6"
+        coordinate = 1 if axis == "z" else 0
+        view = drawing.registry.view_of(name)
+        stations = [drawing.at(view, *point)[coordinate] for point in height.span]
+        strokes = [
+            first[coordinate]
+            for first, second in mark.segments
+            if abs(first[coordinate] - second[coordinate]) < 1e-6
+            and abs(first[1 - coordinate] - second[1 - coordinate]) > 1
+        ]
+        assert all(any(abs(station - stroke) < 1e-6 for stroke in strokes) for station in stations)
+    assert not [issue for issue in drawing.lint() if issue.code == "boss_height_missing"]
+
+
+def test_removing_one_cap_height_exposes_exactly_that_missing_measurement(capped_shaft):
+    part, _drawing, heights, _axis = capped_shaft
+    drawing = build_drawing(part, page="A3", scale=1, scale_policy="strict")
+    names = [
+        name
+        for name in drawing.annotations()
+        if heights[0].id in drawing.registry.measurement_of(name)
+    ]
+    assert len(names) == 1
+    drawing.remove(names[0])
+    assert any(
+        heights[1].id in drawing.registry.measurement_of(name) for name in drawing.annotations()
+    )
+    issues = [issue for issue in drawing.lint() if issue.code == "boss_height_missing"]
+    assert len(issues) == 1
+    assert issues[0].message == "1 boss height(s) are not dimensioned"
+    assert drawing.lint() == drawing.lint()
+
+
+def test_cap_heights_survive_generated_sheet_code(capped_shaft, tmp_path):
+    part, original, _heights, _axis = capped_shaft
+    source = emit_sheet_script(
+        original.model(),
+        "part",
+        str(tmp_path / "caps"),
+        title="T",
+        number="N",
+        page="A3",
+        scale=1,
+        scale_policy="strict",
+        formats=("svg",),
+    )
+    namespace = {"part": part}
+    exec(source, namespace)
+    replay = namespace["drawing"]
+    marks = [
+        mark
+        for name, mark in replay.iter_annotations()
+        if any(
+            mid.parameter == "boss_height.length" for mid in replay.registry.measurement_of(name)
+        )
+    ]
+    assert sorted(mark.label for mark in marks) == ["6", "6"]
+
+
+def test_authored_omission_is_not_rendered_as_an_end_cap(capped_shaft):
+    part, original, heights, _axis = capped_shaft
+    model = original.model()
+    authored = tuple(
+        RequestedDimension(feature, parameter.parameter_id)
+        for feature in model.features
+        for parameter in feature.parameters()
+        if not (
+            feature == heights[0].id.feature and parameter.parameter_id == "boss_height.length"
+        )
+    )
+    drawing = build_drawing(
+        part,
+        model=replace(model, authored_dimensions=authored),
+        page="A3",
+        scale=1,
+        scale_policy="strict",
+    )
+    assert not any(
+        heights[0].id in drawing.registry.measurement_of(name) for name in drawing.annotations()
+    )
+    assert any(
+        heights[1].id in drawing.registry.measurement_of(name) for name in drawing.annotations()
+    )
+
+
+def test_cap_height_witnesses_do_not_require_diameter_annotation(capped_shaft):
+    part, original, heights, axis = capped_shaft
+    model = original.model()
+    authored = tuple(
+        RequestedDimension(feature, parameter.parameter_id)
+        for feature in model.features
+        for parameter in feature.parameters()
+        if not (feature.kind == "boss" and parameter.kind == "diameter")
+    )
+    drawing = build_drawing(
+        part,
+        model=replace(model, authored_dimensions=authored),
+        page="A3",
+        scale=1,
+        scale_policy="strict",
+    )
+    for height in heights:
+        names = [
+            name
+            for name in drawing.annotations()
+            if height.id in drawing.registry.measurement_of(name)
+        ]
+        assert len(names) == 1
+        boss = height.id.feature
+        assert not any(
+            mid.feature == boss and mid.parameter == "boss.diameter"
+            for name in drawing.annotations()
+            for mid in drawing.registry.measurement_of(name)
+        )
+        radial = 0 if axis == "z" else 2
+        raw_span = next(
+            parameter.span
+            for parameter in boss.parameters()
+            if parameter.parameter_id == "boss_height.length"
+        )
+        assert raw_span[0][radial] != height.span[0][radial]
+        assert height.span[0][radial] == pytest.approx(boss.frame.origin[radial] + 20)
+        view = drawing.registry.view_of(names[0])
+        coordinate = 1 if axis == "z" else 0
+        witness_start = (
+            drawing.at(view, *height.span[0])[1 - coordinate] + drawing.draft.extension_gap
+        )
+        strokes = [
+            (first, second)
+            for first, second in drawing.get_annotation(names[0]).segments
+            if abs(first[coordinate] - second[coordinate]) < 1e-6
+            and abs(first[1 - coordinate] - second[1 - coordinate]) > 1
+        ]
+        assert len(strokes) >= 2
+        assert all(
+            min(first[1 - coordinate], second[1 - coordinate]) == pytest.approx(witness_start)
+            for first, second in strokes
+        )
+
+
+@pytest.mark.parametrize("axis", ("x", "y", "z"))
+@pytest.mark.parametrize("tolerance", (None, 0.1))
+def test_full_height_boss_yields_to_overall_only_when_untoleranced(tolerance, axis):
+    part = {"x": Rot(0, 90, 0), "y": Rot(-90, 0, 0), "z": Rot(0, 0, 0)}[axis] * Cylinder(15, 40)
+    model = detect_part_model(part)
+    boss = next(feature for feature in model.features if feature.kind == "boss")
+    assert boss.height == 40
+    if tolerance is not None:
+        model = replace(model, decorations={(boss, "length", "boss_height"): tolerance})
+    drawing = build_drawing(part, model=model)
+    plan = compile_dimensions(drawing.model())
+    marks = [
+        (name, mark)
+        for name, mark in drawing.iter_annotations()
+        if any(
+            mid.parameter == "boss_height.length" for mid in drawing.registry.measurement_of(name)
+        )
+    ]
+    if tolerance is None:
+        assert marks == []
+        omissions = [row for row in plan.diagnostics if row.parameter_id == "boss_height.length"]
+        assert len(omissions) == 1 and omissions[0].conveyed_by is not None
+        owner_names = [
+            name
+            for name in drawing.annotations()
+            if omissions[0].conveyed_by in drawing.registry.measurement_of(name)
+        ]
+        assert len(owner_names) == 1
+        assert drawing.get_annotation(owner_names[0]).label == "40"
+        assert not [issue for issue in drawing.lint() if issue.code == "boss_height_missing"]
+        drawing.remove(owner_names[0])
+        assert [issue.code for issue in drawing.lint() if issue.code == "boss_height_missing"] == [
+            "boss_height_missing"
+        ]
+    else:
+        assert len(marks) == 1 and marks[0][1].label == "40 ±0.1"
+
+
+@pytest.mark.parametrize("selection", ("requested_dimensions", "authored_dimensions"))
+def test_explicit_full_height_boss_keeps_its_own_measurement(selection):
+    model = detect_part_model(Cylinder(15, 40))
+    automatic = compile_dimensions(model)
+    boss = next(feature for feature in model.features if feature.kind == "boss")
+    assert any(
+        row.parameter_id == "boss_height.length" and row.conveyed_by
+        for row in automatic.diagnostics
+    )
+    request = RequestedDimension(boss, "boss_height.length")
+    plan = compile_dimensions(replace(model, **{selection: (request,)}))
+    heights = [group.dim(role="boss_height", kind="length") for group in plan.of_kind("boss")]
+    assert len(heights) == 1 and heights[0].value == 40
+    assert not any(row.parameter_id == "boss_height.length" for row in plan.diagnostics)
+
+
+def test_a_synthetic_overall_owner_survives_script_replay(tmp_path):
+    part = Cylinder(15, 40)
+    original = build_drawing(part)
+    assert not any(feature.kind == "envelope" for feature in original.model().features)
+    source = emit_sheet_script(
+        original.model(),
+        "part",
+        str(tmp_path / "cylinder"),
+        title="T",
+        number="N",
+        formats=("svg",),
+    )
+    assert '"boss_height.length"' not in source
+    namespace = {"part": part}
+    exec(source, namespace)
+    replay = namespace["drawing"]
+    omissions = [
+        row
+        for row in compile_dimensions(replay.model()).diagnostics
+        if row.parameter_id == "boss_height.length"
+    ]
+    assert len(omissions) == 1 and omissions[0].authored and omissions[0].conveyed_by is not None
+    assert not [issue for issue in replay.lint() if issue.code == "boss_height_missing"]
+    replay.remove("dim_height")
+    assert [issue.code for issue in replay.lint() if issue.code == "boss_height_missing"] == [
+        "boss_height_missing"
+    ]
+
+
+def test_an_inactive_overall_contingency_cannot_own_a_boss_height():
+    from draftwright.model.ir import BossFeature, Frame
+
+    align = (Align.CENTER, Align.CENTER, Align.MIN)
+    part = Cylinder(18, 25, align=align) + Pos(0, 0, 25) * Cylinder(16, 25, align=align)
+    model = detect_part_model(part)
+    boss = BossFeature(
+        Frame((0, 0, 50), "z"), diameter=12, height=50, span=((0, 0, 0), (0, 0, 50))
+    )
+    model = replace(model, features=(*model.features, boss))
+    plan = compile_dimensions(model)
+    assert plan.ladder("overall_height") is None
+    assert plan.contingency("step_length").fallback.rungs[0].value == 50
+    heights = [group.dim(role="boss_height", kind="length") for group in plan.of_kind("boss")]
+    assert len(heights) == 1 and heights[0].value == 50
+    assert not any(
+        row.parameter_id == "boss_height.length" and row.conveyed_by for row in plan.diagnostics
+    )

--- a/tests/test_issue_1511_turned_boss_heights.py
+++ b/tests/test_issue_1511_turned_boss_heights.py
@@ -8,6 +8,8 @@ from build123d import Align, Compound, Cylinder, Pos, Rot
 from draftwright import build_drawing
 from draftwright.builder import detect_part_model
 from draftwright.model.compiled import compile_dimensions
+from draftwright.model.declare import _envelope_from_bbox
+from draftwright.model.planner import plan_dimensions
 from draftwright.model.ir import RequestedDimension
 from draftwright.sheet_emit import emit_sheet_script
 
@@ -285,3 +287,54 @@ def test_an_inactive_overall_contingency_cannot_own_a_boss_height():
     assert not any(
         row.parameter_id == "boss_height.length" and row.conveyed_by for row in plan.diagnostics
     )
+
+
+def test_partial_x_chain_and_full_length_boss_reserve_the_same_space_in_script(tmp_path):
+    align = (Align.CENTER, Align.CENTER, Align.MIN)
+    shaft = Cylinder(18, 25, align=align) + Pos(0, 0, 25) * Cylinder(16, 25, align=align)
+    part = Rot(0, 90, 0) * Compound(children=[shaft, Pos(0, 0, -6) * Cylinder(6, 62, align=align)])
+    model = detect_part_model(part)
+    model = replace(model, features=(*model.features, _envelope_from_bbox(model.bbox)))
+    original = build_drawing(
+        part, model=model, page="A3", scale=1, scale_policy="strict", title="T", number="N"
+    )
+    plan = compile_dimensions(original.model())
+    assert len(plan.of_kind("step")) == 2
+    assert sum(group.dim(kind="length").value for group in plan.of_kind("step")) == 50
+    omissions = [row for row in plan.diagnostics if row.parameter_id == "boss_height.length"]
+    assert len(omissions) == 1 and omissions[0].conveyed_by.parameter == "width.length"
+    source = emit_sheet_script(
+        original.model(),
+        "part",
+        str(tmp_path / "partial-x"),
+        title="T",
+        number="N",
+        page="A3",
+        scale=1,
+        scale_policy="strict",
+        formats=("svg",),
+    )
+    namespace = {"part": part}
+    exec(source, namespace)
+    replay = namespace["drawing"]
+    assert set(replay.views) == set(original.views)
+    for view in original.views:
+        assert replay.view_bounds(view) == pytest.approx(original.view_bounds(view))
+    assert sorted(replay.annotations()) == sorted(original.annotations())
+    for name, mark in original.iter_annotations():
+        assert getattr(replay.get_annotation(name), "label", None) == getattr(mark, "label", None)
+    assert replay.lint_summary()["by_code"] == original.lint_summary()["by_code"]
+
+
+def test_consolidated_x_height_does_not_reject_a_supported_diameter_view():
+    model = detect_part_model(Rot(0, 90, 0) * Cylinder(15, 80))
+    boss = next(feature for feature in model.features if feature.kind == "boss")
+    model = replace(
+        model, requested_dimensions=(RequestedDimension(boss, "boss.diameter", view="side"),)
+    )
+    group = next(group for group in plan_dimensions(model) if group.feature == boss)
+    assert group.view == "side"
+    height = next(dimension for dimension in group.dims if dimension.param.kind == "length")
+    assert height.suppressed and height.conveyed_by.parameter == "width.length"
+    diameter = next(dimension for dimension in group.dims if dimension.param.kind == "diameter")
+    assert not diameter.suppressed

--- a/tests/test_issue_1511_turned_boss_heights.py
+++ b/tests/test_issue_1511_turned_boss_heights.py
@@ -9,8 +9,8 @@ from draftwright import build_drawing
 from draftwright.builder import detect_part_model
 from draftwright.model.compiled import compile_dimensions
 from draftwright.model.declare import _envelope_from_bbox
-from draftwright.model.planner import plan_dimensions
 from draftwright.model.ir import RequestedDimension
+from draftwright.model.planner import plan_dimensions
 from draftwright.sheet_emit import emit_sheet_script
 
 

--- a/tests/test_issue_740_leader_assignment.py
+++ b/tests/test_issue_740_leader_assignment.py
@@ -19,7 +19,7 @@ from draftwright.layout import _assign_leader_candidates
 from draftwright.model import FilletFeature, Frame, GrooveFeature, PartModel, pocket
 
 
-def test_late_joint_assignment_stays_scoped_to_the_post_drain_adapters():
+def test_joint_assignment_stays_scoped_to_registered_adapters():
     root = Path(__file__).parents[1] / "src" / "draftwright" / "annotations"
 
     def call_sites(filename):
@@ -43,7 +43,7 @@ def test_late_joint_assignment_stays_scoped_to_the_post_drain_adapters():
         return sites
 
     assert call_sites("from_model.py") | call_sites("holes.py") == {
-        ("from_model.py", "render_diameters", False),
+        ("from_model.py", "render_diameters", True),
         ("from_model.py", "_render_diameter_leaders", True),
         ("from_model.py", "render_chamfers", True),
         ("from_model.py", "_render_radius_callouts", True),
@@ -94,8 +94,8 @@ def test_pre_drain_pattern_keeps_legacy_greedy_semantics(monkeypatch):
     assert [name for name in drawing.annotations() if name.startswith("dim_pocketpat_pitch")]
 
 
-def test_pre_drain_y_diameter_uses_the_shared_analytical_producer_floor(monkeypatch, tmp_path):
-    """The pre-drain semantic stage shares measurement but still emits immediately."""
+def test_y_diameter_joins_inventory_and_keeps_coverage_metadata(monkeypatch, tmp_path):
+    """A queued Y diameter retains identity and builds only the selected survivor."""
     from draftwright.annotations import from_model
 
     locations = ((18, 0), (-18, 0), (0, 18), (0, -18))
@@ -115,12 +115,21 @@ def test_pre_drain_y_diameter_uses_the_shared_analytical_producer_floor(monkeypa
     part = part.rotate(Axis.X, 90)
 
     constructed = []
+    from draftwright.annotations import orchestrator
+
+    real_render = orchestrator.render_diameters
+
+    def counted_pass(*args, **kwargs):
+        constructed.append([])
+        return real_render(*args, **kwargs)
+
+    monkeypatch.setattr(orchestrator, "render_diameters", counted_pass)
     real_leader = from_model.Leader
 
     def counted_leader(*args, **kwargs):
         leader = real_leader(*args, **kwargs)
         if str(leader.label) == "ø25":
-            constructed.append(leader)
+            constructed[-1].append(leader)
         return leader
 
     monkeypatch.setattr(from_model, "Leader", counted_leader)
@@ -135,14 +144,21 @@ def test_pre_drain_y_diameter_uses_the_shared_analytical_producer_floor(monkeypa
 
     diameter = drawing.get_annotation("m_dia_y0")
     assert diameter.label == "ø25"
-    assert constructed == [diameter], "only the selected analytical survivor builds OCC"
+    assert constructed and all(len(batch) == 1 for batch in constructed), (
+        "each placement pass builds only its selected analytical survivor"
+    )
+    assert constructed[-1] == [diameter]
     assert diameter.covers_diameters == (25.0,)
     assert drawing.measurement_keys("m_dia_y0")
     trace = json.loads(trace_path.read_text(encoding="utf-8"))
     event = next(
         item for item in trace["pass_events"] if item["label"] == "Y-axis step diameter_callouts"
     )
-    assert event["assignment"] == "greedy_stage_boundary"
+    assert event["assignment"] != "greedy_stage_boundary"
+    inventory = next(
+        item for item in trace["pass_events"] if item["label"] == "feature_leader_inventory"
+    )
+    assert any(item["name"] == "m_dia_y0" for item in inventory["items"])
     assert any(
         item["name"] == "m_dia_y0" and item["outcome"] == "placed" for item in event["items"]
     )

--- a/tests/test_issue_740_leader_assignment.py
+++ b/tests/test_issue_740_leader_assignment.py
@@ -19,7 +19,7 @@ from draftwright.layout import _assign_leader_candidates
 from draftwright.model import FilletFeature, Frame, GrooveFeature, PartModel, pocket
 
 
-def test_joint_assignment_stays_scoped_to_registered_adapters():
+def test_late_joint_assignment_stays_scoped_to_the_post_drain_adapters():
     root = Path(__file__).parents[1] / "src" / "draftwright" / "annotations"
 
     def call_sites(filename):
@@ -43,7 +43,7 @@ def test_joint_assignment_stays_scoped_to_registered_adapters():
         return sites
 
     assert call_sites("from_model.py") | call_sites("holes.py") == {
-        ("from_model.py", "render_diameters", True),
+        ("from_model.py", "render_diameters", False),
         ("from_model.py", "_render_diameter_leaders", True),
         ("from_model.py", "render_chamfers", True),
         ("from_model.py", "_render_radius_callouts", True),
@@ -94,8 +94,8 @@ def test_pre_drain_pattern_keeps_legacy_greedy_semantics(monkeypatch):
     assert [name for name in drawing.annotations() if name.startswith("dim_pocketpat_pitch")]
 
 
-def test_y_diameter_joins_inventory_and_keeps_coverage_metadata(monkeypatch, tmp_path):
-    """A queued Y diameter retains identity and builds only the selected survivor."""
+def test_pre_drain_y_diameter_uses_the_shared_analytical_producer_floor(monkeypatch, tmp_path):
+    """The pre-drain semantic stage shares measurement but still emits immediately."""
     from draftwright.annotations import from_model
 
     locations = ((18, 0), (-18, 0), (0, 18), (0, -18))
@@ -115,21 +115,12 @@ def test_y_diameter_joins_inventory_and_keeps_coverage_metadata(monkeypatch, tmp
     part = part.rotate(Axis.X, 90)
 
     constructed = []
-    from draftwright.annotations import orchestrator
-
-    real_render = orchestrator.render_diameters
-
-    def counted_pass(*args, **kwargs):
-        constructed.append([])
-        return real_render(*args, **kwargs)
-
-    monkeypatch.setattr(orchestrator, "render_diameters", counted_pass)
     real_leader = from_model.Leader
 
     def counted_leader(*args, **kwargs):
         leader = real_leader(*args, **kwargs)
         if str(leader.label) == "ø25":
-            constructed[-1].append(leader)
+            constructed.append(leader)
         return leader
 
     monkeypatch.setattr(from_model, "Leader", counted_leader)
@@ -144,21 +135,20 @@ def test_y_diameter_joins_inventory_and_keeps_coverage_metadata(monkeypatch, tmp
 
     diameter = drawing.get_annotation("m_dia_y0")
     assert diameter.label == "ø25"
-    assert constructed and all(len(batch) == 1 for batch in constructed), (
-        "each placement pass builds only its selected analytical survivor"
-    )
-    assert constructed[-1] == [diameter]
+    assert constructed == [diameter], "only the selected analytical survivor builds OCC"
     assert diameter.covers_diameters == (25.0,)
     assert drawing.measurement_keys("m_dia_y0")
+    # The added boss heights must not displace existing callouts at this fixed page/scale.
+    assert len([name for name in drawing.annotations() if name.startswith("m_dia_y")]) == 8
+    assert len([name for name in drawing.annotations() if name.startswith("m_pad_height_")]) == 4
+    assert sorted(
+        mark.label for name, mark in drawing.iter_annotations() if name.startswith("m_bossheight")
+    ) == ["4", "6"]
     trace = json.loads(trace_path.read_text(encoding="utf-8"))
     event = next(
         item for item in trace["pass_events"] if item["label"] == "Y-axis step diameter_callouts"
     )
-    assert event["assignment"] != "greedy_stage_boundary"
-    inventory = next(
-        item for item in trace["pass_events"] if item["label"] == "feature_leader_inventory"
-    )
-    assert any(item["name"] == "m_dia_y0" for item in inventory["items"])
+    assert event["assignment"] == "greedy_stage_boundary"
     assert any(
         item["name"] == "m_dia_y0" and item["outcome"] == "placed" for item in event["items"]
     )

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -9794,11 +9794,23 @@ class TestTurnedDiameters:
             auto.lint_summary()["by_code"]
             == replayed.lint_summary()["by_code"]
             == {
+                "annotation_ink_overlap": 2,
                 "hole_requirement_missing": 2,
                 "leader_crosses_silhouette": 1,
                 "section_recess_recognition_refused": 4,
             }
         )
+
+        # PENDING #1512: restored 6/4 boss witnesses cross the repeated step label.
+        # Both bounded repair and deferred chain placement were tried without resolving
+        # this cross-pass pair. Policy B retains the requirements and reports the ink.
+        for drawing in (auto, replayed):
+            pairs = [
+                tuple(issue.message.split("'")[index] for index in (1, 3))
+                for issue in drawing.lint()
+                if issue.code == "annotation_ink_overlap"
+            ]
+            assert sorted(pairs) == [("4", "4× 2"), ("6", "4× 2")]
 
         # ── from #881: the Y-step furniture lands in the right views on the replay ──
         assert replayed.view_of("centerline_side") == "side"


### PR DESCRIPTION
STC618’s two 6 mm end caps were recognized and approved, but a turned-profile guard skipped their height annotations and the corresponding lint check. This change renders those approved heights through the existing corridors, reserves their space before packing, and reports missing boss heights on turned parts.

The compiler retains cylindrical witness support even when the diameter label is omitted, and reconciles untoleranced boss heights with active overall/extents on the same support planes. Explicit requests and tolerances remain independent. X-axis extent ownership settles before composition and view validation, so automatic drawings and generated scripts reserve identical space and valid end-on diameter requests remain supported. Deferred diameter rerouting respects the dimensions that drain first. The original A4 canary retains all eight diameter callouts, four pad heights and both restored boss heights.

STC618 retains all 21 prior measurement annotations and adds the 62 mm overall height from #1510 plus 6, 6 and 60 mm boss heights. Its regenerated drawing has no warning/error lint. The synthetic Y flange retains two reported cross-pass ink crossings; #1512 records the failed bounded repair experiments and the follow-up. The regression asserts their exact pairs and automatic/script parity.

Independent review followed [Google’s code-review standard](https://google.github.io/eng-practices/review/reviewer/standard.html), iterating until no blocking findings or required nits remained. ADR 1: compiler ownership and shared pipeline; ADR 2: compose-before-pack and existing corridor placement; ADR 3: unchanged recognition boundary; ADR 4: authored omission, tolerance and script parity; ADR 5: visible missing-height/collision findings and load-bearing guards. No ADR changes.

Validation: 127 focused view, intent, inspection and chain tests passed; 54 targeted planner regressions passed after the final envelope guard; all 27 new tests passed on Python 3.12; the real-part canary passed. Sixteen deliberate mutations are caught by named tests with exact source restoration. STC618’s PDF/SVG/PNG/DXF exports and physical measurement claims were verified locally. The final full local preflight passed: 7,715 tests passed, 5 skipped and 13 expected failures; total coverage 95.93%, changed-line coverage 99%. Static checks and strict documentation build passed. Required GitHub CI remains the merge gate.

Fixes #1511.
