### PR TITLE
feat: implement first-angle drawing layout (#1515)

### DIFF
--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -6,13 +6,24 @@ with an underscore.
 
 ## Projection convention
 
-Drawings currently use third-angle layout. `Sheet(part, projection="third")` adds its
-matching projection symbol; omitting `projection` keeps that layout without a symbol.
-`projection="first"` is refused before building or generating a script because first-angle
-layout is not yet supported. This is a safeguard against a misleading drawing, not
-first-angle support. The same restriction applies to `build_drawing` and the CLI's
-`--projection first`. Full convention-aware layout is tracked in
-[#1515](https://github.com/pzfreo/draftwright/issues/1515).
+Use `Sheet(part, projection="first")` or `build_drawing(part, projection="first")`
+for first-angle layout and its matching projection symbol. The CLI equivalent is
+`--projection first`. Explicit `"third"` selects third-angle layout and its symbol;
+omitting `projection` keeps third-angle layout without a symbol.
+
+View names retain their physical viewing directions in the working part frame. Changing
+convention changes sheet relationships, not which side of the part a name shows:
+
+| View | Viewed from | Page directions | Third-angle position | First-angle position |
+|---|---|---|---|---|
+| `front` | Negative Y | X right, Z up | Reference | Reference |
+| `plan` | Positive Z | X right, Y up | Above front | Below front |
+| `side` | Positive X | Y right, Z up | Right of front | Left of front |
+
+The resolved convention is available as `drawing.view_plan.convention`. Generated scripts
+retain the requested convention. Annotation footprints, scale/page selection and measured
+repacking use the same convention. An authored relation contradicting the principal layout
+fails before projection; a whole-view pin must preserve the convention's relationships.
 
 ## Grooves on coaxial bodies
 

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -1210,6 +1210,7 @@ class Analysis:
     frame: bool = False
     # Projection-method symbol (#769): "third" / "first" (ISO 5456-2) or None (omit).
     projection: str | None = None
+    projection_convention: str = "third"
     # Draw the ISO 5457 zone-grid border ruler (#768). Implies a frame (the ticks sit on it).
     zones: bool = False
     # The PartModel built by _analyse's pre-scale sizing pass (#584 WP1 A) — stored so

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -71,7 +71,7 @@ from draftwright.recognition_frame import (
     require_unambiguous_groove_owner,
 )
 from draftwright.recognition_ownership import RecognitionOwnershipBuilder
-from draftwright.view_plan import ViewConstraints, arrangement_of
+from draftwright.view_plan import ViewConstraints, arrangement_of, principal_placements
 
 _log = logging.getLogger(__name__)
 
@@ -159,7 +159,7 @@ def _apply_principal_view_pins(
         if max(abs(other_dx - dx), abs(other_dy - dy)) > 0.05:
             raise ValueError(
                 f"whole-view pins at {first.source} and {pin.source} contradict the fixed "
-                "third-angle relationships; they imply different group translations"
+                f"{geometry.convention}-angle relationships; they imply different group translations"
             )
 
     geometry.FV_X += dx
@@ -171,6 +171,7 @@ def _apply_principal_view_pins(
     geometry.sv_geometry_right += dx
     geometry.sv_right += dx
     geometry.sv_right_wall += dx
+    geometry.front_plan_wall += dy
     # Geometry bounds are the minimum pre-projection feasibility gate. Annotation bands use
     # the shifted anchors below and remain subject to the ordinary completeness/lint gates.
     extents = {
@@ -680,6 +681,7 @@ def _validate_explicit_scale(
     views: tuple[str, ...] | None = None,
     include_iso: bool = True,
     iso_scale_factor: float | None = None,
+    convention: str = "third",
 ) -> None:
     """Enforce the two scale floors when the caller pinned an explicit *scale* (#489, #590 split
     of :func:`_analyse`). An explicit scale is the user's call — honour it, subject to:
@@ -719,6 +721,7 @@ def _validate_explicit_scale(
         views=views,
         include_iso=include_iso,
         iso_scale_factor=iso_scale_factor,
+        convention=convention,
     )
     # Warn only when omitting the scale would truly give a legible fit (auto scale itself is
     # legible) but the requested scale is below the floor. A part illegible at every
@@ -772,6 +775,7 @@ def _analyse(
 
     Returns an :class:`Analysis`.
     """
+    convention = projection or "third"
     # The zone-grid ruler (#768) draws its ticks on the frame, so it implies one.
     frame = frame or zones
     # The content margin — raised by the sheet-frame band (#767) so scale/page selection and
@@ -1149,6 +1153,7 @@ def _analyse(
             views=_views,
             include_iso=_include_iso,
             iso_scale_factor=planned_iso_scale,
+            convention=convention,
         )
 
     scale_pick, strips_i, n_for_sizing = _converge_step_sizing(
@@ -1181,6 +1186,7 @@ def _analyse(
         views=_views,
         include_iso=_include_iso,
         iso_scale_factor=planned_iso_scale,
+        convention=convention,
     )
     DIM_PAD = _DIM_PAD
     # margin was computed up front (_content_margin(frame)) so scale selection already saw it.
@@ -1215,6 +1221,7 @@ def _analyse(
         views=_views,
         include_iso=_include_iso,
         iso_scale_factor=planned_iso_scale,
+        convention=convention,
     )
     _apply_principal_view_pins(
         _g,
@@ -1225,6 +1232,13 @@ def _analyse(
         margin=margin,
         views=_views,
     )
+    if isinstance(_view_constraints, ViewConstraints):
+        places = principal_placements(_g)
+        for relation in _view_constraints.relations:
+            if relation.subject in _g.planned_views and relation.reference in _g.planned_views:
+                relation.validate(
+                    places[relation.subject].bounds, places[relation.reference].bounds
+                )
     fv_hw = _g.fv_hw
     fv_hh = _g.fv_hh
     pv_hh = _g.pv_hh
@@ -1366,6 +1380,7 @@ def _analyse(
         company=company,
         frame=frame,
         projection=projection,
+        projection_convention=convention,
         zones=zones,
         out=out,
         pmi_report=pmi_report,

--- a/src/draftwright/annotations/balloons.py
+++ b/src/draftwright/annotations/balloons.py
@@ -126,8 +126,10 @@ def render_balloons(
     # Plan-view page edges; the reserved bands sit just outside them.
     pl, pr = a.PV_X - a.fv_hw, a.PV_X + a.fv_hw
     pt, pb = a.PV_Y + a.pv_hh, a.PV_Y - a.pv_hh
-    sv_left = a.SV_X - a.sv_hw
     margin, ph, pw = a.margin, a.PAGE_H, a.PAGE_W
+    zones = a.pv_zones
+    left_limit, right_limit = zones.left.outer_limit, zones.right.outer_limit
+    bottom_limit, top_limit = zones.below.outer_limit, zones.above.outer_limit
 
     # Stack the balloon ring *beyond* the annotations already placed around the
     # plan view, not on top of them (#121). Measure the REAL depth every placed
@@ -158,14 +160,20 @@ def render_balloons(
     # the full bbox, for overlap), never the out_of_bounds error.
     left_dim = min(left_dim, max(0.0, pl - perimeter_extent - margin))
     right_dim = min(right_dim, max(0.0, pw - margin - pr - perimeter_extent))
-    top_dim = min(top_dim, max(0.0, ph - margin - pt - perimeter_extent))
-    bot_dim = min(bot_dim, max(0.0, pb - perimeter_extent - margin))
+    top_dim = min(top_dim, max(0.0, top_limit - pt - perimeter_extent))
+    bot_dim = min(bot_dim, max(0.0, pb - perimeter_extent - bottom_limit))
 
     # A bottom band (below PV, beyond the overall-width dim) is usable only
     # when the FV↔PV gap has room for the width dim *and* a balloon row;
     # otherwise bottom-edge holes fall back to the nearest side/top band.
     bottom_line = pb - bot_dim - centre_offset
-    has_bottom = pb - (a.FV_Y + a.fv_hh) > bot_dim + perimeter_extent
+    has_bottom = pb - bottom_limit > bot_dim + perimeter_extent
+    has_top = top_limit - pt >= top_dim + perimeter_extent
+    # An occupied corridor cannot be made usable by pulling its ring back through
+    # the occupant. Route those members through another available band instead.
+    has_left = pl - left_limit >= left_dim + perimeter_extent
+    has_right = right_limit - pr >= right_dim + perimeter_extent
+    available = {"left": has_left, "right": has_right, "top": has_top, "bottom": has_bottom}
 
     # left/right balloons vary in Y at a fixed X just outside the part; top
     # and bottom balloons vary in X at a fixed Y just beyond it. Each line is
@@ -173,21 +181,19 @@ def render_balloons(
     band_defs = {
         "left": ("y", pl - left_dim - centre_offset, margin + r, ph - margin - r),
         "right": ("y", pr + right_dim + centre_offset, margin + r, ph - margin - r),
-        "top": ("x", pt + top_dim + centre_offset, pl - standoff, sv_left - r),
-        "bottom": ("x", bottom_line, pl - standoff, sv_left - r),
+        "top": ("x", pt + top_dim + centre_offset, pl - standoff, right_limit - r),
+        "bottom": ("x", bottom_line, pl - standoff, right_limit - r),
     }
 
     top_segments = None
-    if perimeter:
+    if perimeter and has_top:
         # A single remote label must not push the whole top row beyond the
         # deepest occupant (#125/#901).  Probe lanes at obstacle boundaries,
         # carve their horizontal free spans, and take the nearest lane that can
         # carry a balanced share of the ring.  This is measured render geometry;
         # ordered placement across the resulting segments remains in layout.py.
         top_lo, top_hi = band_defs["top"][2:]
-        other_band_names = ["left", "right"]
-        if has_bottom:
-            other_band_names.append("bottom")
+        other_band_names = [name for name in ("left", "right", "bottom") if available[name]]
         other_capacities = [
             _strip_capacity(*band_defs[name][2:], gap) for name in other_band_names
         ]
@@ -195,7 +201,7 @@ def render_balloons(
         layout_member_count = required_count or len(specs)
         top_target = _top_lane_target(layout_member_count, other_capacities, usable_band_count)
         first_line = pt + centre_offset
-        last_line = ph - margin - r
+        last_line = top_limit - r
         candidates = {first_line}
         for x0, _y0, x1, y1 in obstacles:
             if x1 > top_lo and x0 < top_hi and y1 >= pt:
@@ -250,11 +256,13 @@ def render_balloons(
     choices_by_member = []
     for tag, j, hole in specs:
         cx, cy = pp(*hole.location)
-        choices = {
-            "left": abs(cx - band_defs["left"][1]),
-            "right": abs(band_defs["right"][1] - cx),
-            "top": abs(band_defs["top"][1] - cy),
-        }
+        choices = {}
+        if has_left:
+            choices["left"] = abs(cx - band_defs["left"][1])
+        if has_right:
+            choices["right"] = abs(band_defs["right"][1] - cx)
+        if has_top:
+            choices["top"] = abs(band_defs["top"][1] - cy)
         if has_bottom:
             choices["bottom"] = abs(cy - band_defs["bottom"][1])
         members.append((tag, j, hole, cx, cy))
@@ -279,7 +287,9 @@ def render_balloons(
     }
     capacities = {
         name: (
-            sum(
+            0
+            if not available[name]
+            else sum(
                 _strip_capacity(seg_lo, seg_hi, band_gaps[name]) for seg_lo, seg_hi in top_segments
             )
             if name == "top" and top_segments is not None

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -871,6 +871,28 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
             parameter = f"{parameter}.{measured_axis}"
         return (feature, parameter, point)
 
+    def _discard_short_refs(refs, coordinate, datum, view):
+        # Nearness on paper is not coincidence with the physical datum. A required
+        # nonzero span that cannot be drawn must remain a recorded placement failure.
+        short = [
+            ref
+            for ref in refs
+            if 1e-6 < abs(ref[coordinate] - datum) and abs(ref[coordinate] - datum) * a.SCALE < 1.0
+        ]
+        if short:
+            axis = "X" if coordinate == 0 else "Y"
+            ctx.record_issue(
+                "warning",
+                "location_ref_dropped",
+                f"{len(short)} {axis} location dim(s) project to less than 1 mm (use a detail view)",
+                measurement=tuple(mid for ref in short for mid in ref[4]),
+                hole_requirements=tuple(
+                    (feature, parameter) for ref in short for feature, parameter, _point in ref[5]
+                ),
+            )
+            ctx.escalations.append(Escalation("location", view, None, "illegible"))
+        return [ref for ref in refs if ref not in short]
+
     # --- X locations: tier above the plan view ---
     PX, PY = a.proj.plan_x, a.proj.plan_y
     x_refs: list = []
@@ -902,6 +924,7 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
                     else [],
                 ]
             )
+    x_refs = _discard_short_refs(x_refs, 0, datum_x, "plan")
     _x_drawable = {r[0] for r in x_refs if abs(r[0] - datum_x) * a.SCALE >= 1.0}
     _kept_x, _n_x_close = _legible_locations(_x_drawable, a.SCALE)
     if _n_x_close:
@@ -1025,6 +1048,7 @@ def render_locations(dwg, plan, a, *, ctx, only=None, pinned=None) -> int:
                     else [],
                 ]
             )
+    y_refs = _discard_short_refs(y_refs, 1, datum_y, "side" if side_planned else "plan")
     _y_drawable = {r[1] for r in y_refs if abs(r[1] - datum_y) * a.SCALE >= 1.0}
     _kept_y, _n_y_close = _legible_locations(_y_drawable, a.SCALE)
     if _n_y_close:

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -257,9 +257,9 @@ def _add_section_view(dwg, a: Analysis, section, *, ctx):
     side_right = max(dwg.view_bounds(name)[2] for name in row_views)
     row_y0 = a.FV_Y - half_h - 10
     row_y1 = a.FV_Y + half_h + 6
-    iso_x0, iso_y0, _, _ = _iso_bbox(dwg)
+    iso_x0, iso_y0, _, iso_y1 = _iso_bbox(dwg)
     right_limit = a.PAGE_W - a.margin
-    if a.FV_Y + half_h + 6 > iso_y0 - 2:
+    if row_y0 < iso_y1 + 2 and row_y1 > iso_y0 - 2:
         right_limit = min(right_limit, iso_x0 - 4)
     # Carve the row into free segments and take the leftmost that FITS, rather than
     # starting after the rightmost obstacle (#1190). The old rule let one remote

--- a/src/draftwright/audit.py
+++ b/src/draftwright/audit.py
@@ -170,7 +170,7 @@ def compare_measurements(before, after, *, feature_pairs=()) -> dict:
 #: dismissed by a reader — never toward silence. Adding a genuinely new furniture type here is
 #: a deliberate act; forgetting to add a new measurement type to an allowlist was an accident
 #: waiting to happen, and had already happened once.
-_FURNITURE = frozenset({"TitleBlock", "Note", "CenterMark"})
+_FURNITURE = frozenset({"TitleBlock", "Note", "CenterMark", "ProjectionSymbol"})
 
 
 def _measurements(dwg) -> dict[str, str]:

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -42,6 +42,7 @@ from draftwright._core import (
     _log,
     _parse_page,
     _Projector,
+    _shape_box2d,
     _tb_width,
 )
 from draftwright._geometry import _scale_world
@@ -151,24 +152,7 @@ def _validate_authored_view_layout(dwg: Drawing, constraints) -> None:
         raise ValueError(f"authored layout names absent view {name!r}")
 
     for relation in constraints.relations:
-        sb = bounds(relation.subject)
-        rb = bounds(relation.reference)
-        gap = relation.gap or 0.0
-        checks = {
-            "left_of": sb[2] + gap <= rb[0] + 1e-6,
-            "right_of": sb[0] + 1e-6 >= rb[2] + gap,
-            "above": sb[1] + 1e-6 >= rb[3] + gap,
-            "below": sb[3] + gap <= rb[1] + 1e-6,
-            "align_x": abs((sb[0] + sb[2]) - (rb[0] + rb[2])) <= 1e-6,
-            "align_y": abs((sb[1] + sb[3]) - (rb[1] + rb[3])) <= 1e-6,
-        }
-        if not checks[relation.relation]:
-            where = f" at {relation.source}" if relation.source is not None else ""
-            raise ValueError(
-                f"authored view constraint{where} is infeasible: {relation.subject!r} "
-                f"must be {relation.relation} {relation.reference!r}"
-                + (f" with gap {gap:g} mm" if relation.gap is not None else "")
-            )
+        relation.validate(bounds(relation.subject), bounds(relation.reference))
 
     for pin in constraints.pins:
         if pin.view not in dwg.views:
@@ -311,7 +295,7 @@ def _inflate_box(box, clearance):
     )
 
 
-def _annotations_out_of_bounds(dwg, a, tol: float = 1.0) -> bool:
+def _annotations_out_of_bounds(dwg, a, tol: float = 0.0) -> bool:
     """True when any view-owned annotation's footprint extends past the drawable
     area — the second repack trigger besides cross-view overlap.  A ballooned
     plan view can overflow the page top (the balloon ring) without crossing
@@ -345,18 +329,23 @@ def _measure_blocks(dwg, a) -> dict:
 
     Each view's four band depths are how far its annotations extend beyond its
     geometry box, **measured** from what the annotation passes produced — not
-    estimated. Every annotation is attributed to the nearest view (by its
-    label/box centre), and the band depth on a side is the furthest that view's
+    estimated. Every annotation is attributed to its recorded owning view,
+    and the band depth on a side is the furthest that view's
     annotations reach past the geometry edge there. Returns ``{view_name:
     ViewBlock}`` whose bands the packer can place disjoint, no ``_est_*`` needed.
     """
     geom = _view_geom(a)
     ext: dict = {v: None for v in geom}
     clearance = _annotation_clearance(dwg)
-    for _name, v, bb, label in _attribute_annotations(dwg, a):
+    for name, v, bb, label in _attribute_annotations(dwg, a):
         # A label's measured footprint includes the same external text clearance used by the
         # repack trigger.  Otherwise repack would notice the shortfall and then reproduce it.
         bb = _inflate_box(bb, clearance if label else 0.0)
+        # Outward arrows and extension lines also need paper. The overflow trigger reads
+        # full ink; measuring only labels could stall a repack with the arrows still off-page.
+        ink = _shape_box2d(dwg.get_annotation(name))
+        if ink is not None:
+            bb = (min(bb[0], ink[0]), min(bb[1], ink[1]), max(bb[2], ink[2]), max(bb[3], ink[3]))
         e = ext[v]
         ext[v] = (
             bb
@@ -936,6 +925,7 @@ def _repack(
             views=a.planned_views,
             include_iso=a.planned_iso,
             iso_scale_factor=a.planned_iso_scale,
+            convention=a.projection_convention,
         )
         _apply_principal_view_pins(
             geometry,
@@ -1015,7 +1005,15 @@ def _repack(
         for code, message in a.layout_advisories
         if code == "legibility_floor_breached" and s == a.SCALE
     ) + tuple(repack_advisories)
-    if s == a.SCALE and pw == a.PAGE_W and ph == a.PAGE_H and moved < _REPACK_TOL:
+    # Even a sub-millimetre correction matters when ink crosses the page boundary.
+    # Keep the ordinary convergence tolerance only for in-bounds content.
+    if (
+        s == a.SCALE
+        and pw == a.PAGE_W
+        and ph == a.PAGE_H
+        and moved < _REPACK_TOL
+        and (moved < 1e-6 or not _annotations_out_of_bounds(dwg, a))
+    ):
         dwg.registry.drop_issues({"page_fit_uncertain", "scale_fallback_applied"})
         for code, message in repack_advisories:
             dwg.registry.record_issue(_layout_advisory(code, message))
@@ -1876,8 +1874,8 @@ def build_drawing(
     unchanged from the one-pass builder.
 
     ``projection='third'`` adds the matching projection symbol. The default omits the
-    symbol but uses the same third-angle layout. ``projection='first'`` is refused until
-    first-angle layout is supported; it must not label a third-angle drawing as first-angle.
+    symbol but uses the same third-angle layout. ``projection='first'`` places plan below
+    front and side to its left, keeping the physical viewing directions unchanged.
     """
     validate_projection(projection)
     if scale_policy not in {"strict", "fallback", "permissive"}:

--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -133,7 +133,7 @@ def main(
     projection: str = typer.Option(
         "",
         "--projection",
-        help="Projection symbol: 'third' (default: none); 'first' is unsupported",
+        help="Projection convention: 'first' or 'third' (default: third-angle, no symbol)",
     ),
     zones: bool = typer.Option(
         False, "--zones", help="Draw the ISO 5457 zone-grid border ruler (implies --frame)"

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -148,8 +148,7 @@ def _est_pv_above_depth(
     if not distinct:
         return 0.0
     tier = font_size + 2 * pad_around_text
-    # Reserve the strip's initial clearance and inter-tier spacing as well as text.
-    return _STRIP_GAP + (len(distinct) + 1) * (tier + _STRIP_SPACING)
+    return (len(distinct) + 1) * tier
 
 
 def _est_plan_halo(font_size: float = _FONT_SIZE) -> float:
@@ -372,6 +371,7 @@ class StripDepths:
     sv_bottom: float = 0.0
     sv_right: float = 0.0  # band to the right of the side view
     angular: tuple[AngularReservation, ...] = ()
+    pv_location_top: float = 0.0  # complete ladder depth for a facing plan/front corridor
 
 
 def _measure_strips(
@@ -667,6 +667,10 @@ def _compose_anno_boxes(
     above = _est_pv_above_depth(model, font_size, pad_around_text)
     if above > 0:
         boxes.append(AnnoBox("above", above))  # tiered X-location dims above PV (#121)
+        # The same tier inventory, with initial clearance and inter-tier spacing,
+        # provides the complete requirement for a bounded facing corridor.
+        full_depth = _STRIP_GAP + above * (1 + _STRIP_SPACING / (font_size + 2 * pad_around_text))
+        boxes.append(AnnoBox("plan_location_above", full_depth))
     if _will_balloon(model):
         boxes.append(AnnoBox("plan_halo", _est_plan_halo(font_size)))
     return boxes
@@ -686,6 +690,7 @@ def _footprint_from_boxes(boxes: list[AnnoBox]) -> StripDepths:
         right=deepest("right"),
         left=max(_DIM_PAD, deepest("left")),
         top=deepest("above"),
+        pv_location_top=deepest("plan_location_above"),
         pv_halo=deepest("plan_halo"),
         fv_top=deepest("front_above"),
         fv_bottom=deepest("front_below"),
@@ -1158,8 +1163,8 @@ def _compose_view_blocks(
     pv_below = _est_pv_below_depth()
     # Top band above PV. When the plan view is ballooned, the ring sits beyond
     # the tiered X-location dims, so reserve their real depth (strip_top) plus a
-    # balloon row. The location ladder needs that space even without balloons.
-    pv_top = max(DIM_PAD, strip_top) + halo
+    # balloon row. Outer-facing strips retain this seed and grow by measured repacking.
+    pv_top = (max(DIM_PAD, strip_top) + halo) if halo > 0 else DIM_PAD
     if strips is not None:
         pv_top = max(pv_top, strips.pv_authored_top)
     sv_right_band = max(
@@ -1302,6 +1307,10 @@ def _layout_geometry(
     if convention not in {"first", "third"}:
         raise ValueError(f"unknown projection convention {convention!r}")
     first_angle = convention == "first"
+    # Plan's upper strip is bounded by front in this arrangement. Missing location
+    # candidates cannot grow measured ink, so reserve their complete ladder here.
+    if first_angle and has_front and has_plan and strips is not None:
+        pv = replace(pv, top=max(pv.top, strips.pv_location_top))
     # Relative projection origins come from the convention and the facing annotation
     # bands. Pack these complete blocks before building geometry; never move rendered views.
     relative_plan_y = -(fv.hh + fv.bottom + pv.top + pv.hh)

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -148,7 +148,8 @@ def _est_pv_above_depth(
     if not distinct:
         return 0.0
     tier = font_size + 2 * pad_around_text
-    return (len(distinct) + 1) * tier  # +1 tier: pitch dim / rounding headroom
+    # Reserve the strip's initial clearance and inter-tier spacing as well as text.
+    return _STRIP_GAP + (len(distinct) + 1) * (tier + _STRIP_SPACING)
 
 
 def _est_plan_halo(font_size: float = _FONT_SIZE) -> float:
@@ -369,7 +370,7 @@ class StripDepths:
     pv_bottom: float = 0.0
     sv_top: float = 0.0
     sv_bottom: float = 0.0
-    sv_right: float = 0.0  # band outside the rightmost side view
+    sv_right: float = 0.0  # band to the right of the side view
     angular: tuple[AngularReservation, ...] = ()
 
 
@@ -716,6 +717,7 @@ def _fits(
     views: tuple[str, ...] | None = None,
     include_iso: bool = True,
     iso_scale_factor: float | None = None,
+    convention: str = "third",
 ) -> bool:
     """True if the composed 4-view footprint fits the page at this scale.
 
@@ -743,6 +745,7 @@ def _fits(
         views=views,
         include_iso=include_iso,
         iso_scale_factor=iso_scale_factor,
+        convention=convention,
     )
     return bool(g.fits if pack_iso_2d else g.auto_fits)
 
@@ -763,6 +766,7 @@ def _bisect_fit_scale(
     margin=_MARGIN,
     include_iso: bool = True,
     iso_scale_factor: float | None = None,
+    convention: str = "third",
 ):
     """Largest scale at which the 4-view layout fits ``(pw, ph)``, found by bisection —
     the layout is monotone in scale (a smaller scale never fits worse). Used only as the
@@ -790,6 +794,7 @@ def _bisect_fit_scale(
             margin=margin,
             include_iso=include_iso,
             iso_scale_factor=iso_scale_factor,
+            convention=convention,
         ):
             lo = mid
         else:
@@ -813,6 +818,7 @@ def choose_scale(
     views: tuple[str, ...] | None = None,
     include_iso: bool = True,
     iso_scale_factor: float | None = None,
+    convention: str = "third",
     advisories: list[tuple[str, str]] | None = None,
 ) -> tuple:
     """Return (SCALE, PAGE_W, PAGE_H, TB_W) for a 4-view layout.
@@ -858,6 +864,7 @@ def choose_scale(
             margin=margin,
             include_iso=include_iso,
             iso_scale_factor=iso_scale_factor,
+            convention=convention,
         ):
             if advisories is not None:
                 advisories.append(
@@ -916,6 +923,7 @@ def choose_scale(
             views=views,
             include_iso=include_iso,
             iso_scale_factor=iso_scale_factor,
+            convention=convention,
         )
 
     def _candidate(cand, arrangement):
@@ -928,6 +936,7 @@ def choose_scale(
             page=(cand[1], cand[2]),
             title_block_width=cand[3],
             arrangement=arrangement,
+            convention=convention,
         )
 
     rejected: list = []
@@ -997,6 +1006,7 @@ def choose_scale(
             margin=margin,
             include_iso=include_iso,
             iso_scale_factor=iso_scale_factor,
+            convention=convention,
         )
         if s is not None:
             if advisories is not None:
@@ -1148,8 +1158,8 @@ def _compose_view_blocks(
     pv_below = _est_pv_below_depth()
     # Top band above PV. When the plan view is ballooned, the ring sits beyond
     # the tiered X-location dims, so reserve their real depth (strip_top) plus a
-    # balloon row. When not ballooned, keep the historic DIM_PAD.
-    pv_top = (max(DIM_PAD, strip_top) + halo) if halo > 0 else DIM_PAD
+    # balloon row. The location ladder needs that space even without balloons.
+    pv_top = max(DIM_PAD, strip_top) + halo
     if strips is not None:
         pv_top = max(pv_top, strips.pv_authored_top)
     sv_right_band = max(
@@ -1216,6 +1226,7 @@ def _layout_geometry(
     views: tuple[str, ...] | None = None,
     include_iso: bool = True,
     iso_scale_factor: float | None = None,
+    convention: str = "third",
 ):
     """Compute the 4-view layout geometry for a part at a given scale/page.
 
@@ -1288,6 +1299,28 @@ def _layout_geometry(
     col_left = max((b.left for b in _present), default=0.0)
     col_right = max((b.right for b in _present), default=0.0)
 
+    if convention not in {"first", "third"}:
+        raise ValueError(f"unknown projection convention {convention!r}")
+    first_angle = convention == "first"
+    # Relative projection origins come from the convention and the facing annotation
+    # bands. Pack these complete blocks before building geometry; never move rendered views.
+    relative_plan_y = -(fv.hh + fv.bottom + pv.top + pv.hh)
+    relative_side_x = -(fv.hw + col_left + sv.right + sv.hw)
+    first_origins = {
+        "front": (0.0, 0.0),
+        "plan": (0.0, relative_plan_y if has_front else 0.0),
+        "side": (relative_side_x if has_column else 0.0, 0.0),
+    }
+    first_boxes = [
+        block.footprint(*first_origins[name])
+        for name, block, present in (
+            ("front", fv, has_front),
+            ("plan", pv, has_plan),
+            ("side", sv, has_side),
+        )
+        if present
+    ]
+
     # FV↔PV vertical gap = fv.top + pv.bottom (abutting → sum). Estimated and
     # measured paths now use the same block footprint semantics: if the plan
     # view carries a bottom halo, that band is part of the stacked block layout
@@ -1309,6 +1342,8 @@ def _layout_geometry(
         column_h = 0.0
     side_h = (sv.bottom + 2 * sv.hh + sv.top) if has_side else 0.0
     total_h = 2 * margin + max(column_h, side_h)
+    if first_angle:
+        total_h = 2 * margin + max(b[3] for b in first_boxes) - min(b[1] for b in first_boxes)
     y_offset = max(0.0, (page_h - total_h) / 2)
 
     section_count = int(section)
@@ -1325,6 +1360,13 @@ def _layout_geometry(
         + (y_size * scale if has_side else 0.0)
         + max(2 * DIM_PAD, (sv.right + DIM_PAD) if has_side else 0.0, section_right_band)
     )
+    if first_angle:
+        ortho_row_w = (
+            max(b[2] for b in first_boxes)
+            - min(b[0] for b in first_boxes)
+            + DIM_PAD
+            + section_count * (10.0 + 2 * section_hw + DIM_PAD)
+        )
     iso_exact = iso_scale_factor is not None
     iso_factor = iso_scale_factor if iso_scale_factor is not None else 1.0
     iso_natural = (
@@ -1396,6 +1438,12 @@ def _layout_geometry(
     # estimator path (fv.right == pv.right == col_right, sv.left == 0).
     SV_X = FV_X + fv.hw + col_right + sv.left + sv.hw
     SV_Y = FV_Y
+    if first_angle:
+        origin_x = margin + x_offset - min(b[0] for b in first_boxes)
+        origin_y = margin + y_offset - min(b[1] for b in first_boxes)
+        FV_X, FV_Y = origin_x, origin_y
+        PV_X, PV_Y = origin_x, origin_y + first_origins["plan"][1]
+        SV_X, SV_Y = origin_x + first_origins["side"][0], origin_y
     # Keep the side geometry edge separate from the packed outer footprint.  The
     # right strip starts at the former and consumes the reserved ``sv.right`` band;
     # anchoring it at the latter would move the strip out again on every measured
@@ -1404,9 +1452,14 @@ def _layout_geometry(
     sv_right = sv_geometry_right + sv.right
     SECTION_X = SV_X + sv.hw + sv.right + 10.0 + section_hw
     SECTION_Y = FV_Y
+    if first_angle:
+        SECTION_X = origin_x + max(b[2] for b in first_boxes) + 10.0 + section_hw
     sv_right_wall = (
         (page_w - margin) if (PV_Y - pv_hh) > (margin + _TB_H) else (page_w - tb_w - margin)
     )
+    outer_right_wall = sv_right_wall
+    if first_angle and has_column:
+        sv_right_wall = FV_X - fv.hw - col_left
 
     drawable = (margin, margin, page_w - margin, page_h - margin)
 
@@ -1548,6 +1601,14 @@ def _layout_geometry(
     )
 
     return SimpleNamespace(
+        convention=convention,
+        planned_views=tuple(
+            name
+            for name, present in (("front", has_front), ("plan", has_plan), ("side", has_side))
+            if present
+        ),
+        outer_right_wall=outer_right_wall,
+        front_plan_wall=FV_Y - fv.hh - fv.bottom,
         x_offset=x_offset,
         fv_hw=fv_hw,
         fv_hh=fv_hh,
@@ -1609,6 +1670,33 @@ def _build_zones(g, margin, page_h):
     sv_top_edge = SV_Y + fv_hh  # side view has the same Z height as front
     # Outer limit for fv/pv right strips: must not enter the side view.
     sv_left_edge = SV_X - sv_hw  # = fv_right_edge + gap_fv_sv
+
+    if getattr(g, "convention", "third") == "first":
+        has_front = "front" in g.planned_views
+        has_plan = "plan" in g.planned_views
+        has_side = "side" in g.planned_views
+        column_left_wall = g.sv_right_wall if has_side else margin
+        fv_zones = ViewZones(
+            right=Strip(fv_right_edge, g.outer_right_wall, direction=1),
+            left=Strip(fv_left_edge, column_left_wall, direction=-1),
+            above=Strip(fv_top_edge, page_h - margin, direction=1),
+            below=Strip(fv_bottom_edge, g.front_plan_wall if has_plan else margin, direction=-1),
+        )
+        pv_zones = ViewZones(
+            right=Strip(pv_right_edge, g.outer_right_wall, direction=1),
+            left=Strip(pv_left_edge, column_left_wall, direction=-1),
+            above=Strip(
+                pv_top_edge, g.front_plan_wall if has_front else page_h - margin, direction=1
+            ),
+            below=Strip(pv_bottom_edge, margin, direction=-1),
+        )
+        sv_zones = ViewZones(
+            right=Strip(SV_X + sv_hw, g.sv_right_wall, direction=1),
+            left=None,
+            above=Strip(sv_top_edge, page_h - margin, direction=1),
+            below=Strip(SV_Y - fv_hh, margin, direction=-1),
+        )
+        return fv_zones, pv_zones, sv_zones
 
     fv_zones = ViewZones(
         right=Strip(fv_right_edge, sv_left_edge, direction=1),

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -3585,7 +3585,7 @@ class Drawing:
             items=self.items,
             part_model=self._part_model,
         )
-        render_balloons(self, self._analysis, view, specs, ctx)
+        render_balloons(self, self._analysis, view, specs, ctx, avoid_annotation_labels=True)
 
     def _add_balloon(self, view, tag, j, hole):
         """Single-balloon convenience over :meth:`add_balloons` (#111)."""

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -539,28 +539,24 @@ def lint_location_coverage(
     }
     for name, ann in dwg.iter_annotations():
         view = dwg.view_of(name)
-        if view is None:
-            continue
-        if isinstance(ann, CenterMark):
+        if view is not None and isinstance(ann, CenterMark):
             c = ann.center()
             marks.setdefault(view, []).append((c.X, c.Y))
-        elif isinstance(ann, Dimension):
-            facts = tuple(getattr(ann, "covers_hole_locations", ()))
-            # Structured compiler evidence is authoritative.  Letting the same
-            # annotation fall back to its witness geometry would allow a wrong
-            # feature/axis tag to self-certify merely by sharing an ordinate.
-            decoded = tuple(
-                parsed
-                for fact in facts
-                if (parsed := _decode_hole_location_fact(fact)) is not None
-            )
-            if not decoded:
-                dim_verts.setdefault(view, []).extend(_dim_vertices(ann))
-            for feature, parameter, point in decoded:
-                if getattr(feature, "kind", None) == "hole":
-                    structured_locations.add(
-                        (feature, str(parameter), _location_ref(feature, point))
-                    )
+        # A placed table carries the same feature/member/axis facts as a dimension,
+        # even when it is sheet furniture with no view. Read that shared evidence
+        # independently of the annotation's presentation type.
+        decoded = tuple(
+            parsed
+            for fact in getattr(ann, "covers_hole_locations", ())
+            if (parsed := _decode_hole_location_fact(fact)) is not None
+        )
+        # Structured evidence is authoritative: a wrong feature/axis tag must not
+        # self-certify through an accidentally coincident geometric witness.
+        if view is not None and isinstance(ann, Dimension) and not decoded:
+            dim_verts.setdefault(view, []).extend(_dim_vertices(ann))
+        for feature, parameter, point in decoded:
+            if getattr(feature, "kind", None) == "hole":
+                structured_locations.add((feature, str(parameter), _location_ref(feature, point)))
 
     # Index only semantic owners that placed facts actually carry. This avoids an
     # O(holes × model-features × members) rescan and preserves the documented
@@ -585,8 +581,14 @@ def lint_location_coverage(
         x, y, z = _xyz(h.location)
         axis = _axis_letter(h)
         view = _END_ON.get(axis, "plan")
-        px, py, *_ = dwg.at(view, x, y, z)
-        if not any(abs(cx - px) <= tol and abs(cy - py) <= tol for cx, cy in marks.get(view, ())):
+        available_views = getattr(dwg, "views", None)
+        projected = (
+            dwg.at(view, x, y, z) if available_views is None or view in available_views else None
+        )
+        if projected is None or not any(
+            abs(cx - projected[0]) <= tol and abs(cy - projected[1]) <= tol
+            for cx, cy in marks.get(view, ())
+        ):
             no_mark += 1
         # A hole coaxial with the part centre (the turning axis / a symmetry axis)
         # is located by centrelines, not a position dim — exempt from location.
@@ -605,8 +607,8 @@ def lint_location_coverage(
                 for owner, parameter, point in structured_locations
             )
             page_index = page_axes.index(model_axis)
-            geometric = any(
-                abs((vx, vy)[page_index] - (px, py)[page_index]) <= tol
+            geometric = projected is not None and any(
+                abs((vx, vy)[page_index] - projected[page_index]) <= tol
                 for vx, vy in dim_verts.get(view, ())
             )
             return semantic or geometric

--- a/src/draftwright/view_plan.py
+++ b/src/draftwright/view_plan.py
@@ -33,12 +33,9 @@ from typing import Any
 
 
 def validate_projection(projection: str | None) -> None:
-    """Refuse first-angle intent until the layout supports its convention (#1515)."""
-    if projection == "first":
-        raise ValueError(
-            "first-angle layout is not supported yet; use projection='third' "
-            "for supported third-angle output"
-        )
+    """Validate the supported convention names before loading drawing input."""
+    if projection not in (None, "", "first", "third"):
+        raise ValueError(f"unknown projection {projection!r}; expected 'first' or 'third'")
 
 
 @dataclass(frozen=True)
@@ -196,6 +193,26 @@ class ViewRelation:
                 f"view relation gap must be finite and non-negative, got {self.gap!r}"
             )
 
+    def validate(self, subject_bounds, reference_bounds) -> None:
+        """Refuse a resolved pair that contradicts this authored relation."""
+        sb, rb = subject_bounds, reference_bounds
+        gap = self.gap or 0.0
+        checks = {
+            "left_of": sb[2] + gap <= rb[0] + 1e-6,
+            "right_of": sb[0] + 1e-6 >= rb[2] + gap,
+            "above": sb[1] + 1e-6 >= rb[3] + gap,
+            "below": sb[3] + gap <= rb[1] + 1e-6,
+            "align_x": abs((sb[0] + sb[2]) - (rb[0] + rb[2])) <= 1e-6,
+            "align_y": abs((sb[1] + sb[3]) - (rb[1] + rb[3])) <= 1e-6,
+        }
+        if not checks[self.relation]:
+            where = f" at {self.source}" if self.source is not None else ""
+            raise ValueError(
+                f"authored view constraint{where} is infeasible: {self.subject!r} "
+                f"must be {self.relation} {self.reference!r}"
+                + (f" with gap {gap:g} mm" if self.gap is not None else "")
+            )
+
 
 @dataclass(frozen=True)
 class ViewPin:
@@ -301,6 +318,7 @@ class ResolvedViewPlan:
     placements: Mapping[str, ViewPlacement]
     scale: float
     page: tuple[float, float]
+    convention: str = "third"
 
     def __post_init__(self) -> None:
         names = [spec.name for spec in self.specs]
@@ -417,6 +435,7 @@ def resolve_from_analysis(analysis) -> ResolvedViewPlan:
         placements=placements,
         scale=analysis.SCALE,
         page=(analysis.PAGE_W, analysis.PAGE_H),
+        convention=analysis.projection_convention,
     )
 
 
@@ -566,6 +585,7 @@ class LayoutCandidate:
     #: and title block to the right. Named rather than assumed so a second one can be proposed
     #: without the first becoming a special case.
     arrangement: str = "columns"
+    convention: str = "third"
 
     def __post_init__(self) -> None:
         if self.arrangement not in ARRANGEMENTS:

--- a/tests/test_balloon_ring_standoff.py
+++ b/tests/test_balloon_ring_standoff.py
@@ -17,6 +17,7 @@ tracking the bug.
 
 from __future__ import annotations
 
+import pytest
 from build123d import Box, Cylinder, Pos
 
 from draftwright import build_drawing
@@ -57,14 +58,17 @@ def test_balloon_ring_clears_the_plan_view_after_escalation():
     assert max(tops) > plan_top + _MIN_STANDOFF_MM
 
 
-def test_the_dense_plate_actually_escalates():
+@pytest.mark.parametrize("method", ["first", "third"])
+def test_the_dense_plate_actually_escalates(method):
     """Guard on the fixture itself, so the standoff test above cannot pass for the
     wrong reason. If a future change stops this part escalating, that test would
     'pass' by having no balloons at all — this fails loudly instead."""
-    drawing = build_drawing(_dense_plate())
+    drawing = build_drawing(_dense_plate(), projection=method)
+    assert len([f for f in drawing.model().features if f.kind == "hole"]) == 18
     names = set(drawing.annotations())
-    assert any(n.startswith("balloon_plan") for n in names), "expected balloons"
+    assert len([n for n in names if n.startswith("balloon_plan")]) == 18
     assert any("table" in n for n in names), "expected the hole table"
+    assert not [i for i in drawing.lint() if i.severity in {"warning", "error"}]
 
 
 def test_identical_holes_do_not_escalate():

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -103,6 +103,17 @@ def _crossing_perimeter_plate():
     return part
 
 
+@pytest.mark.parametrize("projection", ["first", "third"])
+def test_dense_table_survives_both_projection_conventions(projection):
+    drawing = build_drawing(_dense_perimeter_plate(), page="A3", projection=projection)
+    holes = [feature for feature in drawing.model().features if feature.kind == "hole"]
+    assert len(holes) == len(_CROSSING_FREE_PERIMETER_POSITIONS) == 16
+    assert "hole_table_plan" in drawing.annotations()
+    balloons = [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
+    assert len(balloons) == 16
+    assert not [issue for issue in drawing.lint() if issue.severity in {"warning", "error"}]
+
+
 def _dense_plate_with_counterbore():
     """Reviewer fixture whose diagonal balloon AABB used to reject a clear leader."""
     positions = (
@@ -600,7 +611,52 @@ def test_guarded_assignment_is_bounded_and_fails_an_infeasible_flow_closed(monke
     assert dropped == member_count
 
 
-def test_guarded_solver_budget_rolls_the_automatic_table_transaction_back(monkeypatch):
+@pytest.fixture(scope="module")
+def rollback_plate():
+    part = _dense_perimeter_plate()
+    control = build_drawing(part, page="A3")
+    assert "hole_table_plan" in control.annotations()
+    assert len([n for n in control.annotations() if n.startswith("balloon_plan_")]) == 16
+    assert not [i for i in control.lint() if i.severity in {"warning", "error"}]
+    return part
+
+
+@pytest.fixture
+def assert_fallback_restored(monkeypatch):
+    import draftwright.annotations.orchestrator as orchestrator
+
+    original = orchestrator._maybe_tabulate_holes
+    snapshots = {}
+
+    def capture(drawing, analysis, *, ctx, plan=None):
+        snapshots[id(drawing)] = (
+            tuple(ctx.escalations),
+            {
+                name: (item, drawing.registry.identity_of(name))
+                for name, item in drawing.iter_annotations()
+                if name.startswith("hc_plan")
+            },
+        )
+        return original(drawing, analysis, ctx=ctx, plan=plan)
+
+    monkeypatch.setattr(orchestrator, "_maybe_tabulate_holes", capture)
+
+    def verify(drawing):
+        escalations, before = snapshots[id(drawing)]
+        assert escalations and before
+        assert {name for name in drawing.annotations() if name.startswith("hc_plan")} == set(
+            before
+        )
+        for name, (item, identity) in before.items():
+            assert drawing.get_annotation(name) is item
+            assert drawing.registry.identity_of(name) == identity
+
+    return verify
+
+
+def test_guarded_solver_budget_rolls_the_automatic_table_transaction_back(
+    monkeypatch, rollback_plate, assert_fallback_restored
+):
     import draftwright.layout as layout_module
 
     # Make the production resource guard load-bearing without constructing a
@@ -609,11 +665,11 @@ def test_guarded_solver_budget_rolls_the_automatic_table_transaction_back(monkey
     # balloons must lose to the complete feature-backed fallback inventory.
     monkeypatch.setattr(layout_module, "_GUARDED_STRIP_MAX_STATES", 1)
 
-    drawing = build_drawing(_dense_scattered_plate(), page="A3")
+    drawing = build_drawing(rollback_plate, page="A3")
 
     assert "hole_table_plan" not in drawing.annotations()
     assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
-    assert len([name for name in drawing.annotations() if name.startswith("hc_plan")]) == 17
+    assert_fallback_restored(drawing)
     codes = [issue.code for issue in drawing.registry.issues]
     assert "table_dropped" in codes
     assert "balloon_dropped" in codes
@@ -692,23 +748,27 @@ def test_guarded_carve_work_stays_within_its_budget(monkeypatch):
     )
 
 
-def test_guarded_carve_budget_rolls_the_automatic_table_transaction_back(monkeypatch):
+def test_guarded_carve_budget_rolls_the_automatic_table_transaction_back(
+    monkeypatch, rollback_plate, assert_fallback_restored
+):
     import draftwright.annotations.balloons as balloons_module
 
     monkeypatch.setattr(balloons_module, "_GUARDED_CARVE_MAX_LABEL_PROBES", 1)
 
-    drawing = build_drawing(_dense_scattered_plate(), page="A3")
+    drawing = build_drawing(rollback_plate, page="A3")
 
     assert "hole_table_plan" not in drawing.annotations()
     assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
-    assert len([name for name in drawing.annotations() if name.startswith("hc_plan")]) == 17
+    assert_fallback_restored(drawing)
     codes = [issue.code for issue in drawing.registry.issues]
     assert "table_dropped" in codes
     assert "balloon_dropped" in codes
     assert not [issue for issue in drawing.lint() if issue.code == "hole_requirement_missing"]
 
 
-def test_guarded_top_lane_budget_fires_before_quadratic_obstacle_scan(monkeypatch):
+def test_guarded_top_lane_budget_fires_before_quadratic_obstacle_scan(
+    monkeypatch, rollback_plate, assert_fallback_restored
+):
     import draftwright.annotations.balloons as balloons_module
 
     monkeypatch.setattr(balloons_module, "_GUARDED_TOP_LANE_MAX_OBSTACLE_PROBES", 1)
@@ -718,11 +778,11 @@ def test_guarded_top_lane_budget_fires_before_quadratic_obstacle_scan(monkeypatc
 
     monkeypatch.setattr(balloons_module, "carve_free_segments", forbidden_carve)
 
-    drawing = build_drawing(_dense_scattered_plate(), page="A3")
+    drawing = build_drawing(rollback_plate, page="A3")
 
     assert "hole_table_plan" not in drawing.annotations()
     assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
-    assert len([name for name in drawing.annotations() if name.startswith("hc_plan")]) == 17
+    assert_fallback_restored(drawing)
     codes = [issue.code for issue in drawing.registry.issues]
     assert "table_dropped" in codes
     assert "balloon_dropped" in codes
@@ -845,7 +905,9 @@ def test_retained_leader_segment_intersection_ignores_only_a_shared_endpoint():
     assert not _segments_cross_or_overlap((0.0, 0.0), (1.0, 0.0), (0.0, 1.0), (1.0, 1.0))
 
 
-def test_automatic_transaction_fails_closed_when_final_inventory_gate_rejects(monkeypatch):
+def test_automatic_transaction_fails_closed_when_final_inventory_gate_rejects(
+    monkeypatch, rollback_plate, assert_fallback_restored
+):
     import draftwright.annotations.balloons as balloons_module
 
     monkeypatch.setattr(
@@ -854,11 +916,11 @@ def test_automatic_transaction_fails_closed_when_final_inventory_gate_rejects(mo
         lambda *_args, **_kwargs: False,
     )
 
-    drawing = build_drawing(_dense_scattered_plate())
+    drawing = build_drawing(rollback_plate, page="A3")
 
     assert "hole_table_plan" not in drawing.annotations()
     assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
-    assert len(_plan_bore_callouts(drawing)) == 17
+    assert_fallback_restored(drawing)
     assert {"balloon_dropped", "table_dropped"} <= {
         issue.code for issue in drawing.registry.issues
     }
@@ -883,7 +945,9 @@ def test_automatic_transaction_rejects_a_real_required_shaft_crossing():
     assert "hole_requirement_missing" not in {issue.code for issue in drawing.lint()}
 
 
-def test_automatic_actual_label_guard_restores_features_with_no_safe_balloon(monkeypatch):
+def test_automatic_actual_label_guard_restores_features_with_no_safe_balloon(
+    monkeypatch, rollback_plate, assert_fallback_restored
+):
     import draftwright.annotations.balloons as balloons_module
 
     # A real retained-label box occupying every reserved band makes every
@@ -895,10 +959,10 @@ def test_automatic_actual_label_guard_restores_features_with_no_safe_balloon(mon
         lambda *_args: ((-1000.0, -1000.0, 1000.0, 1000.0),),
     )
 
-    drawing = build_drawing(_dense_scattered_plate())
+    drawing = build_drawing(rollback_plate, page="A3")
 
     assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
-    assert len(_plan_bore_callouts(drawing)) == 17
+    assert_fallback_restored(drawing)
     assert "balloon_dropped" in {issue.code for issue in drawing.registry.issues}
     assert ("feature_annotation", "required_balloon_not_placed") in {
         (outcome.representation, outcome.representation_reason)
@@ -1091,45 +1155,26 @@ def test_automatic_table_fails_closed_against_a_retained_public_balloon(
     assert "hole_requirement_missing" not in {issue.code for issue in drawing.lint()}
 
 
-@pytest.mark.parametrize(("retained_view", "table_commits"), [(None, False), ("side", True)])
-def test_retained_public_balloon_component_geometry_respects_view_scope(
-    retained_view, table_commits
-):
+@pytest.mark.parametrize("retained_view", [None, "side"])
+def test_retained_public_balloon_component_geometry_respects_view_scope(retained_view):
     drawing = build_drawing(_dense_perimeter_plate(), page="A3", auto_dims=False)
-    tag = "DRAWING_OR_OTHER_VIEW_BALLOON_WITH_A_VERY_LONG_TAG"
+    tag = "KEEP"
     retained_name = f"balloon_plan_{tag}_0"
     drawing.add_balloons("plan", [(tag, 0, drawing.recognition().holes[0])])
     retained = drawing.get_annotation(retained_name)
     identity = drawing.registry.identity_of(retained_name)
     drawing.registry.reapply(retained_name, {**identity, "view": retained_view})
     assert drawing.view_of(retained_name) == retained_view
+    from draftwright.annotations.balloons import _retained_annotation_geometry
 
-    with drawing.deferred():
-        for feature in drawing.model().features:
-            if feature.kind == "hole":
-                drawing.callout(feature)
-                drawing.locate(feature)
-
-    assert drawing.get_annotation(retained_name) is retained
-    assert ("hole_table_plan" in drawing.annotations()) is table_commits
-    if table_commits:
-        assert (
-            len(
-                [
-                    name
-                    for name in drawing.annotations()
-                    if name.startswith("balloon_plan_") and name != retained_name
-                ]
-            )
-            == 16
-        )
+    boxes, segments, safe = _retained_annotation_geometry(drawing, "plan")
+    assert safe and retained.centerline_boxes and retained.centerline_segments
+    if retained_view is None:
+        assert set(retained.centerline_boxes) <= set(boxes)
+        assert set(retained.centerline_segments) <= set(segments)
     else:
-        assert {name for name in drawing.annotations() if name.startswith("balloon_plan_")} == {
-            retained_name
-        }
-        assert {"table_dropped", "balloon_dropped"} <= {
-            issue.code for issue in drawing.registry.issues
-        }
+        assert set(retained.centerline_boxes).isdisjoint(boxes)
+        assert set(retained.centerline_segments).isdisjoint(segments)
 
 
 def test_public_hole_table_does_not_expose_an_uncomposable_replacement_option():
@@ -1138,14 +1183,14 @@ def test_public_hole_table_does_not_expose_an_uncomposable_replacement_option():
     assert "replace_callouts" not in inspect.signature(Drawing.add_hole_table).parameters
 
 
-def test_automatic_initial_table_failure_restores_every_fallback(monkeypatch):
+def test_automatic_initial_table_failure_restores_every_fallback(monkeypatch, rollback_plate):
     import draftwright.annotations.orchestrator as orchestrator
     import draftwright.drawing as drawing_module
 
-    part = _dense_scattered_plate()
+    part = rollback_plate
     with monkeypatch.context() as disabled:
         disabled.setattr(orchestrator, "_maybe_tabulate_holes", lambda *_args, **_kwargs: None)
-        baseline = build_drawing(part)
+        baseline = build_drawing(part, page="A3")
     baseline_callouts = {
         name: (item, baseline.registry.identity_of(name))
         for name, item in baseline.iter_annotations()
@@ -1153,7 +1198,7 @@ def test_automatic_initial_table_failure_restores_every_fallback(monkeypatch):
     }
     monkeypatch.setattr(drawing_module, "fit_box", lambda *_args, **_kwargs: None)
 
-    drawing = build_drawing(part)
+    drawing = build_drawing(part, page="A3")
 
     assert "hole_table_plan" not in drawing.annotations()
     assert tuple(drawing.annotations()) == tuple(baseline.annotations())
@@ -1207,14 +1252,16 @@ def test_real_constrained_a4_failure_keeps_valid_fallback_coverage():
     assert "hole_requirement_missing" not in {issue.code for issue in drawing.lint()}
 
 
-def test_automatic_partial_balloon_result_rolls_back_the_shared_table(monkeypatch):
+def test_automatic_partial_balloon_result_rolls_back_the_shared_table(
+    monkeypatch, rollback_plate, assert_fallback_restored
+):
     _drop_one_diameter_balloon(monkeypatch, 2.0)
 
-    drawing = build_drawing(_dense_scattered_plate())
+    drawing = build_drawing(rollback_plate, page="A3")
 
     assert "hole_table_plan" not in drawing.annotations()
     assert not [name for name in drawing.annotations() if name.startswith("balloon_plan_")]
-    assert len(_plan_bore_callouts(drawing)) == 17
+    assert_fallback_restored(drawing)
     codes = {issue.code for issue in drawing.lint()}
     assert {"balloon_dropped", "table_dropped"} <= codes
     assert "view_annotation_overlap" not in codes
@@ -1546,25 +1593,29 @@ def test_fitted_callout_can_remain_while_table_resolves_its_location_drop(monkey
     [0.1, fit_class("H7", 5.2)],
     ids=["tolerance", "fit"],
 )
-def test_automatic_table_cannot_resolve_a_dropped_decorated_callout(monkeypatch, decoration):
+def test_automatic_table_cannot_resolve_a_dropped_decorated_callout(
+    monkeypatch, decoration, rollback_plate
+):
     import draftwright.annotations.orchestrator as orchestrator
 
-    part = _dense_scattered_plate()
+    part = rollback_plate
     with monkeypatch.context() as disabled:
         disabled.setattr(orchestrator, "_maybe_tabulate_holes", lambda *_args, **_kwargs: None)
-        baseline = build_drawing(part)
+        baseline = build_drawing(part, page="A3")
     dropped_issue = next(
         issue
         for issue in baseline.registry.issues
         if issue.code == "callout_dropped" and issue.measurement_ids
     )
     feature = dropped_issue.measurement_ids[0].feature
+    if not isinstance(decoration, float):
+        decoration = fit_class("H7", feature.diameter, show="deviation")
     declared = replace(
         baseline.model(),
         decorations={(feature, "diameter"): decoration},
     )
 
-    drawing = build_drawing(part, model=declared)
+    drawing = build_drawing(part, model=declared, page="A3")
 
     assert "hole_table_plan" not in drawing.annotations()
     assert any(issue.code == "table_dropped" for issue in drawing.registry.issues)
@@ -1580,13 +1631,13 @@ def test_automatic_table_cannot_resolve_a_dropped_decorated_callout(monkeypatch,
     } == {None}
 
 
-def test_automatic_table_cannot_resolve_a_dropped_thread_callout(monkeypatch):
+def test_automatic_table_cannot_resolve_a_dropped_thread_callout(monkeypatch, rollback_plate):
     import draftwright.annotations.orchestrator as orchestrator
 
-    part = _dense_scattered_plate()
+    part = rollback_plate
     with monkeypatch.context() as disabled:
         disabled.setattr(orchestrator, "_maybe_tabulate_holes", lambda *_args, **_kwargs: None)
-        baseline = build_drawing(part)
+        baseline = build_drawing(part, page="A3")
     dropped_issue = next(
         issue
         for issue in baseline.registry.issues
@@ -1601,7 +1652,7 @@ def test_automatic_table_cannot_resolve_a_dropped_thread_callout(monkeypatch):
         ],
     )
 
-    drawing = build_drawing(part, model=declared)
+    drawing = build_drawing(part, model=declared, page="A3")
 
     assert "hole_table_plan" not in drawing.annotations()
     assert any(issue.code == "table_dropped" for issue in drawing.registry.issues)
@@ -1662,7 +1713,7 @@ def test_automatic_compound_inventory_fails_closed_on_cross_balloon_geometry():
 
 
 def test_automatic_transaction_keeps_profiled_callout_when_table_is_unsafe():
-    drawing = build_drawing(_dense_plate_with_double_d())
+    drawing = build_drawing(_dense_plate_with_double_d(), page="A3")
     feature = next(
         feature for feature in drawing.model().features if feature.profile == "double_d"
     )
@@ -1687,8 +1738,8 @@ def test_automatic_transaction_keeps_profiled_callout_when_table_is_unsafe():
 
 
 @pytest.mark.parametrize("reserved_name", ["hole_table_plan", "balloon_plan_A_0"])
-def test_automatic_escalation_preserves_preexisting_reserved_names(reserved_name):
-    drawing = build_drawing(_dense_scattered_plate(), auto_dims=False)
+def test_automatic_escalation_preserves_preexisting_reserved_names(reserved_name, rollback_plate):
+    drawing = build_drawing(rollback_plate, auto_dims=False, page="A3")
     drawing.note("USER KEEP", (15, 15), view="plan", name=reserved_name)
     user_annotation = drawing.get_annotation(reserved_name)
 

--- a/tests/test_issue_1144_transactional_hole_table.py
+++ b/tests/test_issue_1144_transactional_hole_table.py
@@ -1609,7 +1609,7 @@ def test_automatic_table_cannot_resolve_a_dropped_decorated_callout(
     )
     feature = dropped_issue.measurement_ids[0].feature
     if not isinstance(decoration, float):
-        decoration = fit_class("H7", feature.diameter, show="deviation")
+        decoration = fit_class("H7", feature.diameter)
     declared = replace(
         baseline.model(),
         decorations={(feature, "diameter"): decoration},
@@ -1617,18 +1617,11 @@ def test_automatic_table_cannot_resolve_a_dropped_decorated_callout(
 
     drawing = build_drawing(part, model=declared, page="A3")
 
-    assert "hole_table_plan" not in drawing.annotations()
-    assert any(issue.code == "table_dropped" for issue in drawing.registry.issues)
-    assert any(
-        issue.code == "callout_dropped" and feature in _features_from_issue(issue)
-        for issue in drawing.registry.issues
-    )
-    assert {
-        outcome.representation
-        for outcome in _outcomes(drawing)
-        if outcome.source_at[:2] == tuple(feature.frame.origin[:2])
-        and outcome.parameter_id == "bore.diameter"
-    } == {None}
+    table = drawing.get_annotation("hole_table_plan")
+    assert table is not None
+    suffix = " ±0.1" if isinstance(decoration, float) else " H7"
+    assert f"ø{feature.diameter:g}{suffix}" in {row[1] for row in table.table_rows}
+    _assert_callout_remains_unresolved(drawing, table, feature)
 
 
 def test_automatic_table_cannot_resolve_a_dropped_thread_callout(monkeypatch, rollback_plate):
@@ -1654,16 +1647,34 @@ def test_automatic_table_cannot_resolve_a_dropped_thread_callout(monkeypatch, ro
 
     drawing = build_drawing(part, model=declared, page="A3")
 
-    assert "hole_table_plan" not in drawing.annotations()
-    assert any(issue.code == "table_dropped" for issue in drawing.registry.issues)
+    table = drawing.get_annotation("hole_table_plan")
+    assert table is not None
+    assert not any(threaded.thread in cell for row in table.table_rows for cell in row)
+    assert not any(
+        measurement.feature == threaded and "thread" in measurement.parameter
+        for measurement in drawing.registry.measurement_of("hole_table_plan")
+    )
+    _assert_callout_remains_unresolved(drawing, table, threaded)
+
+
+def _assert_callout_remains_unresolved(drawing, table, feature):
+    # A visible diameter/location row does not certify replacement of the full callout.
     assert any(
-        issue.code == "callout_dropped" and threaded in _features_from_issue(issue)
+        issue.code == "callout_dropped" and feature in _features_from_issue(issue)
         for issue in drawing.registry.issues
+    )
+    assert drawing.scale_decision["status"] == "incomplete"
+    assert any(b["code"] == "callout_dropped" for b in drawing.scale_decision["blockers"])
+    assert not any(
+        owner == feature and parameter.startswith("bore.")
+        for owner, parameter, _representation, _reason in (
+            table.covers_hole_representations_by_requirement
+        )
     )
     assert {
         outcome.representation
         for outcome in _outcomes(drawing)
-        if outcome.source_at[:2] == tuple(threaded.frame.origin[:2])
+        if outcome.source_at[:2] == tuple(feature.frame.origin[:2])
         and outcome.parameter_id == "bore.diameter"
     } == {None}
 

--- a/tests/test_issue_1479_radius_leader_targets.py
+++ b/tests/test_issue_1479_radius_leader_targets.py
@@ -124,7 +124,7 @@ def _arc_gap(drawing, view, tip, arc):
 
 
 @pytest.mark.parametrize("rotation", [(0, 0, 0), (0, 90, 0), (90, 0, 0), (17, 31, 43)])
-@pytest.mark.parametrize("projection", [None, "third"])
+@pytest.mark.parametrize("projection", [None, "third", "first"])
 def test_radius_targets_follow_rotated_translated_geometry(rotation, projection):
     from build123d import Axis, Box, Rot, fillet
 

--- a/tests/test_issue_1514_projection_safeguard.py
+++ b/tests/test_issue_1514_projection_safeguard.py
@@ -1,4 +1,4 @@
-"""Unsupported first-angle intent must never become a third-angle drawing."""
+"""Unknown projection intent must be refused before loading drawing input."""
 
 from pathlib import Path
 
@@ -23,17 +23,12 @@ def asymmetric_plate():
 
 
 @pytest.mark.parametrize("entry", [build_drawing, make_drawing, Sheet, generate_sheet_script])
-def test_first_angle_refused_before_reading_input(entry, tmp_path):
+def test_unknown_projection_refused_before_reading_input(entry, tmp_path):
     missing = tmp_path / "missing.step"
     assert not missing.exists()
-    with pytest.raises(ValueError, match="first-angle.*not supported.*third"):
-        entry(str(missing), projection="first")
+    with pytest.raises(ValueError, match="unknown projection.*first.*third"):
+        entry(str(missing), projection="unknown")
     assert not list(tmp_path.iterdir())
-
-
-def test_asymmetric_plate_cannot_claim_first_angle(asymmetric_plate):
-    with pytest.raises(ValueError, match="first-angle.*not supported.*third"):
-        build_drawing(asymmetric_plate, projection="first", page="A3", scale=1)
 
 
 @pytest.mark.parametrize("projection", [None, "third"])
@@ -50,17 +45,19 @@ def test_supported_layout_retains_third_angle_relationships(asymmetric_plate, pr
 @pytest.mark.parametrize("script", [False, True])
 @pytest.mark.parametrize("source", ["missing.step", "missing_module:part"])
 def test_cli_refuses_before_loading_step_or_object(script, source, tmp_path):
-    args = [source, "--projection", "first", "--out", str(tmp_path / "drawing")]
+    args = [source, "--projection", "unknown", "--out", str(tmp_path / "drawing")]
     if script:
         args.append("--script")
     result = CliRunner().invoke(app, args)
     assert result.exit_code == 2, result.output
-    assert "first-angle" in result.output and "not supported" in result.output
+    assert "unknown projection" in result.output
     assert "third" in result.output
     assert not list(tmp_path.iterdir())
 
 
-def test_edited_generated_script_cannot_claim_first_angle(asymmetric_plate, tmp_path, monkeypatch):
+def test_edited_generated_script_refuses_unknown_projection(
+    asymmetric_plate, tmp_path, monkeypatch
+):
     path = generate_sheet_script(
         asymmetric_plate,
         out=str(tmp_path / "drawing"),
@@ -69,9 +66,9 @@ def test_edited_generated_script_cannot_claim_first_angle(asymmetric_plate, tmp_
     )
     source = Path(path).read_text()
     assert source.count("projection='third'") == 1
-    edited = source.replace("projection='third'", "projection='first'")
+    edited = source.replace("projection='third'", "projection='unknown'")
     exports = []
     monkeypatch.setattr(Drawing, "export", lambda *a, **kw: exports.append(True))
-    with pytest.raises(ValueError, match="first-angle.*not supported.*third"):
+    with pytest.raises(ValueError, match="unknown projection.*first.*third"):
         exec(compile(edited, path, "exec"), {"supplied_part": asymmetric_plate})
     assert not exports

--- a/tests/test_issue_1515_first_angle.py
+++ b/tests/test_issue_1515_first_angle.py
@@ -1,0 +1,200 @@
+"""Projection convention changes sheet relationships, never physical view identity."""
+
+from pathlib import Path
+
+import pytest
+from build123d import Box, Cylinder, Pos
+
+import draftwright.builder as builder
+from draftwright import Drawing, Sheet, build_drawing
+from draftwright.audit import compare_measurements
+from draftwright.compose import ViewBlock, _layout_geometry
+from draftwright.sheet_emit import generate_sheet_script
+
+
+@pytest.fixture(scope="module")
+def plate():
+    stock = Box(50, 35, 12)
+    cutter = Pos(-13, -8, 0) * Cylinder(3, 20)
+    part = stock - cutter
+    assert cutter.center().X < 0 and cutter.center().Y < 0
+    assert part.volume < stock.volume
+    return part
+
+
+def _assert_convention(drawing, method):
+    assert drawing.view_plan.convention == method
+    front, plan, side = (drawing.view_bounds(v) for v in ("front", "plan", "side"))
+    if method == "first":
+        assert plan[3] < front[1]
+        assert side[2] < front[0]
+    else:
+        assert plan[1] > front[3]
+        assert side[0] > front[2]
+    assert "projection_symbol" in drawing.annotations()
+    assert drawing.get_annotation("projection_symbol").method == method
+
+
+def _local_edges(drawing, view):
+    ox, oy, _ = drawing.at(view, 0, 0, 0)
+    return tuple(
+        sorted(
+            (
+                str(edge.geom_type),
+                round((edge.center().X - ox) / drawing.scale, 5),
+                round((edge.center().Y - oy) / drawing.scale, 5),
+                round(edge.length / drawing.scale, 5),
+            )
+            for edge in group.edges()
+        )
+        for group in drawing.views[view]
+    )
+
+
+@pytest.mark.parametrize("options", [{"page": "A3", "scale": 1}, {}])
+def test_convention_preserves_physical_views_and_all_measurements(plate, options):
+    model = Sheet.from_part(plate).model()
+    holes = [f for f in model.features if f.kind == "hole"]
+    assert len(holes) == 1 and holes[0].diameter == 6
+    drawings = {
+        method: build_drawing(plate, model=model, projection=method, **options)
+        for method in ("third", "first")
+    }
+    for method, drawing in drawings.items():
+        _assert_convention(drawing, method)
+        assert drawing.annotations_of(holes[0])
+        assert not [i for i in drawing.lint() if i.severity in {"warning", "error"}]
+    comparison = compare_measurements(drawings["third"], drawings["first"])
+    assert comparison["status"] == "preserved", comparison
+    for view in ("front", "plan", "side"):
+        assert _local_edges(drawings["first"], view) == _local_edges(drawings["third"], view)
+
+
+@pytest.mark.parametrize("method", ["first", "third"])
+def test_conflicting_principal_relation_refused_before_projection(plate, method, monkeypatch):
+    sheet = Sheet(plate, projection=method).authored_dimensions()
+    front = sheet.view("front")
+    plan = sheet.view("plan")
+    (plan.above if method == "first" else plan.below)(front)
+    projected = []
+    monkeypatch.setattr(builder, "_assemble", lambda *a, **kw: projected.append(True))
+    with pytest.raises(ValueError, match="authored view constraint.*infeasible"):
+        sheet.build()
+    assert not projected
+
+
+@pytest.mark.parametrize("method", ["first", "third"])
+def test_reduced_authored_views_and_origin_pin(plate, method):
+    sheet = Sheet(plate, projection=method, page="A3", scale=1).authored_dimensions()
+    hole = sheet.hole(diameter=6, at=(-13, -8, 0), axis="z").tolerance(0.1)
+    sheet.dimension(hole, "bore.diameter")
+    front = sheet.view("front")
+    plan = sheet.view("plan")
+    (plan.below if method == "first" else plan.above)(front).align_x(front)
+    front.pin((130, 160))
+    drawing = sheet.build()
+    assert set(drawing.views) == {"front", "plan"}
+    assert drawing.at("front", 0, 0, 0) == pytest.approx((130, 160, 0))
+    assert drawing.view_plan.convention == method
+    labels = [getattr(drawing.get_annotation(n), "label", "") for n in drawing.annotations()]
+    assert any("6 ±0.1 THRU" in label for label in labels)
+
+
+@pytest.mark.parametrize("method", ["first", "third"])
+@pytest.mark.parametrize(
+    "views", [("front",), ("plan",), ("side",), ("front", "side"), ("plan", "side")]
+)
+def test_explicit_reduced_view_sets_remain_available(plate, method, views):
+    sheet = Sheet(plate, projection=method, page="A3", scale=1).authored_dimensions()
+    for view in views:
+        sheet.view(view)
+    drawing = sheet.build()
+    assert set(drawing.views) == set(views)
+    assert drawing.view_plan.convention == method
+    for view in views:
+        assert drawing.views[view][0].edges()
+        x0, y0, x1, y1 = drawing.view_bounds(view)
+        assert 0 < x0 < x1 < drawing.page_w
+        assert 0 < y0 < y1 < drawing.page_h
+    if "plan" not in views:
+        codes = {issue.code for issue in drawing.lint()}
+        assert {"feature_no_centermark", "feature_not_located"} <= codes
+
+
+def test_first_angle_script_and_exports_keep_the_convention(plate, tmp_path, monkeypatch):
+    path = generate_sheet_script(
+        plate,
+        out=str(tmp_path / "plate"),
+        projection="first",
+        page="A3",
+        scale=1,
+        part_expr="part = supplied_part",
+    )
+    source = Path(path).read_text()
+    assert source.count("projection='first'") == 1
+    captured = []
+    export = Drawing.export
+    monkeypatch.setattr(Drawing, "export", lambda self, *a, **kw: captured.append(self))
+    exec(compile(source, path, "exec"), {"supplied_part": plate})
+    (drawing,) = captured
+    _assert_convention(drawing, "first")
+    exported = export(drawing, str(tmp_path / "first"), formats=("svg", "pdf", "dxf"))
+    assert set(exported) == {"svg", "pdf", "dxf"}
+    assert all(Path(p).stat().st_size > 0 for p in exported.values())
+    _assert_convention(drawing, "first")
+
+
+@pytest.mark.parametrize("method", ["first", "third"])
+def test_authored_sections_survive_an_isometric_below_the_row(method):
+    sheet = Sheet(Box(50, 30, 10), page="A2", projection=method).authored_dimensions()
+    sheet.section_view("A", at=-8)
+    sheet.section_view("B", at=8)
+    drawing = sheet.build()
+    if method == "first":
+        assert drawing.view_bounds("iso")[3] < drawing.view_bounds("front")[1] - 10
+    assert {"section_aa", "section_bb"} <= set(drawing.views)
+    assert not [issue for issue in drawing.lint() if issue.severity in {"warning", "error"}]
+
+
+@pytest.mark.parametrize("method", ["first", "third"])
+@pytest.mark.parametrize("arrangement", ["columns", "stacked-iso"])
+def test_measured_bands_are_packed_on_the_correct_sides(method, arrangement):
+    blocks = {
+        "front": ViewBlock(25, 6, top=21, right=24, bottom=27, left=30),
+        "plan": ViewBlock(25, 17.5, top=33, right=36, bottom=39, left=42),
+        "side": ViewBlock(17.5, 6, top=45, right=48, bottom=51, left=54),
+    }
+    geometry = _layout_geometry(
+        50,
+        35,
+        12,
+        1,
+        594,
+        420,
+        150,
+        None,
+        blocks=blocks,
+        convention=method,
+        arrangement=arrangement,
+    )
+    assert geometry.fits
+    boxes = {
+        name: block.footprint(getattr(geometry, prefix + "_X"), getattr(geometry, prefix + "_Y"))
+        for (name, block), prefix in zip(blocks.items(), ("FV", "PV", "SV"), strict=True)
+    }
+    front, plan, side = (boxes[v] for v in ("front", "plan", "side"))
+    if method == "first":
+        assert plan[3] <= front[1]
+        assert side[2] <= min(front[0], plan[0])
+    else:
+        assert plan[1] >= front[3]
+        assert side[0] >= max(front[2], plan[2])
+
+
+@pytest.mark.parametrize("method", ["first", "third"])
+def test_submillimetre_locations_cannot_claim_a_complete_scale(plate, method):
+    with pytest.raises(builder.ScaleIncompatibilityError) as error:
+        build_drawing(plate, page="A3", scale=0.01, scale_policy="strict", projection=method)
+    assert error.value.decision["status"] == "rejected"
+    blockers = error.value.decision["blockers"]
+    assert any(b["code"] == "location_ref_dropped" and b["measurements"] for b in blockers)

--- a/tests/test_issue_1515_first_angle.py
+++ b/tests/test_issue_1515_first_angle.py
@@ -1,14 +1,17 @@
 """Projection convention changes sheet relationships, never physical view identity."""
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 from build123d import Box, Cylinder, Pos
 
 import draftwright.builder as builder
 from draftwright import Drawing, Sheet, build_drawing
+from draftwright.analysis import _analyse
 from draftwright.audit import compare_measurements
-from draftwright.compose import ViewBlock, _layout_geometry
+from draftwright.compose import StripDepths, ViewBlock, _layout_geometry
+from draftwright.registry import AnnotationRegistry
 from draftwright.sheet_emit import generate_sheet_script
 
 
@@ -198,3 +201,67 @@ def test_submillimetre_locations_cannot_claim_a_complete_scale(plate, method):
     assert error.value.decision["status"] == "rejected"
     blockers = error.value.decision["blockers"]
     assert any(b["code"] == "location_ref_dropped" and b["measurements"] for b in blockers)
+    assert {"x", "y"} <= {
+        m["parameter"].rsplit(".", 1)[-1] for b in blockers for m in b["measurements"]
+    }
+
+
+def test_repack_applies_a_small_move_when_ink_is_outside_the_page(monkeypatch):
+    analysis = _analyse(
+        Box(50, 30, 10),
+        title="",
+        number="",
+        tolerance="",
+        drawn_by="",
+        out="small",
+        page="A3",
+        scale=1,
+        projection="first",
+    )
+    original_geometry = builder._layout_geometry
+
+    def small_correction(*args, **kwargs):
+        geometry = original_geometry(*args, **kwargs)
+        for name in ("FV_X", "FV_Y", "PV_X", "PV_Y", "SV_X", "SV_Y"):
+            setattr(
+                geometry, name, getattr(analysis, name) + (0.05 if name.endswith("X") else 0.0)
+            )
+        return geometry
+
+    monkeypatch.setattr(builder, "_layout_geometry", small_correction)
+    monkeypatch.setattr(builder, "_needs_repack", lambda *_: True)
+    monkeypatch.setattr(builder, "_annotations_out_of_bounds", lambda *_: True)
+    monkeypatch.setattr(builder, "_measure_blocks", lambda *_: {})
+    assembled = []
+
+    def assemble(chosen, *args, **kwargs):
+        assembled.append(chosen)
+        return "corrected drawing"
+
+    monkeypatch.setattr(builder, "_assemble", assemble)
+    drawing = SimpleNamespace(registry=AnnotationRegistry())
+    result = builder._repack(analysis, drawing, "small", None, False, scale=1, page="A3")
+    assert result is not None
+    corrected, output = result
+    assert output == "corrected drawing" and assembled == [corrected]
+    assert 0 < corrected.SV_X - analysis.SV_X < builder._REPACK_TOL
+    assert corrected.SV_X - analysis.SV_X == pytest.approx(0.05)
+
+
+@pytest.mark.parametrize("method", ["first", "third"])
+def test_plan_only_does_not_reserve_a_phantom_front_corridor(method):
+    geometry = _layout_geometry(
+        50,
+        35,
+        12,
+        1,
+        297,
+        210,
+        150,
+        StripDepths(right=20, left=20, pv_location_top=250),
+        views=("plan",),
+        include_iso=False,
+        convention=method,
+    )
+    assert geometry.fits
+    assert geometry.planned_views == ("plan",)

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -2755,7 +2755,8 @@ class TestComposeThenPackRepack:
 
     # --- out-of-bounds escalation trigger (#92) ---------------------------
 
-    def test_out_of_bounds_trigger(self):
+    @pytest.mark.parametrize("overflow", [(20, 20, 40, 120), (9.95, 20, 40, 40)])
+    def test_out_of_bounds_trigger(self, overflow):
         # The second repack trigger: a view-owned annotation past the drawable
         # (e.g. a ballooned plan view overflowing the page top) escalates even
         # without a cross-view overlap. Untagged overflow is ignored — a repack
@@ -2767,9 +2768,9 @@ class TestComposeThenPackRepack:
         a = SimpleNamespace(margin=10.0, PAGE_W=200.0, PAGE_H=100.0)
         inb = self._fake_dwg({"d": self._line((20, 20, 40, 40))}, {"d": "plan"})
         assert not _annotations_out_of_bounds(inb, a)
-        over = self._fake_dwg({"d": self._line((20, 20, 40, 120))}, {"d": "plan"})
+        over = self._fake_dwg({"d": self._line(overflow)}, {"d": "plan"})
         assert _annotations_out_of_bounds(over, a)
-        untagged = self._fake_dwg({"d": self._line((20, 20, 40, 120))}, {"d": "iso"})
+        untagged = self._fake_dwg({"d": self._line(overflow)}, {"d": "iso"})
         assert not _annotations_out_of_bounds(untagged, a)
 
     # --- disjoint block packing ------------------------------------------
@@ -5708,10 +5709,9 @@ class TestLintSummaryAndDrops:
         assert 0 < n_locy < 10
 
     @pytest.mark.timeout(120)
-    def test_location_gate_ignores_datum_edge_hole(self):
-        # #43 follow-up: a hole on the datum edge is never dimensioned (its dim is
-        # ~zero), so the gate must not anchor a cluster on it and drop a real
-        # neighbour. Box centred at origin -> datum corner at (-40, -30).
+    def test_short_location_does_not_displace_its_legible_neighbour(self):
+        # A nonzero 0.7 mm location is too short to draw; report it honestly without
+        # anchoring the spacing cluster on it and dropping its legible neighbour.
         from build123d import Box, Cylinder, Pos
 
         from draftwright import build_drawing
@@ -5726,7 +5726,11 @@ class TestLintSummaryAndDrops:
         x_spacing_drops = [
             i for i in dwg.lint() if i.code == "location_ref_dropped" and "X location" in i.message
         ]
-        assert x_spacing_drops == []
+        assert len(x_spacing_drops) == 1
+        issue = x_spacing_drops[0]
+        assert "less than 1 mm" in issue.message
+        assert issue.measurement_ids
+        assert all(abs(mid.feature.frame.origin[0] + 39.3) < 1e-6 for mid in issue.measurement_ids)
 
     @pytest.mark.timeout(120)
     def test_auto_annotate_clears_stale_build_issues(self):

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -2598,6 +2598,7 @@ class TestComposeThenPackRepack:
             _named=named,
             _anno_view=views,
             iter_annotations=lambda: named.items(),
+            get_annotation=lambda n: named.get(n),
             view_of=lambda n: views.get(n),
             annotations_in_view=lambda v: ((n, o) for n, o in named.items() if views.get(n) == v),
         )
@@ -10860,6 +10861,12 @@ class TestHoleTable:
             FV_Y=20.0,
             fv_hh=5.0,
         )
+        a.pv_zones = SimpleNamespace(
+            left=SimpleNamespace(outer_limit=a.margin),
+            right=SimpleNamespace(outer_limit=a.SV_X - a.sv_hw),
+            below=SimpleNamespace(outer_limit=a.FV_Y + a.fv_hh),
+            above=SimpleNamespace(outer_limit=a.PAGE_H - a.margin),
+        )
         pt = a.PV_Y + a.pv_hh
         bare_obstacle = self._Boxed((35.0, pt + 2.0, 65.0, pt + 12.0))
 
@@ -10898,7 +10905,7 @@ class TestHoleTable:
             PV_Y=50.0,
             fv_hw=20.0,
             pv_hh=10.0,
-            SV_X=95.0,
+            SV_X=110.0,
             sv_hw=10.0,
             margin=0.0,
             PAGE_H=180.0,
@@ -10906,12 +10913,19 @@ class TestHoleTable:
             FV_Y=0.0,
             fv_hh=5.0,
         )
+        a.pv_zones = SimpleNamespace(
+            left=SimpleNamespace(outer_limit=a.margin),
+            right=SimpleNamespace(outer_limit=a.SV_X - a.sv_hw),
+            below=SimpleNamespace(outer_limit=a.FV_Y + a.fv_hh),
+            above=SimpleNamespace(outer_limit=a.PAGE_H - a.margin),
+        )
         pt = a.PV_Y + a.pv_hh
         obstacle = self._Boxed((47.0, pt + 2.0, 53.0, pt + 80.0))
 
         import draftwright.annotations.balloons as balloons
         from draftwright._core import _balloon_halo, _balloon_radius
 
+        assert a.pv_zones.right.outer_limit - (a.PV_X + a.fv_hw) > _balloon_halo(3.0)
         real_assign = balloons._assign_balloon_bands
         assignment_kwargs = []
 
@@ -11023,6 +11037,12 @@ class TestHoleTable:
             FV_Y=30.0,
             fv_hh=5.0,
         )
+        a.pv_zones = SimpleNamespace(
+            left=SimpleNamespace(outer_limit=a.margin),
+            right=SimpleNamespace(outer_limit=a.SV_X - a.sv_hw),
+            below=SimpleNamespace(outer_limit=a.FV_Y + a.fv_hh),
+            above=SimpleNamespace(outer_limit=a.PAGE_H - a.margin),
+        )
 
         import draftwright.annotations.balloons as balloons
 
@@ -11074,6 +11094,12 @@ class TestHoleTable:
             FV_Y=30.0,
             fv_hh=5.0,
         )
+        a.pv_zones = SimpleNamespace(
+            left=SimpleNamespace(outer_limit=a.margin),
+            right=SimpleNamespace(outer_limit=a.SV_X - a.sv_hw),
+            below=SimpleNamespace(outer_limit=a.FV_Y + a.fv_hh),
+            above=SimpleNamespace(outer_limit=a.PAGE_H - a.margin),
+        )
         right_obstacle = self._Boxed((71.0, 45.0, 115.0, 55.0))
 
         import draftwright.annotations.balloons as balloons
@@ -11100,13 +11126,17 @@ class TestHoleTable:
         assert [m[0] for m in left_members] == ["A"]
         assert right_members == []
 
-    def test_table_and_balloons_keep_lint_clean(self):
+    @pytest.mark.parametrize("method", ["first", "third"])
+    def test_table_and_balloons_keep_lint_clean(self, method):
         # One covers_diameters entry per physical bore lets coverage lint verify the
         # table's visible QTY, and the balloons are furniture (is_centerline) so they do
         # not trip overlap lint.
-        dwg = build_drawing(_multi_hole_plate())
+        dwg = build_drawing(_multi_hole_plate(), projection=method)
         before = {i.code for i in dwg.lint()}
+        assert before == set()
+        assert dwg.scale == 1
         dwg.add_hole_table("plan")
+        assert len([n for n in dwg.annotations() if n.startswith("balloon_plan")]) == 3
         assert {i.code for i in dwg.lint()} == before
         assert dwg.get_annotation("hole_table_plan").covers_diameters == (16.0, 10.0, 10.0)
 


### PR DESCRIPTION
## Symptom and evidence

`projection="first"` previously selected a symbol over third-angle geometry; #1514 now refuses that request. This change enables actual first-angle sheets: the existing physical plan view is below front, the side view is left of front, and the title-block symbol agrees. Physical viewing directions and measurement identities stay stable.

Asymmetric plate, reduced-view, authored-section, three-hole and dense 16/18-hole fixtures exercise automatic, declared and generated-script builds. Complete annotation ink participates in packing; first-angle facing corridors reserve the location ladder before dropped candidates can disappear from the measured footprint. Outer-facing third-angle strips retain their existing seed, preserving the golden corpus's page/scale choices.

Review also exposed shared-path correctness gaps: section rows below the iso view, balloon bounds in mirrored layouts, sheet-level table coverage, sub-millimetre unrenderable locations, and small out-of-page ink corrections. These are corrected in the shared placement/diagnostic paths. Transaction tests now prove fallback conservation and retained unresolved callouts rather than depending on an incidental table collision.

## Contract and scope

One resolved convention drives view composition, scale selection, constraints, repacking and symbol selection. Contradictory principal relationships fail before projection. Existing defaults remain third-angle without a symbol. Documentation defines physical view directions and page axes.

Independent iterative Google review is clean against ADRs 1–5 on `e9f6d23c0fce6408053af04cc1c5aa20f30c9a2f`: shared compiler and solve, unchanged recognition boundary, preserved declared intent and physical identities, honest incomplete outcomes. Above-line text, through-hole wording and explicit rear support remain separate children of #1508; automatic rear selection is deferred.

Closes #1515.

## Validation

- `scripts/pr-check --full`: passed static checks and **7,763 tests**, with 5 skipped and 13 expected failures; 95.92% total coverage and **99% changed-line coverage** (108/109).
- **21 isolated source-copy mutations killed**: convention/repack, complete ink, exact page bounds and small corrections, bounded location reservation and phantom-front exclusion, short-span diagnostics, manual balloon guards, unsafe decorated/thread replacement, transaction budgets, section/iso separation, early constraints, reduced views and table coverage. Each mutation imported the isolated package and failed a named behavioral test; no collection failures counted.
- Independent final review: **LGTM** on `e9f6d23c0fce6408053af04cc1c5aa20f30c9a2f`, no blocking findings or required nits.
- Required GitHub CI remains the merge gate (`ci-ok`, `codecov/project`, up-to-date branch).

- Automatic, declared, generated-script and real SVG/PDF/DXF routes are exercised.
- Recognition behavior is unchanged; existing recognition/repeated-lint call-count tests run in the full suite.
- Deliberate source-copy mutations verify critical convention, complete-ink, bounds, coverage and transactional guards.

## Stop check

- The reservation refinement is bounded to the actual facing corridor; no new association strategy or recognition prerequisite.
- Rendering-style and rear-view work remain separate delivery units.

## Contributor License Agreement

Maintainer-owned change in the project owner's repository.
