### PR TITLE
Preserve drilling operation identity in hole-count diagnostics and fixes

### DIFF
--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -148,15 +148,22 @@ because it is what let a single call silently declare two dimensions.
 the **escape hatch of last resort** (ADR 0012) and is deprecated: it bypasses the
 layout solve, so nothing re-flows around it.
 
-**Add a diameter callout on a hole the auto-pass missed** — find the bore in the
-model IR and hand it to `callout()`. This is what the `feature_not_dimensioned`
-lint suggestion hands you (it emits `dwg.callout(f)` — say *what*, not *where*):
+**Add a callout on a hole the auto-pass missed** — inspect its semantic requirement
+finding first. Equal diameters can belong to different axes, blind depths, threads
+or fits; a diameter-total warning never authorises increasing a callout count.
 
 ```python
-for f in dwg.model().features:
-    if f.kind == "hole" and abs(f.diameter - 4.0) < 0.2:
-        dwg.callout(f)                   # engine picks the view, leader and elbow
+for issue in dwg.lint():
+    if issue.code.startswith("hole_requirement_"):
+        print(issue.message)
+        if issue.suggestion:
+            print(issue.suggestion)
 ```
+
+For a verified missing bore on an automatic model, the suggestion targets the exact
+feature with `dwg.callout(...)` through the shared solve. It applies to that Drawing;
+re-run lint after rebuilding. Authored omissions, unverified ownership and conflicting
+counts require inspection of the declared operation rather than an automatic count edit.
 
 **Free text** at a chosen point is `note()` — a domain verb, not an escape hatch:
 

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -4004,6 +4004,8 @@ class Drawing:
                 # where detect also falls back to the aggregate.
                 **({"turned_profiles": prof_kw["profiles"]} if "profiles" in prof_kw else {}),
                 registry=self._registry,
+                # Counts belong to lint_hole_coverage's operation/ownership ledger.
+                check_hole_counts=False,
             )
             issues += lint_axial_coverage(
                 working_part,

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -284,6 +284,7 @@ def lint_feature_coverage(
     recognition_evidence=None,
     turned_profiles=_UNSET,
     registry=None,
+    check_hole_counts: bool = True,
 ) -> list:
     """Coarse completeness check: report part diameters with no callout (#80).
 
@@ -333,6 +334,10 @@ def lint_feature_coverage(
     A placed feature-linked note may instead carry explicit ``DimensionId``
     satisfaction provenance. Only canonical diameter parameters on that exact
     feature contribute; the note's prose is never parsed for this purpose (#1351).
+
+    ``check_hole_counts=False`` leaves count reconciliation to the semantic hole
+    ledger, as used by Drawing.lint. The default diameter-total check is only a
+    coarse fallback for standalone callers; it cannot identify drilling operations.
     """
     z_cyls, cross_cyls = cyls if cyls is not None else analyse_cylinders(part)
     if holes is None:
@@ -456,6 +461,9 @@ def lint_feature_coverage(
         if not any(abs(d - v) <= tol for v in mentioned)
         and not any(abs(d - e) <= tol for e in exclude)
     ]
+
+    if not check_hole_counts:
+        return issues
 
     required: dict[float, int] = {}
     for h in holes:

--- a/src/draftwright/linting/hole_coverage.py
+++ b/src/draftwright/linting/hole_coverage.py
@@ -12,9 +12,9 @@ from dataclasses import dataclass, field
 from math import hypot
 from typing import Literal
 
-from quiddity import HoleSpec, RecognitionResult, countersink_matches_hole
+from quiddity import HoleRecord, HoleSpec, RecognitionResult, countersink_matches_hole
 
-from draftwright._core import _decode_hole_location_fact
+from draftwright._core import _decode_hole_location_fact, _fmt
 from draftwright._geometry import _END_ON, _is_principal_axis, _projected_edge_distance
 from draftwright.linting._registry import satisfaction_ids
 from draftwright.linting.issues import (
@@ -1297,12 +1297,23 @@ def lint_hole_coverage(
         if outcome.state in {"placed", "satisfied_by_structured_note", "dropped"}:
             continue
         noun = "hole" if outcome.source_kind == "hole" else f"{outcome.member_count}-hole pattern"
+        if outcome.source_records and isinstance(outcome.source_records[0], HoleRecord):
+            spec = HoleSpec.from_hole(outcome.source_records[0])
+            depth = "unavailable" if spec.depth is None else _fmt(spec.depth)
+            operation = "THRU" if spec.bottom == "through" else f"blind depth {depth}"
+            noun = (
+                f"{outcome.member_count}× ø{_fmt(spec.diameter)} {operation} "
+                f"holes, axis {spec.axis}"
+            )
         issues.append(
             LintIssue(
                 severity=severity,
                 code=f"hole_requirement_{outcome.state}",
                 message=(
                     f"{noun} at {outcome.source_at} {requirement_subject(outcome, noun='requirement')} {messages[outcome.state]}"
+                ),
+                hole_requirement_ids=tuple(
+                    (feature, outcome.parameter_id) for feature in outcome.features
                 ),
             )
         )

--- a/src/draftwright/linting/suggest.py
+++ b/src/draftwright/linting/suggest.py
@@ -6,15 +6,8 @@ hint a caller or LLM can paste and fill in via the public domain API.
 
 from __future__ import annotations
 
-import re
-
-from draftwright._core import _DIAM_RE, _QUOTED_RE, _fmt
+from draftwright._core import _QUOTED_RE
 from draftwright.linting.issues import LintIssue  # noqa: F401 — re-exported for callers
-
-# Tolerance for matching a lint message's reported diameter (dedup representative
-# at tol 0.15, formatted to 1 dp) back to a raw feature diameter when generating a
-# fix snippet (#29).
-_DIAM_MATCH_TOL = 0.2
 
 
 def _suggest_fix(issue, dwg) -> str | None:
@@ -27,43 +20,59 @@ def _suggest_fix(issue, dwg) -> str | None:
     """
     code = issue.code
 
-    if code == "feature_not_dimensioned":
-        # Message: "cylindrical feature ø8 has no diameter callout on the sheet".
-        m = _DIAM_RE.search(issue.message)
-        if m is None:
-            return None
-        d = float(m.group(1))
-        # The reported diameter is the dedup representative (tol 0.15) formatted
-        # to 1 dp, so match raw feature diameters with that combined slack — a
-        # 1e-6 match would silently miss every non-integer bore.
-        for view in ("plan", "front", "side"):
-            if any(abs(f.diameter - d) < _DIAM_MATCH_TOL for f in dwg.features(view)):
-                return (
-                    f"# ø{_fmt(d)} has no callout. Find the bore in the model IR and let the\n"
-                    f"# engine place its callout (say WHAT, not WHERE):\n"
-                    f"for f in dwg.model().features:\n"
-                    f"    if f.kind not in ('hole', 'pattern'):\n"
-                    f"        continue  # a step/boss can share a diameter; the lint is about bores\n"
-                    f"    # a plain hole carries its bore on .diameter; a pattern on .member.diameter\n"
-                    f"    fd = f.diameter if f.kind == 'hole' else f.member.diameter\n"
-                    f"    if abs(fd - {_fmt(d)}) < {_DIAM_MATCH_TOL}:\n"
-                    f"        dwg.callout(f)  # feature-backed ø callout, auto-placed"
-                )
-        return None
-
-    if code == "feature_count_mismatch":
-        # Message: "4 ø8 features on the part but callouts account for 1".
-        # `need` is the leading count; anchor it so diameter digits never
-        # interfere regardless of message word order.
-        m = _DIAM_RE.search(issue.message)
-        need_m = re.match(r"\s*(\d+)", issue.message)
-        if m is None or need_m is None:
-            return None
-        need = need_m.group(1)
+    if code in {"feature_not_dimensioned", "feature_count_mismatch"}:
         return (
-            f"# Only some ø{m.group(1)} holes are counted. Set count={need} on the "
-            f"callout so it covers them all:\n"
-            f"# HoleCallout(..., count={need}, draft=dwg.draft)"
+            "# Diameter totals do not identify drilling operations. Inspect the separate\n"
+            "# hole_requirement_* findings and their feature provenance before editing.\n"
+            "# Keep distinct axes, through/blind depths, threads and fits separate;\n"
+            "# do not increase a callout count to cover a different operation."
+        )
+
+    if code == "hole_requirement_missing":
+        identities = issue.hole_requirement_ids
+        model = dwg.model()
+        if (
+            not identities
+            or any(parameter != "bore.diameter" for _feature, parameter in identities)
+            or model is None
+            or model.authored_dimensions is not None
+        ):
+            return (
+                "# Inspect this requirement on its declared feature. Preserve authored\n"
+                "# omissions and correct any conflicting existing callout before rebuilding;\n"
+                "# a missing count is not permission to add a larger or duplicate callout."
+            )
+        indices = []
+        for feature, _parameter in identities:
+            index = next(
+                (i for i, current in enumerate(model.features) if current is feature), None
+            )
+            if index is None or getattr(feature, "kind", None) not in {"hole", "pattern"}:
+                return None
+            # Existing diameter ink could carry contradictory quantity evidence. Adding
+            # another callout is not a repair for that claim.
+            if any(
+                getattr(identity, "feature", None) is feature
+                and getattr(identity, "parameter", None) == "bore.diameter"
+                for name in dwg.registry.names()
+                for identity in dwg.registry.measurement_of(name)
+            ):
+                return None
+            if index not in indices:
+                indices.append(index)
+        return (
+            "# These exact features belong to this Drawing; re-run lint after rebuilding.\n"
+            "# Restore their own callouts through the shared placement solver.\n"
+            "with dwg.deferred():\n"
+            + "\n".join(f"    dwg.callout(dwg.model().features[{i}])" for i in indices)
+        )
+
+    if code == "hole_requirement_unverifiable":
+        return (
+            "# This recognised operation has no verified measurement ownership. Inspect\n"
+            "# its members and declare the separate hole/group in Sheet with its own\n"
+            "# axis, through/blind depth and known thread/fit intent, then rebuild.\n"
+            "# Do not change another operation's count or infer manufacturing intent."
         )
 
     if code == "annotation_ink_overlap":

--- a/tests/test_declare.py
+++ b/tests/test_declare.py
@@ -1423,15 +1423,20 @@ class TestModelSeam:
         assert warns == [], [i.code for i in warns]
 
     def test_partial_declaration_is_flagged_by_coverage_lint(self):
-        # ADR 4 (was 0011) caveat: the coverage lint re-detects, so a partial declaration is
-        # correctly flagged for the geometry it left undimensioned.
+        # Physical critique keeps the recognised denominator when a declaration is partial.
         plate = Box(80, 50, 8)
         h1 = Pos(20, 10, 0) * Cylinder(3, 8)
         h2 = Pos(-20, 10, 0) * Cylinder(3, 8)
         part = plate - h1 - h2
         dwg = build_drawing(part, model=[envelope(plate), hole(h1)])
-        codes = {i.code for i in dwg.lint() if i.severity in ("warning", "error")}
-        assert "feature_count_mismatch" in codes
+        issues = dwg.lint()
+        assert len(dwg.recognition().holes) == 2
+        assert len([f for f in dwg.model().features if f.kind == "hole"]) == 1
+        unresolved = [i for i in issues if i.code == "hole_requirement_unverifiable"]
+        assert len(unresolved) == 1 and unresolved[0].severity == "warning"
+        assert "2× ø6 THRU" in unresolved[0].message
+        assert unresolved[0].hole_requirement_ids == ()
+        assert "dwg.callout(" not in unresolved[0].suggestion
 
     def test_orientation_inferred_from_step(self):
         shaft = Rot(0, 90, 0) * Cylinder(4, 30)  # a round bar along x

--- a/tests/test_issue_1351_structured_note_coverage.py
+++ b/tests/test_issue_1351_structured_note_coverage.py
@@ -307,9 +307,18 @@ def test_duplicate_notes_do_not_multiply_one_requirement_identity_into_physical_
     sheet.note("INSPECT DIAMETER 6", through, satisfies=("bore.diameter",))
     drawing = sheet.build()
 
-    mismatch = [issue for issue in drawing.lint() if issue.code == "feature_count_mismatch"]
-    assert len(mismatch) == 1
-    assert "account for 1" in mismatch[0].message
+    issues = drawing.lint()
+    assert not any(issue.code == "feature_count_mismatch" for issue in issues)
+    blind = next(
+        feature
+        for feature in drawing.model().features
+        if feature.kind == "hole" and not feature.through
+    )
+    assert any(
+        issue.code == "hole_requirement_suppressed"
+        and (blind, "bore.diameter") in issue.hole_requirement_ids
+        for issue in issues
+    )
 
 
 def test_location_is_a_valid_synthesised_role_and_satisfies_both_required_axes():
@@ -574,10 +583,15 @@ def test_callout_and_note_on_one_diameter_do_not_cover_an_identical_sibling():
     sheet.dimension(first, "bore.diameter")
     sheet.of(first).note("DIAMETER 6", satisfies=("bore.diameter",))
 
-    warning = next(
-        issue for issue in sheet.build().lint() if issue.code == "feature_count_mismatch"
+    drawing = sheet.build()
+    issues = drawing.lint()
+    assert not any(issue.code == "feature_count_mismatch" for issue in issues)
+    sibling = next(feature for feature in holes if feature is not first)
+    assert any(
+        issue.code == "hole_requirement_suppressed"
+        and (sibling, "bore.diameter") in issue.hole_requirement_ids
+        for issue in issues
     )
-    assert "account for 1" in warning.message
 
 
 def test_pre_satisfaction_registry_shape_remains_a_valid_consumer_boundary():

--- a/tests/test_issue_1531_semantic_hole_counts.py
+++ b/tests/test_issue_1531_semantic_hole_counts.py
@@ -1,0 +1,255 @@
+"""Count diagnostics and edits must preserve recognised drilling operations (#1531)."""
+
+from dataclasses import replace
+
+import pytest
+from build123d import Align, Box, Cylinder, Pos, Rot
+
+from draftwright import Sheet, build_drawing
+from draftwright.linting import LintIssue, _suggest_fix, lint_feature_coverage
+from draftwright.linting.hole_coverage import hole_requirement_outcomes
+
+
+@pytest.fixture(scope="module")
+def mixed_part():
+    part = Box(60, 45, 12)
+    for x in (-20, 0, 20):
+        for y in (-7, 9):
+            part -= Pos(x, y, 0) * Cylinder(1.2, 20)
+    for y in (-15, 0, 15):
+        part -= (
+            Pos(28.5, y, 0)
+            * Rot(0, 90, 0)
+            * Cylinder(1.2, 1.5, align=(Align.CENTER, Align.CENTER, Align.MIN))
+        )
+    return part
+
+
+def _groups(drawing):
+    groups = {
+        feature.frame.axis: feature
+        for feature in drawing.model().features
+        if feature.kind == "pattern"
+    }
+    assert set(groups) == {"x", "z"}
+    assert groups["z"].count == 6 and groups["z"].member.through
+    assert groups["x"].count == 3 and not groups["x"].member.through
+    assert groups["x"].member.depth == pytest.approx(1.5)
+    assert groups["x"].member.diameter == groups["z"].member.diameter == 2.4
+    return groups
+
+
+def _bore_issue(drawing, feature):
+    return next(
+        issue
+        for issue in drawing.lint()
+        if issue.code == "hole_requirement_missing"
+        and (feature, "bore.diameter") in issue.hole_requirement_ids
+    )
+
+
+def _counts(drawing):
+    return {
+        feature.frame.axis: sorted(
+            getattr(drawing.get_annotation(name), "covers_count")
+            for name in drawing.annotations_of(feature)
+            if hasattr(drawing.get_annotation(name), "covers_count")
+        )
+        for feature in drawing.model().features
+        if feature.kind == "pattern"
+    }
+
+
+def test_suggestion_restores_three_blind_sockets_without_changing_six_through(mixed_part):
+    drawing = build_drawing(mixed_part, auto_dims=False)
+    groups = _groups(drawing)
+    drawing.callout(groups["z"])
+    assert _counts(drawing) == {"x": [], "z": [6]}
+    # This is the original false arithmetic, independently of the new Drawing path.
+    legacy = lint_feature_coverage(
+        mixed_part,
+        drawing.items,
+        holes=drawing.recognition().holes,
+        bosses=drawing.recognition().bosses,
+        registry=drawing.registry,
+    )
+    mismatch = next(issue for issue in legacy if issue.code == "feature_count_mismatch")
+    assert "9 ø2.4" in mismatch.message and "account for 6" in mismatch.message
+
+    issues = drawing.lint()
+    assert not any(issue.code == "feature_count_mismatch" for issue in issues)
+    missing = _bore_issue(drawing, groups["x"])
+    assert "3× ø2.4 blind depth 1.5" in missing.message
+    assert "axis (-1.0, 0.0, 0.0)" in missing.message
+    assert missing.hole_requirement_ids == ((groups["x"], "bore.diameter"),)
+    assert "count=" not in missing.suggestion
+    exec(missing.suggestion, {"dwg": drawing})
+    assert _counts(drawing) == {"x": [3], "z": [6]}
+    outcomes = hole_requirement_outcomes(
+        drawing.recognition(), drawing.model().features, drawing.registry
+    )
+    assert {o.state for o in outcomes if o.parameter_id == "grouping.count"} == {"placed"}
+    assert {o.member_count for o in outcomes if o.parameter_id == "grouping.count"} == {3, 6}
+    assert not any(i.code == "feature_count_mismatch" for i in drawing.lint())
+
+
+def test_undeclared_sockets_are_identified_without_inventing_an_owner(mixed_part):
+    sheet = Sheet.from_part(mixed_part).take_over(
+        dimensions="authored", principal_views="automatic", derived_views="authored"
+    )
+    socket = next(f for f in sheet.features if f.kind == "pattern" and f.frame.axis == "x")
+    sheet.features.remove(socket)
+    bolts = next(f for f in sheet.features if f.kind == "pattern")
+    sheet.dimension(bolts, "bore.diameter")
+    drawing = sheet.build()
+    issues = drawing.lint()
+    missing = next(i for i in issues if i.code == "hole_requirement_unverifiable")
+    assert "3× ø2.4 blind depth 1.5" in missing.message
+    assert missing.hole_requirement_ids == ()
+    assert "separate hole/group" in missing.suggestion
+    assert "dwg.callout(" not in missing.suggestion
+    assert not any(i.code == "feature_count_mismatch" for i in issues)
+    assert _counts(drawing) == {"z": [6]}
+
+
+def test_stale_equal_feature_is_not_an_executable_target(mixed_part):
+    drawing = build_drawing(mixed_part, auto_dims=False)
+    feature = _groups(drawing)["x"]
+    missing = _bore_issue(drawing, feature)
+    assert "dwg.callout(" in missing.suggestion
+    stale = replace(feature)
+    assert stale is not feature
+    missing.hole_requirement_ids = ((stale, "bore.diameter"),)
+    assert _suggest_fix(missing, drawing) is None
+
+
+def test_conflicting_count_cannot_be_repaired_by_adding_another_callout(mixed_part):
+    drawing = build_drawing(mixed_part, auto_dims=False)
+    feature = _groups(drawing)["z"]
+    drawing.callout(feature)
+    callout = next(
+        drawing.get_annotation(name)
+        for name in drawing.annotations_of(feature)
+        if hasattr(drawing.get_annotation(name), "covers_count")
+    )
+    assert callout.covers_count == 6
+    callout.covers_count = 9
+    # The physical ledger's explicit feature allocation must not mask a contradictory total.
+    issue = next(
+        i
+        for i in drawing.lint()
+        if i.code == "hole_requirement_missing"
+        and (feature, "grouping.count") in i.hole_requirement_ids
+    )
+    assert "dwg.callout(" not in issue.suggestion
+    assert "conflicting existing callout" in issue.suggestion
+
+
+def test_authored_partial_bundle_never_gets_an_automatic_callout_suggestion(mixed_part):
+    sheet = Sheet.from_part(mixed_part).take_over(
+        dimensions="authored", principal_views="automatic", derived_views="authored"
+    )
+    socket = next(f for f in sheet.features if f.kind == "pattern" and f.frame.axis == "x")
+    sheet.dimension(socket, "bore.diameter")
+    drawing = sheet.build()
+    feature = _groups(drawing)["x"]
+    issue = LintIssue(
+        "warning",
+        "the bore annotation was lost",
+        code="hole_requirement_missing",
+        hole_requirement_ids=((feature, "bore.diameter"),),
+    )
+    suggestion = _suggest_fix(issue, drawing)
+    assert "dwg.callout(" not in suggestion
+    assert "Preserve authored" in suggestion
+    assert any(
+        i.code == "hole_requirement_suppressed"
+        and (feature, "bore.depth") in i.hole_requirement_ids
+        for i in drawing.lint()
+    )
+
+
+@pytest.mark.parametrize("difference", ["axis", "depth", "through"])
+def test_each_geometric_operation_distinction_survives_count_reconciliation(difference):
+    part = Box(60, 40, 20)
+    part -= Pos(-15, 0, 7.5) * Cylinder(3, 5)
+    if difference == "axis":
+        part -= Pos(27.5, 0, 0) * Rot(0, 90, 0) * Cylinder(3, 5)
+    elif difference == "depth":
+        part -= Pos(15, 0, 6) * Cylinder(3, 8)
+    else:
+        part -= Pos(15, 0, 0) * Cylinder(3, 30)
+    drawing = build_drawing(part, auto_dims=False)
+    records = drawing.recognition().holes
+    assert len(records) == 2 and {h.diameter for h in records} == {6}
+    outcomes = hole_requirement_outcomes(
+        drawing.recognition(), drawing.model().features, drawing.registry
+    )
+    # Two singleton sources, each with one verified owner, not one diameter-total group.
+    bores = [o for o in outcomes if o.parameter_id == "bore.diameter"]
+    assert len(bores) == 2
+    assert all(o.member_count == 1 and len(o.features) == 1 for o in bores)
+    assert all(len(o.source_records) == 1 for o in bores)
+    first, second = [o.features[0] for o in bores]
+    assert first is not second
+    drawing.callout(first)
+    missing = _bore_issue(drawing, second)
+    assert missing.hole_requirement_ids == ((second, "bore.diameter"),)
+    assert not any(i.code == "feature_count_mismatch" for i in drawing.lint())
+
+
+def test_distinct_thread_and_fit_owners_cannot_borrow_each_others_count():
+    part = Box(60, 40, 20)
+    for x in (-15, 15):
+        part -= Pos(x, 0, 0) * Cylinder(1.2, 30)
+    sheet = Sheet(part)
+    tapped = sheet.hole(diameter=2.4, at=(-15, 0, 0), axis="z", thread="M3x0.5")
+    fitted = sheet.hole(diameter=2.4, at=(15, 0, 0), axis="z").fit("H7")
+    sheet.dimension(tapped, "bore.diameter")
+    drawing = sheet.build()
+    holes = [f for f in drawing.model().features if f.kind == "hole"]
+    assert len(holes) == 2 and {f.count for f in holes} == {1}
+    count_issue = next(
+        i
+        for i in drawing.lint()
+        if i.code == "hole_requirement_missing"
+        and any(parameter == "grouping.count" for _, parameter in i.hole_requirement_ids)
+    )
+    assert len(count_issue.hole_requirement_ids) == 2
+    assert "dwg.callout(" not in count_issue.suggestion
+    assert "count=" not in count_issue.suggestion
+    # Explicitly author the other operation; quantity stays attached to each owner.
+    sheet.dimension(fitted, "bore.diameter")
+    complete = sheet.build()
+    for feature in (f for f in complete.model().features if f.kind == "hole"):
+        callouts = [
+            complete.get_annotation(n)
+            for n in complete.annotations_of(feature)
+            if hasattr(complete.get_annotation(n), "covers_count")
+        ]
+        assert len(callouts) == 1 and callouts[0].covers_count == 1
+        assert ("M3" if feature.thread else "H7") in callouts[0].label
+    assert not any(
+        i.code == "hole_requirement_missing"
+        and any(p == "grouping.count" for _, p in i.hole_requirement_ids)
+        for i in complete.lint()
+    )
+
+
+def test_old_missing_finding_does_not_add_duplicate_ink_after_owner_is_restored(mixed_part):
+    drawing = build_drawing(mixed_part, auto_dims=False)
+    groups = _groups(drawing)
+    issue = _bore_issue(drawing, groups["x"])
+    assert "dwg.callout(" in issue.suggestion
+    drawing.callout(groups["x"])
+    assert _suggest_fix(issue, drawing) is None
+    drawing.callout(groups["x"])
+    # Duplicate evidence on the sockets cannot provide any bolt quantity.
+    assert _counts(drawing) == {"x": [3, 3], "z": []}
+    missing_bolts = _bore_issue(drawing, groups["z"])
+    assert missing_bolts.hole_requirement_ids == ((groups["z"], "bore.diameter"),)
+    assert any(
+        i.code == "hole_requirement_missing"
+        and (groups["z"], "grouping.count") in i.hole_requirement_ids
+        for i in drawing.lint()
+    )

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -8712,55 +8712,30 @@ class TestPlaceDim:
 class TestLintSuggestions:
     """#29: each LintIssue carries a `suggestion` (str | None) with a fix snippet."""
 
-    def test_feature_not_dimensioned_has_suggestion(self):
-        # auto_dims=False leaves the ø10 hole undimensioned → coverage lint fires.
+    def test_diameter_only_finding_has_advice_without_an_unproven_edit(self):
         part = Box(80, 60, 20) - Pos(20, 15, 0) * Cylinder(5, 20)
         dwg = build_drawing(part, auto_dims=False)
-        issues = [i for i in dwg.lint() if i.code == "feature_not_dimensioned"]
-        assert issues, "expected a feature_not_dimensioned issue"
-        sug = issues[0].suggestion
-        assert sug is not None
-        assert "dwg.model()" in sug
-        assert "dwg.callout(" in sug
-        assert (
-            ".member" in sug
-        )  # covers a pattern's bore (on .member.diameter), not just plain holes
+        issue = next(i for i in dwg.lint() if i.code == "feature_not_dimensioned")
+        assert "separate" in issue.suggestion
+        assert "dwg.callout(" not in issue.suggestion
 
-    def test_feature_not_dimensioned_suggestion_is_runnable(self):
-        # The headline #29 promise: paste the snippet and the lint resolves. Post-#817 the snippet
-        # is the DECLARATIVE door (find the IR feature, `dwg.callout(f)` — say WHAT, not WHERE),
-        # not a hand-built Leader through the now-private placement primitive.
-        part = Box(80, 60, 20) - Pos(20, 15, 0) * Cylinder(5, 20)
-        dwg = build_drawing(part, auto_dims=False)
-        assert any(i.code == "feature_not_dimensioned" for i in dwg.lint())
-
-        for f in dwg.model().features:
-            if f.kind not in ("hole", "pattern"):
-                continue
-            fd = f.diameter if f.kind == "hole" else f.member.diameter
-            if abs(fd - 10.0) < 0.16:
-                dwg.callout(f)
-
-        assert not any(i.code == "feature_not_dimensioned" for i in dwg.lint())
-
-    def test_feature_not_dimensioned_suggestion_is_runnable_for_a_pattern(self):
-        # A pattern feature carries its bore on `.member.diameter`, not `.diameter` — the snippet
-        # must read it there (and restrict to hole/pattern kinds so a same-ø step/boss is not
-        # called out instead), else the declarative recipe silently skips a patterned hole and
-        # never resolves the lint (Codex #821).
+    @pytest.mark.parametrize("pattern", [False, True])
+    def test_missing_bore_suggestion_executes_for_its_verified_owner(self, pattern):
         part = Box(120, 40, 20)
-        for x in (-40, -20, 0, 20, 40):
-            part = part - Pos(x, 0, 0) * Cylinder(4, 20)
+        for x in (-40, -20, 0, 20, 40) if pattern else (15,):
+            part -= Pos(x, 0, 0) * Cylinder(4, 20)
         dwg = build_drawing(part, auto_dims=False)
-        assert any(i.code == "feature_not_dimensioned" for i in dwg.lint())
-
-        for f in dwg.model().features:
-            if f.kind not in ("hole", "pattern"):
-                continue
-            fd = f.diameter if f.kind == "hole" else f.member.diameter
-            if abs(fd - 8.0) < 0.16:
-                dwg.callout(f)
-
+        issue = next(
+            i
+            for i in dwg.lint()
+            if i.code == "hole_requirement_missing"
+            and any(parameter == "bore.diameter" for _, parameter in i.hole_requirement_ids)
+        )
+        assert {f.kind for f, _ in issue.hole_requirement_ids} == {
+            "pattern" if pattern else "hole"
+        }
+        assert "dwg.callout(" in issue.suggestion
+        exec(issue.suggestion, {"dwg": dwg})
         assert not any(i.code == "feature_not_dimensioned" for i in dwg.lint())
 
     def test_clean_drawing_has_no_suggestions(self, plain_box_dwg):
@@ -8871,33 +8846,32 @@ class TestLintSuggestions:
         issue = LintIssue(severity="info", message="something", code="some_unhandled_code")
         assert _suggest_fix(issue, dwg) is None
 
-    def test_non_integer_diameter_still_gets_suggestion(self):
-        # Regression guard for the 1e-6-vs-_fmt bug: radius 4.111 gives a raw
-        # diameter of 8.22, but the message reports the 1dp-rounded ø8.2 — a
-        # 0.02 gap that a 1e-6 match would drop. The diameter must round-trip
-        # with tolerance so the suggestion still appears.
+    def test_non_integer_diameter_suggestion_uses_identity_not_rounded_text(self):
         part = Box(80, 60, 20) - Pos(20, 15, 0) * Cylinder(4.111, 20)
         dwg = build_drawing(part, auto_dims=False)
-        issues = [i for i in dwg.lint() if i.code == "feature_not_dimensioned"]
-        assert issues
-        assert "ø8.2" in issues[0].message  # rounded, differs from raw 8.22
-        assert issues[0].suggestion is not None
-        assert "dwg.callout(" in issues[0].suggestion
+        issue = next(
+            i
+            for i in dwg.lint()
+            if i.code == "hole_requirement_missing"
+            and any(parameter == "bore.diameter" for _, parameter in i.hole_requirement_ids)
+        )
+        assert "ø8.2" in issue.message
+        assert "dwg.callout(" in issue.suggestion
+        exec(issue.suggestion, {"dwg": dwg})
+        assert not any(i.code == "feature_not_dimensioned" for i in dwg.lint())
 
-    def test_feature_count_mismatch_suggestion_sets_count(self, plain_box_dwg):
-        # The leading number is `need`; diameter digits (even fractional) must
-        # not interfere with the parse.
+    def test_feature_count_mismatch_cannot_suggest_a_diameter_total(self, plain_box_dwg):
         from draftwright.linting import LintIssue, _suggest_fix
 
-        dwg = plain_box_dwg
         issue = LintIssue(
             severity="warning",
             message="4 ø8.5 features on the part but callouts account for 1",
             code="feature_count_mismatch",
         )
-        sug = _suggest_fix(issue, dwg)
-        assert sug is not None
-        assert "count=4" in sug
+        suggestion = _suggest_fix(issue, plain_box_dwg)
+        assert "count=" not in suggestion
+        assert "HoleCallout(" not in suggestion
+        assert "distinct axes" in suggestion
 
 
 class TestRepair:


### PR DESCRIPTION
Six through holes and three blind sockets sharing a diameter must not produce advice to turn the through-hole callout into nine. Drawing lint now uses the existing semantic hole ledger for counts, and describes unresolved operations by count, signed axis, diameter and through/blind depth. Diameter-only findings give advisory guidance.

Missing-bore suggestions name verified features on the current automatic model and use the shared solver through `dwg.callout`. Authored sets, unverified ownership, count conflicts and already-restored diameter ink receive no executable callout edit. The agent guide no longer teaches diameter-matching edits. Standalone coarse coverage retains its documented diameter-total fallback; it does not establish operation ownership.

Validation:
- Generic regressions cover six-through/three-blind repair, undeclared sockets, partial declarations, each axis/depth/through distinction, distinct thread/fit owners, conflicting quantity, stale identity, authored omissions and duplicate ownership.
- Executed the actual suggested edit on the pinned frame: its through-hole callouts stayed at 4+2, and only the separate three-socket blind-depth-1.5 callout was added. This validates the edit, not completeness of the drawing.
- Removing depth from both semantic keys collapses two operations and fails the new regression. Re-enabling diameter totals and bypassing exact identity each fail their named regressions.
- Independent Google-style review against all five ADRs is clean on current head 4eac2c601b7d8ebe8d3f21dfea0acd6a65126dae. Reviewer independently ran all ten new tests plus the partial-declaration test (11 passed), verified unchanged patches after rebasing onto merged #1539, and reran the real-frame suggested edit on the final head.
- Full local integration gate passed against current main: 8,009 tests, 96.02% total coverage, 100% changed-line coverage (28/28); Ruff, format, mypy, codespell and strict docs build passed. Required CI remains the merge gate.

Architecture: ADR1/3 retain the existing lint ledger, cached recognition inventory and import boundary; ADR2 edits use the shared solver; ADR4 authored omissions remain advisory; ADR5 unjoined physical requirements remain visible. No new recognition, correspondence rules, report model or ADR text.

Fixes #1531. Part of #1529.
