### PR TITLE
feat: independent dimension text position and orientation

### DIFF
--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -25,6 +25,30 @@ retain the requested convention. Annotation footprints, scale/page selection and
 repacking use the same convention. An authored relation contradicting the principal layout
 fails before projection; a whole-view pin must preserve the convention's relationships.
 
+## Dimension text style
+
+Position and reading direction are independent drawing-wide settings:
+
+```python
+sheet = Sheet(part, text_position="above", text_orientation="horizontal")
+# Declare features and dimensions as usual, then build.
+drawing = sheet.build()
+```
+
+`text_position="inline"` (the default) leaves a gap for the value in the dimension
+line; `"above"` keeps the line continuous and offsets the full value and tolerance.
+For angular dimensions, above means outside the arc. `text_orientation="aligned"`
+(the default) follows the dimension line or arc tangent; `"horizontal"` keeps text
+horizontal on the sheet. An aligned vertical value reads from the right. Short
+spans use outside arrows while retaining their complete text.
+
+The same options are accepted by `build_drawing()`, `make_drawing()`,
+`emit_sheet_script()` and `generate_sheet_script()`. The CLI flags are
+`--text-position` and `--text-orientation`. Generated scripts retain these settings;
+SVG, PDF and DXF export the same resolved ink. Unsupported values raise `ValueError`.
+The choices affect rendering and its placement footprint, not feature measurements
+or tolerances. These are explicit rendering choices, not a claim of standards conformity.
+
 ## Grooves on coaxial bodies
 
 When different turned bodies share an axis line, give their steps distinct `profile_group`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     # This novtk release lacks OCP.GccEnt on macOS. The exclusion must reach
     # published wheels, not only uv's development resolver constraints.
     "cadquery-ocp-novtk!=7.9.3.1.1 ; python_full_version >= '3.13'",
-    "build123d-drafting-helpers>=0.14.2",
+    "build123d-drafting-helpers>=0.15.0",
     "quiddity==0.2.6",
     "numpy>=1.24",
     # PNG raster export (SVG→PDF→PNG). Both permissively licensed (Pillow HPND; pypdfium2

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
 
 from build123d import (
     Align,
+    ArrowHead,
     BoundBox,
     Compound,
     Edge,
@@ -172,6 +173,24 @@ def _zone_divisions(page_w: float, page_h: float) -> tuple[int, int]:
 _TB_CLEAR = _MARGIN + 1.0  # title-block inset: one extra mm over _MARGIN for clearance
 
 _FONT_SIZE = 3.0  # annotation text height (page-mm); the draft preset is built with this
+
+
+def _dimension_draft(text_position="inline", text_orientation="aligned"):
+    """One fixed typography preset, with helper-owned validation of text style."""
+    return draft_preset(
+        font_size=_FONT_SIZE,
+        decimal_precision=1,
+        font_path=PLEX_MONO,
+        text_position=text_position,
+        text_orientation=text_orientation,
+    )
+
+
+@functools.lru_cache(maxsize=128)
+def _dimension_head_bounds(arrow_length, head_type):
+    """Measure each fixed-size arrow style once, before candidate evaluation."""
+    box = ArrowHead(arrow_length, head_type=head_type, mode=Mode.PRIVATE).bounding_box()
+    return box.min.X, box.min.Y, box.max.X, box.max.Y
 
 
 _TB_H = 35.0
@@ -1211,6 +1230,8 @@ class Analysis:
     # Projection-method symbol (#769): "third" / "first" (ISO 5456-2) or None (omit).
     projection: str | None = None
     projection_convention: str = "third"
+    text_position: str = "inline"
+    text_orientation: str = "aligned"
     # Draw the ISO 5457 zone-grid border ruler (#768). Implies a frame (the ticks sit on it).
     zones: bool = False
     # The PartModel built by _analyse's pre-scale sizing pass (#584 WP1 A) — stored so

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -18,7 +18,6 @@ from dataclasses import dataclass, replace
 from typing import cast
 
 from build123d import Compound, Shape
-from build123d_drafting.helpers import draft_preset
 from OCP.IFSelect import IFSelect_ReturnStatus
 from OCP.STEPControl import STEPControl_Reader
 from quiddity import (
@@ -41,6 +40,7 @@ from draftwright._core import (
     _MIN_VIEW_MM,
     Analysis,
     _content_margin,
+    _dimension_draft,
     _legible_steps,
     _Projector,
 )
@@ -762,6 +762,8 @@ def _analyse(
     company="",
     frame: bool = False,
     projection: str | None = None,
+    text_position: str = "inline",
+    text_orientation: str = "aligned",
     zones: bool = False,
     _reuse: Analysis | None = None,
     _required_tables=(),
@@ -990,7 +992,7 @@ def _analyse(
     # Construct the same draft preset used later in build_drawing() to read
     # arrow_length and pad_around_text from their authoritative source rather
     # than re-stating them as magic literals in the estimators.
-    _draft_est = draft_preset(font_size=_FONT_SIZE, decimal_precision=1)
+    _draft_est = _dimension_draft(text_position, text_orientation)
     _arrow_length = _draft_est.arrow_length
     _pad_around_text = _draft_est.pad_around_text
     # Empty on the declared path — NOT "this part has no holes", but "nothing was detected".
@@ -1130,6 +1132,8 @@ def _analyse(
             arrow_length=_arrow_length,
             pad_around_text=_pad_around_text,
             bore_callout_width=bore_callout_width,
+            text_position=text_position,
+            text_orientation=text_orientation,
         )
 
     layout_advisories: list[tuple[str, str]] = []
@@ -1380,6 +1384,8 @@ def _analyse(
         company=company,
         frame=frame,
         projection=projection,
+        text_position=text_position,
+        text_orientation=text_orientation,
         projection_convention=convention,
         zones=zones,
         out=out,

--- a/src/draftwright/angular_geometry.py
+++ b/src/draftwright/angular_geometry.py
@@ -14,6 +14,8 @@ class AngularStyle:
     extension_gap: float
     pad_around_text: float
     line_width: float
+    text_position: str = "inline"
+    text_orientation: str = "aligned"
 
 
 def _box(points, padding=0.0):
@@ -73,15 +75,31 @@ class AngularGeometry:
         self.text_size = text_size
         tangent = (self.middle + pi / 2) % (2 * pi)
         self.text_angle = tangent - pi if pi / 2 < tangent <= 3 * pi / 2 else tangent
+        self.text_position = getattr(draft, "text_position", "inline")
+        if getattr(draft, "text_orientation", "aligned") == "horizontal":
+            self.text_angle = 0.0
         width, height = self.text_size
+        relative = self.text_angle - self.middle
+        self.radial_half = abs(cos(relative)) * width / 2 + abs(sin(relative)) * height / 2
+        self.tangent_half = abs(sin(relative)) * width / 2 + abs(cos(relative)) * height / 2
         # This bound leaves room for both arrow shafts and the full text. It also
         # keeps extension lines beyond their physical witness points. Opposite
         # witnesses have negative stations: their extensions cross the vertex.
         self.minimum_radius = max(
             max(lengths) + draft.extension_gap + draft.arrow_length,
-            (width + height + 2 * draft.pad_around_text + 4 * draft.arrow_length) / self.sweep
-            + height / 2
-            + draft.pad_around_text,
+            (
+                4 * draft.arrow_length / self.sweep
+                if self.text_position == "above"
+                else (
+                    2 * self.tangent_half
+                    + 2 * self.radial_half
+                    + 2 * draft.pad_around_text
+                    + 4 * draft.arrow_length
+                )
+                / self.sweep
+                + self.radial_half
+                + draft.pad_around_text
+            ),
         )
 
     @property
@@ -94,7 +112,7 @@ class AngularGeometry:
 
     def label_polygon(self, radius):
         width, height = self.text_size
-        centre = self.point(radius, self.middle)
+        centre = self.label_centre(radius)
         return tuple(
             tuple(a + b for a, b in zip(centre, _rotate(point, self.text_angle), strict=True))
             for point in (
@@ -104,6 +122,11 @@ class AngularGeometry:
                 (-width / 2, height / 2),
             )
         )
+
+    def label_centre(self, radius):
+        if self.text_position == "above":
+            radius += self.radial_half + self.draft.pad_around_text + self.draft.arrow_length
+        return self.point(radius, self.middle)
 
     def extension_segments(self, radius):
         end_radius = radius + self.draft.extension_gap
@@ -118,10 +141,13 @@ class AngularGeometry:
         )
 
     def arc_intervals(self, radius):
-        width, height = self.text_size
-        gap = atan2(
-            width / 2 + self.draft.pad_around_text,
-            radius - height / 2 - self.draft.pad_around_text,
+        gap = (
+            0.0
+            if self.text_position == "above"
+            else atan2(
+                self.tangent_half + self.draft.pad_around_text,
+                radius - self.radial_half - self.draft.pad_around_text,
+            )
         )
         intervals = ((self.start, self.middle - gap), (self.middle + gap, self.start + self.sweep))
         if any((end - start) * radius <= self.draft.arrow_length for start, end in intervals):

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -17,6 +17,7 @@ from itertools import chain
 from pathlib import Path
 from typing import Any
 
+from build123d import FontStyle
 from build123d_drafting.helpers import DEFAULT_FONT_PATH, Dimension, Note, SafeDimension
 
 from draftwright._core import (  # noqa: F401 — _anno_box re-exported (#700)
@@ -24,6 +25,7 @@ from draftwright._core import (  # noqa: F401 — _anno_box re-exported (#700)
     _anno_box,
     _decode_hole_location_fact,
     _dim,
+    _dimension_head_bounds,
     _text_size,
     place_annotation,
 )
@@ -816,7 +818,13 @@ def dim_footprint(p1, p2, side, distance, draft, label):
         draft.font_size,
         getattr(draft, "font_path", DEFAULT_FONT_PATH),
         getattr(draft, "font", "Arial"),
+        getattr(draft, "font_style", FontStyle.REGULAR),
     )
+    if (
+        getattr(draft, "text_position", "inline"),
+        getattr(draft, "text_orientation", "aligned"),
+    ) != ("inline", "aligned"):
+        return _styled_dimension_footprint(p1, p2, side, distance, draft, (w, h))
     hx, hy = (h / 2.0, w / 2.0) if abs(dyp) > abs(dxp) else (w / 2.0, h / 2.0)
     lcx = (p1[0] + p2[0]) / 2.0 + sx * off
     lcy = (p1[1] + p2[1]) / 2.0 + sy * off
@@ -843,6 +851,72 @@ def dim_footprint(p1, p2, side, distance, draft, label):
         ys += [p1[1] + sy * far, p2[1] + sy * far]
     pad = draft.line_width / 2.0
     return (min(xs) - pad, min(ys) - pad, max(xs) + pad, max(ys) + pad)
+
+
+def _styled_dimension_footprint(p1, p2, side, distance, draft, text_size):
+    """Conservative full-ink hull with the helper's resolved orientation and offset.
+
+    The builder warms the fixed arrow envelope before placement; candidates use
+    scalar arithmetic and cached typography. Unclipped witness extents are a
+    conservative bound, followed by the existing actual-ink acceptance check.
+    """
+    width, height = text_size
+    dx, dy = p2[0] - p1[0], p2[1] - p1[1]
+    length = math.hypot(dx, dy)
+    ux, uy = dx / length, dy / length
+    sign = 1 if uy * side[0] - ux * side[1] >= 0 else -1
+    wx, wy = sign * uy, -sign * ux
+    off = abs(distance)
+    ends = [(point[0] + wx * off, point[1] + wy * off) for point in (p1, p2)]
+    angle = math.atan2(uy, ux)
+    aligned = (
+        angle if -math.pi / 2 < angle <= math.pi / 2 else angle - math.copysign(math.pi, angle)
+    )
+    reading = aligned if draft.text_orientation == "aligned" else 0.0
+    relative = reading - angle
+    along = abs(math.cos(relative)) * width / 2 + abs(math.sin(relative)) * height / 2
+    normal = abs(math.sin(relative)) * width / 2 + abs(math.cos(relative)) * height / 2
+    cx, cy = ((ends[0][index] + ends[1][index]) / 2 for index in (0, 1))
+    head_box = _dimension_head_bounds(draft.arrow_length, draft.head_type)
+    head_height = max(abs(head_box[1]), abs(head_box[3]))
+    if draft.text_position == "above":
+        offset = normal + draft.pad_around_text + max(head_height, draft.line_width / 2)
+        cx -= math.sin(aligned) * offset
+        cy += math.cos(aligned) * offset
+    hx = abs(math.cos(reading)) * width / 2 + abs(math.sin(reading)) * height / 2
+    hy = abs(math.sin(reading)) * width / 2 + abs(math.cos(reading)) * height / 2
+    points = [(cx - hx, cy - hy), (cx + hx, cy + hy)]
+    for point in (p1, p2):
+        points.extend(
+            (point[0] + wx * t, point[1] + wy * t)
+            for t in (draft.extension_gap, off + draft.extension_gap)
+        )
+    fits = (
+        2 * along + 2 * draft.arrow_length < length
+        and length / 2 - along - draft.pad_around_text > draft.arrow_length / 2
+    )
+    # Local arrow heads extend behind their tip. Rotate the complete envelope:
+    # separate tip/shaft and transverse extrema miss oblique body corners.
+    for end, direction in zip(ends, (-1, 1) if fits else (1, -1), strict=True):
+        points.extend(
+            (
+                end[0] + direction * (ux * x - uy * y),
+                end[1] + direction * (uy * x + ux * y),
+            )
+            for x in (head_box[0], head_box[2])
+            for y in (head_box[1], head_box[3])
+        )
+    if not fits:
+        points.extend(
+            (
+                end[0] + ux * direction * 2 * draft.arrow_length,
+                end[1] + uy * direction * 2 * draft.arrow_length,
+            )
+            for end, direction in zip(ends, (-1, 1), strict=True)
+        )
+    xs, ys = zip(*points, strict=True)
+    pad = draft.line_width / 2
+    return min(xs) - pad, min(ys) - pad, max(xs) + pad, max(ys) + pad
 
 
 def leader_callout_geometry(tip, elbow, draft, *, text_side="auto", callout_box=None):
@@ -2917,6 +2991,7 @@ def place_strip_candidates(
     # solve, try a bounded contraction using actual segments and labels against
     # both committed ink and this batch. Never move an anchored dimension.
     active_names = {name for name, _build in cands}
+    label_clear = view_label_clearance(dwg, view) if compact_candidates else None
     for name, alternatives in (compact_candidates or {}).items():
         if name not in active_names:
             continue
@@ -2936,6 +3011,7 @@ def place_strip_candidates(
                 or box[2] > dwg.page_w - _MARGIN
                 or box[3] > dwg.page_h - _MARGIN
                 or ((forbid or {}).get(name) is not None and _box_hits(box, (forbid[name],)))
+                or (label_clear is not None and not label_clear(candidate.label_bbox))
                 or not annotation_ink_clear(dwg, candidate, additional=others)
             ):
                 continue

--- a/src/draftwright/annotations/angular.py
+++ b/src/draftwright/annotations/angular.py
@@ -82,7 +82,7 @@ class AngularDimension(Compound):
         text = text.moved(
             Location((-(box.min.X + box.max.X) / 2, -(box.min.Y + box.max.Y) / 2, 0))
         )
-        centre = ink.point(radius, ink.middle)
+        centre = ink.label_centre(radius)
         text = text.moved(Location((*centre, 0), (0, 0, degrees(ink.text_angle))))
         super().__init__(children=[*arrows, extensions, text], label=ink.label)
         self._angular_points = (ink.witnesses[0], ink.vertex, ink.witnesses[1])

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -38,6 +38,8 @@ from draftwright._core import (
     _add_sheet_frame,
     _add_title_block,
     _add_zone_grid,
+    _dimension_draft,
+    _dimension_head_bounds,
     _iso_bbox,
     _log,
     _parse_page,
@@ -67,7 +69,6 @@ from draftwright.compose import (
     _view_geom,
 )
 from draftwright.drawing import Drawing, feature_key
-from draftwright.fonts import PLEX_MONO
 from draftwright.linting import LintIssue
 from draftwright.linting.coverage import lint_axial_coverage
 from draftwright.model import (
@@ -514,13 +515,16 @@ def _assemble(
     build state so the annotate + finalize paths thread it), or ``None``."""
     cxs, cys, czs = a.cx * a.SCALE, a.cy * a.SCALE, a.cz * a.SCALE
     dist = a.bbox_max * a.SCALE + 100
+    draft = _dimension_draft(a.text_position, a.text_orientation)
+    if (a.text_position, a.text_orientation) != ("inline", "aligned"):
+        _dimension_head_bounds(draft.arrow_length, draft.head_type)
 
     dwg = Drawing(
         scale=a.SCALE,
         page_w=a.PAGE_W,
         page_h=a.PAGE_H,
         tb_w=a.TB_W,
-        draft=draft_preset(font_size=_FONT_SIZE, decimal_precision=1, font_path=PLEX_MONO),
+        draft=draft,
         look_at=(cxs, cys, czs),
         dist=dist,
         centroid=(a.cx, a.cy, a.cz),
@@ -1192,6 +1196,8 @@ def _build_drawing_once(
     zones: bool = False,
     reproducible: bool = False,
     framed_recognition: bool = False,
+    text_position: str = "inline",
+    text_orientation: str = "aligned",
     _analysis_base=None,
     _analysis_sink: Callable[[Analysis], None] | None = None,
     _critique_recognition_cache=None,
@@ -1312,6 +1318,8 @@ def _build_drawing_once(
             company=company,
             frame=frame,
             projection=projection,
+            text_position=text_position,
+            text_orientation=text_orientation,
             zones=zones,
             _reuse=reuse,
             _required_tables=_required_tables,
@@ -1854,6 +1862,8 @@ def build_drawing(
     scale_policy: Literal["strict", "fallback", "permissive"] = "fallback",
     reproducible: bool = False,
     framed_recognition: bool = False,
+    text_position: str = "inline",
+    text_orientation: str = "aligned",
     _post_build: Callable[[Drawing], Drawing] | None = None,
     _required_tables=(),
     _views: tuple[str, ...] | None = None,
@@ -1876,8 +1886,12 @@ def build_drawing(
     ``projection='third'`` adds the matching projection symbol. The default omits the
     symbol but uses the same third-angle layout. ``projection='first'`` places plan below
     front and side to its left, keeping the physical viewing directions unchanged.
+
+    ``text_position="inline"|"above"`` and ``text_orientation="aligned"|"horizontal"``
+    independently select dimension typography. Defaults preserve existing appearance.
     """
     validate_projection(projection)
+    _dimension_draft(text_position, text_orientation)
     if scale_policy not in {"strict", "fallback", "permissive"}:
         raise ValueError(
             f"scale_policy must be 'strict', 'fallback', or 'permissive', got {scale_policy!r}"
@@ -1907,6 +1921,8 @@ def build_drawing(
         company=company,
         frame=frame,
         projection=projection,
+        text_position=text_position,
+        text_orientation=text_orientation,
         zones=zones,
         reproducible=reproducible,
         framed_recognition=framed_recognition,
@@ -2773,6 +2789,8 @@ def make_drawing(
     scale_policy: Literal["strict", "fallback", "permissive"] = "fallback",
     reproducible: bool = False,
     framed_recognition: bool = False,
+    text_position: str = "inline",
+    text_orientation: str = "aligned",
 ) -> tuple[str, str]:
     """Generate a 4-view technical drawing from a STEP file or build123d object.
 
@@ -2837,6 +2855,8 @@ def make_drawing(
         company=company,
         frame=frame,
         projection=projection,
+        text_position=text_position,
+        text_orientation=text_orientation,
         zones=zones,
         reproducible=reproducible,
         framed_recognition=framed_recognition,

--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -135,6 +135,10 @@ def main(
         "--projection",
         help="Projection convention: 'first' or 'third' (default: third-angle, no symbol)",
     ),
+    text_position: str = typer.Option("inline", help="Dimension text position: inline or above"),
+    text_orientation: str = typer.Option(
+        "aligned", help="Dimension text reading direction: aligned or horizontal"
+    ),
     zones: bool = typer.Option(
         False, "--zones", help="Draw the ISO 5457 zone-grid border ruler (implies --frame)"
     ),
@@ -246,6 +250,8 @@ def main(
                 frame=frame,
                 zones=zones,
                 projection=projection or None,
+                text_position=text_position,
+                text_orientation=text_orientation,
                 part_expr=source.seam,
                 object_candidates=source.candidates,
                 formats=tuple(formats),
@@ -270,6 +276,8 @@ def main(
                 frame=frame,
                 zones=zones,
                 projection=projection or None,
+                text_position=text_position,
+                text_orientation=text_orientation,
                 pmi=pmi.value if pmi is not None else "off",
                 formats=tuple(formats),
                 inspect=not no_report,
@@ -299,6 +307,8 @@ def main(
         company=company,
         frame=frame,
         projection=projection or None,
+        text_position=text_position,
+        text_orientation=text_orientation,
         zones=zones,
     )
     visual_paths = _emit(dwg, formats)

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -382,6 +382,8 @@ def _measure_strips(
     arrow_length: float = 2.7,
     pad_around_text: float = 2.0,
     bore_callout_width: float = 0.0,
+    text_position: str = "inline",
+    text_orientation: str = "aligned",
 ) -> StripDepths:
     """Compute annotation strip depths from composed annotation boxes (Pass 1 of #131).
 
@@ -397,6 +399,8 @@ def _measure_strips(
             font_size=font_size,
             arrow_length=arrow_length,
             pad_around_text=pad_around_text,
+            text_position=text_position,
+            text_orientation=text_orientation,
         )
     )
 
@@ -432,6 +436,8 @@ def _compose_anno_boxes(
     font_size: float = _FONT_SIZE,
     arrow_length: float = 2.7,
     pad_around_text: float = 2.0,
+    text_position: str = "inline",
+    text_orientation: str = "aligned",
 ) -> list[AnnoBox]:
     """Compose a drawing's annotation bands as ``AnnoBox`` boxes (#112, Step 4a).
 
@@ -490,6 +496,8 @@ def _compose_anno_boxes(
             extension_gap=draft.extension_gap,
             pad_around_text=pad_around_text,
             line_width=draft.line_width,
+            text_position=text_position,
+            text_orientation=text_orientation,
         )
         axes = {"plan": (0, 1), "front": (0, 2), "side": (1, 2)}[view]
         centre = tuple(model.bbox.center())

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -57,6 +57,7 @@ from collections.abc import MutableSequence
 from dataclasses import replace
 from typing import TYPE_CHECKING, Literal, cast
 
+from draftwright._core import _dimension_draft
 from draftwright._geometry import _solids_body
 from draftwright._warnings import SoftDeprecationWarning
 from draftwright.builder import _coerce_model, build_drawing, detect_part_model
@@ -1075,10 +1076,13 @@ class Sheet:
         company=None,
         frame=None,
         projection=None,
+        text_position="inline",
+        text_orientation="aligned",
         zones=None,
         detail_view=None,
     ):
         validate_projection(projection)
+        _dimension_draft(text_position, text_orientation)
         self._part = part
         # (token, feature) entries — identity, not position (#908). `_features` is the
         # view; handles hold tokens and resolve through it, so a reorder of the public
@@ -1161,6 +1165,8 @@ class Sheet:
             ("company", company),
             ("frame", frame),
             ("projection", projection),
+            ("text_position", text_position),
+            ("text_orientation", text_orientation),
             ("zones", zones),
             # The last build option the facade did not forward (#940). It matters now that the
             # Sheet script is the only generated script: the imperative one put a raw

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -44,6 +44,7 @@ from typing import Literal, cast
 
 from build123d import Shape
 
+from draftwright._core import _dimension_draft
 from draftwright.builder import (
     _detect_part_model_analysis,
     build_drawing,
@@ -2054,6 +2055,8 @@ def emit_sheet_script(
     frame: bool = False,
     zones: bool = False,
     projection: str | None = None,
+    text_position: str = "inline",
+    text_orientation: str = "aligned",
     object_ref: bool = False,
     object_candidates: Mapping[str, Shape] | None = None,
     source_part: Shape | None = None,
@@ -2098,6 +2101,7 @@ def emit_sheet_script(
     declaration a person edits; evidence about the run that produced it belongs in the sidecar
     document beside it, where a reader can diff or re-read it without parsing Python (#1460)."""
     _validate_scale_policy(scale, scale_policy)
+    _dimension_draft(text_position, text_orientation)
     # The script declares this model — `model` plus an envelope when the overall height would
     # otherwise be unnameable under the mirrored (authored) set. BEFORE the import scan, since
     # a synthesised envelope needs `EnvelopeFeature` imported like a detected one.
@@ -2183,6 +2187,10 @@ def emit_sheet_script(
         ctor.append("zones=True")
     if projection:
         ctor.append(f"projection={projection!r}")
+    if text_position != "inline":
+        ctor.append(f"text_position={text_position!r}")
+    if text_orientation != "aligned":
+        ctor.append(f"text_orientation={text_orientation!r}")
     from draftwright.model.declare import _envelope_from_bbox
 
     object_refs = _object_references(model.features, source_part, object_candidates)
@@ -2442,6 +2450,8 @@ def generate_sheet_script(
     frame: bool = False,
     zones: bool = False,
     projection: str | None = None,
+    text_position: str = "inline",
+    text_orientation: str = "aligned",
     pmi: Literal["off", "report", "annotate"] = "off",
     part_expr: str | None = None,
     object_candidates: Mapping[str, Shape] | None = None,
@@ -2462,6 +2472,7 @@ def generate_sheet_script(
     :func:`resolve_object_spec` so the script references a live module (#469)."""
     validate_projection(projection)
     _validate_scale_policy(scale, scale_policy)
+    _dimension_draft(text_position, text_orientation)
     is_shape = isinstance(step_file, Shape)
     stem = out or ("drawing" if is_shape else Path(step_file).stem)
     for _ext in (".py", ".svg", ".dxf"):
@@ -2537,6 +2548,8 @@ def generate_sheet_script(
                 frame=frame,
                 zones=zones,
                 projection=projection,
+                text_position=text_position,
+                text_orientation=text_orientation,
                 pmi=pmi,
                 model=model,
             )
@@ -2564,6 +2577,8 @@ def generate_sheet_script(
             frame=frame,
             zones=zones,
             projection=projection,
+            text_position=text_position,
+            text_orientation=text_orientation,
             object_ref=is_shape,
             object_candidates=object_candidates,
             source_part=step_file if isinstance(step_file, Shape) else None,

--- a/tests/test_issue_1516_dimension_text.py
+++ b/tests/test_issue_1516_dimension_text.py
@@ -1,0 +1,213 @@
+"""A drawing-wide text choice must preserve content, ink bounds and replay."""
+
+import json
+from math import cos, radians, sin, sqrt
+
+import pytest
+from build123d import Box, Cylinder, Polygon, Pos, export_step, extrude
+from build123d_drafting import Dimension
+
+from draftwright import Sheet, build_drawing
+from draftwright._core import _dimension_draft
+from draftwright.annotations._common import dim_footprint
+from draftwright.annotations.angular import AngularInk
+from draftwright.audit import compare_measurements
+from draftwright.sheet_emit import emit_sheet_script, generate_sheet_script
+
+
+@pytest.fixture(scope="module")
+def plate():
+    part = Box(50, 35, 12) - Pos(-13, -8, 0) * Cylinder(3, 20)
+    model = Sheet.from_part(part).model()
+    assert len([feature for feature in model.features if feature.kind == "hole"]) == 1
+    return part, model
+
+
+@pytest.mark.parametrize("position", ["inline", "above"])
+@pytest.mark.parametrize("orientation", ["aligned", "horizontal"])
+@pytest.mark.parametrize("projection", ["first", "third"])
+@pytest.mark.parametrize("scale", [None, 1])
+def test_style_preserves_complete_plate_measurements(
+    plate, position, orientation, projection, scale
+):
+    part, model = plate
+    baseline = build_drawing(part, model=model, page="A3", scale=scale, projection=projection)
+    options = json.loads(json.dumps({"text_position": position, "text_orientation": orientation}))
+    drawing = build_drawing(
+        part, model=model, page="A3", scale=scale, projection=projection, **options
+    )
+    assert drawing.draft.text_position == position
+    assert drawing.draft.text_orientation == orientation
+    assert compare_measurements(baseline, drawing)["status"] == "preserved"
+    dimensions = [
+        annotation
+        for _, annotation in drawing.iter_annotations()
+        if isinstance(annotation, Dimension)
+    ]
+    assert len(dimensions) >= 3
+    if orientation == "horizontal":
+        assert all(
+            dim.label_polygon[1][1] == pytest.approx(dim.label_polygon[0][1]) for dim in dimensions
+        )
+    assert not [issue for issue in drawing.lint() if issue.severity in {"warning", "error"}]
+
+
+@pytest.mark.parametrize(
+    "position,orientation",
+    [("above", "aligned"), ("above", "horizontal"), ("inline", "horizontal")],
+)
+@pytest.mark.parametrize("angle", [0, 10, 45, 80, 90, 145])
+@pytest.mark.parametrize("distance", [2, 10])
+@pytest.mark.parametrize("length", [3, 45])
+def test_styled_analytical_bounds_enclose_actual_ink(
+    position, orientation, angle, length, distance
+):
+    end = (length * cos(radians(angle)), length * sin(radians(angle)))
+    side = "left" if angle == 90 else "above"
+    draft = _dimension_draft(position, orientation)
+    label = "3" if length == 3 else "45 ±0.01"
+    estimate = dim_footprint((0, 0), end, side, distance, draft, label)
+    actual = Dimension((0, 0), end, side, distance, draft, label=label).bounding_box()
+    assert estimate[0] <= actual.min.X + 1e-5
+    assert estimate[1] <= actual.min.Y + 1e-5
+    assert estimate[2] >= actual.max.X - 1e-5
+    assert estimate[3] >= actual.max.Y - 1e-5
+    assert estimate[2] - estimate[0] < actual.size.X + 5
+    assert estimate[3] - estimate[1] < actual.size.Y + 5
+
+
+@pytest.mark.parametrize("position", ["inline", "above"])
+@pytest.mark.parametrize("orientation", ["aligned", "horizontal"])
+def test_angular_style_preserves_full_text_and_geometry(position, orientation):
+    draft = _dimension_draft(position, orientation)
+    ink = AngularInk((0, 0), (15, 0), (7.5, 7.5 * sqrt(3)), "60 ±0.01°", draft)
+    annotation = ink.build(ink.minimum_radius + 5)
+    assert annotation.label == "60 ±0.01°"
+    assert annotation.measured_angle == pytest.approx(60)
+    polygon = annotation.label_polygon
+    if orientation == "horizontal":
+        assert polygon[1][1] == pytest.approx(polygon[0][1])
+    radial = ink.bisector
+    nearest = min(x * radial[0] + y * radial[1] for x, y in polygon)
+    if position == "above":
+        assert nearest > annotation.arc_radius + draft.pad_around_text
+        middle = ink.point(annotation.arc_radius, ink.middle)
+        assert any(face.is_inside((*middle, 0)) for face in annotation.faces())
+    else:
+        assert nearest < annotation.arc_radius
+    actual = annotation.bounding_box()
+    box = ink.footprint(annotation.arc_radius)
+    assert box[0] <= actual.min.X and box[1] <= actual.min.Y
+    assert box[2] >= actual.max.X and box[3] >= actual.max.Y
+
+
+def test_declared_angular_style_replays_and_exports(tmp_path):
+    part = extrude(Polygon((0, 0), (30, 0), (15, 15 * sqrt(3)), align=None), amount=12)
+    options = {"text_position": "above", "text_orientation": "horizontal"}
+    sheet = Sheet(part, page="A3", scale=1, **options).authored_dimensions()
+    vertices = ((0, 0, 12), (30, 0, 12), (15, 15 * sqrt(3), 12))
+    for index, vertex in enumerate(vertices):
+        first, second = vertices[(index + 1) % 3], vertices[(index + 2) % 3]
+        angle = sheet.angle(
+            vertex=vertex,
+            first=tuple((a + b) / 2 for a, b in zip(vertex, first, strict=True)),
+            second=tuple((a + b) / 2 for a, b in zip(vertex, second, strict=True)),
+        )
+        angle.tolerance(0.01, on="included.angle")
+        sheet.dimension(angle, "included.angle")
+    direct = sheet.build()
+    script = emit_sheet_script(
+        sheet.model(),
+        "part = supplied_part",
+        str(tmp_path / "replay"),
+        title="STYLE",
+        number="STYLE",
+        page="A3",
+        scale=1,
+        formats=("svg", "pdf", "dxf"),
+        **options,
+    )
+    namespace = {"supplied_part": part}
+    exec(script, namespace)
+    replay = namespace["drawing"]
+    assert replay.draft.text_position == "above" and replay.draft.text_orientation == "horizontal"
+    originals = sheet.model().features
+    recreated = namespace["sheet"].model().features
+    assert len(originals) == len(recreated) == 3
+    # Declaration order is an explicit fixture correspondence, never an
+    # inference performed by the comparison auditor.
+    pairs = tuple(zip(originals, recreated, strict=True))
+    assert all(old.angular_reference == new.angular_reference for old, new in pairs)
+    assert compare_measurements(direct, replay, feature_pairs=pairs)["status"] == "preserved"
+    angles = [a for _, a in replay.iter_annotations() if hasattr(a, "measured_angle")]
+    assert len(angles) == 3 and all("0.01" in angle.label for angle in angles)
+    assert not [issue for issue in replay.lint() if issue.severity in {"warning", "error"}]
+    assert all(
+        (tmp_path / f"replay.{extension}").stat().st_size > 100
+        for extension in ("svg", "pdf", "dxf")
+    )
+
+
+@pytest.mark.parametrize("field", ["text_position", "text_orientation"])
+@pytest.mark.parametrize("route", ["builder", "sheet", "script"])
+def test_invalid_style_refuses_before_accessing_the_part(field, route, tmp_path):
+    options = {field: "unknown"}
+    with pytest.raises(ValueError, match=field):
+        if route == "builder":
+            build_drawing("does-not-exist.step", **options)
+        elif route == "sheet":
+            Sheet(object(), **options)
+        else:
+            generate_sheet_script("does-not-exist.step", out=str(tmp_path / "bad"), **options)
+
+
+@pytest.mark.parametrize("route", ["direct", "step_script", "object_script"])
+def test_cli_style_reaches_real_automatic_ink(route, tmp_path, monkeypatch):
+    from typer.testing import CliRunner
+
+    from draftwright import cli
+
+    part = Box(50, 35, 12)
+    source = tmp_path / "part.step"
+    export_step(part, source)
+    if route == "object_script":
+        source = tmp_path / "part_source.py"
+        source.write_text("from build123d import Box\npart = Box(50, 35, 12)\n")
+        source = f"{source}:part"
+    drawings = []
+    original_emit = cli._emit
+
+    def capture(drawing, formats):
+        drawings.append(drawing)
+        return original_emit(drawing, formats)
+
+    monkeypatch.setattr(cli, "_emit", capture)
+    prefix = tmp_path / "styled"
+    args = [
+        str(source),
+        "--out",
+        str(prefix),
+        "--no-report",
+        "--format",
+        "svg",
+        "--text-position",
+        "above",
+        "--text-orientation",
+        "horizontal",
+    ]
+    if route != "direct":
+        args.append("--script")
+    result = CliRunner().invoke(cli.app, args)
+    assert result.exit_code == 0, result.output
+    if route != "direct":
+        namespace = {}
+        exec(prefix.with_suffix(".py").read_text(), namespace)
+        drawings.append(namespace["drawing"])
+    (drawing,) = drawings
+    assert drawing.draft.text_position == "above"
+    assert drawing.draft.text_orientation == "horizontal"
+    dimensions = [a for _, a in drawing.iter_annotations() if isinstance(a, Dimension)]
+    assert len(dimensions) >= 3
+    assert all(a.label_polygon[0][1] == pytest.approx(a.label_polygon[1][1]) for a in dimensions)
+    assert not [issue for issue in drawing.lint() if issue.severity in {"warning", "error"}]
+    assert prefix.with_suffix(".svg").stat().st_size > 100

--- a/uv.lock
+++ b/uv.lock
@@ -154,15 +154,15 @@ wheels = [
 
 [[package]]
 name = "build123d-drafting-helpers"
-version = "0.14.2"
+version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/34/df/dff98f59bfe5c913fa57314146745f78dcd6a6c5fc0db4fbffc1b64265ab/build123d_drafting_helpers-0.14.2.tar.gz", hash = "sha256:4172b1481ab1e2c8e97cdd63937bb2870a37ff0917e9129f2285b1ea3f929c68", size = 348210, upload-time = "2026-08-25T06:30:15.443Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cb/7d/c263e5345a0f597b6442c1c409094dbc1599f2ddb9084bf051d292725f93/build123d_drafting_helpers-0.15.0.tar.gz", hash = "sha256:060a1ea7e9c975d6782bc1bd87c5c0390144ea644addc3b57e53e86dd3197eae", size = 353542, upload-time = "2026-09-08T17:41:10.722Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/52/c9788ae13927c863389254c710fb6d4676852699ed768962ddbf271b64f7/build123d_drafting_helpers-0.14.2-py3-none-any.whl", hash = "sha256:b09f09995fbd8e028c8daeee95f97e9716fd7658744a385b2dd41e63643abb32", size = 287786, upload-time = "2026-08-25T06:30:14.104Z" },
+    { url = "https://files.pythonhosted.org/packages/13/31/26cb43634e50be88a4f9ed8679a765ded83440551fb413dcea9d9fe64d15/build123d_drafting_helpers-0.15.0-py3-none-any.whl", hash = "sha256:5b6436bc73fb8f009308f38db9ba6c52ecbbe45109736fe6f1a1cfc72e168bd3", size = 289782, upload-time = "2026-09-08T17:41:09.118Z" },
 ]
 
 [[package]]
@@ -745,7 +745,7 @@ requires-dist = [
     { name = "antlr4-python3-runtime", specifier = "<4.10" },
     { name = "build123d", marker = "python_full_version < '3.13'", specifier = ">=0.9.0,<0.11" },
     { name = "build123d", marker = "python_full_version >= '3.13'", specifier = ">=0.11,<0.12" },
-    { name = "build123d-drafting-helpers", specifier = ">=0.14.2" },
+    { name = "build123d-drafting-helpers", specifier = ">=0.15.0" },
     { name = "cadquery-ocp-novtk", marker = "python_full_version >= '3.13'", specifier = "!=7.9.3.1.1" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "ocp-gordon", specifier = "<0.3" },


### PR DESCRIPTION
Dimension values previously had one fixed placement and reading direction. This adds independent drawing-wide `text_position="inline"|"above"` and `text_orientation="aligned"|"horizontal"` choices, keeping existing defaults. Above-line values retain a continuous shaft; angular values sit outside the arc. Automatic builds, Sheet declarations, generated scripts and SVG/PDF/DXF share the policy without changing measurement intent.

Uses released build123d-drafting-helpers 0.15.0 for linear ink. Draftwright carries angular ink and analytical reservations through its existing solver. Full rotated arrowhead envelopes prevent underestimated oblique bounds; bounded angular contractions now check prepared projected edges before accepting labels.

Closes #1516. Part of #1508. Upstream prerequisite: pzfreo/build123d-drafting-helpers#184 (merged and released).

Validation:

- Full local `scripts/pr-check --full`: 7,865 passed, 5 skipped, 13 expected failures; static/docs checks clean, 100% changed-line coverage (76/76).
- 102 new cases cover both conventions, automatic/fixed scales, short oblique dimensions, complete tolerances, all three real CLI routes, and declared script replay to SVG/PDF/DXF. Exported drawing visually inspected.
- Nine isolated-source mutations killed: incomplete head envelope, old bounds, ignored projected edges, broken angular shaft, lost offset/orientation, lost build style and lost script settings.
- Independent iterative Google review against ADRs 1–5: LGTM on `534376e60af56170eab6720e22b058017d509d46`, no blocking findings or required nits. Both original findings were fixed and independently rechecked; twelve additional ordinary/dense drawings retained complete outcomes and clean lint.

Merge is gated on required CI.
