### PR TITLE
fix: preserve authored tolerance magnitudes in drawing text

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -20,6 +20,7 @@ import re
 from bisect import bisect_left, bisect_right
 from collections.abc import Callable
 from dataclasses import dataclass
+from decimal import Decimal
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Literal
@@ -340,9 +341,9 @@ def _build_table(rows, draft, block_cols=None):
 
 def _tol_suffix(tolerance, draft) -> str:
     """The ``±`` / limit tolerance suffix to append to a **callout** label (a ø leader
-    or a hole callout), matching byte-for-byte what ``Dimension(tolerance=…)`` renders
-    on a linear dim (helpers ``_format_label``): a symmetric ``float`` → ``" ±t"``; an
-    ``(lower, upper)`` pair → ``" +upper -lower"`` — all rounded to the draft precision.
+    or a hole callout): a symmetric ``float`` → ``" ±t"``; an ``(lower, upper)`` pair
+    → ``" +upper -lower"``. Draft precision is a minimum; supplied tolerance
+    magnitudes must never be rounded into different engineering requirements.
 
     draftwright owns this suffix ONLY because the pinned helpers' ``Leader`` /
     ``HoleCallout`` take no ``tolerance=`` yet, so we bake it into the label string
@@ -355,11 +356,16 @@ def _tol_suffix(tolerance, draft) -> str:
         return ""
     if isinstance(tolerance, FitClass):
         return tolerance.suffix()
-    prec = draft.decimal_precision
+
+    def magnitude(value):
+        decimal = Decimal(str(value))
+        precision = max(draft.decimal_precision, -int(decimal.as_tuple().exponent))
+        return f"{decimal:.{precision}f}"
+
     if isinstance(tolerance, (int, float)):
-        return f" ±{round(tolerance, prec):.{prec}f}"
+        return f" ±{magnitude(tolerance)}"
     lo, hi = tolerance
-    return f" +{round(hi, prec):.{prec}f} -{round(lo, prec):.{prec}f}"
+    return f" +{magnitude(hi)} -{magnitude(lo)}"
 
 
 def _tag_sequence(n):

--- a/tests/test_issue_1154_one_owner_per_measurement.py
+++ b/tests/test_issue_1154_one_owner_per_measurement.py
@@ -405,7 +405,7 @@ class TestConsolidationMovesTheFactOrDoesNotHappen:
         assert not [o for o in compile_dimensions(drawing.model()).diagnostics if o.conveyed_by], (
             "a toleranced height was consolidated onto an extent that cannot carry it"
         )
-        assert "8 ±0.1" in _labels(drawing), _labels(drawing)
+        assert "8 ±0.05" in _labels(drawing), _labels(drawing)
 
     def test_an_owner_the_rule_set_withholds_is_refused(self):
         # A z-rotational part suppresses its envelope width and depth (the OD conveys them),
@@ -554,7 +554,7 @@ class TestTheToleranceRuleIsAsymmetric:
         return [label for label in _labels(sheet.build()) if label.startswith("8")]
 
     def test_tolerancing_the_yielding_dimension_keeps_both(self):
-        assert self._z_hub_labels(on_boss=True) == ["8", "8 ±0.1"]
+        assert self._z_hub_labels(on_boss=True) == ["8", "8 ±0.05"]
 
     def test_tolerancing_the_owner_still_consolidates(self):
         # The first cut compared the two tolerances and refused whenever they differed, so an
@@ -564,7 +564,7 @@ class TestTheToleranceRuleIsAsymmetric:
         #
         # The label gained its ± in #1215; the RULE is untouched. What this test guards is the
         # COUNT — one label, not two — and that is unchanged.
-        assert self._z_hub_labels(on_envelope=True) == ["8 ±0.1"]
+        assert self._z_hub_labels(on_envelope=True) == ["8 ±0.05"]
 
     def test_equal_tolerances_on_both_sides_still_keep_both(self):
         # The r2 correction then went one step too far and admitted "equal tolerances", on
@@ -581,4 +581,4 @@ class TestTheToleranceRuleIsAsymmetric:
         # changes just because it now can. #1215's last acceptance line proposes revisiting
         # whether transferring beats refusing; that is a separate decision, and this test keeps
         # guarding the count either way.
-        assert self._z_hub_labels(on_boss=True, on_envelope=True) == ["8 ±0.1", "8 ±0.1"]
+        assert self._z_hub_labels(on_boss=True, on_envelope=True) == ["8 ±0.05", "8 ±0.05"]

--- a/tests/test_issue_1215_envelope_tolerance.py
+++ b/tests/test_issue_1215_envelope_tolerance.py
@@ -52,7 +52,7 @@ def _label(drawing, name):
 class TestTheDecorationReachesAllThreeExtents:
     @pytest.mark.parametrize("axis", _AXES)
     def test_the_decorated_extent_prints_its_tolerance(self, axis):
-        assert _label(_built(axis), _ANNOTATION[axis]) == f"{_BARE[axis]} ±0.1"
+        assert _label(_built(axis), _ANNOTATION[axis]) == f"{_BARE[axis]} ±0.05"
 
     @pytest.mark.parametrize("axis", _AXES)
     def test_the_other_two_extents_stay_bare(self, axis):
@@ -85,7 +85,7 @@ class TestTheDecorationReachesAllThreeExtents:
         sheet.auto_dimensions()
         drawing = sheet.build()
         for axis in _AXES:
-            assert _label(drawing, _ANNOTATION[axis]) == f"{_BARE[axis]} ±0.1", axis
+            assert _label(drawing, _ANNOTATION[axis]) == f"{_BARE[axis]} ±0.05", axis
 
     def test_a_limit_pair_prints_both_limits(self):
         assert _label(_built("height", 0.1, 0.2), "dim_height") == "10 +0.2 -0.1"
@@ -100,7 +100,7 @@ class TestTheTwoPathsAgree:
         suffixes = {
             axis: _label(_built(axis), _ANNOTATION[axis]).split(" ", 1)[1] for axis in _AXES
         }
-        assert set(suffixes.values()) == {"±0.1"}, suffixes
+        assert set(suffixes.values()) == {"±0.05"}, suffixes
 
 
 class TestTheToleranceReachesTheInk:
@@ -127,25 +127,11 @@ class TestTheToleranceReachesTheInk:
 
 
 class TestTheCostOnACrowdedSheet:
-    """A longer label grows ALONG the dimension line when the label is rotated.
+    """Tolerances grow the label along its dimension line.
 
-    The height dim is `side="right"`, so its label is rotated and the suffix extends it in Y —
-    the direction the corridor does not reserve, since the strip's depth runs in X. Measured on
-    `Sheet(Box(30, 20, 10)).envelope().tolerance(0.05, on="height")`:
-
-        label bbox height  3.273 -> 12.300
-        annotation bbox    (64.95, 85.05) -> unchanged
-
-    The annotation's own `bounding_box()` not moving is why a bbox comparison misses this
-    entirely, and why the corridor solve does not account for it.
-
-    **What this class does NOT assert is the lint outcome.** On this machine the fixture goes
-    from `view_annotation_inside_extents` (info) to `view_annotation_overlap` (warning), and
-    `repair()` does not clear it. On CI it produces neither — `codes` is the empty set. I first
-    pinned the warning and it failed on three ubuntu shards: whether the taller label actually
-    crosses the front view's edge depends on the solved offset, which differs by platform. The
-    geometry is the durable fact; the lint code is not, and asserting it was pinning my own
-    machine (#1234 review r2, and its CI run).
+    The complete annotation bounds must enclose that ink, including when preserving
+    the tolerance's decimal places makes the text longer than the measured span.
+    Assert geometry rather than a platform-dependent placement or lint outcome.
     """
 
     @staticmethod
@@ -159,13 +145,15 @@ class TestTheCostOnACrowdedSheet:
         # ...and NOT across it: the strip depth is unchanged, which is the whole problem.
         assert round(tol[2] - tol[0], 3) == round(bare[2] - bare[0], 3), (bare, tol)
 
-    def test_the_annotations_own_bounding_box_does_not_move(self):
-        # Why this went unnoticed: the obvious check sees nothing.
-        def box(drawing):
-            b = drawing.registry.named("dim_height").bounding_box()
-            return (round(b.min.Y, 2), round(b.max.Y, 2))
-
-        assert box(_built(axis=None)) == box(_built("height"))
+    def test_the_annotation_bounds_enclose_the_complete_tolerance_label(self):
+        drawing = _built("height")
+        annotation = drawing.registry.named("dim_height")
+        bounds = annotation.bounding_box()
+        x0, y0, x1, y1 = annotation.label_bbox
+        assert bounds.min.X <= x0 + 0.1
+        assert bounds.max.X >= x1 - 0.1
+        assert bounds.min.Y <= y0 + 0.1
+        assert bounds.max.Y >= y1 - 0.1
 
     def test_an_unrotated_extent_grows_the_other_way(self):
         # The contrast that makes the ROTATION the cause rather than the suffix: `m_env_width`
@@ -210,7 +198,7 @@ class TestTheSuffixDoesNotBreakLabelIdentity:
     def test_the_height_dim_is_still_found_when_it_carries_a_tolerance(self):
         from draftwright.annotations.sections import _overall_height_name
 
-        for axis, expected in ((None, "10"), ("height", "10 ±0.1")):
+        for axis, expected in ((None, "10"), ("height", "10 ±0.05")):
             drawing = _built(axis) if axis else _built(axis=None)
             assert _label(drawing, "dim_height") == expected, axis
             found = _overall_height_name(drawing, self._analysis_for(drawing))
@@ -255,7 +243,7 @@ class TestTheGeneralisedFallbackMatchesToo:
         from draftwright.annotations.sections import _overall_height_name
 
         drawing = _built("height")
-        assert _label(drawing, "dim_height") == "10 ±0.1"
+        assert _label(drawing, "dim_height") == "10 ±0.05"
         envelope = next(f for f in drawing.model().features if f.kind == "envelope")
         drawing.remove("dim_height")
         assert "dim_height" not in drawing.registry.names()
@@ -271,7 +259,7 @@ class TestTheGeneralisedFallbackMatchesToo:
             label="10",
             tolerance=0.05,
         )
-        assert str(drawing.get_annotation("dim_length7").label) == "10 ±0.1"
+        assert str(drawing.get_annotation("dim_length7").label) == "10 ±0.05"
         found = _overall_height_name(
             drawing, TestTheSuffixDoesNotBreakLabelIdentity._analysis_for(drawing)
         )

--- a/tests/test_issue_1524_tolerance_magnitude.py
+++ b/tests/test_issue_1524_tolerance_magnitude.py
@@ -1,0 +1,58 @@
+"""Supplied tolerance values survive nominal precision and actual output."""
+
+import pytest
+from build123d import Box, Cylinder, Pos
+
+from draftwright import Sheet
+from draftwright._core import _dimension_draft, _tol_suffix
+from draftwright.annotations.from_model import callout_from_spec
+from draftwright.compose import _est_planned_bore_callout_width
+from draftwright.model.callout import hole_callout_spec
+from draftwright.model.planner import plan_dimensions
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (0.02, " ±0.02"),
+        (0.05, " ±0.05"),
+        (0.2, " ±0.2"),
+        (1, " ±1.0"),
+        (1.234567, " ±1.234567"),
+        (0.000000123, " ±0.000000123"),
+        ((0.002, 0.015), " +0.015 -0.002"),
+        ((0.0, 0.00001), " +0.00001 -0.0"),
+    ],
+)
+def test_numeric_magnitude_is_not_rounded_to_nominal_precision(value, expected):
+    assert _tol_suffix(value, _dimension_draft()) == expected
+
+
+@pytest.mark.parametrize("value,text", [(0.02, "±0.02"), ((0.002, 0.015), "+0.015 -0.002")])
+def test_rendered_callout_table_and_reserved_width_keep_small_tolerances(value, text):
+    tool = Pos(5, 3, 0) * Cylinder(3, 20)
+    part = Box(40, 30, 12) - tool
+    sheet = Sheet(part, page="A3", scale=1)
+    handle = sheet.hole(tool)
+    handle.tolerance(*value) if isinstance(value, tuple) else handle.tolerance(value)
+    sheet.dimension(handle, "bore.diameter")
+    sheet.dimension(handle, "location")
+    model = sheet.model()
+    groups = plan_dimensions(model)
+    (hole_group,) = [group for group in groups if group.feature.kind == "hole"]
+    draft = _dimension_draft()
+    primitive = callout_from_spec(hole_callout_spec(hole_group), draft, None)
+    assert text in primitive.label
+    assert text in " ".join(item[0] for item in primitive.pdf_text_relative_specs)
+    estimate = _est_planned_bore_callout_width([hole_group], draft)
+    assert estimate >= primitive.bounding_box().size.X - 0.1
+    assert estimate < primitive.bounding_box().size.X + 5
+    drawing = sheet.build()
+    marks = [
+        a for _, a in drawing.iter_annotations() if getattr(a, "covers_diameters", ()) == (6,)
+    ]
+    assert len(marks) == 1 and text in marks[0].label
+    table = drawing.add_hole_table(balloons=False)
+    assert table is not None
+    assert any(text in cell for row in table.table_rows for cell in row)
+    assert not [issue for issue in drawing.lint() if issue.severity in {"warning", "error"}]

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -4,9 +4,9 @@ A caller attaches a ± / limit tolerance to a declared dimension (via the ``deco
 side-layer or the ``Sheet.tolerance()`` handle); it rides ``DimParameter.tolerance`` through
 the planner and renders on **both** the linear ``Dimension`` path (step length) and the
 ``Leader`` / ``HoleCallout`` ⌀ path — the latter via draftwright's own ``_tol_suffix`` baked
-into the label string, matching what ``Dimension(tolerance=…)`` formats (helpers has no
-``tolerance=`` on ``Leader``/``HoleCallout`` yet). Tolerances render at the sheet's decimal
-precision (1 dp today), so tests use tolerances that survive 1 dp.
+into the label string. The owned formatter treats sheet precision as a minimum and
+preserves the supplied tolerance magnitude. The separate helper-owned numeric linear
+formatter is tracked in build123d-drafting-helpers#187; it does not define this contract.
 """
 
 import pytest

--- a/tests/test_tolerances.py
+++ b/tests/test_tolerances.py
@@ -49,15 +49,15 @@ def _spec(diameter, **over):
 
 
 class TestTolSuffix:
-    """The owned callout formatter — must byte-match helpers' ``_format_label`` suffix."""
+    """The owned callout formatter preserves the supplied engineering magnitudes."""
 
     def test_symmetric_float(self):
         d = draft_preset(font_size=2.5, decimal_precision=2)
         assert _tol_suffix(0.05, d) == " ±0.05"
 
-    def test_symmetric_respects_precision(self):
+    def test_symmetric_does_not_coarsen_authored_magnitude(self):
         d1 = draft_preset(font_size=2.5, decimal_precision=1)
-        assert _tol_suffix(0.05, d1) == " ±0.1"  # rounds to the draft precision, like Dimension
+        assert _tol_suffix(0.05, d1) == " ±0.05"
 
     def test_limit_pair_is_plus_upper_minus_lower(self):
         d = draft_preset(font_size=2.5, decimal_precision=1)
@@ -501,7 +501,7 @@ class TestSheetTolerance:
             label="CUSTOM",
             tolerance=0.05,
         )
-        assert str(dwg.get_annotation("u0").label) == "CUSTOM ±0.1"
+        assert str(dwg.get_annotation("u0").label) == "CUSTOM ±0.05"
 
     @pytest.mark.parametrize("extra", [{}, {"pin": True}, {"priority": 5.0}])
     def test_a_deferred_dimension_renders_its_tolerance(self, extra):
@@ -551,7 +551,7 @@ class TestSheetTolerance:
         """
         from draftwright.sheet import Sheet as _S
 
-        for tol, expected in ((None, {"15", "30"}), (0.05, {"15 ±0.1", "30 ±0.1"})):
+        for tol, expected in ((None, {"15", "30"}), (0.05, {"15 ±0.05", "30 ±0.05"})):
             sheet = _S(self._staircase(), title="T", number="N")
             handle = sheet.step_level(self._staircase())
             if tol is not None:


### PR DESCRIPTION
A declared tolerance of `0.02` could print as `±0.0`, and `0.05` as `±0.1`, because the shared suffix formatter rounded tolerances to nominal drawing precision. Preserve supplied numeric magnitudes while using drawing precision as a minimum number of decimal places. This covers callouts, explicit dimension labels, hole-table cells and their width reservations; nominal values and FitClass behavior remain unchanged.

Fixes #1524; prerequisite for #1517. The separately owned helper numeric linear formatter is tracked in pzfreo/build123d-drafting-helpers#187.

Validation: full `scripts/pr-check --full` passes at `50e9f10e7b4287771234cb2f47029f7e43f8e7c7`: 7,875 passed, 5 skipped, 13 expected failures; 95.93% overall coverage and 100% changed-line coverage (7/7). 122 focused checks preserve tolerance text, ownership/consolidation and complete label bounds. Three isolated-source mutations are killed: restore rounding, reverse upper/lower limits, and remove reserved tolerance width.

Independent iterative Google review against all five live ADRs: LGTM on that exact commit, no outstanding blockers or nits. The review independently checked numeric preservation and confirmed that longer-label bounds enclose the full text. Existing tests that expected lossy rounding were corrected without weakening ownership or suppression assertions.
