### PR TITLE
Explain drawing review outcomes and preview unresolved leader targets

### DIFF
--- a/docs/reference/reports.md
+++ b/docs/reference/reports.md
@@ -90,6 +90,64 @@ holes disguised as an empty report.
 
 
 
+## Reviewing one sheet
+
+`drawing.lint_summary()` works on both automatic and declared drawings. Its `review`
+field explains the existing observations together:
+
+```python
+summary = drawing.lint_summary()
+for topic, explanation in summary["review"].items():
+    print(topic, explanation)
+```
+
+`passed` only tests whether error-severity findings are absent. Warnings can therefore
+reduce the legacy `score` (also named `diagnostic_score`) to zero while `passed` remains
+true. This penalty is not a composite drawing-quality score. The separate `quality`
+components retain their existing meanings; the explanatory text derives from them without
+changing their scores or the recognized requirement denominator.
+
+Coverage lists placed, structured-note satisfaction, suppressed, dropped, missing,
+unverifiable and unsupported outcomes separately. Its scope remains the audited recognized
+requirements, with exclusions in `quality.completeness`. Legibility and fidelity explain the
+checks performed; neither a clean layout nor an absence of detected contradictions proves
+manufacturing readiness. The report does not assess whether all material, process, finish,
+thread, fit or tolerance decisions have been authored. Ordinary notes receive no inferred
+coverage, and layout repair cannot supply missing physical ownership.
+
+For declared drawings, use this summary and `drawing.lint()`; `drawing.report()` retains its
+stricter raw automatic ownership requirement. On supported automatic drawings,
+`report["recognition"]["requirements"]` supplies the existing occurrence/owner/annotation
+links for individual outcomes. This is single-sheet review, not cross-sheet reconciliation.
+
+### Inspecting a leader target
+
+Diameter and straight-blend radius leader-target findings carry `annotation_name`, an available `view`, and an
+`evidence_reason` explaining a mismatch or the missing physical evidence. Their existing
+`measurement_ids` on `LintIssue` retain feature/parameter references for live inspection;
+these object references are not serialized as persistent IDs. The annotation name belongs
+to the current Drawing registry and must not be reused across builds.
+
+```python
+for issue in drawing.lint():
+    if "leader_target_" in issue.code and issue.annotation_name:
+        print(issue.annotation_name, issue.view, issue.evidence_reason)
+        print(issue.measurement_ids)
+        drawing.preview_annotation(issue.annotation_name, "leader-review.svg")
+        break
+```
+
+`preview_annotation(name, path)` writes an SVG crop including the annotation and its owning
+view when known. Orange marks identify the current ink bounds and drawn leader tip; the
+caption explicitly says the physical target is not certified. A drawn tip remains inspectable
+even when physical ownership is unavailable. The preview does not infer a correct target,
+move annotations, change coverage, finalize queued edits or update the Drawing's export paths.
+Finish a deferred edit first. Unknown names raise `KeyError`; unavailable ink bounds or a
+non-SVG destination raise `ValueError`. The destination's parent directory must exist.
+
+The `review` and diagnostic reference fields are additive inside version 3's open `lint`
+payload. The report-owned schema, existing scores and ownership refusals are unchanged.
+
 `generate_sheet_script(...)` writes its recognition evidence to
 `<stem>.draftwright-inspection.json` beside the generated script — a different document with a
 different schema; see [Recognition evidence](inspection.md). It used to embed a

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -83,6 +83,7 @@ from draftwright.export import (
     add_svg_metadata,
     canonicalize_svg,
     fix_svg_page_size,
+    highlight_svg_annotation,
     sanitize_svg_arcs,
     set_dxf_metadata,
     write_dxf,
@@ -137,7 +138,7 @@ from draftwright.linting import (
 )
 from draftwright.linting.angular import lint_angular_supports, lint_profile_angle_coverage
 from draftwright.linting.issues import _collect_issue_aggregation, _current_issue_aggregation
-from draftwright.linting.quality import quality_components
+from draftwright.linting.quality import quality_components, review_explanation
 from draftwright.linting.section_recess_coverage import lint_section_recess_coverage
 from draftwright.projection import (
     part_material_mesh,
@@ -3459,6 +3460,37 @@ class Drawing:
         """Return the named annotation object, or ``None`` if no such name (#27)."""
         return self._registry.named(name)
 
+    def preview_annotation(self, name: str, path: str | os.PathLike) -> str:
+        """Write a diagnostic SVG highlighting a placed annotation and its drawn tip.
+
+        Includes the owning view when known. This is a snapshot of current ink, not a
+        physical-target certificate. It neither finalizes edits nor alters the drawing or
+        its export paths. Finish a deferred edit before requesting a preview. Unknown names
+        raise ``KeyError``; missing ink bounds or a non-SVG path raise ``ValueError``.
+        """
+        if self._defer_intents or self._intents:
+            raise ValueError("finish deferred edits before previewing an annotation")
+        annotation = self.get_annotation(name)
+        if annotation is None:
+            raise KeyError(name)
+        destination = os.fspath(path)
+        if os.path.splitext(destination)[1].lower() != ".svg":
+            raise ValueError("annotation previews require an .svg destination")
+        if not hasattr(annotation, "bounding_box"):
+            raise ValueError(f"{name}: annotation ink bounds unavailable")
+        box = annotation.bounding_box()
+        bounds = (box.min.X, box.min.Y, box.max.X, box.max.Y)
+        view = self.view_of(name)
+        context = self.view_bounds(view) if view is not None and view in self.views else bounds
+        tip = getattr(annotation, "tip", None)
+        with tempfile.TemporaryDirectory(dir=os.path.dirname(destination) or ".") as temporary:
+            svg_path = self._write_svg(os.path.join(temporary, "preview"))
+            highlight_svg_annotation(
+                svg_path, name=name, view=view, bounds=bounds, context=context, tip=tip
+            )
+            os.replace(svg_path, destination)
+        return destination
+
     def note(self, text, at, *, view=None, rotation=0.0, name=None, align=None):
         """Add a free-form text **note** at page position *at* — ``(x, y)`` in mm from the sheet
         origin, the space :meth:`at` / :meth:`view_bounds` return (#817).
@@ -4314,6 +4346,7 @@ class Drawing:
           composite drawing-quality score is manufactured (#1127). Legibility's existing
           severity/code counts are raw findings; its ``primary_*`` counts and scalar group
           producer-identified pair findings by annotation and failure mechanism (#1147);
+        - ``review`` — concise explanations of those existing observations and their limits;
         - ``errors`` / ``warnings`` / ``infos`` — counts by severity;
         - ``by_code`` — per-check counts;
         - ``geometry_issues`` — count of standards/geometry-correctness issues
@@ -4406,6 +4439,9 @@ class Drawing:
             "score": score,
             "diagnostic_score": score,
             "quality": quality,
+            "review": review_explanation(
+                quality=quality, errors=errors, warnings=warnings, score=score
+            ),
             "errors": errors,
             "warnings": warnings,
             "infos": infos,
@@ -4424,6 +4460,9 @@ class Drawing:
                         else {}
                     ),
                     **({"source_ids": i.source_ids} if i.source_ids else {}),
+                    **({"annotation_name": i.annotation_name} if i.annotation_name else {}),
+                    **({"view": i.view} if i.view is not None else {}),
+                    **({"evidence_reason": i.evidence_reason} if i.evidence_reason else {}),
                     **(
                         {"outcome_stage": i.outcome_stage}
                         if getattr(i, "outcome_stage", None) is not None

--- a/src/draftwright/export.py
+++ b/src/draftwright/export.py
@@ -124,6 +124,93 @@ def _semantic_font_name(font_path: str) -> str:
 _SVG_NS = "{http://www.w3.org/2000/svg}"
 
 
+def highlight_svg_annotation(svg_path, *, name, view, bounds, context, tip) -> None:
+    """Crop exported ink and add a visibly diagnostic overlay in page coordinates."""
+    x0, y0, x1, y1 = bounds
+    cx0, cy0, cx1, cy1 = context
+    values = (*bounds, *context, *(tip if tip is not None else ()))
+    if not all(math.isfinite(value) for value in values) or x1 < x0 or y1 < y0:
+        raise ValueError("annotation preview geometry is invalid")
+    left, bottom = min(x0, cx0) - 5, min(y0, cy0) - 5
+    right, top = max(x1, cx1) + 5, max(y1, cy1) + 5
+    if tip is not None:
+        left, bottom = min(left, tip[0] - 5), min(bottom, tip[1] - 5)
+        right, top = max(right, tip[0] + 5), max(top, tip[1] + 5)
+    # Reserve a caption above the crop. Coordinates retain the export's page Y-up → SVG
+    # Y-down mapping, so the marker overlays the actual rendered tip at every sheet scale.
+    right = max(right, left + 150)
+    top += 15
+    tree = ET.parse(svg_path)
+    root = tree.getroot()
+    root.set("viewBox", f"{left} {-top} {right - left} {top - bottom}")
+    root.set("width", f"{right - left}mm")
+    root.set("height", f"{top - bottom}mm")
+    root.insert(
+        0,
+        ET.Element(
+            _SVG_NS + "rect",
+            {
+                "x": str(left),
+                "y": str(-top),
+                "width": str(right - left),
+                "height": str(top - bottom),
+                "fill": "white",
+            },
+        ),
+    )
+    overlay = ET.SubElement(root, _SVG_NS + "g", {"id": "draftwright-diagnostic"})
+    title = f"DIAGNOSTIC: {name} (view: {view or 'unavailable'})"
+    ET.SubElement(overlay, _SVG_NS + "title").text = title
+    ET.SubElement(
+        overlay,
+        _SVG_NS + "rect",
+        {
+            "x": str(left),
+            "y": str(-top),
+            "width": str(right - left),
+            "height": "14",
+            "fill": "white",
+        },
+    )
+    for offset, text in (
+        (5, title),
+        (10, "Orange: annotation bounds / drawn tip. Physical target not certified."),
+    ):
+        ET.SubElement(
+            overlay,
+            _SVG_NS + "text",
+            {"x": str(left + 2), "y": str(-top + offset), "font-size": "3", "fill": "#9a3412"},
+        ).text = text
+    ET.SubElement(
+        overlay,
+        _SVG_NS + "rect",
+        {
+            "x": str(x0),
+            "y": str(-y1),
+            "width": str(x1 - x0),
+            "height": str(y1 - y0),
+            "fill": "none",
+            "stroke": "#ea580c",
+            "stroke-width": "0.4",
+            "stroke-dasharray": "2 1",
+        },
+    )
+    if tip is not None:
+        ET.SubElement(
+            overlay,
+            _SVG_NS + "circle",
+            {
+                "cx": str(tip[0]),
+                "cy": str(-tip[1]),
+                "r": "2",
+                "fill": "none",
+                "stroke": "#ea580c",
+                "stroke-width": "0.6",
+            },
+        )
+    tree.write(svg_path, encoding="utf-8", xml_declaration=True)
+
+
 def canonicalize_svg(svg_path: str) -> None:
     """Emit the elements of each layer in an order that does not depend on the run.
 

--- a/src/draftwright/linting/blend_coverage.py
+++ b/src/draftwright/linting/blend_coverage.py
@@ -270,6 +270,12 @@ def lint_blend_leader_targets(*, registry, cylinders, project, evidence=None, ow
             )
             arcs = _blend_profile_arcs(faces, feature.radius)
         if not arcs:
+            if key is None:
+                reason = "feature-backed blend measurement unavailable"
+            elif view is None:
+                reason = "annotation view unavailable"
+            else:
+                reason = "trimmed profile arc evidence unavailable"
             issues.append(
                 LintIssue(
                     severity="warning",
@@ -277,6 +283,9 @@ def lint_blend_leader_targets(*, registry, cylinders, project, evidence=None, ow
                     message=f"{name}: the radius leader's physical profile arc cannot be verified",
                     location=tip,
                     measurement_ids=measurements,
+                    annotation_name=name,
+                    view=view,
+                    evidence_reason=reason,
                 )
             )
         elif (
@@ -293,6 +302,9 @@ def lint_blend_leader_targets(*, registry, cylinders, project, evidence=None, ow
                     message=f"{name}: the radius leader tip does not touch its trimmed profile arc",
                     location=tip,
                     measurement_ids=measurements,
+                    annotation_name=name,
+                    view=view,
+                    evidence_reason="drawn tip is outside the trimmed physical profile arc tolerance",
                 )
             )
     return issues

--- a/src/draftwright/linting/hole_coverage.py
+++ b/src/draftwright/linting/hole_coverage.py
@@ -1241,6 +1241,14 @@ def lint_hole_leader_targets(
             for edge in evidence.face(face).edges()
         )
         if not edges:
+            if not valid_evidence:
+                reason = "same-run recognition evidence unavailable"
+            elif view is None:
+                reason = "annotation view unavailable"
+            elif not refs:
+                reason = "exact physical occurrence ownership unavailable"
+            else:
+                reason = "named occurrence has no defining boundary edges"
             issues.append(
                 LintIssue(
                     severity="warning",
@@ -1248,6 +1256,9 @@ def lint_hole_leader_targets(
                     message=f"{name}: the diameter leader's physical boundary cannot be verified",
                     location=tip,
                     measurement_ids=measurements,
+                    annotation_name=name,
+                    view=view,
+                    evidence_reason=reason,
                 )
             )
         elif (
@@ -1264,6 +1275,9 @@ def lint_hole_leader_targets(
                     message=f"{name}: the diameter leader tip does not touch its named physical boundary",
                     location=tip,
                     measurement_ids=measurements,
+                    annotation_name=name,
+                    view=view,
+                    evidence_reason="drawn tip is outside the named physical boundary tolerance",
                 )
             )
     return issues

--- a/src/draftwright/linting/issues.py
+++ b/src/draftwright/linting/issues.py
@@ -45,6 +45,11 @@ class LintIssue:
     # share it; this parallel tuple lets completeness distinguish which member was dropped.
     # Empty for families whose identity is already occurrence-specific.
     measurement_spans: tuple = ()
+    # Producer-recorded inspection references. Names belong to this Drawing's registry;
+    # they are not persistent feature or occurrence IDs and must never be parsed from text.
+    annotation_name: str | None = None
+    view: str | None = None
+    evidence_reason: str | None = None
 
 
 def is_placement_drop(issue: LintIssue) -> bool:

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -818,4 +818,45 @@ def quality_components(
     }
 
 
-__all__ = ["quality_components"]
+def review_explanation(*, quality: dict, errors: int, warnings: int, score: float) -> dict:
+    """Explain existing observations without creating a score or requirement inventory."""
+    completeness = quality["completeness"]
+    if completeness["available"]:
+        coverage = (
+            f"Of {completeness['requirements']} audited recognized requirements: "
+            + ", ".join(
+                f"{completeness[state]} {state.replace('_', ' ')}"
+                for state in _OUTCOME_STATES
+                if state != "inapplicable"
+            )
+            + ". This is partial coverage; see quality.completeness for excluded evidence."
+        )
+    else:
+        coverage = f"Coverage unavailable: {completeness['reason']}."
+
+    def describe_axis(name: str) -> str:
+        component = quality[name]
+        if not component["available"]:
+            return f"Unavailable: {component['reason']}."
+        return (
+            f"{component['raw_issues']} findings in the checks performed "
+            f"(score {component['score']:g}); absence of findings is not proof beyond those checks."
+        )
+
+    return {
+        "summary": (
+            f"{errors} errors, {warnings} warnings. passed={str(errors == 0).lower()}; "
+            f"passed is true only with no error-severity findings. diagnostic_score={score:g} is the legacy "
+            "severity penalty, not a drawing-quality or completeness score."
+        ),
+        "coverage": coverage,
+        "legibility": describe_axis("legibility"),
+        "fidelity": describe_axis("fidelity"),
+        "manufacturing_intent": (
+            "Not assessed: material, process, finish, thread, fit and tolerance intent require "
+            "author input. Free text does not establish requirement coverage."
+        ),
+    }
+
+
+__all__ = ["quality_components", "review_explanation"]

--- a/tests/test_issue_1378_diameter_leader_targets.py
+++ b/tests/test_issue_1378_diameter_leader_targets.py
@@ -130,6 +130,17 @@ def test_lint_requires_the_named_holes_physical_authority(monkeypatch, withdraw)
     (issue,) = lint_hole_leader_targets(**kwargs)
     assert issue.code == "diameter_leader_target_unverifiable"
     assert issue.measurement_ids
+    _, name, _ = _hole_leader(drawing)
+    assert issue.annotation_name == name
+    assert issue.view == drawing.view_of(name)
+    expected = {
+        "faces": "named occurrence has no defining boundary edges",
+        "ownership": "exact physical occurrence ownership unavailable",
+        "foreign_evidence": "same-run recognition evidence unavailable",
+        "owner": "exact physical occurrence ownership unavailable",
+        "view": "annotation view unavailable",
+    }
+    assert issue.evidence_reason == expected[withdraw]
 
 
 @pytest.mark.parametrize("declared", [False, True])

--- a/tests/test_issue_1479_radius_leader_targets.py
+++ b/tests/test_issue_1479_radius_leader_targets.py
@@ -78,6 +78,8 @@ def test_lint_rejects_centre_bore_and_untrimmed_circle_extension(
     assert name in issues[0].message
     assert issues[0].location == tip
     assert issues[0].measurement_ids == automatic.registry.measurement_of(name)
+    assert issues[0].annotation_name == name and issues[0].view == "side"
+    assert "outside the trimmed physical profile arc tolerance" in issues[0].evidence_reason
 
 
 @pytest.mark.parametrize("mode", ["live", "deferred", "retained"])
@@ -184,6 +186,15 @@ def test_lint_reports_unverifiable_target_authority(automatic, monkeypatch, with
     assert len(issues) == 2
     assert all(issue.code == "radius_leader_target_unverifiable" for issue in issues)
     assert all(issue.measurement_ids for issue in issues)
+    for issue in issues:
+        assert issue.annotation_name in automatic.annotations()
+        assert issue.view == registry.view_of(issue.annotation_name)
+        if withdraw in {"owner", "wrong_owner"}:
+            assert issue.evidence_reason == "feature-backed blend measurement unavailable"
+        elif withdraw == "view":
+            assert issue.evidence_reason == "annotation view unavailable"
+        else:
+            assert issue.evidence_reason == "trimmed profile arc evidence unavailable"
 
 
 @pytest.mark.parametrize("defect", ["radius", "side", "direction", "axis", "station", "ambiguous"])

--- a/tests/test_issue_1533_review_diagnostics.py
+++ b/tests/test_issue_1533_review_diagnostics.py
@@ -1,0 +1,159 @@
+"""Explain bounded critique and inspect its actual ink without changing the drawing."""
+
+import json
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import jsonschema
+import pytest
+from build123d import Box, Cylinder, Pos
+
+from draftwright import Drawing, build_drawing
+from draftwright.linting import LintIssue
+
+
+@pytest.fixture(scope="module", params=[False, True], ids=["automatic", "declared"])
+def drawing(request):
+    d = build_drawing(Box(20, 20, 5) - Pos(5, 0, 0) * Cylinder(4, 5), scale=2)
+    if request.param:
+        d = build_drawing(d.working_part, model=d.model(), scale=2)
+    return d
+
+
+def _leader(drawing):
+    (name,) = [
+        name
+        for name, item in drawing.iter_annotations()
+        if hasattr(item, "tip") and drawing.registry.measurement_of(name)
+    ]
+    return name, drawing.get_annotation(name)
+
+
+def test_warning_penalty_is_explained_without_claiming_completeness(monkeypatch):
+    d = Drawing(
+        scale=1,
+        page_w=100,
+        page_h=100,
+        tb_w=20,
+        draft=None,
+        look_at=None,
+        dist=1,
+        centroid=None,
+        out="",
+    )
+    warnings = [LintIssue("warning", "custom critique", code="custom") for _ in range(35)]
+    monkeypatch.setattr(d, "lint", lambda: warnings)
+    summary = d.lint_summary()
+    assert summary["passed"] and summary["score"] == summary["diagnostic_score"] == 0
+    assert summary["warnings"] == 35 and summary["errors"] == 0
+    explanation = summary["review"]
+    assert "0 errors, 35 warnings" in explanation["summary"]
+    assert "passed=true; passed is true only with no error-severity" in explanation["summary"]
+    assert "not a drawing-quality or completeness score" in explanation["summary"]
+    assert "Coverage unavailable" in explanation["coverage"]
+    assert "Unavailable:" in explanation["fidelity"]
+    assert "Not assessed" in explanation["manufacturing_intent"]
+    json.dumps(summary, allow_nan=False)
+
+
+def test_explanations_retain_each_existing_outcome_and_bound(drawing):
+    summary = drawing.lint_summary()
+    coverage = summary["quality"]["completeness"]
+    assert coverage["available"] and coverage["requirements"] > 0
+    for state in (
+        "placed",
+        "satisfied_by_structured_note",
+        "suppressed",
+        "dropped",
+        "missing",
+        "unverifiable",
+        "unsupported",
+    ):
+        assert f"{coverage[state]} {state.replace('_', ' ')}" in summary["review"]["coverage"]
+    assert "partial coverage" in summary["review"]["coverage"]
+    assert "not proof" in summary["review"]["fidelity"]
+    assert "Free text does not establish" in summary["review"]["manufacturing_intent"]
+
+
+def test_target_preview_uses_recorded_name_view_and_actual_tip(drawing, monkeypatch, tmp_path):
+    name, leader = _leader(drawing)
+    assert not [i for i in drawing.lint() if i.code.startswith("diameter_leader_target_")]
+    old_tip = leader.tip
+    monkeypatch.setattr(leader, "location", Pos(0.7, 0, 0) * leader.location)
+    assert leader.tip[0] == pytest.approx(old_tip[0] + 0.7)
+    before = drawing.lint_summary()
+    (issue,) = [i for i in before["issues"] if i["code"] == "diameter_leader_target_mismatch"]
+    assert issue["annotation_name"] == name and issue["view"] == drawing.view_of(name)
+    assert "outside the named physical boundary tolerance" in issue["evidence_reason"]
+    items = tuple(id(item) for item in drawing.items)
+    annotations = drawing.annotations()
+    measurements = drawing.registry.measurement_of(name)
+    paths = (drawing.svg_path, drawing.dxf_path)
+    preview = tmp_path / "target.svg"
+    assert drawing.preview_annotation(issue["annotation_name"], preview) == str(preview)
+    root = ET.parse(preview).getroot()
+    ns = {"s": "http://www.w3.org/2000/svg"}
+    overlay = root.find("s:g[@id='draftwright-diagnostic']", ns)
+    assert overlay is not None
+    circle = overlay.find("s:circle", ns)
+    assert float(circle.attrib["cx"]) == pytest.approx(leader.tip[0])
+    assert float(circle.attrib["cy"]) == pytest.approx(-leader.tip[1])
+    assert "Physical target not certified" in " ".join(overlay.itertext())
+    assert name in " ".join(overlay.itertext()) and issue["view"] in " ".join(overlay.itertext())
+    assert tuple(id(item) for item in drawing.items) == items
+    assert drawing.annotations() == annotations
+    assert drawing.registry.measurement_of(name) == measurements
+    assert (drawing.svg_path, drawing.dxf_path) == paths
+    assert drawing.lint_summary() == before
+
+
+def test_preview_refuses_unfinished_edits_and_unknown_names(drawing, tmp_path):
+    name, _ = _leader(drawing)
+    path = tmp_path / "preview.svg"
+    path.write_text("existing artifact")
+    with pytest.raises(KeyError):
+        drawing.preview_annotation("unknown", path)
+    with pytest.raises(ValueError, match=".svg"):
+        drawing.preview_annotation(name, tmp_path / "preview.pdf")
+    with drawing.deferred(), pytest.raises(ValueError, match="finish deferred"):
+        drawing.preview_annotation(name, path)
+    assert path.read_text() == "existing artifact"
+
+
+def test_open_lint_payload_keeps_report_v3_schema():
+    d = build_drawing(Box(20, 20, 5) - Cylinder(4, 5))
+    report = d.report()
+    assert report["schema_version"] == 3 and "review" in report["lint"]
+    schema = Path(__file__).parents[1] / "docs/reference/draftwright-report-v3.schema.json"
+    jsonschema.validate(report, json.loads(schema.read_text()))
+    before = d.lint_summary()["quality"]["completeness"]
+    assert before["placed"] > 0
+    note = d.note("All holes and requirements are covered", (10, 10))
+    assert d.lint_summary()["quality"]["completeness"] == before
+    name, _ = _leader(d)
+    d.remove(name)
+    after = d.lint_summary()["quality"]["completeness"]
+    assert after["requirements"] == before["requirements"]
+    assert after["placed"] < before["placed"]
+    assert after["missing"] > before["missing"]
+    d.remove(note)
+
+
+def test_preview_handles_unowned_note_and_preserves_artifact_on_bad_geometry(
+    drawing, tmp_path, monkeypatch
+):
+    name = drawing.note("Inspect this text", (10, 10))
+    path = tmp_path / "note.svg"
+    try:
+        drawing.preview_annotation(name, path)
+        root = ET.parse(path).getroot()
+        overlay = root.find("{http://www.w3.org/2000/svg}g[@id='draftwright-diagnostic']")
+        assert "view: unavailable" in " ".join(overlay.itertext())
+        assert overlay.find("{http://www.w3.org/2000/svg}circle") is None
+        before = path.read_bytes()
+        monkeypatch.setattr(drawing, "get_annotation", lambda _: object())
+        with pytest.raises(ValueError, match="bounds unavailable"):
+            drawing.preview_annotation(name, path)
+        assert path.read_bytes() == before
+    finally:
+        drawing.remove(name)

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -5461,6 +5461,7 @@ class TestLintSummaryAndDrops:
             "score",
             "diagnostic_score",
             "quality",
+            "review",
             "errors",
             "warnings",
             "infos",


### PR DESCRIPTION
The frame's declared sheet reports no errors, 36 warnings and a zero diagnostic score. `lint_summary().review` now explains what each existing observation means: the error-only `passed` flag, legacy severity penalty, bounded recognized-requirement coverage, legibility, fidelity and unassessed manufacturing intent. Scores, requirement counts and report-v3 ownership refusals retain their meanings.

Diameter and straight-blend radius target findings now carry their producer-recorded annotation name, view and missing-evidence/mismatch reason. `Drawing.preview_annotation(name, path)` writes a diagnostic SVG over the existing export path, highlighting current ink bounds and the drawn tip in its view. Its caption explicitly says the physical target is not certified. It does not finalize edits, alter annotations or coverage, or update export paths. Live measurement references and existing report relations remain the inspection route; no persistent feature IDs are invented.

Validation:
- 76 focused tests passed, including automatic/declared previews, both target-check families, authority withdrawals, unchanged report-v3 schema, no free-text coverage, and retained physical requirements after an annotation is removed.
- Replayed the pinned frame through public declared Sheet calls without the original private renderer patch. It retains all 58 audited requirements: 2 placed, 3 suppressed, 47 unverifiable and 6 unsupported. Both unresolved target previews were rendered and visually inspected; previewing leaves the full summary unchanged. This is a reduced current macOS replay of the feature sheet, not the original Linux package trial.
- Mutating the SVG Y mapping, deleting producer-recorded annotation identity, or making preview remove the annotation each fails the named regression on both build routes.
- Independent Google-style review against all five ADRs is clean at 07b4af257248c71f26cf499b95ab5798b1965ff8; reviewer independently ran 46 relevant tests and inspected previews.
- Rebased only this PR’s two commits onto merged #1541 (`92363e9d`). `git diff --exit-code 07b4af25 HEAD` passed: the resulting tree at `59bdb49ff346e603b2f5d2d13b64b9f409b2d029` is identical to the reviewed and fully tested tree, so those results carry unchanged.
- Final full local gate passed: 8,028 tests, 96.03% total coverage, 77/78 changed lines covered (98.7%); Ruff, format, mypy, codespell and strict docs build passed. Required CI remains the merge gate.

Architecture: ADR1 keeps existing module ranks and lint ownership; ADR2 adds no placement path; ADR3 adds no recognition or correspondence; ADR4 preserves authored omissions; ADR5 keeps all unresolved outcomes, report refusals and bounded claims. The new summary fields sit inside v3's existing open lint payload. No ADR text changes or multi-sheet reconciliation.

Fixes #1533. Part of #1529.
