### PR TITLE
Report title-block overflow while preserving required dimensions

### DIFF
--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -27,6 +27,58 @@ fails before projection; a whole-view pin must preserve the convention's relatio
 
 ## Dimension text style
 
+### Title fields and notes at paper size
+
+Keep title-block values concise and put longer engineering information in a `notes()` block.
+`title_field_overflow` identifies text wider or taller than its title-block cell, even when the
+text remains inside the page. This is a legibility warning, like overlapping annotations;
+text outside the drawable page remains an `annotation_out_of_bounds` error. The full value
+stays rendered; the diagnostic does not truncate it, shrink the font or invent an abbreviation.
+`lint_summary()["passed"]` checks errors only, so inspect warnings and the legibility component
+as well. A title warning does not prevent scale recovery from restoring missing measurements.
+
+<!-- issue-1536-notes-example -->
+```python
+from build123d import Box
+from draftwright import Sheet
+
+sheet = Sheet(
+    Box(30, 20, 10), page="A4", scale=2,
+    title="FRAME - DFM REVIEW", number="REVIEW", material="SEE NOTES",
+    detail_view=False,
+)
+sheet.authored_dimensions()
+envelope = sheet.envelope()
+for parameter in envelope.dimension_ids():
+    sheet.dimension(envelope, parameter)
+sheet.notes([
+    "QUOTATION / DFM REVIEW - NOT RELEASED",
+    "Material: TITANIUM - GRADE TBD",
+    "Hinge fit and pin retention: engineering decision required",
+], prefer="tr")
+drawing = sheet.build()
+for issue in drawing.lint():
+    print(issue.severity, issue.code, issue.message)
+```
+<!-- /issue-1536-notes-example -->
+
+`page` and `scale` control the sheet and model size. The current annotation preset has a fixed
+3 mm nominal paper font size; changing scale does not enlarge notes. `Sheet.notes()` and
+`Sheet.table()` have no font-size option. `text_position` and `text_orientation` below control
+dimension style, not note size. A smaller model scale makes notes larger relative to the part;
+a smaller page changes how much of the page they occupy. Neither changes their printed size.
+For the A2 frame trial, retain A2 and the requested scale unless the full package fits the new
+constraints with its required measurements intact; the small box example is not proof that
+the frame fits A4.
+
+`prefer="tr"` ranks available table positions near the top-right corner. The shared placement
+solve still measures the whole notes block and checks all occupied regions. If it cannot fit,
+`table_dropped` reports the failure. Split long prose into authored lines or choose an appropriate
+page; do not remove engineering content merely to silence a diagnostic. General notes remain
+uncredited text: they do not automatically satisfy missing dimensions or unsupported features.
+
+### Dimension position and reading direction
+
 Position and reading direction are independent drawing-wide settings:
 
 ```python

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -1419,6 +1419,13 @@ def _make_title_block(dwg, a: Analysis):
             )
         )
     tb.pdf_text_specs = tuple(specs)
+    # Keep the exact rendered field inputs for structural cell-overflow checks. Cell geometry
+    # remains owned by TitleBlock.cell_bbox(); it is not copied into a second layout model.
+    tb.title_field_specs = tuple(
+        (field, value, dwg.draft.font_size, PLEX_SANS_CONDENSED)
+        for field, value in fields
+        if value
+    )
     return tb, cell
 
 

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -58,6 +58,7 @@ _LEGIBILITY_CODES = frozenset(
         "layout_repack_stalled",
         "scale_fallback_applied",
         "annotation_out_of_bounds",
+        "title_field_overflow",
         "annotation_overlap",
         "annotation_ink_overlap",
         "detail_unplaceable",

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -15,7 +15,7 @@ import re
 
 from build123d import GeomType
 
-from draftwright._core import _shape_box2d
+from draftwright._core import _shape_box2d, _text_size
 from draftwright._geometry import (
     BOUNDS_ROUNDOFF,
     MATERIAL_VISIBLE_FLOOR,
@@ -359,6 +359,7 @@ def lint_drawing(
         page_bbox = (p["min_x"], p["min_y"], p["max_x"], p["max_y"])
 
     for item in items:
+        _lint_title_fields(item, issues)
         if getattr(item, "elbow", None) is not None:
             _lint_leader(item, issues, box_cache, warned=warned_label_bbox)
         elif is_dimension_like(item):
@@ -728,6 +729,27 @@ def _view_edge_entries(vs, cache):
         entries = None
     cache[key] = (vs, entries)
     return entries
+
+
+def _lint_title_fields(item, issues) -> None:
+    """Check centred title-field ink against its helper-owned cell, in the build frame."""
+    for field, value, font_size, font_path in getattr(item, "title_field_specs", ()):
+        cell = item.cell_bbox(field)
+        width, height = _text_size(value, font_size, font_path)
+        if width > cell["width"] + BOUNDS_ROUNDOFF or height > cell["height"] + BOUNDS_ROUNDOFF:
+            issues.append(
+                LintIssue(
+                    severity="warning",
+                    code="title_field_overflow",
+                    message=(
+                        f"Title-block field {field!r} overflows its cell: text "
+                        f"{width:.2f} × {height:.2f} mm, cell "
+                        f"{cell['width']:.2f} × {cell['height']:.2f} mm. "
+                        "Use a concise field value and retain the full information in a notes "
+                        "block; text has not been shortened or shrunk."
+                    ),
+                )
+            )
 
 
 def _lint_view_shapes(

--- a/tests/test_issue_1338_scale_before_page_escalation.py
+++ b/tests/test_issue_1338_scale_before_page_escalation.py
@@ -59,6 +59,13 @@ def test_automatic_recovers_on_a4_at_a_larger_scale_instead_of_escalating_the_sh
     assert (drawing.page_w, drawing.page_h, drawing.scale) == (*A4, 5.0)
     assert "iso" in drawing.views
     assert _requirement_failures(drawing) == []
+    # A long default title still overflows its cell at the recovered scale. Reporting this
+    # as a structural error would reject the recovery and return missing axial measurements.
+    overflow = [issue for issue in drawing.lint() if issue.code == "title_field_overflow"]
+    assert overflow and all(issue.severity == "warning" for issue in overflow)
+    legibility = drawing.lint_summary()["quality"]["legibility"]
+    assert legibility["by_code"]["title_field_overflow"] == 1
+    assert legibility["score"] < 1
 
     assert drawing.scale_decision["status"] == "automatic_replanned"
     assert [

--- a/tests/test_issue_1536_title_overflow.py
+++ b/tests/test_issue_1536_title_overflow.py
@@ -1,0 +1,144 @@
+"""Cell overflow is visible even when the composed block stays inside the page."""
+
+from pathlib import Path
+
+import pypdfium2 as pdfium
+import pytest
+from build123d import Align, Box, Mode, Text
+
+from draftwright import Sheet
+from draftwright.fonts import PLEX_SANS_CONDENSED
+
+
+def _box_sheet(**options):
+    sheet = Sheet(Box(30, 20, 10), page="A2", scale=2, detail_view=False, **options)
+    sheet.authored_dimensions()
+    envelope = sheet.envelope()
+    for parameter in envelope.dimension_ids():
+        sheet.dimension(envelope, parameter)
+    return sheet
+
+
+@pytest.fixture(scope="module")
+def crowded_material():
+    return _box_sheet(title="FRAME", material="TITANIUM - GRADE TBD").build()
+
+
+def test_material_crossing_cells_inside_page_is_reported(crowded_material):
+    drawing = crowded_material
+    block = drawing.get_annotation("title_block")
+    ink = Text(
+        "TITANIUM - GRADE TBD",
+        font_size=3,
+        font_path=PLEX_SANS_CONDENSED,
+        align=(Align.CENTER, Align.CENTER),
+        mode=Mode.PRIVATE,
+    ).bounding_box()
+    assert ink.size.X > block.cell_bbox("material")["width"]
+    assert block.bounding_box().max.X < drawing.page_w - 10
+    issues = drawing.lint()
+    assert not any(issue.code == "annotation_out_of_bounds" for issue in issues)
+    overflow = [issue for issue in issues if issue.code == "title_field_overflow"]
+    assert len(overflow) == 1
+    assert overflow[0].severity == "warning"
+    assert "'material'" in overflow[0].message
+    assert "29.59" in overflow[0].message and "22.50" in overflow[0].message
+    summary = drawing.lint_summary()
+    assert summary["passed"]  # The existing flag checks errors, not legibility warnings.
+    assert summary["quality"]["legibility"]["by_code"]["title_field_overflow"] == 1
+    assert summary["quality"]["legibility"]["score"] < 1
+
+
+@pytest.mark.parametrize(
+    "options,field",
+    [
+        ({"title": "FRAME\nMACHINING\nREVIEW\nPRELIMINARY"}, "title"),
+        ({"number": "DOCUMENT NUMBER WITH A LONG SUFFIX"}, "drawing_number"),
+        ({"revision": "PRELIMINARY REVISION A"}, "revision"),
+        ({"date": "SEPTEMBER 9 2026", "revision": ""}, "revision"),
+        (
+            {"tolerance": "TOLERANCE REQUIREMENTS ARE IN THE PROCESS SPECIFICATION"},
+            "general_tolerance",
+        ),
+        ({"drawn_by": "ENGINEERING REVIEW TEAM " * 8}, "designed_by"),
+        ({"company": "MANUFACTURING REVIEW ORGANISATION " * 8}, "legal_owner"),
+    ],
+)
+def test_all_rendered_fields_and_multiline_height_are_checked(options, field):
+    drawing = _box_sheet(**options).build()
+    block = drawing.get_annotation("title_block")
+    value, font_size, font_path = next(
+        spec[1:] for spec in block.title_field_specs if spec[0] == field
+    )
+    ink = Text(
+        value,
+        font_size=font_size,
+        font_path=font_path,
+        align=(Align.CENTER, Align.CENTER),
+        mode=Mode.PRIVATE,
+    ).bounding_box()
+    cell = block.cell_bbox(field)
+    assert ink.size.X > cell["width"] or ink.size.Y > cell["height"]
+    overflow = [issue for issue in drawing.lint() if issue.code == "title_field_overflow"]
+    assert any(f"{field!r}" in issue.message for issue in overflow)
+    assert drawing.draft.font_size == 3
+    if field == "legal_owner":
+        block_bounds = block.bounding_box()
+        assert block_bounds.min.X < 10 or block_bounds.max.X > drawing.page_w - 10
+        page_overflow = [
+            issue for issue in drawing.lint() if issue.code == "annotation_out_of_bounds"
+        ]
+        assert page_overflow and all(issue.severity == "error" for issue in page_overflow)
+
+
+def test_export_preserves_the_full_overflowing_value(crowded_material, tmp_path):
+    before = crowded_material.measurement_snapshot()
+    paths = crowded_material.export(str(tmp_path / "crowded"), formats=("pdf", "svg"))
+    with pdfium.PdfDocument(paths["pdf"]) as pdf:
+        text = pdf[0].get_textpage().get_text_range()
+    assert "TITANIUM - GRADE TBD" in text
+    assert crowded_material.measurement_snapshot() == before
+    assert any(issue.code == "title_field_overflow" for issue in crowded_material.lint())
+
+
+@pytest.fixture(scope="module")
+def note_control_drawings():
+    document = (Path(__file__).parents[1] / "docs/reference/sheet.md").read_text()
+    marked = document.split("<!-- issue-1536-notes-example -->", 1)[1]
+    recipe = marked.split("```python\n", 1)[1].split("```", 1)[0]
+    drawings = []
+    for page, scale in (("A4", 1), ("A4", 2), ("A2", 2)):
+        namespace = {}
+        exec(recipe.replace('page="A4", scale=2', f'page="{page}", scale={scale}'), namespace)
+        drawings.append(namespace["drawing"])
+    return drawings
+
+
+def test_documented_page_scale_controls_preserve_printed_notes_and_measurements(
+    note_control_drawings,
+):
+    sizes = []
+    for drawing in note_control_drawings:
+        assert not drawing.lint()
+        assert drawing.draft.font_size == 3
+        notes = drawing.get_annotation("notes0")
+        assert notes is not None
+        assert any("TITANIUM - GRADE TBD" in row[0] for row in notes.table_rows)
+        sizes.append(notes.table_size)
+        assert {claim.meaning[0][0] for claim in drawing.measurement_snapshot().claims} == {
+            10,
+            20,
+            30,
+        }
+    assert sizes[0] == pytest.approx(sizes[1])
+    assert sizes[1] == pytest.approx(sizes[2])
+
+
+def test_documented_notes_export_without_losing_full_material(note_control_drawings, tmp_path):
+    drawing = note_control_drawings[1]
+    path = drawing.export(str(tmp_path / "notes"), formats=("pdf",))["pdf"]
+    with pdfium.PdfDocument(path) as pdf:
+        text = pdf[0].get_textpage().get_text_range()
+    assert "SEE NOTES" in text
+    assert "TITANIUM - GRADE TBD" in text
+    assert "Hinge fit and pin retention: engineering decision required" in text


### PR DESCRIPTION
A title-block value could cross into neighbouring cells while remaining inside the page and receive no diagnostic. On the small A2 reproduction, the material text is 29.59 mm wide in a 22.5 mm cell; the previous structural lint reported no issues.

`title_field_overflow` now reports each oversized field using the exact rendered text inputs, pinned font metrics and the helper’s own cell bounds. It is a legibility warning, like text overlap within the sheet; ink outside the drawable page remains an error. The full value and fixed typography remain rendered. Making cell overflow an error was tested and rejected because it caused GRM03’s scale-recovery gate to sacrifice required axial measurements for a title that cannot improve with model scale. The regression now requires both the 5:1 recovery and its retained title warning.

The executable Sheet documentation demonstrates a concise material field with the full engineering information in notes, and explains the current fixed 3 mm paper font, page/scale controls, table-drop diagnostics and error-only `passed` flag. It introduces no font-size preference or automatic abbreviation.

Validation:
- Independent Google-style review against all five ADRs is clean at `a7d0bd18dc30c0e73fc5af4b41eed71f6c4f4209`; reviewer independently ran 11 new tests plus the GRM03 recovery regression.
- Three verified runtime mutations fail named guards: disable cell checking, omit height checking, or remove its legibility classification.
- Pinned declared frame replay: replacing the long field with SEE NOTES and preserving its full text in a placed notes block retains all 58 recognized outcomes (2 placed, 3 suppressed, 47 unverifiable, 6 unsupported). The exact-owner measurement comparison has no lost/gained/changed claims; its status remains unknown because the new free-text table has no measurement identity. Both field and notes were inspected in the exported PDF. This reduced replay does not claim complete frame coverage or validate the unresolved targets.
- Final full local `scripts/pr-check --full` passed: 8,055 passed, 5 skipped, 13 xfailed; 96.04% total coverage and 100% of changed production lines covered (9/9). Ruff, format, mypy, codespell and strict docs build passed. Required CI remains the merge gate.

Architecture: ADR1 retains existing module homes; ADR2 keeps fixed typography, shared table placement and required-measurement recovery; ADR3 adds no recognition; ADR4 preserves authored content; ADR5 adds an explicit legibility finding without granting notes coverage or changing the physical denominator. No ADR text change.

Fixes #1536. Part of #1529.

Published head `8aa40495e898787660ca2ba76b6e91f28d530ea7` is whole-tree identical to independently reviewed and full-gated `3a8387191a6644ebc38121b662f769bf192b4b4c` after rebasing onto merged main `4ff6aff4912223b1319bf3bfa9dcede56de21a48` (`git diff --exit-code` passed).
