### PR TITLE
Refuse first-angle requests until layout supports them

### DIFF
--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -4,6 +4,16 @@
 are documented here because they are part of normal use even though their Python names begin
 with an underscore.
 
+## Projection convention
+
+Drawings currently use third-angle layout. `Sheet(part, projection="third")` adds its
+matching projection symbol; omitting `projection` keeps that layout without a symbol.
+`projection="first"` is refused before building or generating a script because first-angle
+layout is not yet supported. This is a safeguard against a misleading drawing, not
+first-angle support. The same restriction applies to `build_drawing` and the CLI's
+`--projection first`. Full convention-aware layout is tracked in
+[#1515](https://github.com/pzfreo/draftwright/issues/1515).
+
 ## Grooves on coaxial bodies
 
 When different turned bodies share an axis line, give their steps distinct `profile_group`

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -92,6 +92,7 @@ from draftwright.view_plan import (
     ViewPlanIncomplete,
     resolve_from_analysis,
     third_angle_view_names,
+    validate_projection,
 )
 
 # A view centre must move by more than this (mm) for the measure-and-repack
@@ -1873,7 +1874,12 @@ def build_drawing(
     Pass ``framed_recognition=True`` to opt an automatic build into the provider-owned local
     recognition frame. Raw remains the default. Other arguments and return semantics are
     unchanged from the one-pass builder.
+
+    ``projection='third'`` adds the matching projection symbol. The default omits the
+    symbol but uses the same third-angle layout. ``projection='first'`` is refused until
+    first-angle layout is supported; it must not label a third-angle drawing as first-angle.
     """
+    validate_projection(projection)
     if scale_policy not in {"strict", "fallback", "permissive"}:
         raise ValueError(
             f"scale_policy must be 'strict', 'fallback', or 'permissive', got {scale_policy!r}"

--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -131,7 +131,9 @@ def main(
         False, "--frame", help="Draw a sheet border; content reserves clearance inside it"
     ),
     projection: str = typer.Option(
-        "", "--projection", help="Projection-method symbol: 'third' or 'first' (default: none)"
+        "",
+        "--projection",
+        help="Projection symbol: 'third' (default: none); 'first' is unsupported",
     ),
     zones: bool = typer.Option(
         False, "--zones", help="Draw the ISO 5457 zone-grid border ruler (implies --frame)"
@@ -195,6 +197,12 @@ def main(
     logging.basicConfig(level=logging.INFO if verbose else logging.WARNING, format="%(message)s")
 
     formats = _parse_formats(output_format)
+    from draftwright.view_plan import validate_projection
+
+    try:
+        validate_projection(projection)
+    except ValueError as error:
+        raise typer.BadParameter(str(error), param_hint="--projection") from error
     if script and style != "sheet":
         # validate before the ~5 s engine import so a typo fails fast
         raise typer.BadParameter("--style must be 'sheet'", param_hint="--style")

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -131,6 +131,7 @@ from draftwright.view_plan import (
     ViewPlanIncomplete,
     ViewRelation,
     ViewSpec,
+    validate_projection,
 )
 
 _SOURCE_CHOICES = ("automatic", "authored")
@@ -1077,6 +1078,7 @@ class Sheet:
         zones=None,
         detail_view=None,
     ):
+        validate_projection(projection)
         self._part = part
         # (token, feature) entries — identity, not position (#908). `_features` is the
         # view; handles hold tokens and resolve through it, so a reorder of the public

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -64,7 +64,7 @@ from draftwright.model.ir import (
     ToleranceDecoration,
 )
 from draftwright.reporting import write_json_document
-from draftwright.view_plan import ViewConstraints
+from draftwright.view_plan import ViewConstraints, validate_projection
 
 _log = logging.getLogger(__name__)
 
@@ -2460,6 +2460,7 @@ def generate_sheet_script(
     surface (flagged inline).
     *part_expr*, when given, overrides the ``part = …`` seam — e.g. the import seam from
     :func:`resolve_object_spec` so the script references a live module (#469)."""
+    validate_projection(projection)
     _validate_scale_policy(scale, scale_policy)
     is_shape = isinstance(step_file, Shape)
     stem = out or ("drawing" if is_shape else Path(step_file).stem)

--- a/src/draftwright/view_plan.py
+++ b/src/draftwright/view_plan.py
@@ -32,6 +32,15 @@ from types import MappingProxyType
 from typing import Any
 
 
+def validate_projection(projection: str | None) -> None:
+    """Refuse first-angle intent until the layout supports its convention (#1515)."""
+    if projection == "first":
+        raise ValueError(
+            "first-angle layout is not supported yet; use projection='third' "
+            "for supported third-angle output"
+        )
+
+
 @dataclass(frozen=True)
 class UncoveredViewRequirement:
     """One semantic requirement no selected principal view can carry.

--- a/tests/test_issue_1479_radius_leader_targets.py
+++ b/tests/test_issue_1479_radius_leader_targets.py
@@ -124,7 +124,7 @@ def _arc_gap(drawing, view, tip, arc):
 
 
 @pytest.mark.parametrize("rotation", [(0, 0, 0), (0, 90, 0), (90, 0, 0), (17, 31, 43)])
-@pytest.mark.parametrize("projection", ["first", "third"])
+@pytest.mark.parametrize("projection", [None, "third"])
 def test_radius_targets_follow_rotated_translated_geometry(rotation, projection):
     from build123d import Axis, Box, Rot, fillet
 

--- a/tests/test_issue_1514_projection_safeguard.py
+++ b/tests/test_issue_1514_projection_safeguard.py
@@ -1,0 +1,77 @@
+"""Unsupported first-angle intent must never become a third-angle drawing."""
+
+from pathlib import Path
+
+import pytest
+from build123d import Box, Cylinder, Pos
+from typer.testing import CliRunner
+
+from draftwright import Drawing, Sheet, build_drawing, make_drawing
+from draftwright.cli import app
+from draftwright.sheet_emit import generate_sheet_script
+
+
+@pytest.fixture(scope="module")
+def asymmetric_plate():
+    stock = Box(50, 35, 12)
+    cutter = Pos(-13, -8, 0) * Cylinder(3, 20)
+    part = stock - cutter
+    assert cutter.center().X == pytest.approx(-13)
+    assert cutter.center().Y == pytest.approx(-8)
+    assert stock.volume - part.volume == pytest.approx(3**2 * 3.141592653589793 * 12)
+    return part
+
+
+@pytest.mark.parametrize("entry", [build_drawing, make_drawing, Sheet, generate_sheet_script])
+def test_first_angle_refused_before_reading_input(entry, tmp_path):
+    missing = tmp_path / "missing.step"
+    assert not missing.exists()
+    with pytest.raises(ValueError, match="first-angle.*not supported.*third"):
+        entry(str(missing), projection="first")
+    assert not list(tmp_path.iterdir())
+
+
+def test_asymmetric_plate_cannot_claim_first_angle(asymmetric_plate):
+    with pytest.raises(ValueError, match="first-angle.*not supported.*third"):
+        build_drawing(asymmetric_plate, projection="first", page="A3", scale=1)
+
+
+@pytest.mark.parametrize("projection", [None, "third"])
+def test_supported_layout_retains_third_angle_relationships(asymmetric_plate, projection):
+    drawing = build_drawing(asymmetric_plate, projection=projection, page="A3", scale=1)
+    assert drawing.model().features
+    assert {"front", "plan", "side"} <= set(drawing.views)
+    front, plan, side = (drawing.view_bounds(v) for v in ("front", "plan", "side"))
+    assert plan[1] > front[3]
+    assert side[0] > front[2]
+    assert ("projection_symbol" in drawing.annotations()) == (projection == "third")
+
+
+@pytest.mark.parametrize("script", [False, True])
+@pytest.mark.parametrize("source", ["missing.step", "missing_module:part"])
+def test_cli_refuses_before_loading_step_or_object(script, source, tmp_path):
+    args = [source, "--projection", "first", "--out", str(tmp_path / "drawing")]
+    if script:
+        args.append("--script")
+    result = CliRunner().invoke(app, args)
+    assert result.exit_code == 2, result.output
+    assert "first-angle" in result.output and "not supported" in result.output
+    assert "third" in result.output
+    assert not list(tmp_path.iterdir())
+
+
+def test_edited_generated_script_cannot_claim_first_angle(asymmetric_plate, tmp_path, monkeypatch):
+    path = generate_sheet_script(
+        asymmetric_plate,
+        out=str(tmp_path / "drawing"),
+        projection="third",
+        part_expr="part = supplied_part",
+    )
+    source = Path(path).read_text()
+    assert source.count("projection='third'") == 1
+    edited = source.replace("projection='third'", "projection='first'")
+    exports = []
+    monkeypatch.setattr(Drawing, "export", lambda *a, **kw: exports.append(True))
+    with pytest.raises(ValueError, match="first-angle.*not supported.*third"):
+        exec(compile(edited, path, "exec"), {"supplied_part": asymmetric_plate})
+    assert not exports

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -11248,19 +11248,18 @@ class TestProjectionSymbol:
         assert "projection_symbol" not in dwg.annotations()
         assert dwg._analysis.projection is None
 
-    def test_third_and_first_render_in_the_title_block_band(self):
+    def test_third_renders_in_the_title_block_band(self):
         from draftwright._core import _TB_CLEAR, _TB_H
 
-        for method in ("third", "first"):
-            dwg = build_drawing(Box(80, 60, 20), projection=method)
-            ps = dwg.get_annotation("projection_symbol")
-            assert ps is not None and getattr(ps, "is_projection_symbol", False)
-            b = ps.bounding_box()
-            a = dwg._analysis
-            # within the page, and in the reserved title-block column/band (above the block)
-            assert b.min.X >= _MARGIN and b.max.X <= a.PAGE_W - _MARGIN
-            assert b.min.Y <= _TB_CLEAR + _TB_H and b.max.Y <= _TB_CLEAR + _TB_H
-            assert b.min.X >= a.PAGE_W - a.TB_W - _TB_CLEAR  # the title-block column
+        dwg = build_drawing(Box(80, 60, 20), projection="third")
+        ps = dwg.get_annotation("projection_symbol")
+        assert ps is not None and getattr(ps, "is_projection_symbol", False)
+        b = ps.bounding_box()
+        a = dwg._analysis
+        # within the page, and in the reserved title-block column/band (above the block)
+        assert b.min.X >= _MARGIN and b.max.X <= a.PAGE_W - _MARGIN
+        assert b.min.Y <= _TB_CLEAR + _TB_H and b.max.Y <= _TB_CLEAR + _TB_H
+        assert b.min.X >= a.PAGE_W - a.TB_W - _TB_CLEAR  # the title-block column
 
     def test_projection_build_is_lint_clean(self):
         dwg = build_drawing(Box(80, 60, 20), projection="third")


### PR DESCRIPTION
First-angle requests currently produce a third-angle layout carrying a first-angle symbol. An asymmetric plate reproduces identical front/plan/side bounds under both requests while both drawings pass lint.

This change refuses first-angle intent through one shared validation rule before part loading in the builder, Sheet constructor, script generator and CLI. Default output and explicit third-angle output retain their layout. Full first-angle support remains #1515; this PR is the immediate safeguard in epic #1508.

Validation: 47 focused tests pass, covering all entry points, edited generated-script replay, third-angle relationships, symbol placement and radius-leader targets. `scripts/pr-check --full` exits 0, including static checks, the full fast suite, total coverage and 100% changed-line coverage. Five isolated source mutations were caught by named tests: removing the shared refusal, or bypassing the builder, Sheet, emitter or CLI checks. The worktree source was unchanged during those mutations.

Independent Google-style review on `13aacec2212ff1fc3ae597ac690660e9524cfa9f`: LGTM, no blocking findings, following inspection of every changed line, all five ADRs and independent execution through all Python entry points and both CLI modes. One optional nit remains in the old projection-symbol test class description. Merge is gated on green required CI (`ci-ok` and `codecov/project`) for this head.

Architecture: ADR 1 shared validation in the leaf view-planning module, with one build pipeline; ADR 2 convention is a hard constraint; ADR 3 refusal precedes part loading/recognition; ADR 4 authored intent is rejected explicitly rather than changed; ADR 5 a contradictory drawing cannot be returned. No ADR amendment is needed.

Closes #1514.
