### PR TITLE
Document and test the authored Sheet section workflow

### DIFF
--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -304,16 +304,83 @@ View declarations are semantic constraints. They name projections, relationships
 anchors; the layout solve owns the resulting page positions. Authored views must be paired with
 authored dimensions so a deliberately omitted view cannot strand planner-selected annotations:
 
-```python
-s = Sheet(part).authored_dimensions().authored_views()
-front = s.view("front")
-plan = s.view("plan").above(front, gap=4).align_x(front)
-s.view("iso").scale(0.75)
+This runnable example includes the part, feature declarations, dimension discovery,
+three principal views and section A–A. The bore's location dimensions are deliberately
+omitted, and lint keeps those omissions visible.
 
-section = s.section_view("A", through=hole)
-detail = s.detail_view("B", around=hole).scale(2)
-dwg = s.build()
+<!-- example: authored-section -->
+```python
+from build123d import Box, Cylinder, Pos
+from draftwright import Sheet
+
+bore_tool = Pos(12, 0, 0) * Cylinder(3, 12)
+part = Box(60, 40, 12) - bore_tool
+sheet = Sheet(part, page="A3", scale=1, projection="third")
+sheet.authored_dimensions().authored_views()
+
+envelope = sheet.envelope(part)
+for parameter_id in envelope.dimension_ids():
+    sheet.dimension(envelope, parameter_id)
+bore = sheet.hole(bore_tool)
+print(bore.dimension_ids())  # discover this handle's Sheet measurement IDs
+sheet.dimension(bore, "bore.diameter")
+
+for name in ("front", "plan", "side"):
+    sheet.view(name)
+sheet.section_view("A", through=bore)  # or at=0 for an explicit model-space Y plane
+
+drawing = sheet.build()
+issues = drawing.lint()
+for issue in issues:
+    print(issue.severity, issue.code, issue.message)
+# drawing.export("build/section", formats=("pdf", "svg"))
 ```
+
+On a Sheet handle, `dimension_ids()` lists dotted measurement IDs; use
+`sheet.dimension(bore, "bore.diameter")`. On a built Drawing, the second argument to
+`drawing.dimension(envelope_feature, "length", role="width")` is a parameter kind,
+with `role=` distinguishing measurements of the same kind. Hole diameter and depth
+are callout content: use `drawing.callout(bore_feature)` for those, not
+`drawing.dimension(...)`. These are different vocabularies.
+
+#### Augmenting automatic views
+
+`view()` and `section_view()` specify complete authored sets. `add_view()` and
+`add_section_view()` instead augment an explicitly automatic set. Choose the source
+before adding views; an authored set cannot be switched to automatic in place.
+
+This separate, runnable example keeps automatic principal and derived views and
+adds a section at model-space Y=0. Its dimensions are still explicitly authored:
+
+<!-- example: automatic-section -->
+```python
+from build123d import Box
+from draftwright import Sheet
+
+part = Box(60, 40, 12)
+sheet = Sheet(part, page="A3", scale=1).authored_dimensions()
+envelope = sheet.envelope(part)
+for parameter_id in envelope.dimension_ids():
+    sheet.dimension(envelope, parameter_id)
+sheet.auto_views()
+sheet.add_section_view("A", at=0)
+drawing = sheet.build()
+issues = drawing.lint()
+for issue in issues:
+    print(issue.severity, issue.code, issue.message)
+```
+
+`auto_views()` emits `SoftDeprecationWarning`: it remains supported and has no removal
+date. The notice recommends the editable authored surface; it does not mean the
+augmentation example is invalid. Automatic dimensions remain supported too, but they
+cannot be paired with a complete authored view set.
+
+`Sheet.section()` is deprecated with removal targeted at 0.6.0. For an authored
+workflow replace it with `section_view("A", through=feature)` or `section_view("A", at=y)`;
+for automatic augmentation use `auto_views()` followed by `add_section_view(...)`.
+`Drawing.section()` is a separate automatic post-build operation and may add no section
+when the geometry does not warrant one.
+
 
 Rear views are explicitly requested. `s.view("rear")` includes rear in an authored
 view set; `s.auto_views().add_view("rear")` adds it to the automatic baseline.

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -29,9 +29,9 @@ verbs existed then, and the dotted parameter ids in Step 2 are new in 0.4.0.)
 everything automatically** (placement is constraint-based; you never compute page
 coordinates). When the first pass isn't perfect, you drive a **build → critique
 → fix** loop (Step "Lint → critique → fix" below), not a hand-layout edit. The
-rationale lives in `docs/adr/`: 0001 (deterministic generation over an editable
-DSL), 0002 (the lint critique → domain-repair loop), 0003 (the constraint-based
-layout engine). Edit through the domain API; treat `Placeable`/page mechanics as
+rationale lives in the five current records in `docs/adr/`: ADR 1 (compiler pipeline),
+ADR 2 (layout and view planning), ADR 3 (recognition), ADR 4 (declared intent), and
+ADR 5 (trust and honest failure). Edit through the domain API; treat `Placeable`/page mechanics as
 internals.
 
 ---
@@ -145,7 +145,7 @@ rather than the bare family role (`"width"`): the bare spelling is deprecated,
 because it is what let a single call silently declare two dimensions.
 
 `place_dim(p1, p2, side, view, …)` still exists for raw page coordinates, but it is
-the **escape hatch of last resort** (ADR 0012) and is deprecated: it bypasses the
+the **escape hatch of last resort** (ADR 4) and is deprecated: it bypasses the
 layout solve, so nothing re-flows around it.
 
 **Add a callout on a hole the auto-pass missed** — inspect its semantic requirement
@@ -190,23 +190,55 @@ warn from 0.4.0. See `docs/deprecations.md`.
 `make_drawing(...)` is `build_drawing(...).export(formats=("svg", "dxf"))`, unpacked to a
 tuple — not a bare `.export()`, which is the deprecated shape above.
 
-**Section views** come from the section verb rather than from projecting a view by
-hand. The two entry points are *not* equivalent:
+**Authored section views** use `section_view()` alongside an explicit dimension and
+view set. This complete example declares the bore diameter and overall extents;
+it deliberately leaves the bore's location dimensions unrequested:
 
+<!-- example: authored-section -->
 ```python
+from build123d import Box, Cylinder, Pos
 from draftwright import Sheet
 
-# Sheet.section() FORCES a cut, wherever you point it.
-cut = Sheet.from_part(part, number="DWG-042").section().build()
-"section_aa" in cut.views                 # True
-# section(feature) cuts through that feature; section(at=y) at an explicit Y.
+bore_tool = Pos(12, 0, 0) * Cylinder(3, 12)
+part = Box(60, 40, 12) - bore_tool
+sheet = Sheet(part, page="A3", scale=1, projection="third")
+sheet.authored_dimensions().authored_views()
 
-# Drawing.section() adds only the AUTOMATIC A–A, which fires just for qualifying
-# hidden internal geometry (a counterbore, spotface, or blind bottom). It returns
-# the placed annotation names, or [] when no section is warranted — so on a plain
-# through-holed block it does nothing at all.
-dwg.section()
+envelope = sheet.envelope(part)
+for parameter_id in envelope.dimension_ids():
+    sheet.dimension(envelope, parameter_id)
+bore = sheet.hole(bore_tool)
+print(bore.dimension_ids())  # discover this handle's Sheet measurement IDs
+sheet.dimension(bore, "bore.diameter")
+
+for name in ("front", "plan", "side"):
+    sheet.view(name)
+sheet.section_view("A", through=bore)  # or at=0 for an explicit model-space Y plane
+
+drawing = sheet.build()
+issues = drawing.lint()
+for issue in issues:
+    print(issue.severity, issue.code, issue.message)
+# drawing.export("build/section", formats=("pdf", "svg"))
 ```
+
+`dimension_ids()` lists the Sheet handle's dotted IDs: use `"bore.diameter"` here.
+Drawing.dimension instead takes a kind and optional role, such as `"length"` with
+`role="width"` for an envelope. Hole diameter/depth use Drawing.callout, not
+Drawing.dimension. Inspect `issues`: authored omissions
+remain visible, so a successfully built section does not prove a complete drawing.
+
+`view()` and `section_view()` define complete authored principal and derived sets.
+To augment automatic views instead, start a new Sheet, explicitly select
+`auto_views()`, and use `add_section_view("A", through=...)` or `at=...`.
+That mode remains supported; `auto_views()` emits a soft-deprecation notice with
+no removal date. Do not switch an already-authored view set to `auto_views()`.
+See the runnable augmentation example in `docs/reference/sheet.md`.
+
+`Sheet.section()` is deprecated with removal targeted at 0.6.0. Migrate it to the
+method for your view source above. `Drawing.section()` remains the automatic
+post-build section operation: it may return no section when the geometry does not
+warrant one. It does not replace an explicit authored section request.
 
 Arbitrary **auxiliary** views have no public verb: `add_view()` was the way to
 project one and is deprecated, so a custom viewing direction is not currently part
@@ -318,7 +350,7 @@ for i in dwg.lint():
 dwg.repair()
 
 # Pin a deliberate placement so repair won't move it (the constraint solver will
-# honour it too as it lands — ADR 0003):
+# honour it too as it lands — ADR 2):
 dwg.pin(name)             # name from dwg.annotations(); dwg.unpin(name) to release
 ```
 

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -2271,8 +2271,10 @@ class Sheet:
         part centre. The section renders last (its room check clears the right-of-side-view
         band), so declare it after the per-feature verbs. Chainable."""
         warnings.warn(
-            "Sheet.section() is deprecated; use add_section_view('A', through=...) or "
-            "add_section_view('A', at=...). Removal target 0.6.0.",
+            "Sheet.section() is deprecated; for authored derived views with authored dimensions use "
+            "section_view('A', through=...) or section_view('A', at=...). "
+            "To augment automatic views, select auto_views() and use add_section_view(...). "
+            "Removal target 0.6.0.",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -2541,9 +2543,14 @@ class Sheet:
             )
         if self._added_derived_views and self._derived_view_source != "automatic":
             source = self._added_derived_views[0]["source"]
+            guidance = (
+                "use section_view()/detail_view() for the authored view set"
+                if "authored" in (self._principal_view_source, self._derived_view_source)
+                else "call auto_views() first"
+            )
             raise ValueError(
                 f"add_section_view()/add_detail_view() at {source} augment automatic derived "
-                "views; call auto_views() first"
+                f"views; {guidance}"
             )
         if self._principal_view_source != "authored":
             additions = tuple(
@@ -2582,7 +2589,8 @@ class Sheet:
         if self._section is not None and records:
             raise ValueError(
                 "deprecated section() cannot be combined with section_view()/detail_view() "
-                "constraints; migrate the legacy call to add_section_view()"
+                "constraints; remove the legacy call and keep section_view() for authored "
+                "derived views or add_section_view() for automatic derived views"
             )
         for record in sections:
             target = record["target"]

--- a/tests/test_adr_corpus.py
+++ b/tests/test_adr_corpus.py
@@ -112,6 +112,7 @@ def test_no_live_document_cites_an_archived_record_as_authority():
         _ROOT / "AGENTS.md",
         _ROOT / "CLAUDE.md",
         _ROOT / "README.md",
+        _ROOT / "skills" / "SKILL.md",
     ]
     for root in roots:
         files = root.rglob("*") if root.is_dir() else [root]

--- a/tests/test_issue_1532_authored_section_examples.py
+++ b/tests/test_issue_1532_authored_section_examples.py
@@ -1,0 +1,123 @@
+"""Execute the section examples users and agents actually read (#1532)."""
+
+import re
+import warnings
+from pathlib import Path
+
+import pytest
+from build123d import Box
+
+from draftwright import Sheet, SoftDeprecationWarning
+
+_ROOT = Path(__file__).parents[1]
+_DOCUMENTS = ("skills/SKILL.md", "docs/reference/sheet.md")
+
+
+def _example(document, name):
+    text = (_ROOT / document).read_text(encoding="utf-8")
+    matches = re.findall(
+        rf"<!-- example: {re.escape(name)} -->\n```python\n(.*?)\n```", text, re.DOTALL
+    )
+    assert len(matches) == 1, f"expected one executable {name} example in {document}"
+    return matches[0]
+
+
+def _run(document, name):
+    namespace = {}
+    with warnings.catch_warnings(record=True) as recorded:
+        warnings.simplefilter("always")
+        exec(compile(_example(document, name), document, "exec"), namespace)
+    return namespace, recorded
+
+
+@pytest.mark.parametrize("document", _DOCUMENTS)
+def test_documented_authored_section_preserves_intent_and_reports_omissions(document):
+    result, recorded = _run(document, "authored-section")
+    assert not recorded, [(type(w.message).__name__, str(w.message)) for w in recorded]
+    sheet, drawing = result["sheet"], result["drawing"]
+    assert sheet.view_constraints.principal_source == "authored"
+    assert sheet.view_constraints.derived_source == "authored"
+    assert set(drawing.views) == {"front", "plan", "side", "section_aa"}
+    assert drawing.section_decision["status"] == "placed"
+    assert "section_hatch" in drawing.annotations()
+    assert "bore.diameter" in result["bore"].dimension_ids()
+    dimensions = drawing.model().authored_dimensions
+    assert dimensions is not None
+    assert {dimension.role for dimension in dimensions} == {
+        "width.length",
+        "height.length",
+        "depth.length",
+        "bore.diameter",
+    }
+    bore = next(f for f in drawing.model().features if f.kind == "hole")
+    assert bore.diameter == 6 and bore.through
+    assert any(
+        measurement.feature is bore and measurement.parameter == "bore.diameter"
+        for name in drawing.annotations_of(bore)
+        for measurement in drawing.registry.measurement_of(name)
+    )
+    issues = result["issues"]
+    assert {i.code for i in issues} == {"feature_not_located", "hole_requirement_suppressed"}
+    assert {
+        parameter
+        for i in issues
+        for feature, parameter in i.hole_requirement_ids
+        if feature is bore
+    } == {"location.location.x", "location.location.y"}
+    assert all(i.severity == "warning" for i in issues)
+
+
+def test_documented_automatic_augmentation_keeps_automatic_views_and_supported_notice():
+    result, recorded = _run("docs/reference/sheet.md", "automatic-section")
+    assert len(recorded) == 1
+    assert recorded[0].category is SoftDeprecationWarning
+    assert "NOT scheduled for removal" in str(recorded[0].message)
+    sheet, drawing = result["sheet"], result["drawing"]
+    assert sheet.view_constraints.principal_source == "automatic"
+    assert sheet.view_constraints.derived_source == "automatic"
+    assert set(drawing.views) == {"front", "plan", "side", "iso", "section_aa"}
+    assert drawing.section_decision["status"] == "placed"
+    assert "section_hatch" in drawing.annotations()
+    assert drawing.model().authored_dimensions is not None
+    assert result["issues"] == []
+
+
+@pytest.mark.parametrize("verb", ["section", "detail"])
+@pytest.mark.parametrize("source", ["principal", "derived"])
+def test_augmentation_on_authored_views_points_back_to_authored_verb(verb, source):
+    sheet = Sheet(Box(60, 40, 12)).authored_dimensions()
+    if source == "principal":
+        sheet.authored_views().view("front")
+    if verb == "section":
+        sheet.add_section_view("A", at=0)
+    else:
+        envelope = sheet.envelope()
+        sheet.add_detail_view("A", around=envelope)
+    if source == "derived":
+        # An addition may precede the authored declaration: preserve that ordering
+        # so the diagnostic must inspect the derived source as well as principals.
+        sheet.section_view("B", at=1)
+    with pytest.raises(ValueError, match=r"use section_view\(\)/detail_view\(\)") as caught:
+        sheet.build()
+    assert "call auto_views() first" not in str(caught.value)
+
+
+def test_legacy_section_warning_names_both_migrations():
+    sheet = Sheet(Box(60, 40, 12)).authored_dimensions()
+    with pytest.warns(DeprecationWarning) as recorded:
+        sheet.section(at=0)
+    assert len(recorded) == 1
+    message = str(recorded[0].message)
+    assert "for authored derived views with authored dimensions use section_view" in message
+    assert "augment automatic views" in message and "add_section_view" in message
+    assert "Removal target 0.6.0" in message
+
+
+def test_legacy_and_authored_section_conflict_does_not_send_user_to_automatic_views():
+    sheet = Sheet(Box(60, 40, 12)).authored_dimensions()
+    with pytest.warns(DeprecationWarning):
+        sheet.section(at=0)
+    sheet.section_view("A", at=0)
+    with pytest.raises(ValueError, match="remove the legacy call") as caught:
+        sheet.build()
+    assert "keep section_view() for authored" in str(caught.value)


### PR DESCRIPTION
The section guide sent authored-sheet users through deprecated `Sheet.section()` and automatic-view augmentation. The resulting advice could loop: `auto_views()` refuses a view set already declared as authored.

The skill and public Sheet reference now contain executable authored-dimensions/section examples, including measurement discovery, explicit view sets and retained omission diagnostics. A separate example demonstrates supported automatic-view augmentation and its soft-deprecation notice. Migration messages select the correct verb for the principal and derived view sources, including reversed declaration order. The guide distinguishes linear Drawing dimensions from hole callouts.

Validation:
- Tests execute the actual Markdown code blocks and check intent, views, section/hatching and expected diagnostics.
- Full local gate passed: 8,018 tests, 96.02% total coverage, 100% changed-line coverage. Ruff, formatting, mypy, codespell and strict documentation build passed. The edited skill was also checked with codespell.
- Restoring the deprecated recipe, omitting the documented bore dimension and removing the derived-source diagnostic condition each fail a named regression.
- Independent Google-style review is clean; reviewer independently ran all nine new tests. The reviewed patch and the full-gated tree at ac5d796d are unchanged after rebasing onto merged main (88495e48; empty tree diff).

All five ADRs fit: this documents the existing compiler and shared placement path, preserves authored-set and automatic-dimension refusals, uses existing recognition/ownership diagnostics and reports deliberate omissions. No new view API or automatic rear-view behavior. The existing ADR citation check now covers the edited skill too.

Fixes #1532. Part of #1529. Depends on the preceding section and count fixes; required CI remains the merge gate.
