### PR TITLE
Fix section hatching provenance and viewing indicators

### DIFF
--- a/src/draftwright/annotations/leaders.py
+++ b/src/draftwright/annotations/leaders.py
@@ -1974,12 +1974,22 @@ def place_feature_leader_jobs(dwg, analysis, ctx, jobs, *, producer_floor=False)
                 names.add(jobs[earlier_job].name)
         return tuple(sorted(names))
 
-    # A complete incumbent already preserves every producer's possible semantic
-    # floor: no alternative can place more than every job. Keep that feasible
-    # result when the search cannot prove the best penalty/cost, and retain the
-    # normal geometry validation below. An incomplete incumbent has no such
-    # guarantee and must still replay the canonical producer floor.
-    if not assignment.optimal and any(choice is None for choice in assignment.choices):
+    # Override the established producer layout only for a proven cardinality
+    # improvement. A complete incumbent beats any floor with an empty job stream;
+    # otherwise the floor may place every job too, with different downstream
+    # section/table opportunities. Peek at most one raw candidate per job and
+    # restore each nonempty stream for the ordinary fallback/validation paths.
+    retain_complete_incumbent = False
+    if not assignment.optimal and all(choice is not None for choice in assignment.choices):
+        empty = object()
+        for job_index, fallback in enumerate(fallback_jobs):
+            first = next(fallback, empty)
+            if first is empty:
+                retain_complete_incumbent = True
+                break
+            fallback_jobs[job_index] = chain((first,), fallback)
+
+    if not assignment.optimal and not retain_complete_incumbent:
         # The layout solver's bounded-search incumbent is seeded from the new
         # exact-ink candidate order, not from every producer's canonical
         # pre-#1166 lazy fallback.  Replaying that producer floor is the only

--- a/src/draftwright/annotations/leaders.py
+++ b/src/draftwright/annotations/leaders.py
@@ -1974,7 +1974,12 @@ def place_feature_leader_jobs(dwg, analysis, ctx, jobs, *, producer_floor=False)
                 names.add(jobs[earlier_job].name)
         return tuple(sorted(names))
 
-    if not assignment.optimal:
+    # A complete incumbent already preserves every producer's possible semantic
+    # floor: no alternative can place more than every job. Keep that feasible
+    # result when the search cannot prove the best penalty/cost, and retain the
+    # normal geometry validation below. An incomplete incumbent has no such
+    # guarantee and must still replay the canonical producer floor.
+    if not assignment.optimal and any(choice is None for choice in assignment.choices):
         # The layout solver's bounded-search incumbent is seeded from the new
         # exact-ink candidate order, not from every producer's canonical
         # pre-#1166 lazy fallback.  Replaying that producer floor is the only
@@ -2019,7 +2024,11 @@ def place_feature_leader_jobs(dwg, analysis, ctx, jobs, *, producer_floor=False)
     # penalty as the major component so the refinement cannot trade a real
     # dimension/witness crossing for future optional furniture.  If either the
     # probe or exact-search budget is exhausted, retain the primary result.
-    provisional = bounded_fixed_obstacles(provisional=True)
+    provisional = (
+        bounded_fixed_obstacles(provisional=True)
+        if assignment.optimal
+        else {view: () for view in views}
+    )
     provisional_inventory_exhausted = provisional is _FIXED_INVENTORY_EXHAUSTED
     provisional_probes_by_view: dict[str, int] = {}
     if not provisional_inventory_exhausted:
@@ -2032,7 +2041,7 @@ def place_feature_leader_jobs(dwg, analysis, ctx, jobs, *, producer_floor=False)
         if provisional_inventory_exhausted
         else sum(provisional_probes_by_view.values())
     )
-    provisional_refinement = "not_needed"
+    provisional_refinement = "not_needed" if assignment.optimal else "primary_state_budget"
     provisional_blockers_by_job: list[list[tuple[str, ...]]] = [
         [() for _candidate in candidates] for candidates in viable_by_job
     ]
@@ -2245,8 +2254,8 @@ def place_feature_leader_jobs(dwg, analysis, ctx, jobs, *, producer_floor=False)
         else 0
     )
     set_assignment(
-        "joint",
-        optimal=True,
+        "joint" if assignment.optimal else "joint_state_budget",
+        optimal=assignment.optimal,
         states=assignment_states,
         fixed_probes=total_fixed_probes,
         fixed_probe_bound=total_fixed_probes,

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -481,7 +481,10 @@ def _add_cutting_plane_arrows(dwg, y_page, x0, x1, *, section, ctx):
     _label, _view, prefix = _section_identity(section)
     wing_h = 2.5 * arrow_sz  # perpendicular stub length
     for x_end, side in ((x0, "left"), (x1, "right")):
-        tip_y = y_page + wing_h
+        # Put the tip on the cut line and the stem on the removed side. The
+        # vector points into retained +Y without occupying a new leader lane.
+        tip_y = y_page
+        tail_y = y_page - wing_h
         arrow = Pos(x_end, tip_y) * ArrowHead(
             arrow_sz,
             head_type=HeadType.STRAIGHT,
@@ -489,15 +492,15 @@ def _add_cutting_plane_arrows(dwg, y_page, x0, x1, *, section, ctx):
         )
         arrow.fixed_ink_polygons = _leader_ink_polygons(
             (x_end, tip_y),
-            (x_end, y_page),
+            (x_end, tail_y),
             arrow_length=arrow_sz,
             line_width=0.0,
         )[-1:]
         ctx.place(arrow, f"{prefix}_arrow_{side}")
         shaft_end_y = tip_y - arrow_sz
-        wing_segment = ((x_end, y_page), (x_end, shaft_end_y))
+        wing_segment = ((x_end, tail_y), (x_end, shaft_end_y))
         wing = Compound(
-            children=[Edge.make_line(Vector(x_end, y_page, 0), Vector(x_end, shaft_end_y, 0))]
+            children=[Edge.make_line(Vector(x_end, tail_y, 0), Vector(x_end, shaft_end_y, 0))]
         )
         wing.fixed_ink_polygons = (_stroke_polygon(*wing_segment, dwg.draft.line_width),)
         ctx.place(

--- a/src/draftwright/annotations/sections.py
+++ b/src/draftwright/annotations/sections.py
@@ -11,9 +11,11 @@ import math
 
 from build123d import (
     ArrowHead,
+    Axis,
     Box,
     Compound,
     Edge,
+    Face,
     GeomType,
     HeadType,
     Pos,
@@ -203,6 +205,12 @@ def _fuzzy_cut(body, cutter, fuzzy: float = 1e-3):
     keep only the solids, so non-solid boolean artefacts can't crash the
     downstream hidden-line projection.
     """
+    result = _cut_with_history(body, cutter, fuzzy)
+    return None if result is None else result[0]
+
+
+def _cut_with_history(body, cutter, fuzzy: float = 1e-3):
+    """Keep the boolean's history beside its solid-only result until lowering."""
     args = TopTools_ListOfShape()
     args.Append(body.wrapped)
     tools = TopTools_ListOfShape()
@@ -211,13 +219,43 @@ def _fuzzy_cut(body, cutter, fuzzy: float = 1e-3):
     op.SetArguments(args)
     op.SetTools(tools)
     op.SetFuzzyValue(fuzzy)
+    op.SetToFillHistory(True)
     op.Build()
     if not op.IsDone():
         return None
     solids = Compound(op.Shape()).solids()
     if not solids:
         return None
-    return solids[0] if len(solids) == 1 else Compound(children=list(solids))
+    shape = solids[0] if len(solids) == 1 else Compound(children=list(solids))
+    return shape, op
+
+
+def _cut_section(body, cutter):
+    """Lower the positive-Y section and its actual cut faces from one boolean.
+
+    The large box removes the negative-Y half. Its upper face is the section
+    plane; the boolean's modified descendants of that face are the hatch regions.
+    Retained original faces behind the plane have no such provenance. History
+    stays local to this operation and does not enter the drawing or feature IR.
+    """
+    result = _cut_with_history(body, cutter)
+    if result is None:
+        return None
+    shape, op = result
+    cutting_face = cutter.faces().sort_by(Axis.Y)[-1]
+    # A coplanar original surface can also be a descendant of the tool face:
+    # it touched the cutter but was already exposed before cutting. Exclude
+    # those original boundaries and their splits by topology identity.
+    original_boundaries = []
+    for face in body.faces():
+        original_boundaries.append(face.wrapped)
+        original_boundaries.extend(op.Modified(face.wrapped))
+    faces = tuple(
+        Face(face)
+        for face in op.Modified(cutting_face.wrapped)
+        if not any(face.IsSame(boundary) for boundary in original_boundaries)
+    )
+    return shape, faces
 
 
 def _add_section_view(dwg, a: Analysis, section, *, ctx):
@@ -322,12 +360,18 @@ def _add_section_view(dwg, a: Analysis, section, *, ctx):
     try:
         # Fuzzy boolean: the exact `body - Box(...)` aborts uncatchably
         # (Standard_DomainError) on some cast geometry — see _fuzzy_cut / #20.
-        keep_behind = _fuzzy_cut(body, Pos(a.cx, y_star - big / 2, a.cz) * Box(big, big, big))
+        cut = _cut_section(body, Pos(a.cx, y_star - big / 2, a.cz) * Box(big, big, big))
     except Exception as exc:  # noqa: BLE001 — OCC booleans raise broadly
         _skip_section(dwg, ctx, "cut_failed", f"cut failed: {exc}", section=section)
         return
-    if keep_behind is None:
+    if cut is None:
         _skip_section(dwg, ctx, "cut_empty", "boolean cut produced no solid", section=section)
+        return
+    keep_behind, cut_faces = cut
+    if not cut_faces:
+        _skip_section(
+            dwg, ctx, "cut_no_intersection", "cut plane creates no section faces", section=section
+        )
         return
     # Resolve the final cutting-plane ink before committing the section view.
     # Optional section furniture yields if a required landed feature leader
@@ -409,7 +453,6 @@ def _add_section_view(dwg, a: Analysis, section, *, ctx):
     SZ = a.proj.front_z
 
     hatch_spacing = dwg.draft.font_size * 1.5
-    cut_faces = [f for f in keep_behind.faces() if f.normal_at().Y < -0.9]
     hatch_edges = []
     for cf in cut_faces:
         hatch_edges.extend(_section_hatch_edges(cf, SX, SZ, hatch_spacing))
@@ -431,18 +474,18 @@ def _place_cutting_plane(dwg, y_page, x0, x1, *, section, ctx):
 def _add_cutting_plane_arrows(dwg, y_page, x0, x1, *, section, ctx):
     """ISO 128-44 cutting-plane end indicators at ``(x0, y_page)``/``(x1, y_page)`` —
     thick wing stubs with solid filled arrowheads pointing in the viewing direction
-    (−Y). Named ``section_arrow_{left,right}``/``section_wing_{left,right}``, shared
+    (+Y in the plan projection). Named ``section_arrow_{left,right}``/``section_wing_{left,right}``, shared
     between the early row reservation (:func:`_reserve_section_row`) and the final
     section render (:func:`_add_section_view`, ADR 2 (was 0009) P5 strand 3)."""
     arrow_sz = dwg.draft.arrow_length
     _label, _view, prefix = _section_identity(section)
     wing_h = 2.5 * arrow_sz  # perpendicular stub length
     for x_end, side in ((x0, "left"), (x1, "right")):
-        tip_y = y_page - wing_h
+        tip_y = y_page + wing_h
         arrow = Pos(x_end, tip_y) * ArrowHead(
             arrow_sz,
             head_type=HeadType.STRAIGHT,
-            rotation=-90,
+            rotation=90,
         )
         arrow.fixed_ink_polygons = _leader_ink_polygons(
             (x_end, tip_y),
@@ -451,7 +494,7 @@ def _add_cutting_plane_arrows(dwg, y_page, x0, x1, *, section, ctx):
             line_width=0.0,
         )[-1:]
         ctx.place(arrow, f"{prefix}_arrow_{side}")
-        shaft_end_y = tip_y + arrow_sz
+        shaft_end_y = tip_y - arrow_sz
         wing_segment = ((x_end, y_page), (x_end, shaft_end_y))
         wing = Compound(
             children=[Edge.make_line(Vector(x_end, y_page, 0), Vector(x_end, shaft_end_y, 0))]

--- a/tests/test_issue_1166_cross_pass_feature_leaders.py
+++ b/tests/test_issue_1166_cross_pass_feature_leaders.py
@@ -2070,13 +2070,28 @@ def test_resource_fallback_never_bypasses_hard_boundaries(monkeypatch, tmp_path,
     assert set(rejected[0]["blockers"]) == {target, "fixed_probe_budget"}
 
 
-def test_candidate_budget_preserves_the_exact_pre_joint_hole_floor(monkeypatch):
+def test_candidate_budget_preserves_the_exact_pre_joint_hole_floor(monkeypatch, tmp_path):
     part = _overfull_distinct_hole_strip_part()
+    trace_path = tmp_path / "complete-state-budget.json"
 
     with pytest.warns(ScaleCompletenessWarning):
-        joint = build_drawing(part, page="A4", scale=1, scale_policy="permissive")
+        joint = build_drawing(
+            part, page="A4", scale=1, scale_policy="permissive", trace=trace_path
+        )
     assert len([name for name in joint.annotations() if name.startswith("hc_plan")]) == 12
     assert not [issue for issue in joint.registry.issues if issue.code == "callout_dropped"]
+    event = next(
+        item
+        for item in json.loads(trace_path.read_text())["pass_events"]
+        if item["label"] == "feature_leader_inventory"
+    )
+    # Correct section indicators expose more routes and exhaust the optimality
+    # proof budget. All twelve jobs already fit: discarding that feasible
+    # incumbent for the six-job producer floor would lose real measurements.
+    assert event["assignment"] == "joint_state_budget"
+    assert event["optimal"] is False
+    assert event["objective"]["placed"] == event["inventory_jobs"] == 12
+    assert event["provisional_refinement"] == "primary_state_budget"
 
     monkeypatch.setattr(
         "draftwright.annotations.leaders._FEATURE_LEADER_MAX_MEASURE_WORK",

--- a/tests/test_issue_1190_section_decision.py
+++ b/tests/test_issue_1190_section_decision.py
@@ -114,7 +114,7 @@ class TestTheReasonCodeIsTheRealReason:
         )
 
     def test_a_failed_cut_is_reported_as_a_failed_cut(self, monkeypatch):
-        monkeypatch.setattr(sections_module, "_fuzzy_cut", lambda *_a, **_k: None)
+        monkeypatch.setattr(sections_module, "_cut_with_history", lambda *_a, **_k: None)
         dwg = build_drawing(_counterbored_block(), page="A3")
         assert dwg.section_decision["reason"] == "cut_empty"
 
@@ -124,7 +124,7 @@ class TestTheReasonCodeIsTheRealReason:
         def explode(*_args, **_kwargs):
             raise RuntimeError("Standard_DomainError")
 
-        monkeypatch.setattr(sections_module, "_fuzzy_cut", explode)
+        monkeypatch.setattr(sections_module, "_cut_with_history", explode)
         dwg = build_drawing(_counterbored_block(), page="A3")
         assert dwg.section_decision["reason"] == "cut_failed"
         assert "Standard_DomainError" in dwg.section_decision["detail"]
@@ -209,7 +209,7 @@ class TestASkippedSectionIsNeverAScaleBlocker:
         ("reason", "attribute", "replacement"),
         [
             ("no_room", "carve_free_segments", lambda *_a, **_k: []),
-            ("cut_empty", "_fuzzy_cut", lambda *_a, **_k: None),
+            ("cut_empty", "_cut_with_history", lambda *_a, **_k: None),
         ],
     )
     def test_no_skip_reason_is_a_placement_drop(self, monkeypatch, reason, attribute, replacement):

--- a/tests/test_issue_1530_section_provenance.py
+++ b/tests/test_issue_1530_section_provenance.py
@@ -1,0 +1,127 @@
+"""Section ink describes the actual cut, not parallel retained surfaces (#1530)."""
+
+import pytest
+from build123d import Box, Compound, Cylinder, Plane, Pos, Rot, section
+
+from draftwright import Drawing, Sheet
+from draftwright.annotations.sections import _section_hatch_edges
+
+
+def _part():
+    # The rear support faces toward the camera but is not cut at Y=0. The
+    # detached bar gives a second cut region; the transverse bore gives a void.
+    base = Box(20, 16, 8) - Pos(-5, 0, 0) * Rot(90, 0, 0) * Cylinder(2, 16)
+    supported = base + Pos(5, 5, 7) * Box(4, 4, 6)
+    return Compound(children=[supported, Pos(18, 0, 0) * Box(4, 16, 4)])
+
+
+def _sheet(part, projection, cut_y):
+    sheet = Sheet(part, page="A2", scale=2, projection=projection)
+    sheet.authored_dimensions().authored_views()
+    envelope = sheet.envelope(part)
+    for parameter in envelope.dimension_ids():
+        sheet.dimension(envelope, parameter)
+    for name in ("front", "plan", "side"):
+        sheet.view(name)
+    sheet.section_view("A", at=cut_y)
+    return sheet
+
+
+@pytest.mark.parametrize("projection", ["first", "third"])
+@pytest.mark.parametrize("translation", [(0, 0, 0), (12, 37, 9)])
+def test_section_regions_camera_and_indicators_agree(monkeypatch, projection, translation):
+    part = Compound(children=[Pos(*translation) * solid for solid in _part().solids()])
+    cut_y = translation[1]
+    plane = Plane(origin=(0, cut_y, 0), x_dir=(1, 0, 0), z_dir=(0, -1, 0))
+    expected = section(part, section_by=plane)
+    captured_faces = []
+    captured_views = []
+    add_view = Drawing._add_view
+
+    def capture_hatch(face, sx, sz, spacing):
+        captured_faces.append(face)
+        return _section_hatch_edges(face, sx, sz, spacing)
+
+    def capture_view(drawing, name, shape, camera, up, position, **kwargs):
+        if name == "section_aa":
+            captured_views.append((shape, camera, drawing.look_at))
+        return add_view(drawing, name, shape, camera, up, position, **kwargs)
+
+    monkeypatch.setattr("draftwright.annotations.sections._section_hatch_edges", capture_hatch)
+    monkeypatch.setattr(Drawing, "_add_view", capture_view)
+    drawing = _sheet(part, projection, cut_y).build()
+
+    assert drawing.section_decision["status"] == "placed"
+    assert len(expected.faces()) == 2 and any(f.inner_wires() for f in expected.faces())
+    assert len(captured_faces) == 2
+    hatched = Compound(children=captured_faces)
+    # Both spatial differences must be empty. Equal areas alone could hide a
+    # missing region replaced by a wrongly hatched region of the same size.
+    assert (hatched - expected).area == pytest.approx(0, abs=1e-7)
+    assert (expected - hatched).area == pytest.approx(0, abs=1e-7)
+    retained, camera, target = captured_views[-1]
+    assert retained.bounding_box().min.Y == pytest.approx(cut_y)
+    assert retained.bounding_box().max.Z == pytest.approx(translation[2] + 10)
+    assert camera[0] == target[0] and camera[2] == target[2]
+    assert camera[1] < target[1]  # viewing toward +Y, into the retained half
+    line_y = drawing.get_annotation("section_line").bounding_box().center().Y
+    for side in ("left", "right"):
+        arrow = drawing.get_annotation(f"section_arrow_{side}")
+        wing = drawing.get_annotation(f"section_wing_{side}")
+        assert wing.bounding_box().min.Y == pytest.approx(line_y)
+        assert arrow.bounding_box().min.Y > line_y
+        # The arrow's unique leading vertex points in projected +Y too.
+        vertices = [(v.X, v.Y) for v in arrow.vertices()]
+        tip_y = max(y for _, y in vertices)
+        assert sum(abs(y - tip_y) < 1e-7 for _, y in vertices) == 1
+        assert wing.bounding_box().max.Y == pytest.approx(arrow.bounding_box().min.Y)
+    assert "section_hatch" in drawing.annotations()
+    assert not any(i.code == "section_dropped" for i in drawing.lint())
+
+
+@pytest.mark.parametrize("cut_y", [-9, -8, 8, 9])
+def test_a_cut_outside_the_open_extent_is_refused(cut_y):
+    with pytest.raises(ValueError, match="not strictly inside"):
+        _sheet(Box(20, 16, 8), "third", cut_y).build()
+
+
+@pytest.mark.parametrize("cut_y", [-4, 0, 4])
+def test_an_internal_gap_or_tangent_cut_has_an_honest_outcome(cut_y):
+    part = Compound(children=[Pos(0, y, 0) * Box(20, 4, 8) for y in (-6, 6)])
+    drawing = _sheet(part, "third", cut_y).build()
+    assert drawing.section_decision["status"] == "skipped"
+    assert drawing.section_decision["reason"] == "cut_no_intersection"
+    assert "section_aa" not in drawing.views
+    assert not any(name.startswith("section_") for name in drawing.annotations())
+    assert any(i.code == "section_dropped" for i in drawing.lint())
+
+
+@pytest.mark.parametrize("case", ["attached", "detached", "adjacent", "notch"])
+def test_preexisting_coplanar_boundaries_are_not_new_cut_faces(monkeypatch, case):
+    base = Box(20, 16, 8)
+    boss = Pos(5, 4, 7) * Box(4, 8, 6)
+    if case == "attached":
+        part = base + boss
+    elif case == "detached":
+        part = Compound(children=[base, Pos(30, 0, 0) * boss])
+    elif case == "adjacent":
+        part = base + Pos(10, 4, 0) * Box(4, 8, 8)
+    else:
+        part = base - Pos(5, -4, 2) * Box(10, 8, 4)
+        # The pocket back wall was already exposed. The independent expected
+        # cut uses a through notch so that wall cannot enter its plane section.
+        base = base - Pos(5, 0, 2) * Box(10, 16, 4)
+    expected = section(base, section_by=Plane.XZ)
+    faces = []
+
+    def capture(face, *args):
+        faces.append(face)
+        return _section_hatch_edges(face, *args)
+
+    monkeypatch.setattr("draftwright.annotations.sections._section_hatch_edges", capture)
+    drawing = _sheet(part, "third", 0).build()
+    assert drawing.section_decision["status"] == "placed"
+    assert faces
+    actual = Compound(children=faces)
+    assert (actual - expected).area == pytest.approx(0, abs=1e-7)
+    assert (expected - actual).area == pytest.approx(0, abs=1e-7)

--- a/tests/test_issue_1530_section_provenance.py
+++ b/tests/test_issue_1530_section_provenance.py
@@ -3,8 +3,9 @@
 import pytest
 from build123d import Box, Compound, Cylinder, Plane, Pos, Rot, section
 
-from draftwright import Drawing, Sheet
+from draftwright import Sheet
 from draftwright.annotations.sections import _section_hatch_edges
+from draftwright.projection import project_view_geometry
 
 
 def _part():
@@ -36,19 +37,18 @@ def test_section_regions_camera_and_indicators_agree(monkeypatch, projection, tr
     expected = section(part, section_by=plane)
     captured_faces = []
     captured_views = []
-    add_view = Drawing._add_view
 
     def capture_hatch(face, sx, sz, spacing):
         captured_faces.append(face)
         return _section_hatch_edges(face, sx, sz, spacing)
 
-    def capture_view(drawing, name, shape, camera, up, position, **kwargs):
+    def capture_view(scale, name, shape, camera, up, position, **kwargs):
         if name == "section_aa":
-            captured_views.append((shape, camera, drawing.look_at))
-        return add_view(drawing, name, shape, camera, up, position, **kwargs)
+            captured_views.append((shape, camera, kwargs["look_at"]))
+        return project_view_geometry(scale, name, shape, camera, up, position, **kwargs)
 
     monkeypatch.setattr("draftwright.annotations.sections._section_hatch_edges", capture_hatch)
-    monkeypatch.setattr(Drawing, "_add_view", capture_view)
+    monkeypatch.setattr("draftwright.drawing.project_view_geometry", capture_view)
     drawing = _sheet(part, projection, cut_y).build()
 
     assert drawing.section_decision["status"] == "placed"
@@ -68,8 +68,8 @@ def test_section_regions_camera_and_indicators_agree(monkeypatch, projection, tr
     for side in ("left", "right"):
         arrow = drawing.get_annotation(f"section_arrow_{side}")
         wing = drawing.get_annotation(f"section_wing_{side}")
-        assert wing.bounding_box().min.Y == pytest.approx(line_y)
-        assert arrow.bounding_box().min.Y > line_y
+        assert wing.bounding_box().max.Y < line_y
+        assert arrow.bounding_box().max.Y == pytest.approx(line_y)
         # The arrow's unique leading vertex points in projected +Y too.
         vertices = [(v.X, v.Y) for v in arrow.vertices()]
         tip_y = max(y for _, y in vertices)

--- a/tests/test_issue_885_prismatic_coverage.py
+++ b/tests/test_issue_885_prismatic_coverage.py
@@ -1,5 +1,7 @@
 """Regression coverage for #885: sparse recognition must not imply completeness."""
 
+import json
+
 from build123d import Align, Box, Cylinder, Plane, Pos, SlotOverall, extrude
 from quiddity import recognise_rectangular_pads
 
@@ -84,8 +86,9 @@ def test_pad_declaration_and_sheet_emission_round_trip_surface():
     ]
 
 
-def test_auto_drawing_defines_pad_footprints_and_pocket_locations():
-    drawing = build_drawing(_case_study())
+def test_auto_drawing_defines_pad_footprints_and_pocket_locations(tmp_path):
+    trace_path = tmp_path / "pad-producer-floor.json"
+    drawing = build_drawing(_case_study(), trace=trace_path)
     detected = detect_part_model(_case_study())
     assert tuple(detected.features) == tuple(drawing.model().features)
     assert [f.kind for f in drawing.model().features].count("pad") == 4
@@ -96,6 +99,21 @@ def test_auto_drawing_defines_pad_footprints_and_pocket_locations():
     assert "pad_footprint_not_defined" not in summary["by_code"]
     assert "pocket_not_located" not in summary["by_code"]
     assert summary["score"] == 1.0
+    # Every producer can place a leader here. An unproven alternate assignment
+    # offers no cardinality gain and loses the section; retain the known floor.
+    assert drawing.section_decision["status"] == "placed"
+    event = next(
+        item
+        for item in json.loads(trace_path.read_text())["pass_events"]
+        if item["label"] == "feature_leader_inventory"
+    )
+    assert event["assignment"] == "greedy_state_budget"
+    assert event["objective"]["placed"] == event["inventory_jobs"] == 7
+    assert all(
+        item["producer_fallback"]["candidates_tried"] > 0
+        and item["producer_fallback"]["selected"] is not None
+        for item in event["items"]
+    )
 
 
 def test_removing_one_pad_size_is_not_credited_from_an_aligned_sibling():

--- a/tests/test_layout_cleanliness.py
+++ b/tests/test_layout_cleanliness.py
@@ -74,10 +74,6 @@ _KNOWN_OVERLAPS: dict[str, set[frozenset[str]]] = {
     # DATUM WITNESS (both anchor y=81, the common base edge) — the same BENIGN
     # running-dimension corridor as plate_holes/holed_slot above.
     "bracket": {
-        # The structural oracle compares full annotation AABBs here.  The
-        # diagonal shaft and straight section head are polygon-disjoint; the
-        # final exact-ink preflight is the authoritative #1166 check.
-        frozenset({"hc_plan0", "section_arrow_left"}),
         frozenset({"m_locx0", "m_locx1"}),
         frozenset({"m_locy0", "m_locy1"}),
     },

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4902,10 +4902,10 @@ class TestLocationDimsAndSection:
             assert len(wing.edges()) == 1
             # arrow is a filled solid (Arrow produces faces, not open barbs)
             assert len(list(arrow.faces())) >= 1
-        # wings are below the section line (tip_y < line y)
+        # Wings point toward retained +Y material, above the plan cutting line.
         sl_y = plate_drawing.get_annotation("section_line").bounding_box().min.Y
-        wl_y = plate_drawing.get_annotation("section_wing_left").bounding_box().min.Y
-        assert wl_y < sl_y
+        wl_y = plate_drawing.get_annotation("section_wing_left").bounding_box().max.Y
+        assert wl_y > sl_y
 
     @pytest.mark.timeout(120)
     def test_section_hatch_present_and_45_degrees(self, plate_drawing):

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -4902,10 +4902,10 @@ class TestLocationDimsAndSection:
             assert len(wing.edges()) == 1
             # arrow is a filled solid (Arrow produces faces, not open barbs)
             assert len(list(arrow.faces())) >= 1
-        # Wings point toward retained +Y material, above the plan cutting line.
+        # Stems sit below the cutting line; the arrow tips point toward retained +Y.
         sl_y = plate_drawing.get_annotation("section_line").bounding_box().min.Y
-        wl_y = plate_drawing.get_annotation("section_wing_left").bounding_box().max.Y
-        assert wl_y > sl_y
+        wl_y = plate_drawing.get_annotation("section_wing_left").bounding_box().min.Y
+        assert wl_y < sl_y
 
     @pytest.mark.timeout(120)
     def test_section_hatch_present_and_45_degrees(self, plate_drawing):


### PR DESCRIPTION
A section could hatch retained support faces that the cutting plane never crossed, and its indicators pointed opposite the rendered viewing direction. Section lowering now uses the boolean's cutting-plane face history, excluding pre-existing body boundaries and their splits, so only newly exposed material is hatched. The shared reservation/final indicators point toward the retained positive-Y half, with tips on the cutting line and stems below it to preserve existing section layout.

The corrected furniture exposed a bounded-solver defect on the existing crowded 12-hole fixture: search had found a feasible placement for all 12 jobs but discarded it at the optimality-proof budget and drew only six. A complete, geometrically validated incumbent now survives that budget with `optimal=False` only when an empty canonical fallback stream proves a strict cardinality gain. Otherwise the established fallback is preserved, including its downstream section opportunity; incomplete incumbents and earlier resource caps also retain that fallback. No budget is increased and no candidate is removed.

Fixes #1530. Part of #1529.

## Evidence and validation

- The pinned whistle frame at `pzfreo/whistle-key@76ccdc2` rebuilds in first- and third-angle layouts: three cut faces, area 101.67622552457176 mm² versus independent section area 101.67622552458516 mm², and zero extra/missing region area. SVG/PDF exports were visually inspected; no consumer correction patch is used.
- Public Sheet regressions cover disconnected regions, a bore void, translated geometry, both conventions, existing coplanar supports, an adjacent cap, a pocket back wall, and honest non-intersecting/tangent outcomes.
- Mutations restoring normal-only selection, accepting existing coplanar boundaries, and reversing indicators each fail their named geometric regression.
- 36 focused section, crowded-hole and layout regression tests pass. The 12-hole test verifies the retained complete assignment, honest non-optimal trace and unchanged six-hole producer floor when the earlier candidate budget is forced.
- The pad/pocket regression verifies that a seven-leader fallback preserves its section when the alternate complete incumbent cannot prove a cardinality gain. The explicit slow incomplete-incumbent fallback regression passes.
- `scripts/pr-check --full` passes at `f56f77f66b551114ea1aaebb5ed83da428d71050`: 7,999 passed, 5 skipped, 13 xfailed; 96.02% total coverage and 100% changed-line coverage (40/40 lines). Static checks, typing, spelling and strict documentation build pass.
- Independent Google-style review against all five ADRs is clean at that exact commit. Mutations that discard the proven improvement or accept an unproven equal-cardinality replacement fail the 12-hole and pad/section regressions respectively.
- Required remote CI remains the final merge gate.

## Architectural fit

ADR 1: one shared section lowering; boolean history stays local and does not enter Drawing state or the IR. ADR 2: provisional reservation and final furniture use the same indicator geometry; placement remains shared. Keeping a validated complete incumbent requires proof that the producer floor must place fewer jobs; optimality of the incumbent’s penalty/cost is explicitly unproven. ADR 3: no recognition pass or provider dependency changes. ADR 4: existing authored/automatic section intents feed the same renderer; no new DSL or coordinate surface. ADR 5: absent cut faces yield an explicit section outcome, and regression oracles compare actual regions rather than trusting face normals or equal areas. No ADR text/boundary change.

The existing fuzzy-cut behavior used by detail cropping is preserved through a shared boolean helper. The [OCCT cut-history API](https://dev.opencascade.org/doc/occt-7.6.0/refman/html/class_b_rep_algo_a_p_i___cut.html) provides the face descendants; both tool and original-body provenance are needed for coplanar surfaces.
