### PR TITLE
feat: support explicitly requested rear views in the shared drawing pipeline

### DIFF
--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -315,6 +315,30 @@ detail = s.detail_view("B", around=hole).scale(2)
 dwg = s.build()
 ```
 
+Rear views are explicitly requested. `s.view("rear")` includes rear in an authored
+view set; `s.auto_views().add_view("rear")` adds it to the automatic baseline.
+Rear looks toward the part from +Y with Z upward, so increasing world X runs left
+on the page. This physical direction is the same under both projection conventions.
+When side is also present, rear sits beyond side in the unfolding direction: left
+for first-angle, right for third-angle.
+
+Y-axis hole and hole-pattern callouts, locations and pitch dimensions can use rear,
+as can overall width and height. For example:
+
+```python
+s = Sheet(part, projection="first").authored_dimensions()
+hole = s.hole(diameter=6, at=(10, 20, 5), axis="y").through("THRU")
+s.dimension(hole, "bore.diameter")
+s.dimension(hole, "location")
+s.view("rear")
+drawing = s.build()
+```
+
+Dimensions still use the shared placement solve. An unsupported measurement/view
+combination is refused; a required depth extent, for example, needs side. Rear is
+never added automatically to improve visibility, coverage or hidden lines. Generated
+scripts preserve an explicit rear request.
+
 `view(...)`, `section_view(...)` and `detail_view(...)` define complete authored sets;
 omission suppresses a view. `add_view(...)`, `add_section_view(...)` and
 `add_detail_view(...)` augment an explicitly selected `auto_views()` source. `row(...)` and
@@ -473,7 +497,7 @@ geometry cannot prove a complete chain or the provider aggregate's Fillet preced
 referential `DimensionIntent`. The handle never carries a replacement nominal and never chooses
 page coordinates. Use `format(decimals=n)` to preserve between 0 and 15 decimal places in the
 printed nominal while reconciliation, tolerance, suppression and provenance continue to read the
-numeric parameter from the feature. Optional `view="front|plan|side"` and
+numeric parameter from the feature. Optional `view="front|plan|side|rear"` and
 `side="above|below|left|right"` arguments select a supported semantic corridor when authored
 routing must override the derived default; the normal placement solve still chooses coordinates
 and reports capacity/crossing failures. Trailing zeroes are intentional manufacturing display text:

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -988,14 +988,14 @@ class DetailRequest:
 class _Projector:
     """Model → page coordinate projection for the orthographic views.
 
-    Each in-plane view axis projects as ``origin + (value - centroid) * scale``.
+    Each in-plane view axis projects from its centroid and page origin. Rear
+    reverses model X while keeping Z up, matching its camera from positive Y.
     Built once in :func:`_analyse` and hung off the analysis namespace as
     ``a.proj`` so the annotation passes share one projector instead of each
     re-deriving the ``FX``/``FZ``/``SX``/``SZ``/``PX``/``PY`` closures.
 
-    This deliberately mirrors those analysis-phase closures byte-for-byte (an
-    unsigned ``+1`` projection), so the consolidation is provably
-    behaviour-preserving. The helpers library's ``ViewCoordinates.px``/``.py``
+    The original three views retain their analysis-phase ``+1`` closures.
+    The helpers library's ``ViewCoordinates.px``/``.py``
     (already built per view as ``dwg._coords``) computes a *signed* projection
     from ``view_axes()``; routing through it would couple the annotation passes
     to render-order ``_coords`` population and could change output where a view
@@ -1017,6 +1017,8 @@ class _Projector:
     cy: float
     cz: float
     scale: float
+    rv_x: float = 0.0
+    rv_y: float = 0.0
 
     def front_x(self, x: float) -> float:
         return self.fv_x + (x - self.cx) * self.scale
@@ -1035,6 +1037,12 @@ class _Projector:
 
     def plan_y(self, y: float) -> float:
         return self.pv_y + (y - self.cy) * self.scale
+
+    def rear_x(self, x: float) -> float:
+        return self.rv_x - (x - self.cx) * self.scale
+
+    def rear_z(self, z: float) -> float:
+        return self.rv_y + (z - self.cz) * self.scale
 
 
 @dataclass(frozen=True)
@@ -1067,6 +1075,8 @@ class LayoutFrame:
     fv_zones: ViewZones
     pv_zones: ViewZones
     sv_zones: ViewZones
+    rear: tuple[float, float, float, float] | None = None
+    rv_zones: ViewZones | None = None
 
     def project(self, view: str, point) -> tuple[float, float]:
         """A part-space *point* in *view*'s page coordinates."""
@@ -1077,6 +1087,8 @@ class LayoutFrame:
             return self.proj.side_x(y), self.proj.side_z(z)
         if view == "plan":
             return self.proj.plan_x(x), self.proj.plan_y(y)
+        if view == "rear" and self.rear is not None:
+            return self.proj.rear_x(x), self.proj.rear_z(z)
         raise ValueError(f"unknown view {view!r}")
 
     def edges(self, view: str) -> tuple[float, float, float, float]:
@@ -1085,11 +1097,24 @@ class LayoutFrame:
         The stored endpoints come from projected world minima/maxima, whose handedness
         need not match page left/right. Normalise here so callers can rely on the names
         this API exposes rather than knowing projector orientation."""
-        x0, x1, y0, y1 = {"front": self.front, "plan": self.plan, "side": self.side}[view]
+        bounds = {"front": self.front, "plan": self.plan, "side": self.side, "rear": self.rear}[
+            view
+        ]
+        if bounds is None:
+            raise ValueError(f"view {view!r} has no planned layout frame")
+        x0, x1, y0, y1 = bounds
         return min(x0, x1), max(x0, x1), min(y0, y1), max(y0, y1)
 
     def zones(self, view: str) -> ViewZones:
-        return {"front": self.fv_zones, "plan": self.pv_zones, "side": self.sv_zones}[view]
+        zones = {
+            "front": self.fv_zones,
+            "plan": self.pv_zones,
+            "side": self.sv_zones,
+            "rear": self.rv_zones,
+        }[view]
+        if zones is None:
+            raise ValueError(f"view {view!r} has no planned annotation zones")
+        return zones
 
 
 def layout_frame(a: Analysis) -> LayoutFrame:
@@ -1124,6 +1149,15 @@ def layout_frame(a: Analysis) -> LayoutFrame:
         fv_zones=a.fv_zones,
         pv_zones=a.pv_zones,
         sv_zones=a.sv_zones,
+        rear=(
+            a.proj.rear_x(a.bb.min.X),
+            a.proj.rear_x(a.bb.max.X),
+            a.proj.rear_z(a.bb.min.Z),
+            a.proj.rear_z(a.bb.max.Z),
+        )
+        if a.rv_zones is not None
+        else None,
+        rv_zones=a.rv_zones,
     )
 
 
@@ -1288,6 +1322,9 @@ class Analysis:
     #: Coordinate-coherent PMI projection used by the compiler. ``None`` means the source
     #: report's records are already in working coordinates (raw and declared builds).
     pmi_working_records: tuple[object, ...] | None = None
+    RV_X: float = 0.0
+    RV_Y: float = 0.0
+    rv_zones: ViewZones | None = None
 
     @property
     def pmi(self) -> list:

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -53,6 +53,7 @@ from draftwright._geometry import (
 )
 from draftwright.compose import (
     StripDepths,
+    _build_rear_zones,
     _build_zones,
     _est_hole_table_sizes,
     _est_planned_bore_callout_width,
@@ -132,15 +133,18 @@ def _apply_principal_view_pins(
         "plan": (geometry.PV_X, geometry.PV_Y),
         "side": (geometry.SV_X, geometry.SV_Y),
     }
+    if "rear" in planned:
+        centres["rear"] = (geometry.RV_X, geometry.RV_Y)
     cx, cy, cz = centre
     projected_centre = {
         "front": (cx * scale, cz * scale),
         "plan": (cx * scale, cy * scale),
         "side": (cy * scale, cz * scale),
+        "rear": (-cx * scale, cz * scale),
     }
     translations = []
     for pin in constraints.pins:
-        if pin.view not in centres:
+        if pin.view not in projected_centre:
             where = f" at {pin.source}" if pin.source is not None else ""
             raise ValueError(
                 f"whole-view pin{where} targets {pin.view!r}; this slice can anchor principal "
@@ -168,6 +172,9 @@ def _apply_principal_view_pins(
     geometry.PV_Y += dy
     geometry.SV_X += dx
     geometry.SV_Y += dy
+    if "rear" in planned:
+        geometry.RV_X += dx
+        geometry.RV_Y += dy
     geometry.sv_geometry_right += dx
     geometry.sv_right += dx
     geometry.sv_right_wall += dx
@@ -179,6 +186,8 @@ def _apply_principal_view_pins(
         "plan": (geometry.PV_X, geometry.PV_Y, geometry.fv_hw, geometry.pv_hh),
         "side": (geometry.SV_X, geometry.SV_Y, geometry.sv_hw, geometry.fv_hh),
     }
+    if "rear" in planned:
+        extents["rear"] = (geometry.RV_X, geometry.RV_Y, geometry.fv_hw, geometry.fv_hh)
     page_w, page_h = page
     for name in planned:
         x, y, hw, hh = extents[name]
@@ -1293,6 +1302,9 @@ def _analyse(
         arrangement=ARRANGEMENT,
         planned_views=_views,
         planned_iso=_include_iso,
+        RV_X=_g.RV_X,
+        RV_Y=_g.RV_Y,
+        rv_zones=_build_rear_zones(_g, margin, PAGE_H),
         planned_iso_scale=planned_iso_scale,
         view_constraints=_view_constraints,
         part=part,
@@ -1354,6 +1366,8 @@ def _analyse(
             sv_y=SV_Y,
             pv_x=PV_X,
             pv_y=PV_Y,
+            rv_x=_g.RV_X,
+            rv_y=_g.RV_Y,
             cx=cx,
             cy=cy,
             cz=cz,

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -72,7 +72,12 @@ from draftwright.recognition_frame import (
     require_unambiguous_groove_owner,
 )
 from draftwright.recognition_ownership import RecognitionOwnershipBuilder
-from draftwright.view_plan import ViewConstraints, arrangement_of, principal_placements
+from draftwright.view_plan import (
+    ViewConstraints,
+    arrangement_of,
+    principal_placements,
+    third_angle_view_names,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -765,6 +770,7 @@ def _analyse(
     model=None,
     decorations=None,
     authored=None,
+    requested=None,
     material="",
     date="",
     revision="A",
@@ -1093,21 +1099,23 @@ def _analyse(
         if ownership_builder is not None
         else None
     )
-    # Authored omission affects annotation FOOTPRINT sizing, but the analysis model retains
-    # its historical automatic requirement inventory for view-feasibility preflight.  The
-    # builder applies the same authored tuple to the render model later.  Keeping this as a
-    # strip-only copy avoids letting a sparse authored dimension set erase semantic view
-    # requirements (for example the parent view needed by an authored detail), while ensuring
-    # suppressed pad bands cannot reduce the selected scale (#1392).
-    strip_sizing_model = (
-        replace(sizing_model, authored_dimensions=tuple(authored))
+    # Dimension feasibility and annotation footprints consume the authored set.
+    # Derived-view dependencies still use sizing_model below; omitting an unrelated
+    # envelope extent must not force its view back onto an authored sheet.
+    strip_sizing_model = replace(
+        sizing_model,
+        authored_dimensions=tuple(authored)
         if authored is not None
-        else sizing_model
+        else sizing_model.authored_dimensions,
+        requested_dimensions=tuple(requested) if requested else sizing_model.requested_dimensions,
     )
     # ADR 2 (was 0018) Phase 5.5: prove the chosen principal set can carry every approved
     # dimension before scale selection or projection.  A reduced view set is therefore a
     # re-plan, not the fixed three-view plan rendered into fewer views.
-    sizing_groups = plan_dimensions(sizing_model, planned_views=_views)
+    sizing_groups = plan_dimensions(
+        strip_sizing_model,
+        planned_views=third_angle_view_names() if _views is None else _views,
+    )
     bore_callout_width = _est_planned_bore_callout_width(
         sizing_groups, _draft_est, font_size=_FONT_SIZE, pad_around_text=_pad_around_text
     )

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1188,7 +1188,7 @@ def render_centermarks(dwg, furniture_groups, *, ctx) -> int:
         hole = feat.member if isinstance(feat, PatternFeature) else feat
         dia = hole.diameter or 0.0
         size = max(2.5, dia * dwg.scale + 2.0)
-        view = _END_ON.get(feat.frame.axis, "plan")
+        view = g.view or _END_ON.get(feat.frame.axis, "plan")
         members = feat.members or (g.anchor,)
         for loc in members:
             px, py, *_ = dwg.at(view, *loc)

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -1190,7 +1190,9 @@ def render_centermarks(dwg, furniture_groups, *, ctx) -> int:
         dia = hole.diameter or 0.0
         size = max(2.5, dia * dwg.scale + 2.0)
         view = g.view or _END_ON.get(feat.frame.axis, "plan")
-        if view not in dwg.views and all(dimension.suppressed for dimension in g.dims):
+        if view not in getattr(dwg, "views", (view,)) and all(
+            dimension.suppressed for dimension in g.dims
+        ):
             continue  # No value-bearing requirement earned furniture in this projection.
         members = feat.members or (g.anchor,)
         for loc in members:
@@ -4711,6 +4713,7 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
                         tier,
                         ctx=ctx,
                         measurements={nm: _mid},
+                        features={nm: env.ref},
                         trace=ctx.trace,
                         trace_label=f"{nm}_above_fallthrough",
                     ):
@@ -4734,6 +4737,7 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
                 on_drop=_drop,
                 priority=_MANDATORY_OVERALL_PRIORITY,
                 force=True,
+                feature=env.ref,
                 measurement=measurement,  # which envelope extent this is (#1002)
                 footprint=footprint,  # analytical measure — no probe build (#602)
             ),
@@ -5921,11 +5925,26 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
     may use an explicitly selected rear view, with its own corridor and witnesses.
     """
     overall = plan.ladder("overall_height")
-    height_view = "front"
+    height_view: str | None = "front"
     if overall is not None:
-        height_view = overall.rungs[0].view or (
-            "front" if "front" in getattr(dwg, "views", ("front",)) else "rear"
+        height_view = overall.rungs[0].view or next(
+            (name for name in ("front", "rear") if name in getattr(dwg, "views", ("front",))),
+            None,
         )
+        if height_view is None:
+            height = overall.rungs[0]
+            ctx.record_issue(
+                "error",
+                "placement_unsatisfiable",
+                "overall height cannot be shown: no planned front or rear view",
+                measurement=height.id,
+                measurement_span=height.span,
+                outcome_stage="placement",
+            )
+            plan = ladder_plan_for(plan, step_height=True, overall=False)
+            if plan.ladder("step_height") is None:
+                return 0
+            height_view = "front"
     if height_view == "front":
         return _render_height_ladder_in_view(
             dwg, plan, frame, ctx=ctx, detail_view=detail_view, view="front"
@@ -6271,7 +6290,11 @@ def _render_height_ladder_in_view(dwg, plan, frame, *, ctx, detail_view, view) -
                 # …and when it IS physically full, they outrank ordinary auto dims rather
                 # than tying with them at 0 and losing on the generated key (#894).
                 priority=_PRINCIPAL_CHAIN_PRIORITY,
-                feature=step if name != "dim_height" else None,
+                feature=step
+                if name != "dim_height"
+                else overall.ref
+                if overall is not None
+                else None,
                 measurement=mid,  # the rung's own compiled id (#1002)
                 footprint=_foot,
             ),

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -60,6 +60,7 @@ from draftwright._core import (
     _text_size,
     _title_block_box,
     _tol_suffix,
+    layout_frame,
 )
 from draftwright._geometry import (
     _blend_profile_arcs,
@@ -1189,6 +1190,8 @@ def render_centermarks(dwg, furniture_groups, *, ctx) -> int:
         dia = hole.diameter or 0.0
         size = max(2.5, dia * dwg.scale + 2.0)
         view = g.view or _END_ON.get(feat.frame.axis, "plan")
+        if view not in dwg.views and all(dimension.suppressed for dimension in g.dims):
+            continue  # No value-bearing requirement earned furniture in this projection.
         members = feat.members or (g.anchor,)
         for loc in members:
             px, py, *_ = dwg.at(view, *loc)
@@ -4741,7 +4744,7 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
     # view, which is why dropping the plan view raised `ViewNotPlanned` from here instead of
     # re-homing the width dim. `views_showing` prefers the view each has always used, so
     # nothing moves while all three principals are planned.
-    zones_for_view = {"front": a.fv_zones, "plan": a.pv_zones, "side": a.sv_zones}
+    frame = layout_frame(a)
     for role, axis, slot, ann_name in (
         ("width", "x", _SLOT_DIM_WIDTH, "m_env_width"),
         ("depth", "y", _SLOT_DIM_DEPTH, "m_env_depth"),
@@ -4774,7 +4777,7 @@ def render_envelope(dwg, plan, a, *, ctx) -> int:
         )
         p1, p2 = dwg.at(view, *start_pt), dwg.at(view, *end_pt)
         witness = p1[1] - _WITNESS_LIFT_MM
-        zones = zones_for_view[view]
+        zones = frame.zones(view)
         _queue(
             ann_name,
             zones.below,
@@ -5912,6 +5915,33 @@ def ladder_plan_for(plan, *, step_height: bool, overall: bool):
 
 
 def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) -> int:
+    """Route approved ladders through the shared vertical-strip placement pass.
+
+    Step rungs retain their front-view renderer. The independent overall height
+    may use an explicitly selected rear view, with its own corridor and witnesses.
+    """
+    overall = plan.ladder("overall_height")
+    height_view = "front"
+    if overall is not None:
+        height_view = overall.rungs[0].view or (
+            "front" if "front" in getattr(dwg, "views", ("front",)) else "rear"
+        )
+    if height_view == "front":
+        return _render_height_ladder_in_view(
+            dwg, plan, frame, ctx=ctx, detail_view=detail_view, view="front"
+        )
+    count = 0
+    for view, steps, height in (("front", True, False), (height_view, False, True)):
+        selected = ladder_plan_for(plan, step_height=steps, overall=height)
+        if selected.ladder("step_height") is None and selected.ladder("overall_height") is None:
+            continue
+        count += _render_height_ladder_in_view(
+            dwg, selected, frame, ctx=ctx, detail_view=detail_view, view=view
+        )
+    return count
+
+
+def _render_height_ladder_in_view(dwg, plan, frame, *, ctx, detail_view, view) -> int:
     """Front-view ladder: prismatic step heights stacked inner→outer, then the overall
     height outermost. The overall height can be authored on the left; candidates enter
     the shared corridor for their side. The leapfrog witness cursor (#237) survives as a
@@ -5933,7 +5963,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
     the plan's diagnostics) and this pass's drop (arrived, did not fit; reported as
     ``placement_unsatisfiable``). Returns the count REGISTERED."""
     draft = dwg.draft
-    _left, right, _bottom, _top = frame.edges("front")
+    _left, right, _bottom, _top = frame.edges(view)
     edge2 = right + 2
     tier = draft.font_size + 2 * draft.pad_around_text
 
@@ -5947,8 +5977,8 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
         review). The span is the compiler's statement of what is being measured; projecting
         both ends of it is what keeps line and label the same claim."""
         return (
-            frame.project("front", entry.span[0])[1],
-            frame.project("front", entry.span[1])[1],
+            frame.project(view, entry.span[0])[1],
+            frame.project(view, entry.span[1])[1],
         )
 
     rung_set = plan.ladder("step_height")
@@ -6046,7 +6076,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
             ctx.escalations.append(
                 Escalation(
                     kind="step",
-                    view="front",
+                    view=view,
                     feature=step,
                     reason="illegible",
                     targets=crowded,
@@ -6124,7 +6154,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
         side = sides[name]
         direction = 1 if side == "right" else -1
         edge = edge2 if side == "right" else _left - 2
-        strip = frame.fv_zones.right if side == "right" else frame.fv_zones.left
+        strip = frame.zones(view).right if side == "right" else frame.zones(view).left
         predecessors = [pn for pn in names[:k] if sides[pn] == side]
 
         def _witness_base(pos, predecessors=predecessors, direction=direction, edge=edge):
@@ -6196,7 +6226,9 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
 
         def _drop(
             nm,
-            drop_msg=drop_msg.replace("right strip", f"{side} strip"),
+            drop_msg=drop_msg.replace("front-view", f"{view}-view").replace(
+                "right strip", f"{side} strip"
+            ),
             strip=strip,
             name=name,
             measurement=mid,
@@ -6205,7 +6237,7 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
             solved.pop(name, None)
             # Name what filled the strip (#736): the #733 diagnosis becomes a glance at the
             # lint message.
-            msg = full_strip_message(drop_msg, dwg, strip, "front", "x")
+            msg = full_strip_message(drop_msg, dwg, strip, view, "x")
             ctx.record_issue(
                 "error",
                 "placement_unsatisfiable",
@@ -6217,9 +6249,9 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
 
         register_corridor(
             ctx,
-            ("front", side),
+            (view, side),
             strip,
-            "front",
+            view,
             "x",
             tier,
             CorridorCandidate(
@@ -6272,8 +6304,8 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
             msg = full_strip_message(
                 "short step-height dimension dropped (front-view left strip full)",
                 dwg,
-                frame.fv_zones.left,
-                "front",
+                frame.zones(view).left,
+                view,
                 "x",
             )
             ctx.record_issue(
@@ -6287,9 +6319,9 @@ def render_height_ladder(dwg, plan, frame, *, ctx, detail_view: bool = False) ->
 
         register_corridor(
             ctx,
-            ("front", "left"),
-            frame.fv_zones.left,
-            "front",
+            (view, "left"),
+            frame.zones(view).left,
+            view,
             "x",
             tier,
             CorridorCandidate(

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -140,7 +140,14 @@ def add_feature_callout(
             "callout(): feature is not from this drawing's model — "
             "pass one from dwg.model().features"
         )
-    group = next((g for g in plan_dimensions(model) if g.feature is feature), None)
+    group = next(
+        (
+            g
+            for g in plan_dimensions(model, planned_views=tuple(dwg.views))
+            if g.feature is feature
+        ),
+        None,
+    )
     spec = hole_callout_spec(group) if group is not None else None
     if spec is None:
         if any(o.feature is feature and o.authored for o in compile_dimensions(model).diagnostics):
@@ -165,9 +172,9 @@ def add_feature_callout(
     # bare path uses — not re-derived from len(members) (#414 review).
     callout = callout_from_spec(spec, draft, spec["count"])
     assert callout is not None  # spec is non-None here, so callout_from_spec returns one
-    view = view or _END_ON[feature.frame.axis]
-    if view not in _END_ON.values():  # front/plan/side — the ortho end-on views only
-        raise ValueError(f"callout(): view {view!r} is not a hole-callout view (front/plan/side)")
+    view = view or (group.view if group is not None else _END_ON[feature.frame.axis])
+    if view not in (*_END_ON.values(), "rear") or (view == "rear" and feature.frame.axis != "y"):
+        raise ValueError(f"callout(): view {view!r} is not a hole-callout view for this axis")
     gap = draft.pad_around_text
     w = callout.callout_width
     tier = draft.font_size + 2 * gap
@@ -179,8 +186,8 @@ def add_feature_callout(
     rep = max(members, key=lambda m: dwg.at(view, *m)[0])
     centre = dwg.at(view, *rep)[:2]
 
-    if view == "front":  # below the view (matches the auto-pass's front-callout side)
-        zones = a.fv_zones if a is not None else None
+    if view in ("front", "rear"):
+        zones = layout_frame(a).zones(view) if a is not None else None
         strip = zones.below if zones is not None else None
         elbow_y = vy0 - max(tier, 0.6 * (a.DIM_PAD if a is not None else 12.0))
         if strip is not None:
@@ -438,7 +445,11 @@ def add_feature_furniture(dwg, feature, model, a, *, view: str | None = None, ct
         )
     if a is None:
         raise ValueError("furniture(): no analysis — build the drawing first")
-    view = view or _END_ON[feature.frame.axis]
+    groups = plan_dimensions(model, planned_views=tuple(dwg.views))
+    group = next((g for g in groups if g.feature is feature), None)
+    view = view or (group.view if group is not None else _END_ON[feature.frame.axis])
+    if view == "rear" and feature.frame.axis != "y":
+        raise ValueError("furniture(): rear is not end-on for this hole axis")
     before = set(dwg.annotations())
 
     # Centre marks — one per member, mirroring render_centermarks' size/placement.
@@ -479,7 +490,7 @@ def add_feature_furniture(dwg, feature, model, a, *, view: str | None = None, ct
             feature,
             lambda loc: dwg.at(view, *loc),
             ctx=ctx,
-            plan=compile_dimensions(model),
+            plan=compile_dimensions(model, groups=groups),
         )
 
     return sorted(set(dwg.annotations()) - before)
@@ -2468,20 +2479,34 @@ def _place_front_callouts(
     meta = {}
     measurements = {}
     tb_box = (tb_left, _TB_CLEAR, a.PAGE_W - _TB_CLEAR, tb_top)
+    # The location corridor runs after these leaders. Its approved X witnesses
+    # extend below the view through this band; prefer the text side they leave clear.
+    # Values and endpoints come from the same compiled entries the corridor consumes.
+    witness_x = {
+        to_page(point)[0]
+        for hole in _approved_off_axis_holes(plan)
+        if hole.view == view and "x" in hole.approved
+        for point in hole.approved["x"].span
+    }
     for i, (locs, dia, callout, feat) in enumerate(specs):
         w = callout.callout_width
         rep = max(locs, key=lambda loc: to_page(loc)[0])
         centre = to_page(rep)
+        text_sides = []
         if centre[0] + gap + w <= a.PAGE_W - a.margin:
-            side = "right"
-        elif centre[0] - gap - w >= a.margin:
-            side = "left"
-        else:
+            text_sides.append(("right", centre[0] + gap, centre[0] + gap + w))
+        if centre[0] - gap - w >= a.margin:
+            text_sides.append(("left", centre[0] - gap - w, centre[0] - gap))
+        if not text_sides:
             _log.info("Hole callout ø%s skipped (no room)", _fmt(dia))
             _record_callout_drop(
                 ctx, dwg, view, dia, "no room beside the view", feat, callout=callout
             )
             continue
+        side, _, _ = min(
+            text_sides,
+            key=lambda candidate: sum(candidate[1] <= x <= candidate[2] for x in witness_x),
+        )
 
         name = _hc_name(only, view, i, hc_used)
 

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -741,7 +741,7 @@ def _approved_off_axis_holes(plan) -> list[_OffHole]:
     return list(holes.values())
 
 
-def _off_axis_drop(dwg, axis, view, *, ctx, measurement=()):
+def _off_axis_drop(dwg, axis, view, *, ctx, measurement=(), reason="no room beside the view"):
     # Recorded at INFO under a code DISTINCT from the plan path's
     # ``location_ref_dropped`` (which is a warning). Two reasons:
     #  - Severity: a best-effort off-axis location dim that did not fit is not
@@ -758,7 +758,7 @@ def _off_axis_drop(dwg, axis, view, *, ctx, measurement=()):
     ctx.record_issue(
         "info",
         "off_axis_location_dropped",
-        f"{axis} location dim for a {view}-view hole not placed (no room beside the view)",
+        f"{axis} location dim for a {view}-view hole not placed ({reason})",
         measurement=measurement,
     )
 
@@ -877,6 +877,15 @@ def _locate_across(dwg, ctx, a: Analysis, off):
             continue  # not approved — the compiler withheld this position
         yo = round(entry.value, 2)
         if yo * a.SCALE < 1.0:
+            if abs(entry.value) > 1e-9:
+                _off_axis_drop(
+                    dwg,
+                    "Y",
+                    "side",
+                    ctx=ctx,
+                    measurement=entry.id,
+                    reason="span shorter than 1 mm at this scale",
+                )
             continue
         name = f"dim_loc_side_y{round(yo * 100)}"
         loc_by_name.setdefault(name, []).append(h)
@@ -1000,6 +1009,15 @@ def _locate_along_planar(dwg, ctx, a: Analysis, off, *, view="front"):
             continue  # not approved
         xo = round(entry.value, 2)
         if xo * a.SCALE < 1.0:
+            if abs(entry.value) > 1e-9:
+                _off_axis_drop(
+                    dwg,
+                    "X",
+                    view,
+                    ctx=ctx,
+                    measurement=entry.id,
+                    reason="span shorter than 1 mm at this scale",
+                )
             continue
         name = f"dim_loc_{view}_x{round(xo * 100)}"
         x_loc_by_name.setdefault(name, []).append(h)
@@ -1074,7 +1092,18 @@ def _locate_along_z(dwg, ctx, a: Analysis, off, *, front_view="front"):
         if entry is None:
             continue  # not approved
         zo = round(entry.value, 2)
-        if zo * a.SCALE < 1.0 or zo in seen_z:
+        if zo * a.SCALE < 1.0:
+            if abs(entry.value) > 1e-9:
+                _off_axis_drop(
+                    dwg,
+                    "Z",
+                    front_view if h.axis == "y" else "side",
+                    ctx=ctx,
+                    measurement=entry.id,
+                    reason="span shorter than 1 mm at this scale",
+                )
+            continue
+        if zo in seen_z:
             continue
         seen_z.add(zo)
         hz = h.location[2]

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -9,6 +9,7 @@ shared placement helpers come from annotations._common. Below annotate, no cycle
 from __future__ import annotations
 
 import math
+from functools import partial
 from typing import NamedTuple
 
 from build123d_drafting.helpers import (
@@ -33,6 +34,7 @@ from draftwright._core import (
     _fmt,
     _iso_bbox,
     _log,
+    layout_frame,
 )
 from draftwright._geometry import _leader_ink_crosses_box, plane_axes
 from draftwright.annotations._common import (
@@ -680,6 +682,7 @@ class _OffHole(NamedTuple):
     location: tuple
     feature: HoleFeature | PatternFeature
     approved: dict
+    view: str
 
 
 def _approved_off_axis_holes(plan) -> list[_OffHole]:
@@ -720,7 +723,9 @@ def _approved_off_axis_holes(plan) -> list[_OffHole]:
         key = (entry.ref, member)
         hole = holes.get(key)
         if hole is None:
-            hole = holes[key] = _OffHole(entry.axis, member, resolve_feature(entry.ref), {})
+            group = plan.group_for(entry.ref)
+            view = group.view if group is not None else _END_ON[entry.axis]
+            hole = holes[key] = _OffHole(entry.axis, member, resolve_feature(entry.ref), {}, view)
         hole.approved[entry.discriminator] = entry
     return list(holes.values())
 
@@ -963,12 +968,12 @@ def _locate_across(dwg, ctx, a: Analysis, off):
     )
 
 
-def _locate_along_planar(dwg, ctx, a: Analysis, off):
+def _locate_along_planar(dwg, ctx, a: Analysis, off, *, view="front"):
     """The "along" phase's planar dim: a Y-axis hole's X position below the FRONT view, placed
     after the envelope + turned-diameter passes so it never evicts those from the contended
     front-below strip (#133). Promoted (#638)."""
     draft = dwg.draft
-    FX, FZ = a.proj.front_x, a.proj.front_z
+    FX, FZ = (a.proj.rear_x, a.proj.rear_z) if view == "rear" else (a.proj.front_x, a.proj.front_z)
     dx, dz = a.bb.min.X, a.bb.min.Z
     tier = draft.font_size + 2 * draft.pad_around_text
     xw = FZ(dz) - _WITNESS_LIFT_MM
@@ -985,7 +990,7 @@ def _locate_along_planar(dwg, ctx, a: Analysis, off):
         xo = round(entry.value, 2)
         if xo * a.SCALE < 1.0:
             continue
-        name = f"dim_loc_front_x{round(xo * 100)}"
+        name = f"dim_loc_{view}_x{round(xo * 100)}"
         x_loc_by_name.setdefault(name, []).append(h)
         x_mids_by_name.setdefault(name, []).append(entry.id)
         x_coverage_by_name.setdefault(name, []).append(_hole_location_coverage_fact(entry))
@@ -1010,21 +1015,21 @@ def _locate_along_planar(dwg, ctx, a: Analysis, off):
         dwg,
         ctx,
         tier,
-        a.fv_zones.below,
-        "front",
+        layout_frame(a).zones(view).below,
+        view,
         "below",
         "y",
         x_cands,
         features=x_feats,
         measurements=x_measurements,
         on_drop=lambda nm: _off_axis_drop(
-            dwg, "x", "front", ctx=ctx, measurement=x_measurements.get(nm, ())
+            dwg, "x", view, ctx=ctx, measurement=x_measurements.get(nm, ())
         ),
         order_key=lambda nm, _i: order_x.get(nm, _i),
     )
 
 
-def _locate_along_z(dwg, ctx, a: Analysis, off):
+def _locate_along_z(dwg, ctx, a: Analysis, off, *, front_view="front"):
     """The "along" phase's height dim: a hole's height (Z) is visible to the RIGHT of both the
     side and the front view. Neither right strip is universally free, so try the natural strip
     first, then RELOCATE to the other view if a bore-callout leader sits in the natural
@@ -1032,10 +1037,15 @@ def _locate_along_z(dwg, ctx, a: Analysis, off):
     same-feature crossing — never drop a real dim (policy B, #133). Promoted (#638)."""
     draft = dwg.draft
     SX, SZ = a.proj.side_x, a.proj.side_z
-    FX, FZ = a.proj.front_x, a.proj.front_z
+    FX, FZ = (
+        (a.proj.rear_x, a.proj.rear_z)
+        if front_view == "rear"
+        else (a.proj.front_x, a.proj.front_z)
+    )
     dz = a.bb.min.Z
     tier = draft.font_size + 2 * draft.pad_around_text
-    zr, zrf = SX(a.bb.max.Y), FX(a.bb.max.X)
+    zr = SX(a.bb.max.Y)
+    zrf = FX(a.bb.min.X if front_view == "rear" else a.bb.max.X)
     z_locs: dict = {}  # z-offset -> contributing hole locations (for provenance)
     z_mids: dict = {}
     z_coverage: dict = {}
@@ -1075,8 +1085,16 @@ def _locate_along_z(dwg, ctx, a: Analysis, off):
             return {f"dim_loc_{view}_z{round(_zo * 100)}": tuple(z_mids[_zo])}
 
         side_cand = (a.sv_zones.right, "side", (zr, SZ(dz), 0), (zr, SZ(hz), 0), zr)
-        front_cand = (a.fv_zones.right, "front", (zrf, FZ(dz), 0), (zrf, FZ(hz), 0), zrf)
-        order = (side_cand, front_cand) if h.axis == "x" else (front_cand, side_cand)
+        front_cand = (
+            layout_frame(a).zones(front_view).right,
+            front_view,
+            (zrf, FZ(dz), 0),
+            (zrf, FZ(hz), 0),
+            zrf,
+        )
+        order = [side_cand, front_cand] if h.axis == "x" else [front_cand, side_cand]
+        if a.planned_views is not None:
+            order = [candidate for candidate in order if candidate[1] in a.planned_views]
         primary, *alternates = order
         strip, view, p_lo, p_hi, edge = primary
         primary_cand = _zc(view, p_lo, p_hi, edge)
@@ -1239,8 +1257,11 @@ def _locate_off_axis_holes(dwg, ctx, a: Analysis, *, which, plan):
     if which == "across":
         _locate_across(dwg, ctx, a, off)
         return
-    _locate_along_planar(dwg, ctx, a, off)
-    _locate_along_z(dwg, ctx, a, off)
+    for view in ("front", "rear"):
+        selected = [h for h in off if (h.view == "rear") == (view == "rear")]
+        if selected:
+            _locate_along_planar(dwg, ctx, a, selected, view=view)
+            _locate_along_z(dwg, ctx, a, selected, front_view=view)
 
 
 def _add_furniture(
@@ -2516,8 +2537,8 @@ def _place_front_callouts(
 
     left = place_strip_candidates(
         dwg,
-        a.fv_zones.below,
-        "front",
+        layout_frame(a).zones(view).below,
+        view,
         "y",
         cands,
         min_gap,
@@ -3221,7 +3242,7 @@ def _annotate_holes(
     furnished: set[int] = set()
 
     for view, view_groups in by_view.items():
-        to_page = view_of_axis[{"plan": "z", "front": "y", "side": "x"}[view]][1]
+        to_page = partial(layout_frame(a).project, view)
         specs = list(view_groups)  # (locs, dia, callout, feat), from the IR groups
         # No fixed cap (#36): every spec is attempted; the per-view placement
         # bounds below (front-view shaft rows, plan/side strip Y-solver) are the
@@ -3230,7 +3251,7 @@ def _annotate_holes(
         # features win the available room.
         specs.sort(key=lambda s: s[1], reverse=True)
 
-        if view == "front":
+        if view in {"front", "rear"}:
             _place_front_callouts(
                 dwg,
                 a,

--- a/src/draftwright/annotations/holes.py
+++ b/src/draftwright/annotations/holes.py
@@ -1382,7 +1382,7 @@ def _furnish_uncalled_patterns(dwg, a: Analysis, view_of_axis, plan, *, ctx, fur
         axis = feat.frame.axis
         if axis not in view_of_axis:
             continue
-        view = _END_ON[axis]
+        view = group.view
         j = 0
         while any(
             nm == f"dim_pitch_{view}{j}" or nm.startswith(f"dim_pitch_{view}{j}_")
@@ -1395,7 +1395,7 @@ def _furnish_uncalled_patterns(dwg, a: Analysis, view_of_axis, plan, *, ctx, fur
             view,
             j,
             feat,
-            view_of_axis[axis][1],
+            partial(layout_frame(a).project, view),
             ctx=ctx,
             plan=plan,
             furnished=furnished,
@@ -1603,25 +1603,10 @@ def _place_pitch_dim(
         return
     ux, uy = ux / norm, uy / norm
     mid = ((p1[0] + p2[0]) / 2, (p1[1] + p2[1]) / 2)
-    # view extents in page coordinates, to push the dim line outside
-    if view == "plan":
-        corners = [
-            (a.proj.plan_x(x), a.proj.plan_y(y))
-            for x in (a.bb.min.X, a.bb.max.X)
-            for y in (a.bb.min.Y, a.bb.max.Y)
-        ]
-    elif view == "front":
-        corners = [
-            (a.proj.front_x(x), a.proj.front_z(z))
-            for x in (a.bb.min.X, a.bb.max.X)
-            for z in (a.bb.min.Z, a.bb.max.Z)
-        ]
-    else:
-        corners = [
-            (a.proj.side_x(y), a.proj.side_z(z))
-            for y in (a.bb.min.Y, a.bb.max.Y)
-            for z in (a.bb.min.Z, a.bb.max.Z)
-        ]
+    # Every principal uses its selected view's composed, handed page frame.
+    frame = layout_frame(a)
+    x0, x1, y0, y1 = frame.edges(view)
+    corners = [(x, y) for x in (x0, x1) for y in (y0, y1)]
     # Pick the perpendicular side from the page layout, not raw distance:
     # below the plan view sit dim_width and the front view, above the front
     # view sits the plan — so plan dims go up, front dims go down, and
@@ -1721,7 +1706,7 @@ def _place_pitch_dim(
     # `sgn` the exact outward sign (±1); `distance = sgn*(pos - mid[axis])` then lands the line at
     # the carved `pos`. The tight threshold (≈1.6°) keeps a tilted row off this path — its dim
     # isn't axis-aligned, so it can't cleanly occupy a tier — routing it to the vector fallback.
-    zones = {"plan": a.pv_zones, "front": a.fv_zones, "side": a.sv_zones}[view]
+    zones = frame.zones(view)
     sx, sy = side[0], side[1]
     strip = axis = perp = None
     witness = sgn = 0.0

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -543,18 +543,6 @@ def _assemble(
     # Detected path: reuse the model _analyse already built for sizing (#584 WP1 A) —
     # detectors run once per build (ADR 1 (was 0008 Amdt 5), #602). build_model(a) remains the
     # fallback for a manually-constructed Analysis with no stored model.
-    if model is None and (requested or authored is not None):
-        # Both verbs name a DECLARED feature object (ADR 4 (was 0016) / #872, #874), and detection
-        # builds its own. Silently dropping them would leave a caller's add_dimension() /
-        # dimension() with no effect and no diagnostic — the failure mode this project
-        # treats as worse than a visible error (#630/#631/#632). An authored set is the
-        # worse of the two to drop: the build would quietly revert to the automatic
-        # dimensions the author was replacing (#921 review).
-        verb = "requested=" if requested else "authored="
-        raise ValueError(
-            f"{verb} names declared features, so it needs model= too; a detected "
-            "model builds its own feature objects that no request can target"
-        )
     pm = (
         _coerce_model(model, a.part, decorations, requested, authored)
         if model is not None
@@ -1308,6 +1296,19 @@ def _build_drawing_once(
     title = title or stem.replace("_", " ").upper()
     tracer = _resolve_trace(trace, out)
 
+    if model is None and (requested or authored is not None):
+        # Both verbs name a DECLARED feature object (ADR 4 (was 0016) / #872, #874), and detection
+        # builds its own. Silently dropping them would leave a caller's add_dimension() /
+        # dimension() with no effect and no diagnostic — the failure mode this project
+        # treats as worse than a visible error (#630/#631/#632). An authored set is the
+        # worse of the two to drop: the build would quietly revert to the automatic
+        # dimensions the author was replacing (#921 review).
+        verb = "requested=" if requested else "authored="
+        raise ValueError(
+            f"{verb} names declared features, so it needs model= too; a detected "
+            "model builds its own feature objects that no request can target"
+        )
+
     def analyse(*, reuse, views):
         return _analyse(
             step_file,
@@ -1378,6 +1379,27 @@ def _build_drawing_once(
         )
     if uncovered_measured:
         raise ViewPlanIncomplete(planned_principals, uncovered_measured)
+    if auto_dims and not {"front", "rear"}.intersection(planned_principals):
+        # A model without an envelope can still approve a synthetic bbox height.
+        # It has no feature parameter for plan_dimensions to check, so prove its
+        # compiled view requirement before projecting a reduced principal set.
+        from draftwright.model.compiled import compile_dimensions
+
+        overall = compile_dimensions(explicit_model).ladder("overall_height")
+        if overall is not None:
+            height = overall.rungs[0]
+            raise ViewPlanIncomplete(
+                planned_principals,
+                [
+                    UncoveredViewRequirement(
+                        identity=height.id,
+                        label="overall_height.length",
+                        preferred_view="front",
+                        eligible_views=("front", "rear"),
+                        reason="requires a planned front or rear view",
+                    )
+                ],
+            )
     view_attempts: tuple[dict[str, object], ...] = ()
     view_status = "selected"
     if _select_automatic_views and _views is None and auto_dims:

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -64,6 +64,7 @@ from draftwright.annotations.orchestrator import (
 from draftwright.compose import (
     ViewBlock,
     _attribute_annotations,
+    _build_rear_zones,
     _build_zones,
     _layout_geometry,
     _view_geom,
@@ -704,6 +705,7 @@ def _assemble(
         "front": ((cxs, cys - dist, czs), (0, 0, 1)),
         "plan": ((cxs, cys, czs + dist), (0, 1, 0)),
         "side": ((cxs + dist, cys, czs), (0, 0, 1)),
+        "rear": ((cxs, cys + dist, czs), (0, 0, 1)),
     }
     dwg._build.view_plan = view_plan = resolve_from_analysis(a)
     for spec in view_plan.of_kind("principal"):
@@ -1001,6 +1003,8 @@ def _repack(
         abs(g.PV_Y - a.PV_Y),
         abs(g.SV_X - a.SV_X),
         abs(g.SV_Y - a.SV_Y),
+        abs(g.RV_X - a.RV_X) if "rear" in (a.planned_views or ()) else 0.0,
+        abs(g.RV_Y - a.RV_Y) if "rear" in (a.planned_views or ()) else 0.0,
     )
     # Seed fit warnings yield to the measured result; retain the explicit legibility
     # advisory only at the scale for which it was evaluated.
@@ -1037,6 +1041,9 @@ def _repack(
         PV_Y=g.PV_Y,
         SV_X=g.SV_X,
         SV_Y=g.SV_Y,
+        RV_X=g.RV_X,
+        RV_Y=g.RV_Y,
+        rv_zones=_build_rear_zones(g, a.margin, ph),
         fv_hw=g.fv_hw,
         fv_hh=g.fv_hh,
         pv_hh=g.pv_hh,
@@ -1055,6 +1062,8 @@ def _repack(
             sv_y=g.SV_Y,
             pv_x=g.PV_X,
             pv_y=g.PV_Y,
+            rv_x=g.RV_X,
+            rv_y=g.RV_Y,
             cx=a.cx,
             cy=a.cy,
             cz=a.cz,

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -1322,6 +1322,7 @@ def _build_drawing_once(
             model=model,
             decorations=decorations,
             authored=authored,
+            requested=requested,
             material=material,
             date=date,
             revision=revision,
@@ -1341,42 +1342,42 @@ def _build_drawing_once(
         )
 
     a = analyse(reuse=_analysis_base, views=_views)
-    if _views is not None:
-        # Measured dimensions are model-routed (ADR 1 (was 0015)) and therefore do not enter
-        # plan_dimensions' requirement check.  An authored principal set is nevertheless
-        # a hard constraint: reject a measured mark targeting an absent projection before
-        # corridor placement can misreport the contradiction as a capacity drop.
-        explicit_model = (
-            _coerce_model(model, a.part, decorations, requested, authored)
-            if model is not None
-            else cast("PartModel", a.model if a.model is not None else build_model(a))
+    planned_principals = third_angle_view_names() if _views is None else _views
+    # Measured dimensions are model-routed (ADR 1 (was 0015)) and therefore do not enter
+    # plan_dimensions' requirement check.  An authored principal set is nevertheless
+    # a hard constraint: reject a measured mark targeting an absent projection before
+    # corridor placement can misreport the contradiction as a capacity drop.
+    explicit_model = (
+        _coerce_model(model, a.part, decorations, requested, authored)
+        if model is not None
+        else cast("PartModel", a.model if a.model is not None else build_model(a))
+    )
+    uncovered_measured = []
+    for feature in explicit_model.features:
+        feature_view = authored_dimension_target_view(
+            getattr(feature, "dimension_kind", ""),
+            getattr(feature, "dominant_axis", ""),
+            getattr(feature, "view", None),
+            getattr(feature, "side", None),
+            getattr(feature, "angular_reference", None),
         )
-        uncovered_measured = []
-        for feature in explicit_model.features:
-            feature_view = authored_dimension_target_view(
-                getattr(feature, "dimension_kind", ""),
-                getattr(feature, "dominant_axis", ""),
-                getattr(feature, "view", None),
-                getattr(feature, "side", None),
-                getattr(feature, "angular_reference", None),
+        if (
+            getattr(feature, "kind", None) != "authored_dimension"
+            or not isinstance(feature_view, str)
+            or feature_view in set(planned_principals)
+        ):
+            continue
+        uncovered_measured.append(
+            UncoveredViewRequirement(
+                identity=feature,
+                label=getattr(feature, "source_id", "") or "measured_dimension",
+                preferred_view=feature_view,
+                eligible_views=(feature_view,),
+                reason=f"is explicitly placed in `{feature_view}`",
             )
-            if (
-                getattr(feature, "kind", None) != "authored_dimension"
-                or not isinstance(feature_view, str)
-                or feature_view in set(_views)
-            ):
-                continue
-            uncovered_measured.append(
-                UncoveredViewRequirement(
-                    identity=feature,
-                    label=getattr(feature, "source_id", "") or "measured_dimension",
-                    preferred_view=feature_view,
-                    eligible_views=(feature_view,),
-                    reason=f"is explicitly placed in `{feature_view}`",
-                )
-            )
-        if uncovered_measured:
-            raise ViewPlanIncomplete(_views, uncovered_measured)
+        )
+    if uncovered_measured:
+        raise ViewPlanIncomplete(planned_principals, uncovered_measured)
     view_attempts: tuple[dict[str, object], ...] = ()
     view_status = "selected"
     if _select_automatic_views and _views is None and auto_dims:

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -90,6 +90,7 @@ from draftwright.projection import (
 from draftwright.recognition_cache import RecognitionCache
 from draftwright.view_plan import (
     ARRANGEMENTS,
+    PRINCIPAL_VIEW_NAMES,
     UncoveredViewRequirement,
     ViewConstraints,
     ViewPlanIncomplete,
@@ -307,7 +308,7 @@ def _annotations_out_of_bounds(dwg, a, tol: float = BOUNDS_ROUNDOFF) -> bool:
     by escalating the sheet."""
     lo, hi_x, hi_y = a.margin, a.PAGE_W - a.margin, a.PAGE_H - a.margin
     for name, o in dwg.iter_annotations():
-        if dwg.view_of(name) not in ("front", "plan", "side"):
+        if dwg.view_of(name) not in PRINCIPAL_VIEW_NAMES:
             continue
         # Match the lint, which tests each item's FULL bounding_box (extension
         # lines, arrowheads, leader + balloon ring) — not just the label rect —

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -60,7 +60,11 @@ from draftwright.fonts import PLEX_MONO
 from draftwright.layout import fit_box
 from draftwright.model.callout import hole_callout_batches, hole_callout_suffix
 from draftwright.model.ir import authored_dimension_target_view
-from draftwright.model.planner import angular_pattern_label, plan_dimensions
+from draftwright.model.planner import (
+    angular_pattern_label,
+    authored_location_omitted,
+    plan_dimensions,
+)
 from draftwright.view_plan import (
     ARRANGEMENTS,
     LayoutCandidate,
@@ -371,6 +375,7 @@ class StripDepths:
     sv_right: float = 0.0  # band to the right of the side view
     angular: tuple[AngularReservation, ...] = ()
     pv_location_top: float = 0.0  # complete ladder depth for a facing plan/front corridor
+    rv_right: float = 0.0
 
 
 def _measure_strips(
@@ -678,6 +683,16 @@ def _compose_anno_boxes(
         # provides the complete requirement for a bounded facing corridor.
         full_depth = _STRIP_GAP + above * (1 + _STRIP_SPACING / (font_size + 2 * pad_around_text))
         boxes.append(AnnoBox("plan_location_above", full_depth))
+    rear_locations = sum(
+        len(feature.members or (feature.frame.origin,))
+        for feature in model.features
+        if feature.kind in {"hole", "pattern"}
+        and feature.frame.axis == "y"
+        and not authored_location_omitted(model, feature)
+    )
+    if rear_locations:
+        tier = font_size + 2 * pad_around_text
+        boxes.append(AnnoBox("rear_right", _STRIP_GAP + rear_locations * (tier + _STRIP_SPACING)))
     if _will_balloon(model):
         boxes.append(AnnoBox("plan_halo", _est_plan_halo(font_size)))
     return boxes
@@ -706,6 +721,7 @@ def _footprint_from_boxes(boxes: list[AnnoBox]) -> StripDepths:
         sv_top=deepest("side_above"),
         sv_bottom=deepest("side_below"),
         sv_right=deepest("side_right"),
+        rv_right=deepest("rear_right"),
         angular=tuple(box.angular for box in boxes if box.angular is not None),
     )
 
@@ -1205,6 +1221,14 @@ def _compose_view_blocks(
             bottom=strips.sv_bottom if strips else 0.0,
         ),
     }
+    result["rear"] = ViewBlock(
+        fv_hw,
+        fv_hh,
+        top=DIM_PAD,
+        bottom=DIM_PAD,
+        left=gap_left,
+        right=max(gap_fv_sv, strips.rv_right if strips else 0.0),
+    )
     for reservation in strips.angular if strips else ():
         block = result[reservation.view]
         x0, y0, x1, y1 = reservation.footprint(scale)
@@ -1265,6 +1289,7 @@ def _layout_geometry(
         x_size, y_size, z_size, scale, strips, n_steps, section=section
     )
     est_fv, est_pv, est_sv = est_blocks["front"], est_blocks["plan"], est_blocks["side"]
+    est_rv = est_blocks["rear"]
     section_hw = max(fv_hw, 12.0)
     section_hh = fv_hh
     if blocks is not None:
@@ -1290,8 +1315,9 @@ def _layout_geometry(
         fv = _merge(est_fv, blocks.get("front", est_fv))
         pv = _merge(est_pv, blocks.get("plan", est_pv))
         sv = _merge(est_sv, blocks.get("side", est_sv))
+        rv = _merge(est_rv, blocks.get("rear", est_rv))
     else:
-        fv, pv, sv = est_fv, est_pv, est_sv
+        fv, pv, sv, rv = est_fv, est_pv, est_sv, est_rv
     # Per-side corridor depths from the (possibly measured) blocks. The front and
     # plan views stack vertically (same X, different Y) so they SHARE the left and
     # right corridors — the deeper of the two facing bands. The side view ABUTS
@@ -1305,6 +1331,7 @@ def _layout_geometry(
     has_front = views is None or "front" in views
     has_plan = views is None or "plan" in views
     has_side = views is None or "side" in views
+    has_rear = views is not None and "rear" in views
     has_column = has_front or has_plan
     _present = [b for b, present in ((fv, has_front), (pv, has_plan)) if present]
 
@@ -1314,25 +1341,48 @@ def _layout_geometry(
     if convention not in {"first", "third"}:
         raise ValueError(f"unknown projection convention {convention!r}")
     first_angle = convention == "first"
+    composed_origins = first_angle or has_rear
     # Plan's upper strip is bounded by front in this arrangement. Missing location
     # candidates cannot grow measured ink, so reserve their complete ladder here.
     if first_angle and has_front and has_plan and strips is not None:
         pv = replace(pv, top=max(pv.top, strips.pv_location_top))
     # Relative projection origins come from the convention and the facing annotation
     # bands. Pack these complete blocks before building geometry; never move rendered views.
-    relative_plan_y = -(fv.hh + fv.bottom + pv.top + pv.hh)
-    relative_side_x = -(fv.hw + col_left + sv.right + sv.hw)
-    first_origins = {
+    relative_plan_y = (
+        -(fv.hh + fv.bottom + pv.top + pv.hh)
+        if first_angle
+        else fv.hh + fv.top + pv.bottom + pv.hh
+    )
+    relative_side_x = (
+        -(fv.hw + col_left + sv.right + sv.hw)
+        if first_angle
+        else fv.hw + col_right + sv.left + sv.hw
+    )
+    principal_origins = {
         "front": (0.0, 0.0),
         "plan": (0.0, relative_plan_y if has_front else 0.0),
         "side": (relative_side_x if has_column else 0.0, 0.0),
     }
-    first_boxes = [
-        block.footprint(*first_origins[name])
+    # Rear is the next elevation beyond side in the convention's unfolding
+    # direction. Only selected blocks take space; rear alone starts at the origin.
+    if has_side:
+        neighbor_x, neighbor_hw = principal_origins["side"][0], sv.hw
+        neighbor_band = sv.left if first_angle else sv.right
+    elif has_column:
+        neighbor_x, neighbor_hw = 0.0, fv.hw
+        neighbor_band = col_left if first_angle else col_right
+    else:
+        neighbor_x = neighbor_hw = neighbor_band = 0.0
+    rear_offset = neighbor_hw + neighbor_band + rv.hw + (rv.right if first_angle else rv.left)
+    rear_x = neighbor_x + (-rear_offset if first_angle else rear_offset)
+    principal_origins["rear"] = (rear_x if has_side or has_column else 0.0, 0.0)
+    principal_boxes = [
+        block.footprint(*principal_origins[name])
         for name, block, present in (
             ("front", fv, has_front),
             ("plan", pv, has_plan),
             ("side", sv, has_side),
+            ("rear", rv, has_rear),
         )
         if present
     ]
@@ -1358,8 +1408,10 @@ def _layout_geometry(
         column_h = 0.0
     side_h = (sv.bottom + 2 * sv.hh + sv.top) if has_side else 0.0
     total_h = 2 * margin + max(column_h, side_h)
-    if first_angle:
-        total_h = 2 * margin + max(b[3] for b in first_boxes) - min(b[1] for b in first_boxes)
+    if composed_origins:
+        total_h = (
+            2 * margin + max(b[3] for b in principal_boxes) - min(b[1] for b in principal_boxes)
+        )
     y_offset = max(0.0, (page_h - total_h) / 2)
 
     section_count = int(section)
@@ -1376,10 +1428,10 @@ def _layout_geometry(
         + (y_size * scale if has_side else 0.0)
         + max(2 * DIM_PAD, (sv.right + DIM_PAD) if has_side else 0.0, section_right_band)
     )
-    if first_angle:
+    if composed_origins:
         ortho_row_w = (
-            max(b[2] for b in first_boxes)
-            - min(b[0] for b in first_boxes)
+            max(b[2] for b in principal_boxes)
+            - min(b[0] for b in principal_boxes)
             + DIM_PAD
             + section_count * (10.0 + 2 * section_hw + DIM_PAD)
         )
@@ -1454,12 +1506,14 @@ def _layout_geometry(
     # estimator path (fv.right == pv.right == col_right, sv.left == 0).
     SV_X = FV_X + fv.hw + col_right + sv.left + sv.hw
     SV_Y = FV_Y
-    if first_angle:
-        origin_x = margin + x_offset - min(b[0] for b in first_boxes)
-        origin_y = margin + y_offset - min(b[1] for b in first_boxes)
+    if composed_origins:
+        origin_x = margin + x_offset - min(b[0] for b in principal_boxes)
+        origin_y = margin + y_offset - min(b[1] for b in principal_boxes)
         FV_X, FV_Y = origin_x, origin_y
-        PV_X, PV_Y = origin_x, origin_y + first_origins["plan"][1]
-        SV_X, SV_Y = origin_x + first_origins["side"][0], origin_y
+        PV_X, PV_Y = origin_x, origin_y + principal_origins["plan"][1]
+        SV_X, SV_Y = origin_x + principal_origins["side"][0], origin_y
+    RV_X = (origin_x + principal_origins["rear"][0]) if composed_origins else 0.0
+    RV_Y = origin_y if composed_origins else 0.0
     # Keep the side geometry edge separate from the packed outer footprint.  The
     # right strip starts at the former and consumes the reserved ``sv.right`` band;
     # anchoring it at the latter would move the strip out again on every measured
@@ -1468,8 +1522,8 @@ def _layout_geometry(
     sv_right = sv_geometry_right + sv.right
     SECTION_X = SV_X + sv.hw + sv.right + 10.0 + section_hw
     SECTION_Y = FV_Y
-    if first_angle:
-        SECTION_X = origin_x + max(b[2] for b in first_boxes) + 10.0 + section_hw
+    if composed_origins:
+        SECTION_X = origin_x + max(b[2] for b in principal_boxes) + 10.0 + section_hw
     sv_right_wall = (
         (page_w - margin) if (PV_Y - pv_hh) > (margin + _TB_H) else (page_w - tb_w - margin)
     )
@@ -1505,6 +1559,7 @@ def _layout_geometry(
             *([fv.footprint(FV_X, FV_Y)] if has_front else []),
             *([pv.footprint(PV_X, PV_Y)] if has_plan else []),
             *([sv.footprint(SV_X, SV_Y)] if has_side else []),
+            *([rv.footprint(RV_X, RV_Y)] if has_rear else []),
             title_block.footprint(tb_cx, tb_cy),
         ]
     else:
@@ -1512,6 +1567,7 @@ def _layout_geometry(
             *([_padded_box(FV_X, FV_Y, fv_hw, fv_hh)] if has_front else []),
             *([_padded_box(PV_X, PV_Y, fv_hw, pv_hh)] if has_plan else []),
             *([_padded_box(SV_X, SV_Y, sv_hw, fv_hh)] if has_side else []),
+            *([rv.footprint(RV_X, RV_Y)] if has_rear else []),
             title_block.footprint(tb_cx, tb_cy),
         ]
     section_blocks = []
@@ -1565,6 +1621,7 @@ def _layout_geometry(
         *([fv.footprint(FV_X, FV_Y)] if has_front else []),
         *([pv.footprint(PV_X, PV_Y)] if has_plan else []),
         *([sv.footprint(SV_X, SV_Y)] if has_side else []),
+        *([rv.footprint(RV_X, RV_Y)] if has_rear else []),
     ]
     _view_boxes.extend(section_blocks)
     cx0 = min(b[0] for b in _view_boxes)
@@ -1589,6 +1646,7 @@ def _layout_geometry(
         *([fv.footprint(FV_X, FV_Y)] if has_front else []),
         *([pv.footprint(PV_X, PV_Y)] if has_plan else []),
         *([sv.footprint(SV_X, SV_Y)] if has_side else []),
+        *([rv.footprint(RV_X, RV_Y)] if has_rear else []),
         title_block.footprint(tb_cx, tb_cy),
     ]
     table_obstacles.extend(section_blocks)
@@ -1620,7 +1678,12 @@ def _layout_geometry(
         convention=convention,
         planned_views=tuple(
             name
-            for name, present in (("front", has_front), ("plan", has_plan), ("side", has_side))
+            for name, present in (
+                ("front", has_front),
+                ("plan", has_plan),
+                ("side", has_side),
+                ("rear", has_rear),
+            )
             if present
         ),
         outer_right_wall=outer_right_wall,
@@ -1636,6 +1699,9 @@ def _layout_geometry(
         PV_Y=PV_Y,
         SV_X=SV_X,
         SV_Y=SV_Y,
+        RV_X=RV_X,
+        RV_Y=RV_Y,
+        rear_block=rv,
         SECTION_X=SECTION_X,
         SECTION_Y=SECTION_Y,
         sv_geometry_right=sv_geometry_right,
@@ -1660,6 +1726,20 @@ def _layout_geometry(
         auto_row_w=_auto_row_w,
         # The arrangement this geometry was laid out under — resolved, never "auto".
         arrangement=arrangement,
+    )
+
+
+def _build_rear_zones(g, margin, page_h):
+    """The rear block's reserved strips, shared by initial layout and repacking."""
+    if "rear" not in g.planned_views:
+        return None
+    block = g.rear_block
+    x, y = g.RV_X, g.RV_Y
+    return ViewZones(
+        right=Strip(x + block.hw, x + block.hw + block.right, direction=1),
+        left=Strip(x - block.hw, x - block.hw - block.left, direction=-1),
+        above=Strip(y + block.hh, page_h - margin, direction=1),
+        below=Strip(y - block.hh, margin, direction=-1),
     )
 
 

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -690,9 +690,20 @@ def _compose_anno_boxes(
         and feature.frame.axis == "y"
         and not authored_location_omitted(model, feature)
     )
-    if rear_locations:
+    rear_height = any(
+        group.feature.kind == "envelope"
+        and any(
+            not dimension.suppressed
+            and dimension.param.role == "height"
+            and dimension.view in (None, "rear")
+            and dimension.side != "left"
+            for dimension in group.dims
+        )
+        for group in plan_dimensions(model)
+    )
+    if rear_tiers := rear_locations + int(rear_height):
         tier = font_size + 2 * pad_around_text
-        boxes.append(AnnoBox("rear_right", _STRIP_GAP + rear_locations * (tier + _STRIP_SPACING)))
+        boxes.append(AnnoBox("rear_right", _STRIP_GAP + rear_tiers * (tier + _STRIP_SPACING)))
     if _will_balloon(model):
         boxes.append(AnnoBox("plan_halo", _est_plan_halo(font_size)))
     return boxes

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -2961,10 +2961,10 @@ class Drawing:
                     self,
                     a,
                     build_view_of_axis(a),
-                    plan_dimensions(model),
+                    plan_dimensions(model, planned_views=tuple(self.views)),
                     feature_hole_keys(model, a),
                     ctx=ctx,
-                    plan=compile_dimensions(model),
+                    plan=compile_dimensions(model, planned_views=tuple(self.views)),
                     only=r.only_callout,
                     place_furniture=False,
                 )
@@ -2983,7 +2983,7 @@ class Drawing:
                 assert a is not None and isinstance(model, PartModel)  # ⟹ routable
                 render_locations(
                     self,
-                    compile_dimensions(model),
+                    compile_dimensions(model, planned_views=tuple(self.views)),
                     a,
                     ctx=ctx,
                     only=r.only_loc,
@@ -2998,7 +2998,11 @@ class Drawing:
             if r.off_axis_loc_ids:
                 assert a is not None
                 _locate_off_axis_holes(
-                    self, ctx, a, which="across", plan=compile_dimensions(model)
+                    self,
+                    ctx,
+                    a,
+                    which="across",
+                    plan=compile_dimensions(model, planned_views=tuple(self.views)),
                 )
 
         def _s_off_axis_along():
@@ -3006,7 +3010,13 @@ class Drawing:
             # (mirrors the auto pass's off_axis_along stage; after the envelope candidates).
             if r.off_axis_loc_ids:
                 assert a is not None
-                _locate_off_axis_holes(self, ctx, a, which="along", plan=compile_dimensions(model))
+                _locate_off_axis_holes(
+                    self,
+                    ctx,
+                    a,
+                    which="along",
+                    plan=compile_dimensions(model, planned_views=tuple(self.views)),
+                )
 
         def _s_height_ladder():
             # Prismatic step-height ladder through the auto-pass renderer. (#636) This

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -147,6 +147,7 @@ from draftwright.projection import (
 from draftwright.recognition_cache import RecognitionCache
 from draftwright.registry import AnnotationRegistry
 from draftwright.repair import repair_drawing
+from draftwright.view_plan import PRINCIPAL_VIEW_NAMES, VIEW_AXES
 
 
 def _exact_vertex_rotation(source_vertices, target_vertices) -> float | None:
@@ -930,7 +931,7 @@ class Drawing:
         annotatable from that view):
 
         - ``"plan"``  → Z-axis holes
-        - ``"front"`` → Y-axis holes
+        - ``"front"`` / ``"rear"`` → Y-axis holes
         - ``"side"``  → X-axis holes
 
         Returns an empty list when no analysis is available or the view name
@@ -940,7 +941,10 @@ class Drawing:
         if a is None:
             return []
 
-        _axis_for_view = {"plan": "z", "front": "y", "side": "x"}
+        _axis_for_view = {
+            name: next(axis for axis in "xyz" if axis not in axes)
+            for name, axes in VIEW_AXES.items()
+        }
         target_axis = _axis_for_view.get(view)
         if target_axis is None:
             return []
@@ -1475,7 +1479,7 @@ class Drawing:
                 convert world coordinates.
             p2: second page-coordinate tuple ``(px, py, 0)``.
             side: ``"above"``, ``"below"``, ``"left"``, or ``"right"``.
-            view: ``"front"``, ``"plan"``, or ``"side"``.
+            view: ``"front"``, ``"plan"``, ``"side"``, or ``"rear"``.
             draft: the drawing's :attr:`draft` preset.
             name: optional annotation name for later :meth:`remove` / replace.
             slot: strip slot depth (mm); the perpendicular space reserved per dim.
@@ -1531,7 +1535,12 @@ class Drawing:
         behaviour notes.
         """
         a = self._analysis
-        _view_zones = {"front": "fv_zones", "plan": "pv_zones", "side": "sv_zones"}
+        _view_zones = {
+            "front": "fv_zones",
+            "plan": "pv_zones",
+            "side": "sv_zones",
+            "rear": "rv_zones",
+        }
         strip = None
         if a is not None:
             zones = getattr(a, _view_zones.get(view, ""), None)
@@ -1697,7 +1706,7 @@ class Drawing:
 
     def _resolve_dimension_span(self, feature, param, *, role=None, view=None):
         """Return ``(param_record, view, p1, p2)`` for a feature linear dimension."""
-        _ortho = ("front", "plan", "side")
+        _ortho = PRINCIPAL_VIEW_NAMES
         if view is not None and view not in _ortho:
             raise ValueError(
                 f"view must be one of {_ortho}, not {view!r} (it foreshortens the span)"
@@ -1733,7 +1742,7 @@ class Drawing:
         (lo, hi) = span
         p1 = p2 = None
         chosen = view
-        automatic_views: tuple[str, ...] = _ortho
+        automatic_views = tuple(name for name in _ortho if name in self.views)
         if view is None and getattr(feature, "kind", None) == "through_step":
             automatic_views = (_END_ON[feature.axis],)
         for v in [view] if view else automatic_views:
@@ -1831,7 +1840,12 @@ class Drawing:
 
         side = it.kwargs.get("side")
         view = it.kwargs.get("view")
-        zones_name = {"front": "fv_zones", "plan": "pv_zones", "side": "sv_zones"}
+        zones_name = {
+            "front": "fv_zones",
+            "plan": "pv_zones",
+            "side": "sv_zones",
+            "rear": "rv_zones",
+        }
         rec, view, p1, p2 = self._resolve_dimension_span(
             it.feature,
             it.kwargs["param"],
@@ -1972,11 +1986,11 @@ class Drawing:
         an exact parameter id/discriminator to pick one — an ambiguous kind raises rather
         than guessing.
 
-        ``view`` is chosen automatically as the orthographic view (``"front"``/``"plan"``/
-        ``"side"``) where the span projects non-degenerate — a length along the turning
+        ``view`` is chosen from the selected principal views (``"front"``/``"plan"``/
+        ``"side"``/``"rear"``) where the span projects non-degenerate — a length along the turning
         axis vanishes in its end-on view, so the view follows the geometry. Through-step legs
         share their semantic axis end view and natural outside-corner sides. Pass ``view=``
-        to force one of those three (a non-orthographic view foreshortens the span and is
+        to select a principal explicitly (a non-orthographic view foreshortens the span and is
         rejected). An implicit ``side`` is ``"above"`` except for through-step legs, whose
         missing corner selects the natural outside corridor. ``kwargs`` forward to the dimension
         — except ``tolerance=``, which is folded into the label (see :meth:`place_dim`),
@@ -3430,7 +3444,7 @@ class Drawing:
         return self._registry.iter_named()
 
     def view_of(self, name):
-        """The owning orthographic view for *name* ("front"/"plan"/"side"), or
+        """The owning orthographic view for *name* ("front"/"plan"/"side"/"rear"), or
         ``None`` — instead of reading ``dwg._anno_view`` directly (#241)."""
         return self._registry.view_of(name)
 

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -582,6 +582,8 @@ def lint_location_coverage(
         axis = _axis_letter(h)
         views = ("front", "rear") if axis == "y" else (_END_ON.get(axis, "plan"),)
         available_views = getattr(dwg, "views", None)
+        if available_views is None:
+            views = (_END_ON.get(axis, "plan"),)
         projections = {
             view: dwg.at(view, x, y, z)
             for view in views

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -580,13 +580,16 @@ def lint_location_coverage(
     for h in holes:
         x, y, z = _xyz(h.location)
         axis = _axis_letter(h)
-        view = _END_ON.get(axis, "plan")
+        views = ("front", "rear") if axis == "y" else (_END_ON.get(axis, "plan"),)
         available_views = getattr(dwg, "views", None)
-        projected = (
-            dwg.at(view, x, y, z) if available_views is None or view in available_views else None
-        )
-        if projected is None or not any(
-            abs(cx - projected[0]) <= tol and abs(cy - projected[1]) <= tol
+        projections = {
+            view: dwg.at(view, x, y, z)
+            for view in views
+            if available_views is None or view in available_views
+        }
+        if not any(
+            abs(cx - point[0]) <= tol and abs(cy - point[1]) <= tol
+            for view, point in projections.items()
             for cx, cy in marks.get(view, ())
         ):
             no_mark += 1
@@ -599,16 +602,16 @@ def lint_location_coverage(
             continue
 
         features = feature_index.get((axis, ref), set())
-        page_axes = VIEW_AXES[view]
 
         def _axis_covered(model_axis):
             semantic = any(owner in features for owner in satisfied_locations) or any(
                 owner in features and parameter.endswith(f".{model_axis}") and point == ref
                 for owner, parameter, point in structured_locations
             )
-            page_index = page_axes.index(model_axis)
-            geometric = projected is not None and any(
-                abs((vx, vy)[page_index] - projected[page_index]) <= tol
+            geometric = any(
+                abs((vx, vy)[page_index] - point[page_index]) <= tol
+                for view, point in projections.items()
+                for page_index in (VIEW_AXES[view].index(model_axis),)
                 for vx, vy in dim_verts.get(view, ())
             )
             return semantic or geometric

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -1192,12 +1192,13 @@ def _compile_overall_height(
     # honest failure.
     height_tol = None
     height_side = None
+    height_view = None
     if env is not None:
         height_param = next(pm for pm in env.parameters() if pm.role == "height")
         height_tol = _decorated(model, env, height_param).tolerance
-        height_side = next(
+        height_intent = next(
             (
-                pd.side
+                pd
                 for group in planned
                 if group.feature is env
                 for pd in group.dims
@@ -1205,6 +1206,9 @@ def _compile_overall_height(
             ),
             None,
         )
+        if height_intent is not None:
+            height_side = height_intent.side
+            height_view = height_intent.view
     ladder = ApprovedLadder(
         "overall_height",
         (
@@ -1216,6 +1220,7 @@ def _compile_overall_height(
                 ref=env_ref,
                 tolerance=height_tol,
                 side=height_side,
+                view=height_view,
                 # `rendered_label` is the BARE value while `tolerance` is set beside it, so for
                 # a toleranced rung this field is not the "complete compiler-owned label" its
                 # own docstring promises — the renderer composes the suffix. It has to:

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -36,13 +36,14 @@ from draftwright._geometry import (
 from draftwright.blend_contract import register_blend_ir_types, validate_blend_fields
 from draftwright.feature_identity import register_oriented_slot_feature_type
 from draftwright.section_recess_contract import validate_pocket_mouth
+from draftwright.view_plan import PRINCIPAL_VIEW_NAMES
 
 if TYPE_CHECKING:
     from draftwright.fits import FitClass
 
 Point = tuple[float, float, float]
 CylinderSense = Literal["external", "internal"]
-PLACEMENT_VIEWS = frozenset({"front", "plan", "side"})
+PLACEMENT_VIEWS = frozenset(PRINCIPAL_VIEW_NAMES)
 PLACEMENT_SIDES = frozenset({"above", "below", "left", "right"})
 
 

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -414,6 +414,12 @@ def _group_view(feature: Feature, planned_views=None) -> str | None:
     preferred = _preferred_group_view(feature)
     if planned_views is None or preferred in set(planned_views):
         return preferred
+    if (
+        isinstance(feature, HoleFeature | PatternFeature)
+        and feature.frame.axis == "y"
+        and "rear" in planned_views
+    ):
+        return "rear"
     if feature.kind == "envelope":
         return views_showing("x", planned_views, horizontal=True)
     return None
@@ -1256,6 +1262,7 @@ def _group_placement(feature: Feature, dims: list[PlannedDimension], planned_vie
             "plan": {"left", "right"},
             "side": {"left", "right"},
             "front": {"below"},
+            "rear": {"below"},
         }.get(selected_view or "", set())
         if (
             not isinstance(feature, HoleFeature | PatternFeature)
@@ -1423,6 +1430,8 @@ def _parameter_view_preferences(feature: Feature, pd: PlannedDimension) -> tuple
     role = pd.param.role
     kind = feature.kind
     axis = feature.frame.axis
+    if isinstance(feature, HoleFeature | PatternFeature) and axis == "y":
+        return ("front", "rear")
     if kind == "envelope":
         if role == "width":
             return ("plan", "front")
@@ -1602,7 +1611,7 @@ def _uncovered_location_requirements(
             continue
         parameters: tuple[str, ...]
         if isinstance(feature, HoleFeature | PatternFeature):
-            view = _END_ON[feature.frame.axis]
+            view = _group_view(feature, planned_views) or _END_ON[feature.frame.axis]
             bbox: Any = model.bbox
             datum = (float(bbox.min.X), float(bbox.min.Y), float(bbox.min.Z))
             parameters = tuple(

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -1434,11 +1434,11 @@ def _parameter_view_preferences(feature: Feature, pd: PlannedDimension) -> tuple
         return ("front", "rear")
     if kind == "envelope":
         if role == "width":
-            return ("plan", "front")
+            return ("plan", "front", "rear")
         if role == "depth":
             return ("side",)
         if role == "height":
-            return ("front",)
+            return ("front", "rear")
     if role in {"boss_height", "stock_length"}:
         return (_PROFILE.get(axis, "front"),)
     if kind == "step_level" and role == "step_height":

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -1287,7 +1287,7 @@ class Sheet:
         appeared in a release, so this refusal is the only notice it gets — a documented
         break (`docs/deprecations.md`).
 
-        ``view`` selects ``front``/``plan``/``side`` and ``side`` selects the corresponding
+        ``view`` selects ``front``/``plan``/``side``/``rear`` and ``side`` selects the corresponding
         ``above``/``below``/``left``/``right`` corridor where that dimension renderer supports
         it. They express authored placement intent, not page coordinates; invalid or
         unrenderable pairs fail clearly during planning.

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -132,6 +132,7 @@ from draftwright.view_plan import (
     ViewPlanIncomplete,
     ViewRelation,
     ViewSpec,
+    third_angle_view_names,
     validate_projection,
 )
 
@@ -1963,6 +1964,7 @@ class Sheet:
             "front": "principal",
             "plan": "principal",
             "side": "principal",
+            "rear": "principal",
             "iso": "pictorial",
         }
         if name not in kinds:
@@ -2549,9 +2551,16 @@ class Sheet:
                 "views; call auto_views() first"
             )
         if self._principal_view_source != "authored":
+            additions = tuple(
+                record["name"]
+                for record in self._added_principal_views
+                if record["kind"] == "principal"
+            )
+            if additions:
+                return tuple(dict.fromkeys((*third_angle_view_names(), *additions))), True
             return None, True
         names = tuple(record["name"] for record in self._principal_views)
-        principals = tuple(name for name in names if name in {"front", "plan", "side"})
+        principals = tuple(name for name in names if name in {"front", "plan", "side", "rear"})
         if not principals:
             source = (
                 self._principal_views[0]["source"]
@@ -2560,7 +2569,7 @@ class Sheet:
             )
             raise ValueError(
                 f"the authored view set from {source} has no principal orthographic view; "
-                "add view('front'), view('plan'), or view('side')"
+                "add view('front'), view('plan'), view('side'), or view('rear')"
             )
         return principals, "iso" in names
 

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -125,6 +125,7 @@ from draftwright.model.planner import (
 )
 from draftwright.model.planner import location_role as _location_role
 from draftwright.view_plan import (
+    PRINCIPAL_VIEW_NAMES,
     ConstraintSource,
     ViewConstraint,
     ViewConstraints,
@@ -1960,13 +1961,7 @@ class Sheet:
     @staticmethod
     def _principal_view_name(name) -> tuple[str, str]:
         name = str(name).strip().lower()
-        kinds = {
-            "front": "principal",
-            "plan": "principal",
-            "side": "principal",
-            "rear": "principal",
-            "iso": "pictorial",
-        }
+        kinds = {**dict.fromkeys(PRINCIPAL_VIEW_NAMES, "principal"), "iso": "pictorial"}
         if name not in kinds:
             raise ValueError(
                 f"unknown view {name!r}; expected one of {tuple(kinds)}. "
@@ -2560,7 +2555,7 @@ class Sheet:
                 return tuple(dict.fromkeys((*third_angle_view_names(), *additions))), True
             return None, True
         names = tuple(record["name"] for record in self._principal_views)
-        principals = tuple(name for name in names if name in {"front", "plan", "side", "rear"})
+        principals = tuple(name for name in names if name in PRINCIPAL_VIEW_NAMES)
         if not principals:
             source = (
                 self._principal_views[0]["source"]

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -65,7 +65,7 @@ from draftwright.model.ir import (
     ToleranceDecoration,
 )
 from draftwright.reporting import write_json_document
-from draftwright.view_plan import ViewConstraints, validate_projection
+from draftwright.view_plan import PRINCIPAL_VIEW_NAMES, ViewConstraints, validate_projection
 
 _log = logging.getLogger(__name__)
 
@@ -1949,7 +1949,7 @@ def _adopted_view_block(constraints: ViewConstraints, names: Mapping[int, str]) 
         spec = item.spec
         reject_unexpressed_spec_fields(spec)
         expected_kind = "pictorial" if spec.name == "iso" else "principal"
-        if spec.name not in {"front", "plan", "side", "iso"} or spec.kind != expected_kind:
+        if spec.name not in (*PRINCIPAL_VIEW_NAMES, "iso") or spec.kind != expected_kind:
             raise ValueError(f"cannot emit principal view {spec.name!r} with kind {spec.kind!r}")
         if spec.target is not None:
             raise ValueError(f"cannot emit principal view {spec.name!r} with a target")

--- a/src/draftwright/view_plan.py
+++ b/src/draftwright/view_plan.py
@@ -98,6 +98,7 @@ _PRINCIPAL_PAGE_AXES = {
 
 # Supported vocabulary is larger than the automatic candidate set. Rear is an
 # authored choice even when visibility or coverage would benefit from it.
+PRINCIPAL_VIEW_NAMES = tuple(_PRINCIPAL_PAGE_AXES)
 _AUTOMATIC_PRINCIPALS = ("front", "plan", "side")
 
 
@@ -729,12 +730,7 @@ def arrangement_of(pick) -> str:
 #: The primitive everything below derives from, so the derivations cannot drift from each
 #: other or be quietly mis-stated: `front` is the x-z elevation, `plan` looks down at x-y,
 #: `side` is the y-z elevation.
-VIEW_AXES: dict[str, tuple[str, str]] = {
-    "front": ("x", "z"),
-    "plan": ("x", "y"),
-    "side": ("y", "z"),
-    "rear": ("x", "z"),
-}
+VIEW_AXES: dict[str, tuple[str, str]] = dict(_PRINCIPAL_PAGE_AXES)
 
 #: Axis letter -> the principal views that can carry a requirement about it, preference
 #: ordered. `_geometry._END_ON` answers "which single view does this feature read face-on

--- a/src/draftwright/view_plan.py
+++ b/src/draftwright/view_plan.py
@@ -93,7 +93,12 @@ _PRINCIPAL_PAGE_AXES = {
     "front": ("x", "z"),
     "plan": ("x", "y"),
     "side": ("y", "z"),
+    "rear": ("x", "z"),
 }
+
+# Supported vocabulary is larger than the automatic candidate set. Rear is an
+# authored choice even when visibility or coverage would benefit from it.
+_AUTOMATIC_PRINCIPALS = ("front", "plan", "side")
 
 
 @dataclass(frozen=True)
@@ -345,9 +350,18 @@ def third_angle_principals() -> tuple[ViewSpec, ...]:
     caller. What this function fixes is the SET and its page-axis mapping — the part that was
     previously a sentence in `choose_scale`'s docstring.
     """
+    return principal_specs(_AUTOMATIC_PRINCIPALS)
+
+
+def principal_specs(names: tuple[str, ...]) -> tuple[ViewSpec, ...]:
+    """Describe an explicit principal set without expanding automatic candidates."""
+    unknown = set(names) - _PRINCIPAL_PAGE_AXES.keys()
+    if unknown:
+        raise ValueError(f"unknown principal views: {sorted(unknown)}")
     return tuple(
         ViewSpec(name=name, kind="principal", page_axes=axes)
         for name, axes in _PRINCIPAL_PAGE_AXES.items()
+        if name in names
     )
 
 
@@ -357,7 +371,7 @@ def third_angle_view_names() -> tuple[str, ...]:
     One source for "which views a candidate contains", so a candidate generator and the resolver
     cannot disagree about the set while both claiming to describe the same drawing.
     """
-    return tuple(_PRINCIPAL_PAGE_AXES)
+    return _AUTOMATIC_PRINCIPALS
 
 
 def principal_placements(analysis) -> dict[str, ViewPlacement]:
@@ -370,11 +384,16 @@ def principal_placements(analysis) -> dict[str, ViewPlacement]:
     The stub was right and the coupling was wrong; a consumer that needs placements should ask
     for placements.
     """
-    return {
+    placements = {
         "front": ViewPlacement(analysis.FV_X, analysis.FV_Y, analysis.fv_hw, analysis.fv_hh),
         "plan": ViewPlacement(analysis.PV_X, analysis.PV_Y, analysis.fv_hw, analysis.pv_hh),
         "side": ViewPlacement(analysis.SV_X, analysis.SV_Y, analysis.sv_hw, analysis.fv_hh),
     }
+    if "rear" in (getattr(analysis, "planned_views", None) or ()):
+        placements["rear"] = ViewPlacement(
+            analysis.RV_X, analysis.RV_Y, analysis.fv_hw, analysis.fv_hh
+        )
+    return placements
 
 
 def resolve_from_analysis(analysis) -> ResolvedViewPlan:
@@ -399,7 +418,7 @@ def resolve_from_analysis(analysis) -> ResolvedViewPlan:
     principals = third_angle_principals()
     wanted = getattr(analysis, "planned_views", None)
     if wanted is not None:
-        principals = tuple(spec for spec in principals if spec.name in set(wanted))
+        principals = principal_specs(wanted)
         placements = {name: place for name, place in placements.items() if name in set(wanted)}
     constraints = getattr(analysis, "view_constraints", None)
     requested_by_name = {}
@@ -714,6 +733,7 @@ VIEW_AXES: dict[str, tuple[str, str]] = {
     "front": ("x", "z"),
     "plan": ("x", "y"),
     "side": ("y", "z"),
+    "rear": ("x", "z"),
 }
 
 #: Axis letter -> the principal views that can carry a requirement about it, preference

--- a/src/draftwright/view_plan.py
+++ b/src/draftwright/view_plan.py
@@ -746,9 +746,9 @@ VIEW_AXES: dict[str, tuple[str, str]] = dict(_PRINCIPAL_PAGE_AXES)
 #: The first entry of each is the view that extent has always been placed in, so consulting
 #: this changes nothing while all three principals are planned.
 VIEWS_SHOWING: dict[str, tuple[str, ...]] = {
-    "x": ("plan", "front"),
+    "x": ("plan", "front", "rear"),
     "y": ("side", "plan"),
-    "z": ("front", "side"),
+    "z": ("front", "side", "rear"),
 }
 
 

--- a/tests/test_adr0018_view_selection.py
+++ b/tests/test_adr0018_view_selection.py
@@ -72,7 +72,7 @@ class TestTheObservabilityModel:
             assert {horizontal, vertical} <= {"x", "y", "z"}
 
     def test_the_three_views_between_them_show_every_axis_twice(self):
-        seen = [axis for axes in VIEW_AXES.values() for axis in axes]
+        seen = [axis for view in ("front", "plan", "side") for axis in VIEW_AXES[view]]
         assert {axis: seen.count(axis) for axis in "xyz"} == {"x": 2, "y": 2, "z": 2}
 
     def test_views_showing_agrees_with_the_page_axes(self):
@@ -368,7 +368,7 @@ class TestAnExtentMovesOrIsReported:
         assert [item.identity.parameter for item in caught.value.uncovered] == ["depth.length"]
         assert "envelope.depth.length" in str(caught.value)
 
-    def test_a_width_diagnostic_lists_both_semantically_eligible_views(self):
+    def test_a_width_diagnostic_lists_all_semantically_eligible_views(self):
         from draftwright.model.planner import plan_dimensions
 
         model = detect_part_model(_plain_box())
@@ -378,8 +378,8 @@ class TestAnExtentMovesOrIsReported:
         width = next(
             item for item in caught.value.uncovered if item.identity.parameter == "width.length"
         )
-        assert width.eligible_views == ("plan", "front")
-        assert "add one of `plan`, `front`" in str(caught.value)
+        assert width.eligible_views == ("plan", "front", "rear")
+        assert "add one of `plan`, `front`, `rear`" in str(caught.value)
 
     def test_an_authored_slot_position_uses_the_slot_plane_not_its_long_axis(self):
         from draftwright.model import Frame, PartModel, SlotFeature

--- a/tests/test_compiled_plan_boundary.py
+++ b/tests/test_compiled_plan_boundary.py
@@ -240,11 +240,18 @@ class TestTheRendererCannotSeeContent:
     def test_the_body_never_touches_the_feature_inventory(self):
         """Reads the source rather than trusting the signature: a renderer could still
         reach content through an argument that legitimately carries it."""
-        src = inspect.getsource(render_height_ladder)
-        tree = ast.parse(src)
+        tree = ast.parse(inspect.getsource(inspect.getmodule(render_height_ladder)))
+        renderers = [
+            node
+            for node in tree.body
+            if isinstance(node, ast.FunctionDef)
+            and node.name in {"render_height_ladder", "_render_height_ladder_in_view"}
+        ]
+        assert len(renderers) == 2
         reads = {
             node.attr
-            for node in ast.walk(tree)
+            for renderer in renderers
+            for node in ast.walk(renderer)
             if isinstance(node, ast.Attribute) and isinstance(node.ctx, ast.Load)
         }
         # `_feature` is the FeatureRef escape hatch: resolving a provenance handle back to

--- a/tests/test_issue_1260_view_constraints.py
+++ b/tests/test_issue_1260_view_constraints.py
@@ -417,7 +417,7 @@ class TestBuildEffects:
         hole = detail.hole(diameter=6, at=(0, 0, 0), axis="z")
         detail.view("front")
         detail.detail_view("A", around=hole)
-        with pytest.raises(ValueError, match="cannot be shown"):
+        with pytest.raises(ValueError, match="needs parent view.*plan"):
             detail.build()
 
     def test_exact_view_scales_fail_instead_of_relaxing(self, monkeypatch):

--- a/tests/test_issue_1372_pocket_pattern_completeness_evidence.py
+++ b/tests/test_issue_1372_pocket_pattern_completeness_evidence.py
@@ -768,6 +768,8 @@ def test_pitch_fallback_rejects_unverifiable_real_geometry(
         margin=10.0,
         PAGE_W=210.0,
         PAGE_H=297.0,
+        SCALE=1.0,
+        rv_zones=None,
         bb=SimpleNamespace(min=point(50.0), max=point(130.0)),
         proj=project,
         pv_zones=zones,

--- a/tests/test_issue_1466_dimension_options.py
+++ b/tests/test_issue_1466_dimension_options.py
@@ -76,6 +76,9 @@ def test_location_and_envelope_constraints_are_discoverable():
         {"view": "front", "side": None},
         {"view": "front", "side": "left"},
         {"view": "front", "side": "right"},
+        {"view": "rear", "side": None},
+        {"view": "rear", "side": "left"},
+        {"view": "rear", "side": "right"},
     ]
     assert not sheet.validate_dimension(envelope, "height.length", side="above")["supported"]
     result = sheet.validate_dimension(hole_handle, "location", axis="y", side="below")

--- a/tests/test_issue_1518_explicit_rear.py
+++ b/tests/test_issue_1518_explicit_rear.py
@@ -242,3 +242,225 @@ def test_rear_pattern_pitch_never_draws_in_an_absent_front_view(with_bore, conve
     ]
     assert len(pitches) == 1
     assert pitches[0].measured_length == pytest.approx(40)
+
+
+@pytest.mark.parametrize("convention", ["first", "third"])
+@pytest.mark.parametrize("explicit_dimensions", [False, True])
+def test_rear_envelope_width_and_height_keep_spans_and_identity(convention, explicit_dimensions):
+    from draftwright import Sheet
+
+    part = Pos(13, 7, -8) * Box(80, 40, 50)
+    sheet = Sheet(
+        part, page="A3", scale=1, scale_policy="strict", projection=convention
+    ).authored_dimensions()
+    envelope = sheet.envelope()
+    placement = {"view": "rear"} if explicit_dimensions else {}
+    sheet.dimension(envelope, "width.length", **placement)
+    sheet.dimension(envelope, "height.length", side="left", **placement)
+    sheet.view("rear")
+    drawing = sheet.build()
+    expected = {"m_env_width": ("80", 80), "dim_height": ("50", 50)}
+    for name, (label, length) in expected.items():
+        annotation = drawing.get_annotation(name)
+        assert drawing.view_of(name) == "rear"
+        assert annotation.label == label
+        assert annotation.measured_length == pytest.approx(length)
+        assert drawing.registry.measurement_of(name)
+    assert not drawing.lint()
+
+    from draftwright.view_plan import ViewPlanIncomplete
+
+    sheet.dimension(envelope, "depth.length")
+    with pytest.raises(ViewPlanIncomplete, match="envelope.depth.length.*side"):
+        sheet.build()
+
+
+@pytest.mark.parametrize("convention", ["first", "third"])
+def test_translated_rear_origin_pin_moves_the_complete_view(convention):
+    from draftwright import Sheet
+
+    part = Pos(13, 7, -8) * Box(80, 40, 50)
+
+    def declared(pin=None):
+        sheet = Sheet(
+            part, page="A3", scale=1, scale_policy="strict", projection=convention
+        ).authored_dimensions()
+        envelope = sheet.envelope()
+        sheet.dimension(envelope, "width.length")
+        sheet.dimension(envelope, "height.length")
+        view = sheet.view("rear")
+        if pin is not None:
+            view.pin(pin)
+        return sheet
+
+    baseline = declared().build()
+    origin = baseline.at("rear", 0, 0, 0)
+    target = (origin[0] + 10, origin[1] + 10)
+    moved = declared(target).build()
+    assert moved.at("rear", 0, 0, 0)[:2] == pytest.approx(target)
+    for name in ("m_env_width", "dim_height"):
+        before = baseline.get_annotation(name).bounding_box().center()
+        after = moved.get_annotation(name).bounding_box().center()
+        assert tuple(after - before) == pytest.approx((10, 10, 0))
+    assert not moved.lint()
+    with pytest.raises(ValueError, match="pin.*infeasible.*not relaxed"):
+        declared((-1000, target[1])).build()
+
+
+@pytest.mark.parametrize("convention", ["first", "third"])
+def test_rear_only_visibility_pressure_never_adds_an_automatic_rear(rear_enclosure, convention):
+    from draftwright import Sheet
+
+    # Native HLR proves the two bore rims are absent from visible front geometry.
+    visible, hidden = rear_enclosure.project_to_viewport((0, -1000, 0), look_at=(0, 0, 0))
+    assert not any(edge.geom_type == GeomType.CIRCLE for edge in visible)
+    assert any(edge.geom_type == GeomType.CIRCLE for edge in hidden)
+    sheet = Sheet(
+        rear_enclosure, projection=convention, page="A3", scale=1, scale_policy="permissive"
+    )
+    for diameter, x, z in ((4, -21, 11), (7, 14, -9)):
+        hole = sheet.hole(diameter=diameter, at=(x, 20, z), axis="y", through=False, depth=1.5)
+        sheet.dimension(hole, "bore.diameter")
+        sheet.dimension(hole, "bore.depth")
+        sheet.dimension(hole, "location")
+    drawing = sheet.auto_views().build()
+    assert "rear" not in drawing.views
+    assert "rear" not in drawing.view_plan.principal_names
+    # Requesting the same measurements in rear must fail when rear was not requested.
+    sheet = Sheet(rear_enclosure, projection=convention)
+    hole = sheet.hole(diameter=4, at=(-21, 20, 11), axis="y", through=False, depth=1.5)
+    sheet.dimension(hole, "bore.diameter", view="rear")
+    from draftwright.view_plan import ViewPlanIncomplete
+
+    with pytest.raises(ViewPlanIncomplete, match="rear"):
+        sheet.build()
+
+
+@pytest.mark.parametrize("deferred", [False, True])
+def test_rear_callout_and_furniture_edits_preserve_the_physical_view(rear_enclosure, deferred):
+    from contextlib import nullcontext
+
+    drawing = _rear_hole_sheet(rear_enclosure, "third").build()
+    hole = drawing.model().features[0]
+    drawing.drop(hole)
+    with drawing.deferred() if deferred else nullcontext():
+        name = drawing.callout(hole)
+        marks = drawing.furniture(hole)
+    claims = drawing.annotations_of(hole)
+    assert claims
+    assert all(drawing.view_of(name) == "rear" for name in claims)
+    if not deferred:
+        assert name in claims and set(marks) <= set(claims)
+    assert any(getattr(drawing.get_annotation(name), "label", "") == "⌀4 ↧ 1.5" for name in claims)
+    assert not [
+        issue for issue in drawing.lint() if issue.code == "diameter_leader_target_mismatch"
+    ]
+
+
+@pytest.mark.parametrize("convention", ["first", "third"])
+def test_epic_1508_combined_style_rear_and_wording_canary(rear_enclosure, convention, tmp_path):
+    from collections import Counter
+
+    from draftwright import Sheet, build_drawing
+    from draftwright.audit import compare_measurements
+    from draftwright.sheet_emit import emit_sheet_script
+
+    # The third hole passes through the 2 mm back wall; the other two remain blind.
+    part = rear_enclosure - Pos(0, 19, -16) * Rot(90, 0, 0) * Cylinder(2.5, 4)
+    assert not part.is_inside(Vector(0, 18.25, -16))
+    assert part.is_inside(Vector(-21, 18.25, 11))
+    options = dict(
+        page="A3",
+        scale=1,
+        scale_policy="strict",
+        projection=convention,
+        text_position="above",
+        text_orientation="horizontal",
+    )
+    sheet = Sheet(part, **options).authored_dimensions()
+    for diameter, x, z in ((4, -21, 11), (7, 14, -9)):
+        hole = sheet.hole(diameter=diameter, at=(x, 20, z), axis="y", through=False, depth=1.5)
+        sheet.dimension(hole, "bore.diameter")
+        sheet.dimension(hole, "bore.depth")
+        sheet.dimension(hole, "location")
+    through = sheet.hole(diameter=5, at=(0, 20, -16), axis="y").through("DURCH")
+    sheet.dimension(through, "bore.diameter")
+    sheet.dimension(through, "location")
+    envelope = sheet.envelope()
+    sheet.dimension(envelope, "width.length")
+    sheet.dimension(envelope, "height.length")
+    sheet.view("rear")
+    original = sheet.build()
+    direct = build_drawing(
+        part,
+        model=sheet.model(),
+        _views=("rear",),
+        _include_iso=False,
+        _view_constraints=sheet.view_constraints,
+        **options,
+    )
+    script = emit_sheet_script(
+        sheet.model(),
+        "part = supplied_part",
+        str(tmp_path / "epic"),
+        title="EPIC",
+        number="1508",
+        formats=("svg", "pdf", "dxf"),
+        view_constraints=sheet.view_constraints,
+        **options,
+    )
+    namespace = {"supplied_part": part}
+    exec(script, namespace)
+    replay = namespace["drawing"]
+    original_features = sheet.model().features
+    for drawing in (original, direct, replay):
+        labels = Counter(
+            annotation.label
+            for name, annotation in drawing.iter_annotations()
+            if drawing.view_of(name) == "rear" and getattr(annotation, "label", "")
+        )
+        assert labels == Counter(
+            ["⌀4 ↧ 1.5", "⌀7 ↧ 1.5", "⌀5 DURCH", "80", "50", "19", "54", "40", "16", "36", "9"]
+        )
+        assert drawing.view_plan.principal_names == ("rear",)
+        assert drawing.view_plan.convention == convention
+        assert drawing.draft.text_position == "above"
+        assert drawing.draft.text_orientation == "horizontal"
+        pairs = tuple(zip(original_features, drawing.model().features, strict=True))
+        assert (
+            compare_measurements(original, drawing, feature_pairs=pairs)["status"] == "preserved"
+        )
+        assert not [
+            issue
+            for issue in drawing.lint()
+            if issue.code
+            in {
+                "diameter_leader_target_mismatch",
+                "annotation_overlap",
+                "annotation_ink_overlap",
+                "callout_dropped",
+                "overall_dim_withheld",
+                "placement_unsatisfiable",
+                "bore_through_not_placed",
+            }
+        ]
+    assert all((tmp_path / f"epic.{ext}").stat().st_size > 100 for ext in ("svg", "pdf", "dxf"))
+
+
+@pytest.mark.parametrize("intent", ["authored", "requested"])
+def test_unrequested_rear_dimension_refuses_before_projection(rear_enclosure, intent, monkeypatch):
+    import draftwright.builder as builder
+    from draftwright import build_drawing
+    from draftwright.model import hole
+    from draftwright.model.ir import RequestedDimension
+    from draftwright.view_plan import ViewPlanIncomplete
+
+    feature = hole(diameter=4, at=(-21, 20, 11), axis="y", through=False, depth=1.5)
+    request = RequestedDimension(feature, "bore.diameter", view="rear")
+
+    def forbidden_projection(*args, **kwargs):
+        raise AssertionError("unshowable rear requirement reached projection")
+
+    monkeypatch.setattr(builder, "_assemble", forbidden_projection)
+    with pytest.raises(ViewPlanIncomplete, match="rear"):
+        build_drawing(rear_enclosure, model=[feature], **{intent: (request,)})

--- a/tests/test_issue_1518_explicit_rear.py
+++ b/tests/test_issue_1518_explicit_rear.py
@@ -640,12 +640,12 @@ def test_rear_grid_and_bolt_circle_keep_pattern_measurements(kind, convention):
 
 @pytest.mark.parametrize("operation", ["project", "edges", "zones"])
 def test_absent_rear_has_no_fallback_layout_frame(operation):
-    from draftwright import build_drawing
     from draftwright._core import layout_frame
+    from draftwright.analysis import _analyse
 
-    drawing = build_drawing(Box(40, 30, 20), auto_dims=False)
-    assert "rear" not in drawing.views
-    frame = layout_frame(drawing._analysis)
+    analysis = _analyse(Box(40, 30, 20), "FRAME", "1518", 0.1, "", "")
+    frame = layout_frame(analysis)
+    assert frame.rear is None and frame.rv_zones is None
     arguments = ("rear", (1, 2, 3)) if operation == "project" else ("rear",)
     with pytest.raises(ValueError, match="rear"):
         getattr(frame, operation)(*arguments)

--- a/tests/test_issue_1518_explicit_rear.py
+++ b/tests/test_issue_1518_explicit_rear.py
@@ -518,17 +518,26 @@ def test_rear_discovery_exposes_rendered_holes_at_their_physical_positions(rear_
     assert drawing.features("front") == []
 
 
-@pytest.mark.parametrize("axis,point", [("x", (-39.5, 20, 5)), ("z", (-21, 20, -24.5))])
-def test_short_rear_location_is_a_reported_loss_and_strict_refusal(axis, point):
+@pytest.mark.parametrize(
+    "axis,point,hole_axis,view",
+    [
+        ("x", (-39.5, 20, 5), "y", "rear"),
+        ("z", (-21, 20, -24.5), "y", "rear"),
+        ("y", (40, -19.5, 5), "x", "side"),
+    ],
+)
+def test_short_rear_location_is_a_reported_loss_and_strict_refusal(axis, point, hole_axis, view):
     from draftwright import Sheet
     from draftwright.builder import ScaleIncompatibilityError
 
-    part = Box(80, 40, 50) - Pos(point[0], 19.5, point[2]) * Rot(90, 0, 0) * Cylinder(0.1, 2)
-    assert part.is_valid and not part.is_inside(Vector(point[0], 19.5, point[2]))
+    centre = (point[0], 19.5, point[2]) if hole_axis == "y" else (39.5, point[1], point[2])
+    rotation = Rot(90, 0, 0) if hole_axis == "y" else Rot(0, 90, 0)
+    part = Box(80, 40, 50) - Pos(*centre) * rotation * Cylinder(0.1, 2)
+    assert part.is_valid and not part.is_inside(Vector(*centre))
     sheet = Sheet(part, page="A3", scale=1, scale_policy="strict")
-    hole = sheet.hole(diameter=0.2, at=point, axis="y", through=False, depth=1.5)
+    hole = sheet.hole(diameter=0.2, at=point, axis=hole_axis, through=False, depth=1.5)
     sheet.dimension(hole, "location")
-    sheet.view("rear")
+    sheet.view(view)
     with pytest.raises(ScaleIncompatibilityError, match="off_axis_location_dropped"):
         sheet.build()
     from draftwright import build_drawing
@@ -538,7 +547,7 @@ def test_short_rear_location_is_a_reported_loss_and_strict_refusal(axis, point):
         drawing = build_drawing(
             part,
             model=sheet.model(),
-            _views=("rear",),
+            _views=(view,),
             _include_iso=False,
             page="A3",
             scale=1,
@@ -627,3 +636,38 @@ def test_rear_grid_and_bolt_circle_keep_pattern_measurements(kind, convention):
         for issue in drawing.lint()
         if issue.code.endswith("_dropped") or issue.code == "diameter_leader_target_mismatch"
     ]
+
+
+@pytest.mark.parametrize("operation", ["project", "edges", "zones"])
+def test_absent_rear_has_no_fallback_layout_frame(operation):
+    from draftwright import build_drawing
+    from draftwright._core import layout_frame
+
+    drawing = build_drawing(Box(40, 30, 20), auto_dims=False)
+    assert "rear" not in drawing.views
+    frame = layout_frame(drawing._analysis)
+    arguments = ("rear", (1, 2, 3)) if operation == "project" else ("rear",)
+    with pytest.raises(ValueError, match="rear"):
+        getattr(frame, operation)(*arguments)
+
+
+def test_unknown_principal_refuses_in_shared_view_vocabulary():
+    with pytest.raises(ValueError, match="unknown principal views.*backwards"):
+        principal_specs(("rear", "backwards"))
+
+
+def test_rear_furniture_refuses_a_hole_not_normal_to_the_rear():
+    from draftwright import Sheet
+
+    cutter = Cylinder(2, 40)
+    part = Box(40, 30, 20) - cutter
+    sheet = Sheet(part).authored_dimensions()
+    sheet.hole(cutter)
+    sheet.auto_views().add_view("rear")
+    drawing = sheet.build()
+    hole = drawing.model().features[0]
+    assert hole.frame.axis == "z"
+    before = set(drawing.annotations())
+    with pytest.raises(ValueError, match="rear is not end-on"):
+        drawing.furniture(hole, view="rear")
+    assert set(drawing.annotations()) == before

--- a/tests/test_issue_1518_explicit_rear.py
+++ b/tests/test_issue_1518_explicit_rear.py
@@ -128,3 +128,117 @@ def test_rear_target_validation_rejects_another_holes_visible_rim(rear_enclosure
     errors = [issue for issue in drawing.lint() if issue.code == "diameter_leader_target_mismatch"]
     assert len(errors) == 1 and name in errors[0].message
     assert errors[0].measurement_ids == drawing.registry.measurement_of(name)
+
+
+@pytest.mark.parametrize("convention", ["first", "third"])
+def test_added_rear_retains_measurements_through_script_and_export(
+    rear_enclosure, convention, tmp_path
+):
+    from draftwright import Sheet
+    from draftwright.audit import compare_measurements
+    from draftwright.sheet_emit import emit_sheet_script
+
+    sheet = Sheet(rear_enclosure, projection=convention, page="A2", scale=1, scale_policy="strict")
+    for diameter, x, z in ((4, -21, 11), (7, 14, -9)):
+        hole = sheet.hole(diameter=diameter, at=(x, 20, z), axis="y", through=False, depth=1.5)
+        sheet.dimension(hole, "bore.diameter", view="rear")
+        sheet.dimension(hole, "bore.depth", view="rear")
+        sheet.dimension(hole, "location")
+    sheet.auto_views().add_view("rear")
+    original = sheet.build()
+    assert set(original.view_plan.principal_names) == {"front", "plan", "side", "rear"}
+    source = emit_sheet_script(
+        sheet.model(),
+        "part = supplied_part",
+        str(tmp_path / "rear"),
+        title="REAR",
+        number="REAR",
+        page="A2",
+        scale=1,
+        scale_policy="strict",
+        projection=convention,
+        formats=("svg", "pdf", "dxf"),
+        view_constraints=sheet.view_constraints,
+    )
+    assert 'sheet.add_view("rear")' in source
+    namespace = {"supplied_part": rear_enclosure}
+    exec(source, namespace)
+    replay = namespace["drawing"]
+    assert replay.view_plan.principal_names == original.view_plan.principal_names
+    assert replay.view_plan.convention == convention
+    pairs = tuple(zip(sheet.model().features, namespace["sheet"].model().features, strict=True))
+    assert compare_measurements(original, replay, feature_pairs=pairs)["status"] == "preserved"
+    for feature in namespace["sheet"].model().features:
+        assert all(replay.view_of(name) == "rear" for name in replay.annotations_of(feature))
+    assert all(
+        (tmp_path / f"rear.{extension}").stat().st_size > 100
+        for extension in ("svg", "pdf", "dxf")
+    )
+
+
+def test_rear_ink_overflow_triggers_shared_repack():
+    from types import SimpleNamespace
+
+    import draftwright.builder as builder
+
+    ink = SimpleNamespace(
+        bounding_box=lambda: SimpleNamespace(min=Vector(9, 20, 0), max=Vector(30, 40, 0))
+    )
+    drawing = SimpleNamespace(
+        iter_annotations=lambda: [("rear_ink", ink)], view_of=lambda name: "rear"
+    )
+    analysis = SimpleNamespace(margin=10, PAGE_W=100, PAGE_H=100)
+    assert builder._annotations_out_of_bounds(drawing, analysis)
+
+
+def test_external_location_judge_does_not_invent_a_rear_view():
+    from draftwright import build_drawing
+    from draftwright.linting import lint_location_coverage
+
+    part = Box(100, 60, 20) - Pos(30, 0, 0) * Rot(90, 0, 0) * Cylinder(4, 80)
+    drawing = build_drawing(part, auto_dims=False)
+
+    class ExternalDrawing:
+        at = drawing.at
+        iter_annotations = drawing.iter_annotations
+        view_of = drawing.view_of
+
+    expected = [issue.code for issue in lint_location_coverage(part, drawing)]
+    assert expected == ["feature_no_centermark", "feature_not_located"]
+    assert [issue.code for issue in lint_location_coverage(part, ExternalDrawing())] == expected
+
+
+@pytest.mark.parametrize("with_bore", [False, True])
+@pytest.mark.parametrize("convention", ["first", "third"])
+def test_rear_pattern_pitch_never_draws_in_an_absent_front_view(with_bore, convention):
+    from draftwright import Sheet
+    from draftwright.model import hole
+
+    part = Box(80, 40, 50)
+    for x in (-20, 0, 20):
+        part -= Pos(x, 19.5, 5) * Rot(90, 0, 0) * Cylinder(2, 2)
+    sheet = Sheet(part, page="A3", scale=1, scale_policy="strict", projection=convention)
+    pattern = sheet.pattern(
+        hole(diameter=4, at=(-20, 20, 5), axis="y", through=False, depth=1.5),
+        kind="linear",
+        count=3,
+        at=(0, 20, 5),
+        members=((-20, 20, 5), (0, 20, 5), (20, 20, 5)),
+        pitch=20,
+        direction=(1, 0, 0),
+    )
+    sheet.dimension(pattern, "pitch.length")
+    if with_bore:
+        sheet.dimension(pattern, "bore.diameter")
+        sheet.dimension(pattern, "bore.depth")
+    sheet.view("rear")
+    drawing = sheet.build()
+    assert drawing.view_plan.principal_names == ("rear",)
+    assert all(drawing.view_of(name) in (None, "rear") for name in drawing.annotations())
+    pitches = [
+        annotation
+        for _, annotation in drawing.iter_annotations()
+        if getattr(annotation, "label", "") == "2× 20"
+    ]
+    assert len(pitches) == 1
+    assert pitches[0].measured_length == pytest.approx(40)

--- a/tests/test_issue_1518_explicit_rear.py
+++ b/tests/test_issue_1518_explicit_rear.py
@@ -1,0 +1,130 @@
+"""An explicit rear view preserves physical handedness without becoming automatic."""
+
+import pytest
+from build123d import Box, Cylinder, GeomType, Pos, Rot, Vector
+
+from draftwright.view_plan import (
+    principal_specs,
+    third_angle_principals,
+    third_angle_view_names,
+)
+
+
+@pytest.fixture(scope="module")
+def rear_enclosure():
+    stock = Box(80, 40, 50)
+    part = stock - Pos(0, -2, 0) * Box(74, 40, 44)
+    for radius, x, z in ((2, -21, 11), (3.5, 14, -9)):
+        part -= Pos(x, 19.5, z) * Rot(90, 0, 0) * Cylinder(radius, 2)
+        # The 1.5 mm blind bore leaves 0.5 mm of the back wall intact.
+        assert part.is_inside(Vector(x, 18.25, z))
+        assert not part.is_inside(Vector(x, 19.5, z))
+    assert part.is_valid and len(part.solids()) == 1
+    assert 0 < part.volume < stock.volume
+    return part
+
+
+def test_fixture_rear_targets_are_visible_only_from_rear(rear_enclosure):
+    visible_front, _ = rear_enclosure.project_to_viewport((0, -1000, 0), look_at=(0, 0, 0))
+    visible_rear, _ = rear_enclosure.project_to_viewport((0, 1000, 0), look_at=(0, 0, 0))
+    assert not [edge for edge in visible_front if edge.geom_type == GeomType.CIRCLE]
+    circles = sorted(
+        (round(edge.radius, 5), tuple(round(v, 5) for v in edge.arc_center))
+        for edge in visible_rear
+        if edge.geom_type == GeomType.CIRCLE
+    )
+    assert circles == [(2.0, (21.0, 11.0, 0.0)), (3.5, (-14.0, -9.0, 0.0))]
+
+
+def test_supported_rear_does_not_expand_automatic_candidate_roster():
+    # Extending the supported vocabulary must not let a coverage retry invent rear.
+    (rear,) = principal_specs(("rear",))
+    assert rear.kind == "principal" and rear.page_axes == ("x", "z")
+    assert third_angle_view_names() == ("front", "plan", "side")
+    assert tuple(spec.name for spec in third_angle_principals()) == ("front", "plan", "side")
+
+
+@pytest.mark.parametrize("convention", ["first", "third"])
+@pytest.mark.parametrize("view_names", [("rear",), ("front", "side", "rear")])
+def test_explicit_rear_geometry_has_physical_handedness(rear_enclosure, convention, view_names):
+    from draftwright import Sheet
+
+    sheet = Sheet(rear_enclosure, projection=convention, page="A3", scale=1).authored_dimensions()
+    for name in view_names:
+        sheet.view(name)
+    drawing = sheet.build()
+    assert set(drawing.view_plan.principal_names) == set(view_names)
+    assert drawing.scale == 1
+    origin = drawing.at("rear", 0, 0, 0)
+    left_hole = drawing.at("rear", -21, 20, 11)
+    right_hole = drawing.at("rear", 14, 20, -9)
+    assert left_hole[0] - origin[0] == pytest.approx(21)
+    assert right_hole[0] - origin[0] == pytest.approx(-14)
+    assert left_hole[1] - origin[1] == pytest.approx(11)
+    assert right_hole[1] - origin[1] == pytest.approx(-9)
+    assert drawing.views["rear"][0].edges()
+    x0, y0, x1, y1 = drawing.view_bounds("rear")
+    assert 0 < x0 < x1 < drawing.page_w
+    assert 0 < y0 < y1 < drawing.page_h
+    if "side" in view_names:
+        side = drawing.view_bounds("side")
+        assert x1 < side[0] if convention == "first" else x0 > side[2]
+
+
+def _rear_hole_sheet(part, convention):
+    from draftwright import Sheet
+
+    sheet = Sheet(part, projection=convention, page="A3", scale=1, scale_policy="strict")
+    for diameter, x, z in ((4, -21, 11), (7, 14, -9)):
+        hole = sheet.hole(diameter=diameter, at=(x, 20, z), axis="y", through=False, depth=1.5)
+        sheet.dimension(hole, "bore.diameter")
+        sheet.dimension(hole, "bore.depth")
+        sheet.dimension(hole, "location")
+    sheet.view("rear")
+    return sheet
+
+
+@pytest.mark.parametrize("convention", ["first", "third"])
+def test_rear_carries_bore_sizes_depths_and_both_location_axes(rear_enclosure, convention):
+    from collections import Counter
+
+    drawing = _rear_hole_sheet(rear_enclosure, convention).build()
+    labels = Counter(
+        getattr(annotation, "label", "")
+        for name, annotation in drawing.iter_annotations()
+        if drawing.view_of(name) == "rear" and getattr(annotation, "label", "")
+    )
+    assert labels == Counter(["⌀4 ↧ 1.5", "⌀7 ↧ 1.5", "19", "54", "16", "36"])
+    assert len(drawing.model().features) == 2
+    for feature in drawing.model().features:
+        claims = drawing.annotations_of(feature)
+        assert claims
+        assert all(drawing.view_of(name) == "rear" for name in claims)
+    # The shell's undeclared plates/cavity remain honestly outside this bounded
+    # hole fixture; no hole, physical-target or placement warning is accepted.
+    background = {
+        "unrecognised_defining_geometry",
+        "plate_requirement_unverifiable",
+        "pocket_requirement_unverifiable",
+    }
+    assert not [issue for issue in drawing.lint() if issue.code not in background]
+
+
+def test_rear_target_validation_rejects_another_holes_visible_rim(rear_enclosure, monkeypatch):
+    drawing = _rear_hole_sheet(rear_enclosure, "first").build()
+    (hole,) = [feature for feature in drawing.model().features if feature.diameter == 4]
+    (name,) = [
+        name
+        for name in drawing.annotations_of(hole)
+        if hasattr(drawing.get_annotation(name), "tip")
+    ]
+    leader = drawing.get_annotation(name)
+    target = drawing.at("rear", 17.5, 20, -9)  # Physical rim of the other, 7 mm hole.
+    monkeypatch.setattr(
+        leader,
+        "location",
+        Pos(target[0] - leader.tip[0], target[1] - leader.tip[1], 0) * leader.location,
+    )
+    errors = [issue for issue in drawing.lint() if issue.code == "diameter_leader_target_mismatch"]
+    assert len(errors) == 1 and name in errors[0].message
+    assert errors[0].measurement_ids == drawing.registry.measurement_of(name)

--- a/tests/test_issue_1518_explicit_rear.py
+++ b/tests/test_issue_1518_explicit_rear.py
@@ -258,6 +258,8 @@ def test_rear_envelope_width_and_height_keep_spans_and_identity(convention, expl
     sheet.dimension(envelope, "width.length", **placement)
     sheet.dimension(envelope, "height.length", side="left", **placement)
     sheet.view("rear")
+    if explicit_dimensions:
+        sheet.view("front")
     drawing = sheet.build()
     expected = {"m_env_width": ("80", 80), "dim_height": ("50", 50)}
     for name, (label, length) in expected.items():
@@ -464,3 +466,164 @@ def test_unrequested_rear_dimension_refuses_before_projection(rear_enclosure, in
     monkeypatch.setattr(builder, "_assemble", forbidden_projection)
     with pytest.raises(ViewPlanIncomplete, match="rear"):
         build_drawing(rear_enclosure, model=[feature], **{intent: (request,)})
+
+
+@pytest.mark.parametrize("explicit", [False, True])
+@pytest.mark.parametrize("deferred", [False, True])
+def test_rear_linear_edit_uses_selected_view_and_shared_strip(explicit, deferred):
+    from contextlib import nullcontext
+
+    from draftwright import Sheet
+
+    sheet = Sheet(Box(80, 40, 50), page="A3", scale=1).authored_dimensions()
+    envelope = sheet.envelope()
+    sheet.dimension(envelope, "width.length")
+    sheet.dimension(envelope, "height.length")
+    sheet.view("rear")
+    drawing = sheet.build()
+    feature = drawing.model().features[0]
+    assert set(drawing.drop(feature)) == {"m_env_width", "dim_height"}
+    with drawing.deferred() if deferred else nullcontext():
+        drawing.dimension(
+            feature,
+            "width.length",
+            view="rear" if explicit else None,
+            name="edited_width",
+            priority=1,
+        )
+        drawing.dimension(
+            feature,
+            "height.length",
+            view="rear" if explicit else None,
+            name="edited_height",
+            side="right",
+            priority=1,
+        )
+    for name, value in (("edited_width", 80), ("edited_height", 50)):
+        annotation = drawing.get_annotation(name)
+        assert drawing.view_of(name) == "rear"
+        assert annotation.measured_length == pytest.approx(value)
+        assert drawing.registry.measurement_of(name)
+    assert not drawing.lint()
+
+
+def test_rear_discovery_exposes_rendered_holes_at_their_physical_positions(rear_enclosure):
+    drawing = _rear_hole_sheet(rear_enclosure, "first").build()
+    features = drawing.features("rear")
+    assert sorted(feature.diameter for feature in features) == [4, 7]
+    for feature in features:
+        x, z = (-21, 11) if feature.diameter == 4 else (14, -9)
+        assert feature.page_pos == pytest.approx(drawing.at("rear", x, 20, z)[:2])
+        assert not feature.through and feature.depth == 1.5
+    assert drawing.features("front") == []
+
+
+@pytest.mark.parametrize("axis,point", [("x", (-39.5, 20, 5)), ("z", (-21, 20, -24.5))])
+def test_short_rear_location_is_a_reported_loss_and_strict_refusal(axis, point):
+    from draftwright import Sheet
+    from draftwright.builder import ScaleIncompatibilityError
+
+    part = Box(80, 40, 50) - Pos(point[0], 19.5, point[2]) * Rot(90, 0, 0) * Cylinder(0.1, 2)
+    assert part.is_valid and not part.is_inside(Vector(point[0], 19.5, point[2]))
+    sheet = Sheet(part, page="A3", scale=1, scale_policy="strict")
+    hole = sheet.hole(diameter=0.2, at=point, axis="y", through=False, depth=1.5)
+    sheet.dimension(hole, "location")
+    sheet.view("rear")
+    with pytest.raises(ScaleIncompatibilityError, match="off_axis_location_dropped"):
+        sheet.build()
+    from draftwright import build_drawing
+    from draftwright._warnings import ScaleCompletenessWarning
+
+    with pytest.warns(ScaleCompletenessWarning):
+        drawing = build_drawing(
+            part,
+            model=sheet.model(),
+            _views=("rear",),
+            _include_iso=False,
+            page="A3",
+            scale=1,
+            scale_policy="permissive",
+        )
+    drops = [issue for issue in drawing.lint() if issue.code == "off_axis_location_dropped"]
+    assert len(drops) == 1 and "shorter than 1 mm" in drops[0].message
+    assert any(identity.parameter.endswith(f".{axis}") for identity in drops[0].measurement_ids)
+    assert not [issue for issue in drawing.lint() if issue.code == "hole_requirement_missing"]
+
+
+@pytest.mark.parametrize("axis,views", [("x", ("side",)), ("z", ("plan",))])
+def test_bbox_height_requires_a_selected_elevation_before_projection(axis, views, monkeypatch):
+    import draftwright.builder as builder
+    from draftwright import build_drawing
+    from draftwright.model import hole
+    from draftwright.view_plan import ViewPlanIncomplete
+
+    cutter = Cylinder(2, 100) if axis == "z" else Rot(0, 90, 0) * Cylinder(2, 100)
+    part = Box(80, 40, 50) - cutter
+    feature = hole(diameter=4, at=(0, 0, 0), axis=axis)
+
+    def forbidden_projection(*args, **kwargs):
+        raise AssertionError("unshowable height reached projection")
+
+    with monkeypatch.context() as guard:
+        guard.setattr(builder, "_assemble", forbidden_projection)
+        with pytest.raises(ViewPlanIncomplete, match="overall_height.length"):
+            build_drawing(part, model=[feature], _views=views, _include_iso=False)
+    drawing = build_drawing(
+        part, model=[feature], _views=views, _include_iso=False, auto_dims=False
+    )
+    drawing.overall_height()
+    assert "rear" not in drawing.views and "dim_height" not in drawing.annotations()
+    issues = [issue for issue in drawing.lint() if issue.code == "placement_unsatisfiable"]
+    assert len(issues) == 1 and "no planned front or rear" in issues[0].message
+    assert issues[0].measurement_ids
+
+
+@pytest.mark.parametrize("kind", ["grid", "bolt_circle"])
+@pytest.mark.parametrize("convention", ["first", "third"])
+def test_rear_grid_and_bolt_circle_keep_pattern_measurements(kind, convention):
+    from draftwright import Sheet
+    from draftwright.model import hole, pattern
+
+    grammar = (
+        dict(count=4, grid=(16, 24), rows=2, cols=2) if kind == "grid" else dict(count=3, bcd=24)
+    )
+    member = hole(diameter=4, at=(0, 20, 0), axis="y", through=False, depth=1.5)
+    layout = pattern(member, kind=kind, **grammar)
+    part = Box(80, 40, 50)
+    for x, _, z in layout.members:
+        part -= Pos(x, 19.5, z) * Rot(90, 0, 0) * Cylinder(2, 2)
+    visible, _ = part.project_to_viewport((0, 1000, 0), look_at=(0, 0, 0))
+    assert len([edge for edge in visible if edge.geom_type == GeomType.CIRCLE]) == layout.count
+    sheet = Sheet(part, page="A3", scale=1, scale_policy="strict", projection=convention)
+    handle = sheet.pattern(member, kind=kind, **grammar)
+    for parameter in layout.parameters():
+        sheet.dimension(handle, parameter.parameter_id, axis=parameter.discriminator)
+    sheet.view("rear")
+    drawing = sheet.build()
+    assert drawing.view_plan.principal_names == ("rear",)
+    marks = [
+        (name, annotation)
+        for name, annotation in drawing.iter_annotations()
+        if getattr(annotation, "label", "") and drawing.view_of(name) == "rear"
+    ]
+    callouts = [
+        annotation
+        for _, annotation in marks
+        if getattr(annotation, "covers_count", 0) == layout.count
+    ]
+    assert len(callouts) == 1 and "1.5" in callouts[0].label
+    if kind == "grid":
+        dimensions = [
+            annotation.measured_length
+            for _, annotation in marks
+            if hasattr(annotation, "measured_length")
+        ]
+        assert sorted(dimensions) == pytest.approx([16, 24])
+    else:
+        assert "24" in callouts[0].label
+        assert any(name.startswith("bc_rear") for name in drawing.annotations())
+    assert not [
+        issue
+        for issue in drawing.lint()
+        if issue.code.endswith("_dropped") or issue.code == "diameter_leader_target_mismatch"
+    ]

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -7977,10 +7977,14 @@ class TestFeatureEdits:
 
     def test_drop_feature_with_no_annotations_is_noop(self):
         dwg = build_drawing(_holed_plate())
-        # An envelope feature carries no centre marks (its dims aren't tagged yet).
-        env = next((f for f in dwg.model().features if f.kind == "envelope"), None)
-        if env is not None:
-            assert dwg.drop(env) == []
+        env = next(f for f in dwg.model().features if f.kind == "envelope")
+        owned = set(dwg.annotations_of(env))
+        assert owned, "the envelope must own its overall dimensions"
+        unrelated = set(dwg.annotations()) - owned
+        assert set(dwg.drop(env)) == owned
+        assert set(dwg.annotations()) == unrelated
+        assert dwg.annotations_of(env) == {}
+        assert dwg.drop(env) == []
 
     def test_manual_add_records_feature_provenance(self):
         from build123d_drafting import CenterMark

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -2247,7 +2247,7 @@ class TestComposeViewBlocks:
         )
 
         blocks = _compose_view_blocks(60.0, 40.0, 20.0, 2.0, None, n_steps=3)
-        assert set(blocks) == {"front", "plan", "side"}
+        assert set(blocks) == {"front", "plan", "side", "rear"}
         assert blocks["front"].hw == pytest.approx(60.0)
         assert blocks["front"].hh == pytest.approx(20.0)
         assert blocks["front"].right == pytest.approx(_est_right_strip_depth(3))


### PR DESCRIPTION
## Symptom and evidence

`Sheet.view("rear")` previously refused a principal needed to show rear-only features. Explicit rear views now use the shared view planner, projector and annotation solver. An asymmetric enclosure with two rear-only blind holes gets a physically handed rear projection, bore/depth callouts and both location axes. Rear is supported by `Sheet.view("rear")` and `auto_views().add_view("rear")`, including generated-script replay.

The native fixture proves the unequal blind bores are visible only from rear and leave material behind their bottoms. A combined strict canary adds a separate through hole with authored `DURCH` wording and above-line horizontal text. It preserves exactly 11 labels through Sheet, declared IR build and script replay, with real SVG/PDF/DXF exports. The rendered canary was visually inspected. Its undeclared enclosure shell remains honestly diagnosed.

Sixteen isolated-source mutations failed named tests, covering rear projection/camera signs, automatic rear selection, replay, complete ink, phantom dimensions, height/location reservations, deferred routing, explicit height choice, pattern pitch, discovery, edits, short-span diagnostics, preflight and envelope ownership.

## Contract and scope

The selected convention controls sheet relationships while physical view identity stays fixed. Rear participates in complete-footprint composition, fixed-scale checks, repacking and origin pins. Supported hole, pattern and envelope measurements, discovery and live/deferred edits retain feature and measurement identities. Unsupported or too-short dimensions produce attributed losses or an explicit preflight refusal.

Shared-path fixes found during review preserve envelope ownership during drop/edit, reserve height and future location ink, and prevent missing elevations or pattern renderers from inventing unrequested views. Automatic candidates remain front/plan/side, including under visibility and coverage pressure. Automatic rear selection remains deferred.

ADR 1: one view/plan/emit pipeline. ADR 2: explicit view selection, shared placement and complete footprints. ADR 3: existing native projection/recognition boundary. ADR 4: preserved authored views and measurement intent. ADR 5: independent target checks and attributed failures. No ADR text changes.

Closes #1518. Final delivery in #1508, following merged #1526.

## Validation

- Full local `scripts/pr-check --full`: **7,983 passed**, 5 skipped, 13 expected failures; static/docs checks clean, 96.00% total coverage and **229/230 changed lines covered (99.57%)**. This ran on `c7386fbf` before the rebase; the rebased production, docs and #1518 tests are byte-identical. The only incoming change is #1517's additional immediate-drop test case.
- Final-head validation: all four updated parent cases and both combined canaries pass (**6 passed**). Fifty rear-support cases are included in the full gate. The quick subset is covered by the full gate.
- All **16 mutations killed**; the short-location mutation was rerun after its test gained the side-view case. No production changes followed those results.
- Automatic no-rear behavior, declared builds, generated scripts and exports checked. Existing recognition/repeated-lint guards passed in the full suite.
- Independent iterative Google review against all five ADRs: **LGTM `d3f81969bb27013ada0e890db0add757799039e5`**, no blocking findings. Reviewer verified the rebase preserved the reviewed implementation exactly.
- Required current-head CI remains the merge gate.

## Stop check

Review findings were fixed in the shared planning, placement and diagnostic paths; no replacement association strategy or new prerequisite is introduced. The rendering/wording prerequisite was delivered separately in #1526.

## Contributor License Agreement

Maintainer-owned change in the project owner's repository.
