### PR TITLE
docs: measure frame exports and preserve review artifacts

### DIFF
--- a/docs/reference/generated-artifacts.md
+++ b/docs/reference/generated-artifacts.md
@@ -1,0 +1,145 @@
+# Managing generated drawing artifacts
+
+Keep the editable generator, source model, dependency record and review evidence together.
+Treat SVG, DXF, PDF and previews as generated outputs. A smaller archive is easier to transfer;
+its size says nothing about drawing completeness.
+
+## Keep source review readable
+
+If drawings are committed, scope these root `.gitattributes` rules to the generated directory:
+
+```gitattributes
+drawings/generated/**/*.svg binary linguist-generated=true
+drawings/generated/**/*.dxf binary linguist-generated=true
+drawings/generated/**/*.pdf binary linguist-generated=true
+drawings/generated/**/*.png binary linguist-generated=true
+```
+
+Git's `binary` attribute disables textual diffs, text merges and newline conversion for those
+paths. Conflicting generated files require regeneration or an explicit choice; Git does not
+silently merge their content. `linguist-generated=true` additionally hides generated content in
+GitHub diffs by default. These rules leave Python generators, JSON evidence and dependency files
+reviewable. Adjust the directory to your project; do not classify every SVG or every file in the
+repository as generated. See the [Git attributes manual](https://git-scm.com/docs/gitattributes)
+and [GitHub's generated-file guidance](https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github).
+
+Check the effective rules, including any local overrides:
+
+```sh
+git check-attr diff merge text linguist-generated -- \
+  drawings/generated/frame-features.svg drawings/generated/frame-features.dxf \
+  drawings/generated/frame-features.pdf drawings/generated/frame-preview.png \
+  drawings/generated/frame.draftwright.json scripts/draw_frame.py
+```
+
+Alternatively, ignore a dedicated build-output directory and distribute a reviewed archive.
+Keep source, generator and environment records under version control. Attributes change diff
+presentation; they do not reduce repository history size or replace visual drawing review.
+
+## Inventory a review bundle
+
+The following packaging example uses an explicit list of artifacts. Adapt the names to the
+files returned by `drawing.export()`. It neither builds a drawing nor runs recognition. Save
+the function in your packaging script; `root` is the directory containing the listed files.
+
+<!-- issue-1537-bundle-example -->
+```python
+import hashlib
+import json
+from pathlib import Path
+from zipfile import ZIP_DEFLATED, ZipFile
+
+
+def bundle_review(root):
+    root = Path(root)
+    roles = {
+        "source": ["frame-reference.step"],
+        "generator": ["draw_titanium_frame.py"],
+        "generation_environment": ["requirements.txt"],
+        "drawings": [
+            f"frame-{sheet}.{extension}"
+            for sheet in ("general", "features")
+            for extension in ("svg", "dxf", "pdf")
+        ],
+    }
+    # Retain available evidence as separate documents, without joining their IDs.
+    evidence_names = (
+        "frame-general.draftwright.json", "frame-features.draftwright.json",
+        "frame.draftwright-inspection.json", "drawing-checks.json",
+    )
+    roles["review_evidence"] = [name for name in evidence_names if (root / name).is_file()]
+    payload = {
+        name: (root / name).read_bytes()
+        for names in roles.values() for name in names
+    }  # Missing required files fail before creating the archive.
+    manifest = {
+        "scope": "bundled-file-integrity",
+        "review_status": "QUOTATION / DFM REVIEW - NOT RELEASED",
+        "unresolved_decisions": ["material grade", "hinge fit and pin retention"],
+        "generation_environment_record": "requirements.txt",
+        "evidence": {
+            "present": roles["review_evidence"],
+            "not_provided": [name for name in evidence_names if name not in payload],
+            "assessment": "Read each document under its own schema and scope.",
+        },
+        "files": [
+            {"role": role, "path": name, "bytes": len(payload[name]),
+             "sha256": hashlib.sha256(payload[name]).hexdigest()}
+            for role, names in roles.items() for name in names
+        ],
+    }
+    manifest_bytes = (json.dumps(manifest, indent=2, allow_nan=False) + "\n").encode()
+    archive = root / "frame-review.zip"
+    with ZipFile(archive, "x", compression=ZIP_DEFLATED) as bundle:
+        for name, data in payload.items():
+            bundle.writestr(name, data)
+        bundle.writestr("bundle-manifest.json", manifest_bytes)
+    # Verify the exact bytes written, including every listed artifact.
+    with ZipFile(archive) as bundle:
+        assert set(bundle.namelist()) == {*payload, "bundle-manifest.json"}
+        assert bundle.read("bundle-manifest.json") == manifest_bytes
+        for name, data in payload.items():
+            assert bundle.read(name) == data
+    return archive
+```
+<!-- /issue-1537-bundle-example -->
+
+The output is a ZIP with the original artifact bytes and a bundle manifest. An existing ZIP is
+refused, so a rerun does not overwrite a previously reviewed package. This small example holds
+the selected files in memory and assumes generation has finished; it does not promise an atomic
+snapshot of a concurrently edited directory. Archive timestamps are not a reproducibility API.
+
+The environment record must come from **generation**, including the Draftwright, Quiddity,
+build123d and drafting-helpers versions or exact source revisions used. Do not substitute the
+versions installed on a machine that merely packages old drawings. Preserve the existing
+[`Drawing.report()`](reports.md) and [inspection sidecar](inspection.md) when available: their
+producer, source and run information retain their original meaning. A report and an inspection
+document answer different questions. Legacy `drawing-checks.json` is included as review evidence,
+not relabelled as a current Draftwright report.
+
+The example explicitly lists absent evidence. In particular, a declared drawing may refuse a
+strict report; record that limitation in the review record rather than manufacturing an empty
+report. Do not trigger a second recognition run merely to fill a packaging field. File hashes
+prove which bytes were bundled, not that the outputs were generated from the adjacent source
+or that manufacturing decisions have been resolved. Inspect available generation evidence and
+the actual drawings before changing the authored review status.
+
+## Size and fidelity
+
+For the pinned #1529 field-report exports, the feature/general DXFs were 8,548,578 and
+8,743,378 bytes. Their annotation layers accounted for 7,860,774 and 7,952,882 bytes. The
+entity census contains curves and lines, with no native `TEXT` or `MTEXT` entities; those layers
+also contain annotation geometry other than text. This makes their size consistent with the
+stored vector representation, rather than evidence of unnecessary hidden part geometry.
+
+Lossless gzip reduced those files to 667,005 and 682,691 bytes in the measured environment,
+and decompressing restored every byte. ZIP similarly transports the original files without
+replacing physical curves, annotation outlines or labels. Do not reduce size by flattening
+curves or deleting drawing content without a separate fidelity case. The detailed pinned
+[measurement record](https://github.com/pzfreo/draftwright/blob/main/docs/research/1537-export-size.md)
+includes all formats, hashes and a repeatable analyzer.
+
+`reproducible=True` is a different control: repeated exports of one drawing on one version
+agree byte-for-byte. It does not promise stability across versions, feature correspondence,
+coverage, portable generated source paths, or a manufacturing release. Portable generated
+paths and other CLI artifact changes remain tracked in #1255.

--- a/docs/research/1537-export-size.json
+++ b/docs/research/1537-export-size.json
@@ -1,0 +1,176 @@
+[
+  {
+    "file": "frame-features.dxf",
+    "bytes": 8548578,
+    "sha256": "15da19ec8cf408f5b5ce069e6626c0dc51c6551879c3d7bddbb47bd18a6f932a",
+    "gzip_bytes": 667005,
+    "sections": {
+      "HEADER": 6192,
+      "CLASSES": 1459,
+      "TABLES": 3375,
+      "BLOCKS": 426,
+      "ENTITIES": 8532652,
+      "OBJECTS": 4466,
+      "OUTSIDE": 8
+    },
+    "entities": {
+      "SPLINE": {
+        "count": 20265,
+        "bytes": 6273619
+      },
+      "LINE": {
+        "count": 13752,
+        "bytes": 2206445
+      },
+      "ELLIPSE": {
+        "count": 162,
+        "bytes": 36730
+      },
+      "ARC": {
+        "count": 76,
+        "bytes": 12495
+      },
+      "CIRCLE": {
+        "count": 30,
+        "bytes": 3327
+      }
+    },
+    "layers": {
+      "part": 679,
+      "hidden": 1607,
+      "dims": 31999
+    },
+    "layer_bytes": {
+      "part": 159119,
+      "hidden": 512723,
+      "dims": 7860774
+    },
+    "spline_degrees": {
+      "2": 20075,
+      "1": 178,
+      "3": 12
+    }
+  },
+  {
+    "file": "frame-features.pdf",
+    "bytes": 565358,
+    "sha256": "6dd6d2015cccc5a4f5aecd0996ebde23a568c9734f3615d81d54b597619dd256",
+    "gzip_bytes": 460903
+  },
+  {
+    "file": "frame-features.svg",
+    "bytes": 1479246,
+    "sha256": "8cf7a18f92d0de061dd37a1d5cc34d6358c3dc263b9d5eea60e3eda71fe19e08",
+    "gzip_bytes": 306272,
+    "elements": {
+      "svg": 1,
+      "metadata": 1,
+      "RDF": 1,
+      "Description": 1,
+      "creator": 1,
+      "source": 1,
+      "description": 1,
+      "g": 4,
+      "line": 1826,
+      "path": 2095,
+      "circle": 30,
+      "a": 1,
+      "rect": 1
+    },
+    "path_data_bytes": 1301474,
+    "path_commands": {
+      "M": 2588,
+      "Q": 20925,
+      "L": 14418,
+      "A": 238,
+      "C": 120
+    }
+  },
+  {
+    "file": "frame-general.dxf",
+    "bytes": 8743378,
+    "sha256": "3c458e81fe968fcd9bda60c15ed22da4503138a12a90e4133badad865804248a",
+    "gzip_bytes": 682691,
+    "sections": {
+      "HEADER": 6192,
+      "CLASSES": 1459,
+      "TABLES": 3375,
+      "BLOCKS": 426,
+      "ENTITIES": 8727452,
+      "OBJECTS": 4466,
+      "OUTSIDE": 8
+    },
+    "entities": {
+      "SPLINE": {
+        "count": 20311,
+        "bytes": 6308932
+      },
+      "LINE": {
+        "count": 14841,
+        "bytes": 2365004
+      },
+      "ELLIPSE": {
+        "count": 162,
+        "bytes": 36722
+      },
+      "ARC": {
+        "count": 76,
+        "bytes": 12147
+      },
+      "CIRCLE": {
+        "count": 42,
+        "bytes": 4611
+      }
+    },
+    "layers": {
+      "part": 740,
+      "hidden": 1995,
+      "dims": 32697
+    },
+    "layer_bytes": {
+      "part": 170899,
+      "hidden": 603635,
+      "dims": 7952882
+    },
+    "spline_degrees": {
+      "2": 20069,
+      "1": 230,
+      "3": 12
+    }
+  },
+  {
+    "file": "frame-general.pdf",
+    "bytes": 561741,
+    "sha256": "18ee4239e94c254710cd6c6f25c02d1c384a857965da3ed5885ade16dec5ec99",
+    "gzip_bytes": 458069
+  },
+  {
+    "file": "frame-general.svg",
+    "bytes": 1519262,
+    "sha256": "685528d32d10abc1623d23388203cd3ed84eb3d3e3d7e980f16667d8f9439b3f",
+    "gzip_bytes": 300672,
+    "elements": {
+      "svg": 1,
+      "metadata": 1,
+      "RDF": 1,
+      "Description": 1,
+      "creator": 1,
+      "source": 1,
+      "description": 1,
+      "g": 4,
+      "line": 2204,
+      "path": 2066,
+      "circle": 42,
+      "a": 1,
+      "rect": 1
+    },
+    "path_data_bytes": 1323976,
+    "path_commands": {
+      "M": 2604,
+      "Q": 20963,
+      "L": 15857,
+      "A": 238,
+      "C": 120
+    }
+  }
+]

--- a/docs/research/1537-export-size.md
+++ b/docs/research/1537-export-size.md
@@ -1,0 +1,72 @@
+# Archived frame export measurements — #1537
+
+Measured the six original exports under
+[`whistle-key@76ccdc2/drawings/titanium`](https://github.com/pzfreo/whistle-key/tree/76ccdc2/drawings/titanium)
+on macOS with Python 3.14.7 and ezdxf 1.4.4. These are the field-report artifacts, not regenerated
+output from current Draftwright. The archived generator and dependency record determine their
+generation environment; the analyzer's environment determines only these measurements.
+
+## Results
+
+| Sheet | DXF bytes | SVG bytes | PDF bytes | DXF gzip bytes |
+|---|---:|---:|---:|---:|
+| Features | 8,548,578 | 1,479,246 | 565,358 | 667,005 |
+| General | 8,743,378 | 1,519,262 | 561,741 | 682,691 |
+
+| DXF entity | Features count / bytes | General count / bytes |
+|---|---:|---:|
+| SPLINE | 20,265 / 6,273,619 | 20,311 / 6,308,932 |
+| LINE | 13,752 / 2,206,445 | 14,841 / 2,365,004 |
+| ELLIPSE | 162 / 36,730 | 162 / 36,722 |
+| ARC | 76 / 12,495 | 76 / 12,147 |
+| CIRCLE | 30 / 3,327 | 42 / 4,611 |
+
+The raw DXF section-byte partition accounts for every byte, including headers, classes,
+tables, blocks, objects and section delimiters. Entity counts independently agree with
+`ezdxf.readfile(path).modelspace()`. These fixtures have no extra paper-space entities; the
+analyzer refuses a census mismatch rather than silently ignoring a different layout.
+
+The `dims` layer holds 31,999 / 32,697 entities and 7,860,774 / 7,952,882 bytes. Part geometry
+accounts for 159,119 / 170,899 bytes and hidden geometry for 512,723 / 603,635 bytes. There are
+no native TEXT/MTEXT entities. Of the splines, 20,075 / 20,069 are degree 2. This identifies
+annotation vector data as the dominant storage cost; it does not attribute every annotation
+curve specifically to a font glyph.
+
+SVG path-data strings account for 1,301,474 / 1,323,976 bytes. Parsed XML element counts and
+path commands are recorded in the result JSON. This byte count covers decoded path-attribute
+values, not all XML syntax. gzip sizes for SVG are 306,272 / 300,672 bytes and for PDF are
+460,903 / 458,069 bytes. gzip is measured with `mtime=0`; compressed size depends on the
+compressor version. Every compressed artifact was decompressed and compared with its original
+bytes. No exporter or drawing geometry was changed.
+
+## Repeat the measurement
+
+Download the six files from the pinned directory into a scratch directory. Verify their hashes
+against [the recorded result](1537-export-size.json), then run from the Draftwright checkout:
+
+```sh
+uv run python docs/research/1537-measure-exports.py \
+  /path/to/frame-exports > /tmp/frame-export-measurements.json
+```
+
+The analyzer requires exactly the named six files and reads their bytes. It measures ASCII DXF
+tags and parses SVG; it neither imports STEP geometry nor runs recognition, lint or rendering.
+It is a bounded research tool, not a general CAD-file validator or an export-size CI threshold.
+Malformed/unexpected DXF record layouts fail rather than being repaired for counting.
+
+## Decision and next useful work
+
+Retain the exported vector fidelity and use lossless packaging for transport. The
+[artifact workflow](../reference/generated-artifacts.md) keeps generators and evidence
+reviewable while preventing generated graphics from dominating text diffs. The measurements
+do not establish an exporter defect that warrants removing curves or adding a lossy option.
+
+If uncompressed DXF size becomes a demonstrated downstream limit, the next investigation is
+repeated annotation geometry: measure opportunities for exact block reuse and the receiving
+CAD systems' support before changing the representation. It must preserve physical curves,
+annotation membership, labels, transformations and downstream compatibility. The current
+evidence does not prove such a change safe. #1255's portable generator paths and PDF background
+work are separate from compression.
+
+ADRs 1–5: this delivery adds no compiler, layout, recognition or intent path. The bundle retains
+existing evidence without merging its identities, changing coverage or implying readiness.

--- a/docs/research/1537-measure-exports.py
+++ b/docs/research/1537-measure-exports.py
@@ -1,0 +1,86 @@
+"""Bounded byte accounting for the archived #1529 frame exports (not a geometry validator)."""
+
+import argparse
+import gzip
+import json
+import re
+import xml.etree.ElementTree as ET
+from collections import Counter, defaultdict
+from hashlib import sha256
+from pathlib import Path
+
+import ezdxf
+
+parser = argparse.ArgumentParser(description="Measure the six pinned frame exports; no CAD build.")
+parser.add_argument("directory", type=Path)
+root = parser.parse_args().directory
+results = []
+for path in sorted(
+    root / f"frame-{sheet}.{extension}"
+    for sheet in ("features", "general")
+    for extension in ("dxf", "svg", "pdf")
+):
+    b = path.read_bytes()
+    compressed = gzip.compress(b, mtime=0)
+    assert gzip.decompress(compressed) == b
+    r = {
+        "file": path.name,
+        "bytes": len(b),
+        "sha256": sha256(b).hexdigest(),
+        "gzip_bytes": len(compressed),
+    }
+    if path.suffix == ".dxf":
+        lines = b.splitlines(keepends=True)
+        assert len(lines) % 2 == 0
+        pairs = [
+            (int(lines[i].strip()), lines[i + 1].strip(), len(lines[i]) + len(lines[i + 1]))
+            for i in range(0, len(lines), 2)
+        ]
+        starts = [i for i, p in enumerate(pairs) if p[0] == 0] + [len(pairs)]
+        section = None
+        rows = defaultdict(lambda: {"count": 0, "bytes": 0})
+        sections = Counter()
+        layer_bytes = Counter()
+        spline_degrees = Counter()
+        for left, right in zip(starts, starts[1:]):
+            chunk = pairs[left:right]
+            kind = chunk[0][1].decode("ascii")
+            n = sum(p[2] for p in chunk)
+            if kind == "SECTION":
+                section = next(p[1].decode("ascii") for p in chunk if p[0] == 2)
+            sections[section or "OUTSIDE"] += n
+            if section == "ENTITIES" and kind not in ("SECTION", "ENDSEC"):
+                rows[kind]["count"] += 1
+                rows[kind]["bytes"] += n
+                layer = next((p[1].decode("utf-8") for p in chunk if p[0] == 8), "0")
+                layer_bytes[layer] += n
+                if kind == "SPLINE":
+                    spline_degrees[
+                        str(next(p[1].decode("ascii") for p in chunk if p[0] == 71))
+                    ] += 1
+            if kind == "ENDSEC":
+                section = None
+        assert sum(sections.values()) == len(b), (path, sections, len(b))
+        doc = ezdxf.readfile(path)
+        verified = Counter(e.dxftype() for e in doc.modelspace())
+        assert verified == Counter({k: v["count"] for k, v in rows.items()}), (verified, rows)
+        r.update(
+            sections=dict(sections),
+            entities=dict(sorted(rows.items(), key=lambda kv: -kv[1]["bytes"])),
+            layers=dict(Counter(e.dxf.layer for e in doc.modelspace())),
+            layer_bytes=dict(layer_bytes),
+            spline_degrees=dict(spline_degrees),
+        )
+    elif path.suffix == ".svg":
+        tree = ET.fromstring(b)
+        counts = Counter(e.tag.rsplit("}", 1)[-1] for e in tree.iter())
+        data = [e.get("d", "") for e in tree.iter() if e.tag.rsplit("}", 1)[-1] == "path"]
+        r.update(
+            elements=dict(counts),
+            path_data_bytes=sum(len(d.encode()) for d in data),
+            path_commands=dict(
+                Counter(c for d in data for c in re.findall("[MmLlHhVvCcSsQqTtAaZz]", d))
+            ),
+        )
+    results.append(r)
+print(json.dumps(results, indent=2, allow_nan=False))

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
       - Sheet and fluent handles: reference/sheet.md
       - Drawing results: reference/drawing.md
       - Machine-readable reports: reference/reports.md
+      - Generated artifacts: reference/generated-artifacts.md
       - Read-only STEP inspection: reference/inspection.md
       - Feature declarations: reference/declarations.md
       - Recogniser capability contract: reference/recogniser-capabilities.md


### PR DESCRIPTION
The #1529 frame exports produced noisy source diffs and large drawing files. This documents scoped Git attributes and an executable review-bundle recipe that keeps original source, generator, environment records, drawing outputs and available evidence together. The manifest reports missing evidence explicitly and describes file integrity without implying drawing completeness, shared feature identities or manufacturing readiness.

Measured all six pinned original exports with exact DXF section/entity/layer byte accounting, independently checked against ezdxf. Annotation vector data dominates the 8.55/8.74 MB DXFs; gzip reduced them to 667,005/682,691 bytes and restored every original byte. The delivery chooses lossless transport; the measurements do not establish a geometry-removal fix or justify a lossy exporter option. The analyzer and full measurements are committed with their scope and environment.

Validation:
- Independent Google-style review against ADRs 1–5: LGTM at `76c2dc03b4888d2507646805e7cf64b72e75f280`; reviewer independently repeated analyzer and bundle checks.
- Exact documented bundle executed against all ten archived files: names, bytes, hashes, missing-evidence entries, existing-archive refusal and failure before archive creation when required inputs are missing.
- Exact Git rules exercised on eight direct/nested graphic paths and four source/evidence paths. Actual Git diffs show graphics as binary while source and JSON remain textual.
- Tracked analyzer output exactly matches the recorded six-artifact JSON; gzip round-trips preserve original bytes.
- Full `scripts/pr-check --full` exited 0: 8,055 passed, 5 skipped, 13 xfailed; 96.04% total coverage. Static checks and strict documentation build passed; no changed production lines.

All five ADRs fit: no compiler, layout, recognition, intent or reporting engine changes; existing evidence is retained without changing its ownership or scope. Hashes establish bundled bytes, not source derivation or release readiness.

Fixes #1537. Part of #1529.

The full preflight passed on `dbc203c2ca98b62d10f30e588e05ac2272ee8a04`. After rebasing this single documentation commit onto merged main `ccf18d8f`, the complete tree at `3e515688452709e110aefe6aea437db8180ccc9c` is byte-for-byte identical to that tested tree (`git diff --exit-code dbc203c2 HEAD`). Required PR CI still gates merge.
