### PR TITLE
Add shared document ownership and requirement reconciliation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ Compact map, bottom to top:
   (the ADR 5 (was 0002) lint→repair safety net), `pmi.py` (STEP AP242 PMI), `linting/`
   (draftwright-owned lint and recognition requirement ledgers, ADR 3 (was 0007)), `reporting.py`
   (versioned projection over explicitly supplied finished-build state and those ledgers),
+  `document_evidence.py` (confirmed claim binding, engineering agreement and dependency proofs),
   `model/` (the ADR 1 (was 0015) IR waist: `ir`/`detect`/`planner`/`declare`/`compiled`),
   `drawing.py` (the `Drawing` result object; single-owner `BuildState`), and
   `annotations/` (the render passes; `orchestrator.py` owns `_PASS_SEQUENCE`, the one

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,8 @@ Compact map, bottom to top:
   lifecycle), `recognition_ownership.py` (run-local accepted-occurrence outcomes, including
   final-IR binding, group/pattern absorption, and settled ownerless consumer policy),
   `plate_correspondence.py` (pure shared Plate-record/final-IR correspondence predicates),
+  `measurement_support.py` (producer-issued exact measurement and member witnesses),
+  `location_contract.py` (shared pocket/pad datum reference and coincidence rules),
   `profile_angles.py` (face-profile drafting requirements from issued ordered supports),
   `angular_geometry.py` (analytic angular ink boxes shared by sizing and rendering),
   `recogniser_policy.py` (single Draftwright-owned unsupported/deferred/evidence-only policy),
@@ -55,6 +57,8 @@ Compact map, bottom to top:
   `_warnings.py`, and `_pmi_part21.py`.
 - **`_core.py`** — shared primitives: the `Analysis` namespace, dim/format helpers,
   page/slot/margin constants.
+- **`document_input.py`** — common source/analysis authority and sealed physical membership,
+  beside `_core`; member models copy authoring containers while retaining exact owners.
 - **Stage modules** — `analysis.py` (classification + one-shot feature inventory),
   `projection.py` (HLR + material lowering), `compose.py` (the ADR 2 (was 0004) outer
   compose-then-pack layout), `export.py` (SVG→PDF→PNG chain, DXF), `repair.py`
@@ -67,7 +71,8 @@ Compact map, bottom to top:
   canonical stage order; `_common.py` owns the corridor solve + late-furniture seam).
 - **`builder.py`** — build orchestration: `build_drawing`, `make_drawing`.
 - **Facades / top layer** — `make_drawing.py` + `annotate.py` (thin compat),
-  `sheet.py` (the fluent `Sheet` facade, ADR 4 (was 0011)), `sheet_emit.py` (the `--script`
+  `sheet.py` (the fluent `Sheet` facade, ADR 4 (was 0011)),
+  `document.py` (explicit member sheets over a common source and conversion authority), `sheet_emit.py` (the `--script`
   emitter — it also writes the `inspection.py` document as a sidecar from its own
   single detect run), `cli.py` (Typer; engine imported lazily inside command bodies, #313),
   `_build_profile.py` (developer-only pytest/runner profiling support),

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -286,6 +286,8 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   and the original analysis for reuse through the existing builder.
 - **`document.py`** — rank-7 explicit document facade. It takes one STEP snapshot, binds member
   Sheets to the common source, and builds them through the existing pipeline with named failures.
+  Live member snapshots reach `reporting.py` for schema-v4 coverage, carrier attribution and
+  engineering conflict assessment; ordinary Drawing reports retain schema v3.
 - **`inspection.py`** — the rank-7 public read-only STEP inspection surface (`inspect_step`).
   It hashes one immutable source-byte snapshot, drives the shared one-run
   `_detect_part_model_analysis` seam over a private copy of those bytes, and projects the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,7 +11,7 @@ keep that table, this document, and `CLAUDE.md`'s compact map in step. The
 The dependency graph is a DAG (the #138 / ADR 1 (was 0005) split is complete). Bottom to
 top: leaf modules (`progress.py`, `layout.py`, `registry.py`, `fonts.py`, `_geometry.py`,
 `fits.py`, `intents.py`, `recognition_cache.py`, `recognition_ownership.py`,
-`plate_correspondence.py`, `profile_angles.py`, `angular_geometry.py`, `recogniser_policy.py`, `recogniser_schema.py`,
+`plate_correspondence.py`, `measurement_support.py`, `location_contract.py`, `profile_angles.py`, `angular_geometry.py`, `recogniser_policy.py`, `recogniser_schema.py`,
 `recognition_frame.py`, `oriented_slot_contract.py`, `feature_identity.py`, and the strict
 `blend_contract.py` provider-record boundary) →
 `_core.py` → stage modules (`export.py`,
@@ -226,6 +226,8 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   owners, and settled
   unsupported/deferred/evidence-only occurrences are classified; remaining conditional
   cross-family records stay unclassified.
+- **`measurement_support.py`** — run-local producer-issued measurement, interval and member witnesses.
+- **`location_contract.py`** — shared pocket/pad datum reference and coincidence predicates.
 - **`plate_correspondence.py`** — pure shared Plate-record/final-IR correspondence predicates.
 - **`profile_angles.py`** — bounded face-profile angle requirements projected from Quiddity's
   ordered supports, with issued body/profile identity retained outside the IR. The detection
@@ -277,6 +279,11 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   reads. It validates inspection manifest format 1/API major 1, the exact installed recogniser
   release, and only the stable `quiddity.inspection` symbols and value schemas consumed
   by `model/declare.py`. It deliberately does not declare recognition-family semantics.
+- **`document_input.py`** — rank-1 common intake authority: exact raw recognition/ownership,
+  sealed physical membership and copies of member authoring containers. It retains source bytes
+  and the original analysis for reuse through the existing builder.
+- **`document.py`** — rank-7 explicit document facade. It takes one STEP snapshot, binds member
+  Sheets to the common source, and builds them through the existing pipeline with named failures.
 - **`inspection.py`** — the rank-7 public read-only STEP inspection surface (`inspect_step`).
   It hashes one immutable source-byte snapshot, drives the shared one-run
   `_detect_part_model_analysis` seam over a private copy of those bytes, and projects the

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -247,6 +247,8 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
 - **`recogniser_schema.py`** — the rank-0 Draftwright-owned table of public provider record
   schema versions consumed by adapters. The report projector and rank-7 cross-repository
   validator share this leaf, so the engine never imports the validator to learn schema metadata.
+- **`document_evidence.py`** — rank-2 binding of confirmed member claims to exact interval/member
+  witnesses, engineering agreement and producer-issued dependency proof evaluation.
 - **`reporting.py`** — the rank-2 pure schema-v1 report projector, and the named seam
   (`project_occurrences`, `json_value`, `producer`, `write_json_document`) that the
   drawing report and the STEP-inspection document are both built from (#1461). The

--- a/docs/reference/document.md
+++ b/docs/reference/document.md
@@ -1,0 +1,91 @@
+# Shared drawing documents
+
+`Document` builds explicitly named sheets against one immutable STEP snapshot and one
+recognition inventory. Use it when dimensions intentionally live on different sheets.
+The member sheets use the existing Sheet declarations, compiler and placement solver.
+
+```python
+from pathlib import Path
+from draftwright import Document
+
+package = Document.from_part("part.step")
+general = package.sheet("general", detail_view=False)
+holes = package.sheet("holes", detail_view=False)
+for sheet in (general, holes):
+    sheet.authored_dimensions().authored_views()
+    for view in ("front", "plan", "side"):
+        sheet.view(view)
+
+for feature in package.features:
+    if feature.kind == "envelope":
+        for parameter in feature.parameters():
+            general.dimension(feature, parameter.parameter_id)
+    elif feature.kind == "hole":
+        holes.dimension(feature, "bore.diameter")
+
+result = package.build()
+report = result.report()
+print(report["assessment"])
+Path("out").mkdir(exist_ok=True)
+result.write_report("out/document.json")
+for name, drawing in result.sheets.items():
+    drawing.export(f"out/{name}", formats=("pdf", "svg"))
+```
+
+This example selects envelope measurements and hole diameters. Other recognized requirements,
+including omitted depths and locations, remain visible in the report. Use the discovered
+measurements and operation identities to choose the dimensions needed for your part.
+
+`package.features` holds the exact common IR features. Pass those objects to each member's
+`dimension()` or `of()` methods. Physical membership is sealed: deleting a feature, replacing it
+with an equal clone, or changing its geometry through an aspect verb is refused. Dimension
+selection, supported decorations, notes and GD&T remain member declarations. Existing
+single-sheet authoring is unchanged.
+
+A build snapshots every member's declarations before building the first member. A failure names
+the member through `DocumentBuildError.sheet_name`; cancellation names it in
+`BuildCancelled.diagnostic["sheet"]`. Neither returns a complete partial package.
+
+## Read the document report
+
+`result.report()` returns schema version **4**, with `scope: "document"`. The schema is published as
+[`draftwright-report-v4.schema.json`](draftwright-report-v4.schema.json). Individual
+`Drawing.report()` calls retain version 3. The document report contains:
+
+- One source hash, recognition inventory and physical requirement catalog. Repeated annotations
+  receive at most one coverage credit for each obligation.
+- Sheet-local outcomes and lint, with carrying annotation references identifying the sheet and
+  annotation. A structured-note satisfaction remains distinct from a verified measurement.
+- Complete dependency proofs where an existing producer permits several measurements to
+  establish another requirement. Missing, conflicting or unconfirmed prerequisites do not
+  establish such a proof.
+- Separate coverage, layout, fidelity and manufacturing assessments. Conflicting confirmed
+  engineering meanings retain both claims. Matching nominal numbers on different owners do
+  not join their operations.
+
+`bounded-clear` names the report's recognition and verification limits. Unsupported geometry,
+unknown cardinality, unconfirmed claims and unresolved dispositions remain explicit.
+Manufacturing readiness is unassessed. Free-text notes do not acquire measurement authority.
+
+## Edits, persistence and replay
+
+Member Drawings remain editable through their public verbs. Read `result.report()` again after
+editing: deleting the last carrying annotation loses its credit without removing its obligation.
+A live callout respects the member's authored dimension set; author its destination measurement
+before building a sheet that will carry it. Use `deferred()` for batches of supported edits.
+If physical membership is corrupted after the build, document reporting refuses.
+
+A returned report is detached JSON. Calls and edits must be serialized by the caller; the API
+makes no concurrent-mutation snapshot promise. `write_report()` uses the existing atomic writer
+and requires its parent directory to exist. Export remains explicit, per member.
+
+The source hash identifies the retained STEP bytes. Report-local owner, occurrence, sheet,
+requirement and claim IDs expire with that report; they are not reusable feature handles.
+The report records member build options, dimension selection, view constraints, ordinary table
+text and resolved layout decisions. Preserve your source recipe for decorations, GD&T,
+feature-linked notes, measured dimensions, member PMI declarations and live edits. Replaying a recipe means loading the source and selecting
+current exact features with operation/cardinality assertions. It never means deserializing old
+IDs or treating an independently built Drawing or PDF as common authority.
+
+Typed feature schedules and the complete two-sheet frame recipe are tracked separately in
+#1543 and #1544.

--- a/docs/reference/draftwright-report-v4.schema.json
+++ b/docs/reference/draftwright-report-v4.schema.json
@@ -1,0 +1,1167 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://draftwright.dev/schema/draftwright-report-v4.schema.json",
+  "title": "Draftwright common-source document report v4",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "schema_version",
+    "scope",
+    "status",
+    "producer",
+    "source",
+    "run_options",
+    "outputs",
+    "recognition",
+    "sheets",
+    "claims",
+    "assessment",
+    "replay"
+  ],
+  "properties": {
+    "schema": {
+      "const": "draftwright-report"
+    },
+    "schema_version": {
+      "const": 4
+    },
+    "scope": {
+      "const": "document"
+    },
+    "status": {
+      "enum": [
+        "needs-attention",
+        "bounded-clear"
+      ]
+    },
+    "producer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "draftwright",
+        "quiddity"
+      ],
+      "properties": {
+        "draftwright": {
+          "type": "string",
+          "minLength": 1
+        },
+        "quiddity": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "name",
+        "sha256"
+      ],
+      "properties": {
+        "kind": {
+          "const": "step"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    },
+    "run_options": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "pmi",
+        "frame"
+      ],
+      "properties": {
+        "pmi": {
+          "enum": [
+            "off",
+            "report",
+            "annotate"
+          ]
+        },
+        "frame": {
+          "const": "raw"
+        }
+      }
+    },
+    "outputs": {
+      "type": "object"
+    },
+    "recognition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "identity_scope",
+        "occurrences",
+        "owners",
+        "requirements",
+        "summary",
+        "unresolved_occurrences"
+      ],
+      "properties": {
+        "identity_scope": {
+          "const": "document-local"
+        },
+        "occurrences": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/occurrence"
+          }
+        },
+        "owners": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/owner"
+          }
+        },
+        "requirements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/requirement"
+          }
+        },
+        "summary": {
+          "$ref": "#/$defs/summary"
+        },
+        "unresolved_occurrences": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "sheets": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/sheet"
+      }
+    },
+    "claims": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/claim"
+      }
+    },
+    "assessment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "coverage",
+        "layout",
+        "fidelity",
+        "manufacturing"
+      ],
+      "properties": {
+        "coverage": {
+          "$ref": "#/$defs/coverage"
+        },
+        "layout": {
+          "$ref": "#/$defs/axis_assessment"
+        },
+        "fidelity": {
+          "$ref": "#/$defs/fidelity"
+        },
+        "manufacturing": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status",
+            "readiness"
+          ],
+          "properties": {
+            "status": {
+              "const": "unassessed"
+            },
+            "readiness": {
+              "const": "not-certified"
+            }
+          }
+        }
+      }
+    },
+    "replay": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "identity_lifetime",
+        "source_snapshot",
+        "member_reads",
+        "requires",
+        "durable_feature_identity",
+        "serialized_declaration_scope",
+        "source_recipe_required_for",
+        "script_deserialization"
+      ],
+      "properties": {
+        "identity_lifetime": {
+          "const": "this-report-only"
+        },
+        "source_snapshot": {
+          "const": "immutable-step-bytes"
+        },
+        "member_reads": {
+          "const": "live-at-report-call"
+        },
+        "requires": {
+          "const": "source-recipe-and-current-inventory-assertions"
+        },
+        "durable_feature_identity": {
+          "const": false
+        },
+        "serialized_declaration_scope": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "source_recipe_required_for": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "script_deserialization": {
+          "const": false
+        }
+      }
+    }
+  },
+  "$defs": {
+    "owner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "occurrence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "family",
+        "record_type",
+        "record_schema_version",
+        "record",
+        "disposition",
+        "reason_code",
+        "tracking",
+        "owners",
+        "requirements"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "family": {
+          "type": "string",
+          "minLength": 1
+        },
+        "record_type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "record_schema_version": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "record": {
+          "type": "object"
+        },
+        "disposition": {
+          "enum": [
+            "represented",
+            "absorbed",
+            "unsupported",
+            "deferred",
+            "evidence_only",
+            "unexpectedly_missing"
+          ]
+        },
+        "reason_code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tracking": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "owners": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/owner"
+          }
+        },
+        "requirements": {
+          "$ref": "#/$defs/requirement_refs"
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "total",
+        "represented",
+        "absorbed",
+        "unsupported",
+        "deferred",
+        "evidence_only",
+        "unexpectedly_missing"
+      ],
+      "properties": {
+        "total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "represented": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "absorbed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "unsupported": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "deferred": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "evidence_only": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "unexpectedly_missing": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "requirement_refs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "coverage",
+        "ids"
+      ],
+      "properties": {
+        "coverage": {
+          "enum": [
+            "ledger",
+            "not-projected",
+            "not-applicable",
+            "deferred",
+            "unavailable"
+          ]
+        },
+        "ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "annotation_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sheet_id",
+        "annotation"
+      ],
+      "properties": {
+        "sheet_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "annotation": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "carrier": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sheet_id",
+        "annotation",
+        "evidence_kind"
+      ],
+      "properties": {
+        "sheet_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "annotation": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_kind": {
+          "enum": [
+            "measurement",
+            "structured_note",
+            "angular_measurement",
+            "physical_location",
+            "physical_requirement"
+          ]
+        }
+      }
+    },
+    "local_outcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sheet_id",
+        "state",
+        "reason_code"
+      ],
+      "properties": {
+        "sheet_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "state": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reason_code": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "proof": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "alternative",
+        "supports",
+        "distinct_witnesses"
+      ],
+      "properties": {
+        "alternative": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "supports": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "distinct_witnesses": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "requirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "family",
+        "occurrence_ids",
+        "owner_ids",
+        "parameter_id",
+        "requirement_count",
+        "requirement_count_known",
+        "state",
+        "coverage_credit",
+        "local_outcomes",
+        "carrying_annotations",
+        "carrier_attribution",
+        "dependency_proofs",
+        "intrinsic_exclusion"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "family": {
+          "type": "string",
+          "minLength": 1
+        },
+        "occurrence_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "owner_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "parameter_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
+        },
+        "requirement_count": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "requirement_count_known": {
+          "type": "boolean"
+        },
+        "state": {
+          "enum": [
+            "placed",
+            "satisfied_by_structured_note",
+            "dependency-derived",
+            "inapplicable",
+            "unresolved",
+            "uncovered"
+          ]
+        },
+        "coverage_credit": {
+          "enum": [
+            0,
+            1
+          ]
+        },
+        "local_outcomes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/local_outcome"
+          }
+        },
+        "carrying_annotations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/carrier"
+          }
+        },
+        "carrier_attribution": {
+          "enum": [
+            "available",
+            "unavailable"
+          ]
+        },
+        "dependency_proofs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/proof"
+          }
+        },
+        "intrinsic_exclusion": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "reason_code",
+                "occurrence_ids",
+                "span"
+              ],
+              "properties": {
+                "reason_code": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "occurrence_ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "span": {}
+              }
+            }
+          ]
+        },
+        "profile_source": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "profile_id",
+            "support_ids"
+          ],
+          "properties": {
+            "kind": {
+              "const": "planar_outer_profile"
+            },
+            "profile_id": {
+              "type": "string",
+              "pattern": "^profile:[1-9][0-9]*$"
+            },
+            "support_ids": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "pattern": "^support:[1-9][0-9]*$"
+              }
+            }
+          }
+        }
+      }
+    },
+    "meaning": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "value",
+        "tolerance",
+        "span",
+        "axis",
+        "discriminator",
+        "location_member",
+        "angular_reference"
+      ],
+      "properties": {
+        "value": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "tolerance": {},
+        "span": {},
+        "axis": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "discriminator": {},
+        "location_member": {},
+        "angular_reference": {}
+      }
+    },
+    "claim": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "sheet_id",
+        "annotation",
+        "owner_id",
+        "parameter_id",
+        "address",
+        "meaning",
+        "rendered",
+        "verification"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sheet_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "annotation": {
+          "type": "string",
+          "minLength": 1
+        },
+        "owner_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "parameter_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "address": {
+          "type": "array",
+          "items": {}
+        },
+        "meaning": {
+          "$ref": "#/$defs/meaning"
+        },
+        "rendered": {
+          "type": "array",
+          "items": {}
+        },
+        "verification": {
+          "const": "confirmed-within-measurement-verifier-scope"
+        }
+      }
+    },
+    "dimension_intent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "owner_id",
+        "role",
+        "discriminator",
+        "member",
+        "display_decimals",
+        "view",
+        "side"
+      ],
+      "properties": {
+        "owner_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "role": {
+          "type": "string",
+          "minLength": 1
+        },
+        "discriminator": {},
+        "member": {},
+        "display_decimals": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "view": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "side": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "dimension_intents": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source",
+        "authored",
+        "requested"
+      ],
+      "properties": {
+        "source": {
+          "enum": [
+            "authored",
+            "automatic"
+          ]
+        },
+        "authored": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/dimension_intent"
+              }
+            }
+          ]
+        },
+        "requested": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/dimension_intent"
+          }
+        }
+      }
+    },
+    "view_intents": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "principal_source",
+        "derived_source",
+        "principals",
+        "added_principals",
+        "derived",
+        "added_derived",
+        "relations",
+        "pins"
+      ],
+      "properties": {
+        "principal_source": {
+          "enum": [
+            null,
+            "authored",
+            "automatic"
+          ]
+        },
+        "derived_source": {
+          "enum": [
+            null,
+            "authored",
+            "automatic"
+          ]
+        },
+        "principals": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "added_principals": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "derived": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "added_derived": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "relations": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "pins": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "sheet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "options",
+        "resolved",
+        "dimension_intents",
+        "view_intents",
+        "table_intents",
+        "lint"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "options": {
+          "type": "object"
+        },
+        "resolved": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "scale",
+            "page_mm",
+            "scale_decision",
+            "view_decision"
+          ],
+          "properties": {
+            "scale": {
+              "type": "number"
+            },
+            "page_mm": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "items": {
+                "type": "number"
+              }
+            },
+            "scale_decision": {},
+            "view_decision": {}
+          }
+        },
+        "dimension_intents": {
+          "$ref": "#/$defs/dimension_intents"
+        },
+        "view_intents": {
+          "$ref": "#/$defs/view_intents"
+        },
+        "table_intents": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "rows",
+              "prefer",
+              "name",
+              "block_cols"
+            ],
+            "properties": {
+              "rows": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "prefer": {
+                "type": "string",
+                "minLength": 1
+              },
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "block_cols": {}
+            }
+          }
+        },
+        "lint": {
+          "type": "object"
+        }
+      }
+    },
+    "axis_assessment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "affected_sheets",
+        "unassessed_sheets"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "needs-attention",
+            "unassessed",
+            "clear-within-lint-scope"
+          ]
+        },
+        "affected_sheets": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "unassessed_sheets": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "fidelity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "affected_sheets",
+        "unassessed_sheets",
+        "conflicts",
+        "unknown_claims",
+        "scope",
+        "unassessed_scope"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "needs-attention",
+            "unassessed",
+            "clear-within-lint-scope"
+          ]
+        },
+        "affected_sheets": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "unassessed_sheets": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "conflicts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "code",
+              "claim_ids"
+            ],
+            "properties": {
+              "code": {
+                "const": "conflicting_engineering_meanings"
+              },
+              "claim_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        },
+        "unknown_claims": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "sheet_id",
+              "annotation",
+              "reason_code"
+            ],
+            "properties": {
+              "sheet_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "annotation": {
+                "type": "string",
+                "minLength": 1
+              },
+              "reason_code": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          }
+        },
+        "scope": {
+          "const": "verified-measurement-claims-and-member-fidelity-lint"
+        },
+        "unassessed_scope": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "coverage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scope",
+        "known_requirement_count",
+        "unknown_cardinality_rows",
+        "credited_requirements",
+        "audited_score",
+        "uncovered_or_unresolved",
+        "unattributed_carriers",
+        "excludes"
+      ],
+      "properties": {
+        "scope": {
+          "const": "accepted-occurrences-and-profile-requirements"
+        },
+        "known_requirement_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "unknown_cardinality_rows": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "credited_requirements": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "audited_score": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 1
+        },
+        "uncovered_or_unresolved": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "unattributed_carriers": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "excludes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/reference/reports.md
+++ b/docs/reference/reports.md
@@ -1,5 +1,9 @@
 # Machine-readable reports
 
+For common-source multi-sheet reports, see [Shared drawing documents](document.md).
+`DocumentResult.report()` uses document scope/version 4; the single-sheet version-3
+contract described below remains unchanged.
+
 `Drawing.report()` returns a JSON-compatible Draftwright report. Version 3 is a
 bounded contract: it projects the accepted occurrences from one raw automatic recognition
 run, their exact consumer dispositions and final IR owners, the recognition-owned semantic

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -20,6 +20,7 @@ nav:
       - Entry points: reference/entry-points.md
       - Sheet and fluent handles: reference/sheet.md
       - Drawing results: reference/drawing.md
+      - Shared drawing documents: reference/document.md
       - Machine-readable reports: reference/reports.md
       - Generated artifacts: reference/generated-artifacts.md
       - Read-only STEP inspection: reference/inspection.md

--- a/src/draftwright/__init__.py
+++ b/src/draftwright/__init__.py
@@ -37,6 +37,9 @@ _LAZY = {
     "InspectionUnavailableError": "draftwright.inspection",
     "inspect_step": "draftwright.inspection",
     "Sheet": "draftwright.sheet",
+    "Document": "draftwright.document",
+    "DocumentResult": "draftwright.document",
+    "DocumentBuildError": "draftwright.document",
     "lint_feature_coverage": "draftwright.linting",
     "PmiExtractionReport": "draftwright.pmi",
     "PmiRecord": "draftwright.pmi",
@@ -92,6 +95,7 @@ if TYPE_CHECKING:  # static analysers / IDEs — no runtime import, no kernel co
     from draftwright._warnings import ScaleCompletenessWarning, SoftDeprecationWarning
     from draftwright.builder import ScaleIncompatibilityError, build_drawing, make_drawing
     from draftwright.compose import choose_scale
+    from draftwright.document import Document, DocumentBuildError, DocumentResult
     from draftwright.drawing import Drawing, FeatureInfo
     from draftwright.inspection import (
         INSPECTION_SCHEMA,
@@ -127,6 +131,9 @@ __all__ = [
     "INSPECTION_SCHEMA",
     "INSPECTION_SCHEMA_VERSION",
     "Drawing",
+    "Document",
+    "DocumentResult",
+    "DocumentBuildError",
     "SoftDeprecationWarning",
     "FeatureInfo",
     "InspectionUnavailableError",

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -789,11 +789,22 @@ def _analyse(
     _include_iso: bool = True,
     _view_constraints=None,
     _framed_recognition: bool = False,
+    _document_input=None,
 ) -> Analysis:
     """Load STEP or use a build123d Shape, analyse geometry, compute layout.
 
     Returns an :class:`Analysis`.
     """
+    if _document_input is not None:
+        if model is None or _framed_recognition:
+            raise ValueError("document members require their sealed raw model")
+        _document_input.validate(
+            step_file, model.features if isinstance(model, PartModel) else model
+        )
+        if _reuse is None:
+            _reuse = _document_input.analysis
+        elif _reuse.part is not _document_input.analysis.part:
+            raise ValueError("document analysis reuse names a foreign working solid")
     convention = projection or "third"
     # The zone-grid ruler (#768) draws its ticks on the frame, so it implies one.
     frame = frame or zones
@@ -1101,6 +1112,11 @@ def _analyse(
         if ownership_builder is not None
         else None
     )
+    if _document_input is not None:
+        # Declared sizing still reads only the member's authored model. Critique receives
+        # the original conversion authority rather than acquiring another recognition run.
+        recognition_evidence = _document_input.analysis.recognition_evidence
+        recognition_ownership = _document_input.analysis.recognition_ownership
     # Dimension feasibility and annotation footprints consume the authored set.
     # Derived-view dependencies still use sizing_model below; omitting an unrelated
     # envelope extent must not force its view back onto an authored sheet.

--- a/src/draftwright/annotations/_common.py
+++ b/src/draftwright/annotations/_common.py
@@ -84,11 +84,8 @@ def _hole_location_coverage_fact(location):
         feature = location.id.feature
     assert feature is not None and location.span is not None
     if isinstance(feature, HoleFeature | PatternFeature):
-        parameter = (
-            f"{location.role}.{location.discriminator}"
-            if isinstance(feature, HoleFeature) and location.axis != "z"
-            else f"{location.role}.location.{location.discriminator}"
-        )
+        parameter = location.physical_location_component
+        assert parameter is not None
         return (feature, parameter, tuple(location.span[1]))
     parameter = location.id.parameter if location.id is not None else location.parameter_id
     if (

--- a/src/draftwright/audit.py
+++ b/src/draftwright/audit.py
@@ -28,7 +28,7 @@ reads; no cross-run provider identity is reconstructed or serialized.
 from __future__ import annotations
 
 from collections import Counter
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
@@ -41,6 +41,7 @@ class MeasurementClaim:
     meaning: tuple
     rendered: tuple
     witnesses: tuple = ()
+    approved: tuple = field(default=(), repr=False, compare=False, kw_only=True)
 
 
 @dataclass(frozen=True)

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -654,7 +654,9 @@ def _assemble(
     dwg._build.attach_recognition(
         a.recognition,
         evidence=a.recognition_evidence,
-        cache=critique_recognition_cache if a.recognition is None else None,
+        cache=critique_recognition_cache
+        if a.recognition is None and a.recognition_evidence is None
+        else None,
         ownership=a.recognition_ownership,
     )
     dwg._build.part_model = pm
@@ -1208,6 +1210,7 @@ def _build_drawing_once(
     _view_constraints=None,
     _required_tables=(),
     _select_automatic_views: bool = False,
+    _document_input=None,
 ) -> Drawing:
     """Build a customisable 4-view :class:`Drawing` without exporting it.
 
@@ -1343,6 +1346,7 @@ def _build_drawing_once(
             _include_iso=_include_iso,
             _view_constraints=_view_constraints,
             _framed_recognition=framed_recognition,
+            _document_input=_document_input,
         )
 
     with stage("analysis"):
@@ -1907,6 +1911,7 @@ def build_drawing(
     _views: tuple[str, ...] | None = None,
     _include_iso: bool = True,
     _view_constraints=None,
+    _document_input=None,
 ) -> Drawing:
     """Build a drawing, protecting required annotations under an explicit scale.
 
@@ -1967,6 +1972,7 @@ def build_drawing(
         _required_tables=_required_tables,
         _include_iso=_include_iso,
         _view_constraints=_view_constraints,
+        _document_input=_document_input,
     )
     analysis_base = None
     build_attempt = 0
@@ -2036,6 +2042,8 @@ def build_drawing(
             _select_automatic_views=select_automatic_views,
         )
         _validate_authored_view_layout(built, _view_constraints)
+        if _document_input is not None:
+            _document_input.validate(built.working_part, built.model().features)
         return _post_build(built) if _post_build is not None else built
 
     def scale_blockers_for(built: Drawing) -> tuple[dict, ...]:

--- a/src/draftwright/document.py
+++ b/src/draftwright/document.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from hashlib import sha256
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import MappingProxyType
@@ -14,8 +15,10 @@ from draftwright.progress import BuildCancelled, stage
 from draftwright.reporting import (
     ReportUnavailableError,
     build_requirement_catalog,
+    document_report,
     evaluate_document_requirements,
     match_requirement_catalog,
+    write_json_document,
 )
 from draftwright.sheet import Sheet
 
@@ -31,20 +34,21 @@ class DocumentBuildError(RuntimeError):
 class DocumentResult:
     """Live member drawings and the authority under which they were built."""
 
-    def __init__(self, source: DocumentInput, sheets: Mapping, catalog):
+    def __init__(self, source: DocumentInput, sheets: Mapping, catalog, member_recipes=None):
         self._source = source
         self._sheets = MappingProxyType(dict(sheets))
         self._catalog = catalog
+        self._member_recipes = dict(member_recipes or {})
 
     @property
     def sheets(self):
         return self._sheets
 
-    def _project_members(self):
+    def _project_members(self, *, include_lint=False):
         members = []
         for name, drawing in self._sheets.items():
             try:
-                snapshot = drawing.requirement_snapshot()
+                snapshot = drawing.requirement_snapshot(include_lint=include_lint)
                 self._source.validate_model(snapshot.part, snapshot.model)
                 catalog = build_requirement_catalog(
                     evidence=snapshot.evidence,
@@ -59,8 +63,8 @@ class DocumentResult:
             members.append((name, snapshot, aligned))
         return tuple(members)
 
-    def _evaluate(self):
-        members = self._project_members()
+    def _evaluate(self, *, include_lint=False):
+        members = self._project_members(include_lint=include_lint)
         claims = tuple(
             bind_document_claims(name, drawing.measurement_snapshot(), drawing.registry)
             for name, drawing in self._sheets.items()
@@ -72,6 +76,41 @@ class DocumentResult:
             members,
             claims,
         )
+
+    def report(self) -> dict[str, object]:
+        """Read a schema-v4 document report over live members and one source catalog.
+
+        IDs belong only to this report. A returned JSON value does not change when
+        members are edited; call again for new evidence. Bounded clearance is not
+        manufacturing readiness. Missing common authority raises ReportUnavailableError.
+        """
+        evaluation = self._evaluate(include_lint=True)
+        resolved = {
+            name: {
+                "scale": drawing.scale,
+                "page_mm": (drawing.page_w, drawing.page_h),
+                "scale_decision": drawing.scale_decision,
+                "view_decision": drawing.view_decision,
+            }
+            for name, drawing in self._sheets.items()
+        }
+        return document_report(
+            catalog=self._catalog,
+            evaluation=evaluation,
+            model=self._source.model(self._source.initial_features()),
+            source={
+                "kind": "step",
+                "name": self._source.source_name,
+                "sha256": sha256(self._source.source_bytes).hexdigest(),
+            },
+            run_options={"pmi": self._source.analysis.pmi_mode, "frame": "raw"},
+            member_recipes=self._member_recipes,
+            resolved=resolved,
+        )
+
+    def write_report(self, path) -> str:
+        """Atomically write the strict document report without exporting drawing ink."""
+        return write_json_document(self.report(), path)
 
 
 class Document:
@@ -122,11 +161,12 @@ class Document:
         members = []
         for name, sheet in tuple(self._sheets.items()):
             try:
-                members.append((name, sheet._snapshot_for_document()))
+                snapshot = sheet._snapshot_for_document()
+                members.append((name, snapshot, snapshot._document_recipe()))
             except Exception as exc:
                 raise DocumentBuildError(name, exc) from exc
         drawings = {}
-        for name, sheet in members:
+        for name, sheet, _recipe in members:
             try:
                 with stage(f"document sheet {name}"):
                     drawings[name] = sheet.build()
@@ -136,4 +176,9 @@ class Document:
                 raise
             except Exception as exc:
                 raise DocumentBuildError(name, exc) from exc
-        return DocumentResult(self._source, drawings, self._catalog)
+        return DocumentResult(
+            self._source,
+            drawings,
+            self._catalog,
+            {name: recipe for name, _sheet, recipe in members},
+        )

--- a/src/draftwright/document.py
+++ b/src/draftwright/document.py
@@ -8,11 +8,13 @@ from tempfile import TemporaryDirectory
 from types import MappingProxyType
 
 from draftwright.builder import _detect_part_model_analysis
+from draftwright.document_evidence import bind_document_claims
 from draftwright.document_input import DocumentInput
 from draftwright.progress import BuildCancelled, stage
 from draftwright.reporting import (
     ReportUnavailableError,
     build_requirement_catalog,
+    evaluate_document_requirements,
     match_requirement_catalog,
 )
 from draftwright.sheet import Sheet
@@ -43,7 +45,7 @@ class DocumentResult:
         for name, drawing in self._sheets.items():
             try:
                 snapshot = drawing.requirement_snapshot()
-                self._source.validate(snapshot.part, snapshot.model.features)
+                self._source.validate_model(snapshot.part, snapshot.model)
                 catalog = build_requirement_catalog(
                     evidence=snapshot.evidence,
                     ownership=snapshot.ownership,
@@ -56,6 +58,20 @@ class DocumentResult:
                 raise ReportUnavailableError(f"document sheet {name!r}: {exc}") from exc
             members.append((name, snapshot, aligned))
         return tuple(members)
+
+    def _evaluate(self):
+        members = self._project_members()
+        claims = tuple(
+            bind_document_claims(name, drawing.measurement_snapshot(), drawing.registry)
+            for name, drawing in self._sheets.items()
+        )
+        return evaluate_document_requirements(
+            self._catalog,
+            self._source.model(self._source.initial_features()),
+            self._source.analysis.part,
+            members,
+            claims,
+        )
 
 
 class Document:

--- a/src/draftwright/document.py
+++ b/src/draftwright/document.py
@@ -1,0 +1,123 @@
+"""Explicit multi-sheet authoring over one source and recognition authority."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from types import MappingProxyType
+
+from draftwright.builder import _detect_part_model_analysis
+from draftwright.document_input import DocumentInput
+from draftwright.progress import BuildCancelled, stage
+from draftwright.reporting import (
+    ReportUnavailableError,
+    build_requirement_catalog,
+    match_requirement_catalog,
+)
+from draftwright.sheet import Sheet
+
+
+class DocumentBuildError(RuntimeError):
+    """A named member failed; no complete document result was produced."""
+
+    def __init__(self, sheet_name, cause):
+        self.sheet_name = sheet_name
+        super().__init__(f"document sheet {sheet_name!r} failed: {cause}")
+
+
+class DocumentResult:
+    """Live member drawings and the authority under which they were built."""
+
+    def __init__(self, source: DocumentInput, sheets: Mapping, catalog):
+        self._source = source
+        self._sheets = MappingProxyType(dict(sheets))
+        self._catalog = catalog
+
+    @property
+    def sheets(self):
+        return self._sheets
+
+    def _project_members(self):
+        members = []
+        for name, drawing in self._sheets.items():
+            try:
+                snapshot = drawing.requirement_snapshot()
+                self._source.validate(snapshot.part, snapshot.model.features)
+                catalog = build_requirement_catalog(
+                    evidence=snapshot.evidence,
+                    ownership=snapshot.ownership,
+                    model=snapshot.model,
+                    part=snapshot.part,
+                    requirement_outcomes=snapshot.outcomes,
+                )
+                aligned = match_requirement_catalog(self._catalog, catalog)
+            except (ValueError, ReportUnavailableError) as exc:
+                raise ReportUnavailableError(f"document sheet {name!r}: {exc}") from exc
+            members.append((name, snapshot, aligned))
+        return tuple(members)
+
+
+class Document:
+    """Author explicit sheets against an immutable common physical-feature membership."""
+
+    def __init__(self, source: DocumentInput):
+        self._source = source
+        self._catalog = build_requirement_catalog(
+            evidence=source.analysis.recognition_evidence,
+            ownership=source.analysis.recognition_ownership,
+            model=source.model(source.initial_features()),
+            part=source.analysis.part,
+        )
+        self._sheets: dict[str, Sheet] = {}
+
+    @classmethod
+    def from_part(cls, path, *, pmi="off"):
+        """Read one STEP byte snapshot and retain its one raw detection acquisition."""
+        resolved = Path(path).resolve()
+        source_bytes = resolved.read_bytes()
+        with TemporaryDirectory(prefix="draftwright-document-") as directory:
+            snapshot = Path(directory) / resolved.name
+            snapshot.write_bytes(source_bytes)
+            _model, analysis = _detect_part_model_analysis(snapshot, pmi=pmi)
+        try:
+            source = DocumentInput(analysis, Path(path).name, source_bytes)
+        except ValueError as exc:
+            raise ReportUnavailableError(str(exc)) from exc
+        return cls(source)
+
+    @property
+    def features(self):
+        return self._source.features
+
+    def sheet(self, name: str, **options) -> Sheet:
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("a document sheet needs a nonempty name")
+        if name in self._sheets:
+            raise ValueError(f"duplicate document sheet {name!r}")
+        sheet = Sheet(self._source.analysis.part, **options)
+        sheet._bind_document(self._source)
+        self._sheets[name] = sheet
+        return sheet
+
+    def build(self) -> DocumentResult:
+        if not self._sheets:
+            raise ValueError("a document needs at least one sheet")
+        members = []
+        for name, sheet in tuple(self._sheets.items()):
+            try:
+                members.append((name, sheet._snapshot_for_document()))
+            except Exception as exc:
+                raise DocumentBuildError(name, exc) from exc
+        drawings = {}
+        for name, sheet in members:
+            try:
+                with stage(f"document sheet {name}"):
+                    drawings[name] = sheet.build()
+            except BuildCancelled as exc:
+                exc.diagnostic = {**exc.diagnostic, "sheet": name}
+                exc.completed_result = None
+                raise
+            except Exception as exc:
+                raise DocumentBuildError(name, exc) from exc
+        return DocumentResult(self._source, drawings, self._catalog)

--- a/src/draftwright/document_evidence.py
+++ b/src/draftwright/document_evidence.py
@@ -174,8 +174,6 @@ def _narrowed_claim_confirmed(claim, address, meaning, registry):
         for raw, entry in zip(claim.meaning, claim.approved, strict=True)
         if _normalised_entry(raw) == meaning
     )
-    if not approved:
-        return False
     isolated = AnnotationRegistry()
     isolated.add(
         registry.named(claim.annotation),

--- a/src/draftwright/document_evidence.py
+++ b/src/draftwright/document_evidence.py
@@ -1,0 +1,328 @@
+"""Run-local document agreement over confirmed, physically addressed measurement claims."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from math import isfinite
+from numbers import Real
+from types import SimpleNamespace
+
+from draftwright._core import _decode_hole_location_fact
+from draftwright.fits import FitClass
+from draftwright.linting.evidence import verify_measurement_claims
+from draftwright.registry import AnnotationRegistry
+
+
+@dataclass(frozen=True)
+class DocumentClaim:
+    """One confirmed annotation bound to one of its approved measurement meanings."""
+
+    sheet: str
+    owner: object
+    parameter: str
+    annotation: str
+    address: tuple
+    meaning: tuple
+    rendered: tuple
+    witnesses: tuple
+
+
+@dataclass(frozen=True)
+class DocumentClaimSnapshot:
+    claims: tuple[DocumentClaim, ...]
+    unknown: tuple[tuple[str, str, str], ...]
+
+
+@dataclass(frozen=True)
+class DocumentConflict:
+    claims: tuple[DocumentClaim, ...]
+
+
+def _point(value):
+    return (
+        isinstance(value, tuple)
+        and len(value) == 3
+        and all(
+            isinstance(item, Real) and not isinstance(item, bool) and isfinite(item)
+            for item in value
+        )
+    )
+
+
+def _span(value):
+    return isinstance(value, tuple) and len(value) == 2 and all(_point(point) for point in value)
+
+
+def _same_point(first, second, *, normal=None):
+    # Binding tolerates only arithmetic noise. Approved values/spans are retained
+    # verbatim for semantic comparison; the physical-ledger 0.5 mm join is not used.
+    return all(
+        abs(a - b) <= 1e-9
+        for axis, a, b in zip("xyz", first, second, strict=True)
+        if axis != normal
+    )
+
+
+def _same_span(first, second):
+    return (
+        _span(first)
+        and _span(second)
+        and all(_same_point(a, b) for a, b in zip(first, second, strict=True))
+    )
+
+
+def _normalised_entry(entry):
+    value, tolerance, span, axis, discriminator, member, angular = entry
+    if isinstance(tolerance, FitClass):
+        tolerance = replace(tolerance, show="class")
+    return value, tolerance, span, axis, discriminator, member, angular
+
+
+def _normalised_meanings(claim):
+    result = []
+    for entry in claim.meaning:
+        if len(entry) != 7:
+            return ()
+        meaning = _normalised_entry(entry)
+        if meaning not in result:
+            result.append(meaning)
+    return tuple(result)
+
+
+def _location_address(claim, meaning, axis):
+    if len(claim.approved) != len(claim.meaning):
+        return None
+    components = {
+        approved.physical_location_component or f"{approved.role}.location.{axis}"
+        for raw, approved in zip(claim.meaning, claim.approved, strict=True)
+        if _normalised_entry(raw) == meaning and approved.is_location_measurement
+    }
+    if len(components) != 1 or axis not in {"x", "y", "z"} or not _span(meaning[2]):
+        return None
+    component = next(iter(components))
+    # A location measures in the feature's transverse plane. The normal coordinate
+    # may differ between the rendered opening witness and compiler's reference point;
+    # exact feature/member identity and the complete approved meaning remain retained.
+    point = tuple(
+        0.0 if direction == meaning[3] else value
+        for direction, value in zip("xyz", meaning[2][1], strict=True)
+    )
+    return "location", component, point
+
+
+def _bind_claim(claim):
+    meanings = _normalised_meanings(claim)
+    if not meanings:
+        return (), "compiled_meaning_unavailable"
+    span, locations = claim.witnesses if len(claim.witnesses) == 2 else (None, ())
+    location = any(entry.is_location_measurement for entry in claim.approved)
+    if location and not locations:
+        if len(meanings) != 1 or meanings[0][4] not in {"x", "y", "z"}:
+            return (), "location_component_unavailable"
+        address = _location_address(claim, meanings[0], meanings[0][4])
+        if address is None:
+            return (), "location_meaning_unbound"
+        return ((address, meanings[0]),), None
+    if locations:
+        bound = []
+        for component, point in locations:
+            decoded = _decode_hole_location_fact((claim.owner, component, point))
+            if (
+                decoded is None
+                or not _point(point)
+                or component.rsplit(".", 1)[-1] not in {"x", "y", "z"}
+            ):
+                return (), "location_witness_invalid"
+            measured_axis = component.rsplit(".", 1)[-1]
+            candidates = tuple(
+                meaning
+                for meaning in meanings
+                if _span(meaning[2])
+                and meaning[4] in {None, measured_axis}
+                and _same_point(meaning[2][1], point, normal=meaning[3])
+            )
+            if len(candidates) != 1:
+                return (), "location_meaning_unbound"
+            address = _location_address(claim, candidates[0], measured_axis)
+            if address is None or address[1] != component:
+                return (), "location_meaning_unbound"
+            bound.append((address, candidates[0]))
+        return tuple(bound), None
+    if span is not None:
+        if not _span(span):
+            return (), "span_witness_invalid"
+        candidates = tuple(meaning for meaning in meanings if _same_span(meaning[2], span))
+        if len(candidates) != 1:
+            return (), "span_meaning_unbound"
+        return ((("span", candidates[0][2]), candidates[0]),), None
+    if len(meanings) != 1:
+        return (), "measurement_meaning_ambiguous"
+    # A unique compiled interval has the same address with or without the optional
+    # rendered-span rider. Otherwise dropping that rider could evade a conflict.
+    address = ("span", meanings[0][2]) if _span(meanings[0][2]) else ()
+    return ((address, meanings[0]),), None
+
+
+def _narrowed_claim_confirmed(claim, address, meaning, registry):
+    location_axis = address[1].rsplit(".", 1)[-1] if address and address[0] == "location" else None
+    if len(_normalised_meanings(claim)) == 1 and location_axis is None:
+        return True
+    if registry is None or len(claim.approved) != len(claim.meaning):
+        return False
+    approved = tuple(
+        entry
+        for raw, entry in zip(claim.meaning, claim.approved, strict=True)
+        if _normalised_entry(raw) == meaning
+    )
+    if not approved:
+        return False
+    isolated = AnnotationRegistry()
+    isolated.add(
+        registry.named(claim.annotation),
+        claim.annotation,
+        registry.view_of(claim.annotation),
+        feature=claim.owner,
+        measurement=approved[0].id,
+    )
+    outcomes = verify_measurement_claims(
+        isolated,
+        SimpleNamespace(locations=approved),
+        location_components={claim.annotation: location_axis},
+    )
+    return bool(outcomes) and all(outcome.state == "confirmed" for outcome in outcomes)
+
+
+def bind_document_claims(sheet, snapshot, registry=None) -> DocumentClaimSnapshot:
+    """Narrow the existing measurement snapshot without changing edit comparison.
+
+    A location component or recorded interval supplies an address within a coarse
+    parameter. Labels, nominal equality and annotation names never supply that address.
+    """
+    claims: list[DocumentClaim] = []
+    unknown = [(sheet, name, reason) for name, reason in snapshot.unknown]
+    for claim in snapshot.claims:
+        if not any(owner is claim.owner for owner in snapshot.owners):
+            unknown.append((sheet, claim.annotation, "physical_owner_unavailable"))
+            continue
+        bindings, reason = _bind_claim(claim)
+        if reason is not None:
+            unknown.append((sheet, claim.annotation, reason))
+            continue
+        if not all(
+            _narrowed_claim_confirmed(claim, address, meaning, registry)
+            for address, meaning in bindings
+        ):
+            unknown.append((sheet, claim.annotation, "bound_claim_unconfirmed"))
+            continue
+        claims.extend(
+            DocumentClaim(
+                sheet,
+                claim.owner,
+                claim.parameter,
+                claim.annotation,
+                address,
+                meaning,
+                claim.rendered,
+                claim.witnesses,
+            )
+            for address, meaning in bindings
+        )
+    return DocumentClaimSnapshot(tuple(claims), tuple(dict.fromkeys(unknown)))
+
+
+def document_conflicts(snapshots) -> tuple[DocumentConflict, ...]:
+    """Retain every disagreeing confirmed claim; no sheet or tighter tolerance wins."""
+    groups: dict[tuple, list[DocumentClaim]] = {}
+    for snapshot in snapshots:
+        for claim in snapshot.claims:
+            key = (id(claim.owner), claim.parameter, claim.address)
+            groups.setdefault(key, []).append(claim)
+    return tuple(
+        DocumentConflict(tuple(claims))
+        for claims in groups.values()
+        if any(claim.meaning != claims[0].meaning for claim in claims[1:])
+    )
+
+
+@dataclass(frozen=True)
+class DocumentSupportProof:
+    """One complete producer-issued conjunction, retaining every carrying claim."""
+
+    alternative: int
+    carriers: tuple[tuple[DocumentClaim, ...], ...]
+    witnesses: tuple[DocumentClaim, ...]
+
+
+def _supports_claim(support, claim):
+    if claim.owner is not support.feature or claim.parameter != support.parameter_id:
+        return False
+    if support.location_point is not None:
+        if not claim.address or claim.address[0] != "location":
+            return False
+        if not _same_point(claim.address[2], support.location_point, normal=claim.meaning[3]):
+            return False
+        if support.axis is not None and not claim.address[1].endswith("." + support.axis):
+            return False
+    if support.lo is not None or support.hi is not None:
+        from draftwright.linting.through_step_coverage import _interval_matches
+
+        # This is the producer's attribution rule, not equality of engineering meaning.
+        # The claim was separately bound and confirmed against its exact compiled span.
+        return (
+            bool(claim.address)
+            and claim.address[0] == "span"
+            and _interval_matches(support, claim.meaning[2])
+        )
+    if support.axis is not None and support.location_point is None:
+        return claim.meaning[3] == support.axis
+    return True
+
+
+def _distinct_support_witnesses(carriers):
+    # Match terms to physical claim addresses, not annotation names. Repeating one
+    # dimension on another sheet cannot supply a missing second interval.
+    assigned: dict[tuple, int] = {}
+    selected: dict[int, DocumentClaim] = {}
+
+    def assign(term, seen):
+        for claim in carriers[term]:
+            key = (id(claim.owner), claim.parameter, claim.address)
+            if key in seen:
+                continue
+            seen.add(key)
+            if key not in assigned or assign(assigned[key], seen):
+                assigned[key] = term
+                selected[term] = claim
+                return True
+        return False
+
+    if all(assign(term, set()) for term in range(len(carriers))):
+        return tuple(selected[term] for term in range(len(carriers)))
+    return ()
+
+
+def document_support_proofs(
+    alternatives, snapshots, conflicts
+) -> tuple[DocumentSupportProof, ...]:
+    """Evaluate complete alternatives over confirmed ink, never over other credits.
+
+    Reading only actual claims makes cyclic requirement recipes incapable of proving
+    themselves. Empty rich recipes are explicitly unproved, not vacuous conjunctions.
+    """
+    conflicted = {id(claim) for conflict in conflicts for claim in conflict.claims}
+    available = tuple(
+        claim for snapshot in snapshots for claim in snapshot.claims if id(claim) not in conflicted
+    )
+    proofs = []
+    for index, alternative in enumerate(alternatives):
+        supports = tuple(getattr(alternative, "supports", alternative))
+        if not supports:
+            continue
+        carriers = tuple(
+            tuple(claim for claim in available if _supports_claim(support, claim))
+            for support in supports
+        )
+        witnesses = _distinct_support_witnesses(carriers)
+        if witnesses:
+            proofs.append(DocumentSupportProof(index, carriers, witnesses))
+    return tuple(proofs)

--- a/src/draftwright/document_input.py
+++ b/src/draftwright/document_input.py
@@ -77,6 +77,16 @@ class DocumentInput:
             raise ValueError("document members must use the exact common working solid")
         self.validate_features(features)
 
+    def validate_model(self, part, model):
+        """Member measurement references retain the common layout datum authority."""
+        self.validate(part, model.features)
+        expected = tuple(datum for datum in self._model.datums if datum.id == "datum_xy")
+        actual = tuple(datum for datum in model.datums if datum.id == "datum_xy")
+        if len(actual) != len(expected) or any(
+            first is not second for first, second in zip(expected, actual, strict=True)
+        ):
+            raise ValueError("document layout datum is sealed; retain the exact common datum")
+
     def model(self, features):
         """Copy mutable authoring containers while preserving exact source owners."""
         self.validate_features(features)

--- a/src/draftwright/document_input.py
+++ b/src/draftwright/document_input.py
@@ -1,0 +1,91 @@
+"""Common source authority for explicitly related drawing builds (ADR 1/3/5)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+
+from draftwright._core import Analysis
+from draftwright.model.ir import (
+    AuthoredDimension,
+    ControlFrame,
+    DatumRef,
+    Finish,
+    Note,
+    PartModel,
+    PmiFeature,
+)
+
+_ANNOTATION_FEATURES = (AuthoredDimension, ControlFrame, DatumRef, Finish, Note, PmiFeature)
+
+
+def physical_features(features):
+    """Retain physical owners; unknown feature kinds are physical, never exemptions."""
+    return tuple(feature for feature in features if not isinstance(feature, _ANNOTATION_FEATURES))
+
+
+@dataclass(frozen=True)
+class DocumentInput:
+    """An owned intake; references establish authority only within its lifetime."""
+
+    analysis: Analysis
+    source_name: str
+    source_bytes: bytes = field(repr=False)
+    features: tuple = field(init=False)
+    _model: PartModel = field(init=False, repr=False)
+
+    def __post_init__(self):
+        analysis = self.analysis
+        evidence, ownership = analysis.recognition_evidence, analysis.recognition_ownership
+        if (
+            (analysis.recognition_frame_decision or {}).get("status") != "raw"
+            or evidence is None
+            or ownership is None
+            or evidence.result is not analysis.recognition
+            or ownership.evidence is not evidence
+            or not isinstance(analysis.model, PartModel)
+        ):
+            raise ValueError("a document requires exact raw recognition and conversion ownership")
+        model = analysis.model
+        features = tuple(model.features)
+        physical = physical_features(features)
+        if len({id(feature) for feature in physical}) != len(physical):
+            raise ValueError("the document physical inventory repeats an owner")
+        object.__setattr__(self, "features", physical)
+        object.__setattr__(
+            self,
+            "_model",
+            replace(
+                model,
+                features=list(features),
+                datums=list(model.datums),
+                decorations=dict(model.decorations),
+            ),
+        )
+
+    def validate_features(self, features):
+        current = physical_features(features)
+        if len(current) != len(self.features) or any(
+            sum(candidate is feature for candidate in current) != 1 for feature in self.features
+        ):
+            raise ValueError(
+                "document physical features are sealed; use exact common features and "
+                "per-sheet dimension intents or decorations"
+            )
+
+    def validate(self, part, features):
+        if part is not self.analysis.part:
+            raise ValueError("document members must use the exact common working solid")
+        self.validate_features(features)
+
+    def model(self, features):
+        """Copy mutable authoring containers while preserving exact source owners."""
+        self.validate_features(features)
+        return replace(
+            self._model,
+            features=list(features),
+            datums=list(self._model.datums),
+            decorations=dict(self._model.decorations),
+        )
+
+    def initial_features(self):
+        return tuple(self._model.features)

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1436,6 +1436,7 @@ class Drawing:
                                 if feature is identity.feature
                             ),
                         ),
+                        approved=approved,
                     )
                 )
         return MeasurementSnapshot(tuple(model.features), tuple(claims), tuple(unknown))

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1070,7 +1070,7 @@ class Drawing:
             requirement_outcomes=snapshot.outcomes,
         )
 
-    def requirement_snapshot(self):
+    def requirement_snapshot(self, *, include_lint=False):
         """Capture live source-owned outcomes for single-sheet and document review.
 
         This reuses the report's exact-authority validation and existing producers.
@@ -1101,6 +1101,10 @@ class Drawing:
             ownership=ownership,
             datum=next((datum for datum in model.datums if datum.id == "datum_xy"), None),
         )
+        lint = None
+        if include_lint:
+            with _reuse_report_requirements(self, outcomes, dimension_plan):
+                lint = self.lint_summary()
         return RequirementSnapshot(
             evidence,
             ownership,
@@ -1111,6 +1115,7 @@ class Drawing:
             dimension_plan,
             self._working_part,
             outcomes,
+            lint,
         )
 
     def write_report(self, path: str | os.PathLike[str]) -> str:

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1052,45 +1052,65 @@ class Drawing:
         shrinking the denominator. Calling this method never changes rendered drawing content.
         """
 
-        from draftwright.reporting import drawing_report, validate_report_inputs
+        from draftwright.reporting import drawing_report
+
+        snapshot = self.requirement_snapshot()
+        with _reuse_report_requirements(self, snapshot.outcomes, snapshot.dimension_plan):
+            lint = self.lint_summary()
+        return drawing_report(
+            evidence=snapshot.evidence,
+            ownership=snapshot.ownership,
+            model=snapshot.model,
+            lint=lint,
+            source=snapshot.source,
+            registry=snapshot.registry,
+            omissions=snapshot.omissions,
+            dimension_plan=snapshot.dimension_plan,
+            part=snapshot.part,
+            requirement_outcomes=snapshot.outcomes,
+        )
+
+    def requirement_snapshot(self):
+        """Capture live source-owned outcomes for single-sheet and document review.
+
+        This reuses the report's exact-authority validation and existing producers.
+        It neither recognizes geometry nor derives requirements from the compiled plan.
+        The returned references belong to this build and must not be persisted or
+        combined with another recognition run. Serialize edits and snapshot reads.
+        """
+        from draftwright.reporting import RequirementSnapshot, validate_report_inputs
 
         analysis = self._analysis
         source = getattr(analysis, "step_file", None) if analysis is not None else None
-        evidence = self.recognition_evidence()
-        ownership = self.recognition_ownership()
-        model = self.model()
-        # Preserve schema-v1's fail-before-critique boundary. In particular, a declared drawing
-        # with no conversion-time ownership must refuse without lint lazily running recognition.
-        evidence, ownership, model = validate_report_inputs(evidence, ownership, model)
+        evidence, ownership, model = validate_report_inputs(
+            self.recognition_evidence(), self.recognition_ownership(), self.model()
+        )
         from draftwright.linting.requirements import recognized_requirement_outcomes
         from draftwright.model.compiled import compile_dimensions
 
         dimension_plan = compile_dimensions(model)
-        requirement_outcomes = recognized_requirement_outcomes(
+        omissions = tuple(self._build.omissions)
+        outcomes = recognized_requirement_outcomes(
             evidence.result,
             tuple(model.features),
             self.registry,
-            self._build.omissions,
+            omissions,
             dimension_plan=dimension_plan,
             part=self._working_part,
             evidence=evidence,
             ownership=ownership,
+            datum=next((datum for datum in model.datums if datum.id == "datum_xy"), None),
         )
-
-        with _reuse_report_requirements(self, requirement_outcomes, dimension_plan):
-            lint = self.lint_summary()
-
-        return drawing_report(
-            evidence=evidence,
-            ownership=ownership,
-            model=model,
-            lint=lint,
-            source=source,
-            registry=self.registry,
-            omissions=self._build.omissions,
-            dimension_plan=dimension_plan,
-            part=self._working_part,
-            requirement_outcomes=requirement_outcomes,
+        return RequirementSnapshot(
+            evidence,
+            ownership,
+            model,
+            source,
+            self.registry,
+            omissions,
+            dimension_plan,
+            self._working_part,
+            outcomes,
         )
 
     def write_report(self, path: str | os.PathLike[str]) -> str:

--- a/src/draftwright/linting/_registry.py
+++ b/src/draftwright/linting/_registry.py
@@ -2,6 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Any, TypeVar, cast
+
+from draftwright.measurement_support import RequirementCarrier
+
+_Outcome = TypeVar("_Outcome")
+
 
 def satisfaction_of(registry, name) -> tuple:
     """Read one optional satisfaction axis, or return empty for a pre-axis registry."""
@@ -30,3 +36,124 @@ def annotation_owner(registry, annotation):
             if owner is not None:
                 return owner
     return None
+
+
+def requirement_measurements(outcome) -> tuple[tuple[object, str], ...]:
+    """Read the exact identities published by a typed physical requirement outcome."""
+    explicit = tuple(getattr(outcome, "measurement_ids", ()))
+    if explicit:
+        return explicit
+    representation = getattr(outcome, "representation_feature", None)
+    parameter = getattr(outcome, "representation_parameter", None)
+    if representation is not None and isinstance(parameter, str):
+        return ((representation, parameter),)
+    parameter = getattr(outcome, "parameter_id", None)
+    if not isinstance(parameter, str) or parameter == "?":
+        return ()
+    return tuple((feature, parameter) for feature in getattr(outcome, "features", ()))
+
+
+def measurement_carrier_index(registry):
+    """Preserve names alongside the registry's exact measurement/satisfaction axes."""
+    result: dict[tuple[int, str], tuple[object, list[RequirementCarrier]]] = {}
+    if registry is None:
+        return result
+    for name in sorted(registry.names()):
+        for kind, identities in (
+            ("measurement", registry.measurement_of(name)),
+            ("structured_note", satisfaction_of(registry, name)),
+        ):
+            for identity in identities:
+                feature, parameter = (
+                    getattr(identity, "feature", None),
+                    getattr(identity, "parameter", None),
+                )
+                record_measurement_carrier(result, name, feature, parameter, kind)
+    return result
+
+
+def record_measurement_carrier(index, name, feature, parameter, kind):
+    """Retain a name alongside already-read identity fields without rereading the claim."""
+    if feature is not None and isinstance(parameter, str):
+        entry = index.setdefault((id(feature), parameter), (feature, []))
+        if entry[0] is feature:
+            carrier = RequirementCarrier(name, kind)
+            if carrier not in entry[1]:
+                entry[1].append(carrier)
+
+
+def exact_measurement_carriers(index, measurements):
+    """Project only producer-selected exact identities; no parameter aliases inferred."""
+    carriers = []
+    for feature, parameter in measurements:
+        entry = index.get((id(feature), parameter))
+        if entry is not None and entry[0] is feature:
+            for carrier in entry[1]:
+                if carrier not in carriers:
+                    carriers.append(carrier)
+    return tuple(carriers)
+
+
+def with_measurement_carriers(outcomes: list[_Outcome], registry) -> list[_Outcome]:
+    """Retain ordinary exact-ID evidence; special producer predicates add their own."""
+    from dataclasses import replace
+
+    index = measurement_carrier_index(registry)
+    return [
+        cast(
+            _Outcome,
+            replace(
+                cast(Any, outcome),
+                carriers=exact_measurement_carriers(index, requirement_measurements(outcome)),
+            ),
+        )
+        for outcome in outcomes
+    ]
+
+
+class RequirementCarrierEvidence:
+    """Names retained by a producer alongside its accepted physical evidence."""
+
+    def __init__(self, registry):
+        from collections import defaultdict
+
+        self.measurements = measurement_carrier_index(registry)
+        self.locations: dict[tuple, list[RequirementCarrier]] = defaultdict(list)
+        self.counts: dict[tuple, list[RequirementCarrier]] = defaultdict(list)
+        self.outcomes: dict[tuple, tuple[RequirementCarrier, ...]] = {}
+
+    def accept(self, feature, parameter, state, *, parameters=(), physical=()):
+        kind = "measurement" if state == "placed" else "structured_note"
+        exact = exact_measurement_carriers(
+            self.measurements, ((feature, item) for item in parameters)
+        )
+        self.outcomes[(feature, parameter)] = tuple(
+            dict.fromkeys(
+                (
+                    *self.outcomes.get((feature, parameter), ()),
+                    *physical,
+                    *(item for item in exact if item.kind == kind),
+                )
+            )
+        )
+        return state
+
+    def attach(self, outcomes: list[_Outcome]) -> list[_Outcome]:
+        from dataclasses import replace
+
+        return [
+            cast(
+                _Outcome,
+                replace(
+                    cast(Any, outcome),
+                    carriers=tuple(
+                        carrier
+                        for feature in getattr(outcome, "features", ())
+                        for carrier in self.outcomes.get(
+                            (feature, getattr(outcome, "parameter_id", None)), ()
+                        )
+                    ),
+                ),
+            )
+            for outcome in outcomes
+        ]

--- a/src/draftwright/linting/angular.py
+++ b/src/draftwright/linting/angular.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from math import atan2, degrees, dist, fsum, hypot, isfinite, pi
 from statistics import median
 from types import SimpleNamespace
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 from build123d import GeomType
 
 from draftwright.linting.issues import LintIssue
+from draftwright.measurement_support import RequirementCarrier
 from draftwright.profile_angles import (
     ProfileAngle,
     profile_angle_repetitions,
@@ -446,6 +447,7 @@ class ProfileAngleOutcome:
     state: str
     features: tuple = ()
     parameter_id: str = "included.angle"
+    carriers: tuple[RequirementCarrier, ...] = field(default=(), kw_only=True)
 
 
 def profile_angle_requirement_outcomes(evidence, ownership, features, registry, omissions=()):
@@ -491,6 +493,7 @@ def profile_angle_requirement_outcomes(evidence, ownership, features, registry, 
                 parameter_id = representations[0][1]
         final = tuple(owner for owner in owners if any(owner is feature for feature in features))
         state = "unverifiable"
+        carriers: tuple[RequirementCarrier, ...] = ()
         if owners and not final:
             state = "missing"
         elif final:
@@ -499,17 +502,21 @@ def profile_angle_requirement_outcomes(evidence, ownership, features, registry, 
             def matches_id(identity):
                 return identity.feature is owner and identity.parameter == parameter_id
 
-            if any(
-                hasattr(registry.named(name), "angular_points")
+            measured = tuple(
+                RequirementCarrier(name, "angular_measurement")
+                for name in sorted(registry.names())
+                if hasattr(registry.named(name), "angular_points")
                 and any(matches_id(identity) for identity in registry.measurement_of(name))
-                for name in registry.names()
-            ):
+            )
+            satisfied = tuple(
+                RequirementCarrier(name, "structured_note")
+                for name in sorted(registry.names())
+                if any(matches_id(identity) for identity in registry.satisfaction_of(name))
+            )
+            carriers = measured + satisfied
+            if measured:
                 state = "placed"
-            elif any(
-                matches_id(identity)
-                for name in registry.names()
-                for identity in registry.satisfaction_of(name)
-            ):
+            elif satisfied:
                 state = "satisfied_by_structured_note"
             elif any(
                 omission.feature is owner
@@ -527,7 +534,9 @@ def profile_angle_requirement_outcomes(evidence, ownership, features, registry, 
                 state = "dropped"
             else:
                 state = "missing"
-        outcomes.append(ProfileAngleOutcome(requirement, state, final, parameter_id))
+        outcomes.append(
+            ProfileAngleOutcome(requirement, state, final, parameter_id, carriers=carriers)
+        )
     return outcomes
 
 

--- a/src/draftwright/linting/blend_coverage.py
+++ b/src/draftwright/linting/blend_coverage.py
@@ -18,8 +18,13 @@ from draftwright.blend_contract import (
     is_exact_blend_feature,
     validate_blend_fields,
 )
-from draftwright.linting._registry import satisfaction_ids, satisfaction_of
+from draftwright.linting._registry import (
+    satisfaction_ids,
+    satisfaction_of,
+    with_measurement_carriers,
+)
 from draftwright.linting.issues import LintIssue, is_placement_drop
+from draftwright.measurement_support import RequirementCarrier
 
 BlendRequirementState = Literal[
     "placed",
@@ -41,6 +46,7 @@ class BlendRequirementOutcome:
     features: tuple = ()
     parameter_id: str = "blend.radius"
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
+    carriers: tuple[RequirementCarrier, ...] = field(default=(), kw_only=True)
 
 
 def _source_at(key: tuple | None) -> tuple[float, float, float]:
@@ -189,7 +195,7 @@ def blend_requirement_outcomes(
                 source_records=(source_record,),
             )
         )
-    return outcomes
+    return with_measurement_carriers(outcomes, registry)
 
 
 def lint_blend_coverage(

--- a/src/draftwright/linting/chamfer_coverage.py
+++ b/src/draftwright/linting/chamfer_coverage.py
@@ -15,8 +15,13 @@ from typing import Literal
 
 from quiddity import RecognitionResult
 
-from draftwright.linting._registry import satisfaction_ids, satisfaction_of
+from draftwright.linting._registry import (
+    satisfaction_ids,
+    satisfaction_of,
+    with_measurement_carriers,
+)
 from draftwright.linting.issues import LintIssue, is_placement_drop
+from draftwright.measurement_support import RequirementCarrier
 
 ChamferRequirementState = Literal[
     "placed",
@@ -38,6 +43,7 @@ class ChamferRequirementOutcome:
     features: tuple = ()
     parameter_id: str = "chamfer.length"
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
+    carriers: tuple[RequirementCarrier, ...] = field(default=(), kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -160,7 +166,7 @@ def chamfer_requirement_outcomes(
         outcomes.append(
             ChamferRequirementOutcome(key[1], state, features=(feature,), source_records=(source,))
         )
-    return outcomes
+    return with_measurement_carriers(outcomes, registry)
 
 
 def lint_chamfer_coverage(

--- a/src/draftwright/linting/channel_coverage.py
+++ b/src/draftwright/linting/channel_coverage.py
@@ -7,8 +7,13 @@ from typing import Literal
 
 from quiddity import RecognitionResult, SectionRecess, has_multi_axis_plates
 
-from draftwright.linting._registry import satisfaction_ids, satisfaction_of
+from draftwright.linting._registry import (
+    satisfaction_ids,
+    satisfaction_of,
+    with_measurement_carriers,
+)
 from draftwright.linting.issues import LintIssue
+from draftwright.measurement_support import RequirementCarrier
 from draftwright.section_recess_contract import recesses_with_kind, section_recess_fields
 
 ChannelRequirementState = Literal[
@@ -30,6 +35,7 @@ class ChannelRequirementOutcome:
     state: ChannelRequirementState
     features: tuple = ()
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
+    carriers: tuple[RequirementCarrier, ...] = field(default=(), kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -188,7 +194,7 @@ def channel_requirement_outcomes(
                     source_records=(source,),
                 )
             )
-    return outcomes
+    return with_measurement_carriers(outcomes, registry)
 
 
 def lint_channel_coverage(

--- a/src/draftwright/linting/circular_blind_step_coverage.py
+++ b/src/draftwright/linting/circular_blind_step_coverage.py
@@ -16,8 +16,13 @@ from typing import Literal
 from quiddity import CircularBlindStep, RecognitionResult
 
 from draftwright._geometry import quantised_radius_agrees, quantised_span_agrees
-from draftwright.linting._registry import satisfaction_ids, satisfaction_of
+from draftwright.linting._registry import (
+    satisfaction_ids,
+    satisfaction_of,
+    with_measurement_carriers,
+)
 from draftwright.linting.issues import LintIssue, is_placement_drop
+from draftwright.measurement_support import RequirementCarrier
 
 CircularBlindStepRequirementState = Literal[
     "placed",
@@ -39,6 +44,7 @@ class CircularBlindStepRequirementOutcome:
     requirement_count: int = 1
     features: tuple = ()
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
+    carriers: tuple[RequirementCarrier, ...] = field(default=(), kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -315,7 +321,7 @@ def circular_blind_step_requirement_outcomes(
                     source_records=(source,),
                 )
             )
-    return outcomes
+    return with_measurement_carriers(outcomes, registry)
 
 
 def lint_circular_blind_step_coverage(

--- a/src/draftwright/linting/evidence.py
+++ b/src/draftwright/linting/evidence.py
@@ -55,7 +55,7 @@ ClaimState = Literal["confirmed", "value_absent", "unresolved", "unreadable", "n
 _VALUE_TOL = 1e-6
 
 
-def _expected_numbers(approved) -> frozenset[float]:
+def _expected_numbers(approved, *, location_component=None) -> frozenset[float]:
     """Every number the sheet may legitimately show for *approved*.
 
     From ``value_text``, NOT ``value``. The compiler formats for display — a 13.649 mm extent
@@ -107,6 +107,12 @@ def _expected_numbers(approved) -> frozenset[float]:
     # intent rather than this inference (#1218 review round 2).
     excluded = "xyz".index(axis) if axis in ("x", "y", "z") else None
     indices = [i for i in range(3) if i != excluded]
+    if location_component is not None:
+        # A document may bind one recorded component of a legacy coarse location.
+        # Narrow this existing compiler-span check; never accept its sibling offset.
+        if location_component not in "xyz" or len(location_component) != 1:
+            return frozenset()
+        indices = [i for i in indices if "xyz"[i] == location_component]
     return frozenset(
         float(_fmt(abs(float(end[index]) - float(start[index])))) for index in indices
     )
@@ -239,7 +245,7 @@ def rendered_numbers(annotation) -> frozenset[float] | None:
     return frozenset(float(match.group()) for text in texts for match in _NUMBER_RE.finditer(text))
 
 
-def verify_measurement_claims(registry, plan) -> list[ClaimOutcome]:
+def verify_measurement_claims(registry, plan, *, location_components=None) -> list[ClaimOutcome]:
     """Resolve every annotation's measurement claims against what it renders.
 
     **Four limits, all measured rather than reasoned about** (#1218 review found each of them
@@ -357,7 +363,15 @@ def verify_measurement_claims(registry, plan) -> list[ClaimOutcome]:
                 continue
             expected = tuple(entry.value_text for entry in entries)
             wanted = (
-                frozenset().union(*(_expected_numbers(entry) for entry in entries))
+                frozenset().union(
+                    *(
+                        _expected_numbers(
+                            entry,
+                            location_component=(location_components or {}).get(name),
+                        )
+                        for entry in entries
+                    )
+                )
                 if entries
                 else frozenset()
             )

--- a/src/draftwright/linting/fillet_coverage.py
+++ b/src/draftwright/linting/fillet_coverage.py
@@ -14,8 +14,13 @@ from typing import Literal
 
 from quiddity import RecognitionResult
 
-from draftwright.linting._registry import satisfaction_ids, satisfaction_of
+from draftwright.linting._registry import (
+    satisfaction_ids,
+    satisfaction_of,
+    with_measurement_carriers,
+)
 from draftwright.linting.issues import LintIssue, is_placement_drop
+from draftwright.measurement_support import RequirementCarrier
 
 FilletRequirementState = Literal[
     "placed",
@@ -37,6 +42,7 @@ class FilletRequirementOutcome:
     features: tuple = ()
     parameter_id: str = "fillet.radius"
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
+    carriers: tuple[RequirementCarrier, ...] = field(default=(), kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -157,7 +163,7 @@ def fillet_requirement_outcomes(
         outcomes.append(
             FilletRequirementOutcome(key[1], state, features=(feature,), source_records=(source,))
         )
-    return outcomes
+    return with_measurement_carriers(outcomes, registry)
 
 
 def lint_fillet_coverage(

--- a/src/draftwright/linting/flat_coverage.py
+++ b/src/draftwright/linting/flat_coverage.py
@@ -14,8 +14,13 @@ from typing import Literal
 from quiddity import RecognitionResult
 
 from draftwright._geometry import _canonical_axis_direction
-from draftwright.linting._registry import satisfaction_ids, satisfaction_of
+from draftwright.linting._registry import (
+    satisfaction_ids,
+    satisfaction_of,
+    with_measurement_carriers,
+)
 from draftwright.linting.issues import LintIssue
+from draftwright.measurement_support import RequirementCarrier
 
 FlatRequirementState = Literal[
     "placed",
@@ -49,6 +54,7 @@ class FlatRequirementOutcome:
     features: tuple = ()
     parameter_id: str = "flat.length"
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
+    carriers: tuple[RequirementCarrier, ...] = field(default=(), kw_only=True)
 
 
 def _rounded_pair(values) -> tuple[float, float]:
@@ -191,7 +197,7 @@ def flat_requirement_outcomes(
                 source_records=tuple(source_records[requirement]),
             )
         )
-    return outcomes
+    return with_measurement_carriers(outcomes, registry)
 
 
 def lint_flat_coverage(

--- a/src/draftwright/linting/groove_coverage.py
+++ b/src/draftwright/linting/groove_coverage.py
@@ -16,13 +16,18 @@ from typing import Literal
 
 from quiddity import RecognitionResult
 
-from draftwright.linting._registry import satisfaction_ids, satisfaction_of
+from draftwright.linting._registry import (
+    satisfaction_ids,
+    satisfaction_of,
+    with_measurement_carriers,
+)
 from draftwright.linting.issues import (
     UNJOINED_PARAMETER_ID,
     LintIssue,
     is_placement_drop,
     requirement_subject,
 )
+from draftwright.measurement_support import RequirementCarrier
 from draftwright.recognition_frame import validated_groove_geometry
 
 GrooveRequirementState = Literal[
@@ -48,6 +53,7 @@ class GrooveRequirementOutcome:
     requirement_count_known: bool = True
     features: tuple = ()
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
+    carriers: tuple[RequirementCarrier, ...] = field(default=(), kw_only=True)
 
 
 def groove_key(groove) -> tuple:
@@ -231,7 +237,7 @@ def groove_requirement_outcomes(
             )
             for parameter in parameter_ids
         )
-    return outcomes
+    return with_measurement_carriers(outcomes, registry)
 
 
 def lint_groove_coverage(

--- a/src/draftwright/linting/hole_coverage.py
+++ b/src/draftwright/linting/hole_coverage.py
@@ -8,7 +8,7 @@ suppressed, and dropped outcomes. Rendered labels and annotation names are never
 from __future__ import annotations
 
 from collections import Counter, defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from math import hypot
 from typing import Literal
 
@@ -16,7 +16,11 @@ from quiddity import HoleRecord, HoleSpec, RecognitionResult, countersink_matche
 
 from draftwright._core import _decode_hole_location_fact, _fmt
 from draftwright._geometry import _END_ON, _is_principal_axis, _projected_edge_distance
-from draftwright.linting._registry import satisfaction_ids
+from draftwright.linting._registry import (
+    exact_measurement_carriers,
+    record_measurement_carrier,
+    satisfaction_of,
+)
 from draftwright.linting.issues import (
     UNJOINED_PARAMETER_ID,
     LintIssue,
@@ -24,6 +28,7 @@ from draftwright.linting.issues import (
     requirement_subject,
 )
 from draftwright.linting.profiled_bore_coverage import profiled_bore_target_sources
+from draftwright.measurement_support import RequirementCarrier
 
 HoleRequirementState = Literal[
     "placed",
@@ -63,6 +68,7 @@ class HoleRequirementOutcome:
     members: tuple[tuple[float, float, float], ...] = ()
     features: tuple = ()
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
+    carriers: tuple[RequirementCarrier, ...] = field(default=(), kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -550,6 +556,10 @@ class _HoleEvidence:
     centers: dict[object, set[tuple[tuple[float, float, float], str]]]
     representations: dict[tuple[object, str], set[tuple[str, str]]]
     unmarked_representations: set[tuple[object, str]]
+    count_names: dict = field(default_factory=dict)
+    location_names: dict = field(default_factory=dict)
+    center_names: dict = field(default_factory=dict)
+    carrier_index: dict = field(default_factory=dict)
 
 
 def _normalised_location(feature, point) -> tuple[float, float, float]:
@@ -586,17 +596,26 @@ def _member_location_drop_parameter(parameter: str) -> str | None:
 def _index_hole_evidence(registry) -> _HoleEvidence:
     placed = set()
     satisfied: set[tuple[object, str]] = set()
-    for identity in satisfaction_ids(registry):
-        feature = getattr(identity, "feature", None)
-        parameter = getattr(identity, "parameter", None)
-        if feature is not None and isinstance(parameter, str):
-            satisfied.add((feature, parameter))
+    carrier_index: dict = {}
     requirement_counts: dict[tuple[object, str], set[int]] = defaultdict(set)
     locations: dict[tuple[object, str], set[tuple[float, float, float]]] = defaultdict(set)
     centers: dict[object, set[tuple[tuple[float, float, float], str]]] = defaultdict(set)
     representations: dict[tuple[object, str], set[tuple[str, str]]] = defaultdict(set)
     unmarked_representations: set[tuple[object, str]] = set()
+    count_names, location_names, center_names = (
+        defaultdict(set),
+        defaultdict(set),
+        defaultdict(set),
+    )
     for name in registry.names():
+        for identity in satisfaction_of(registry, name):
+            feature = getattr(identity, "feature", None)
+            parameter = getattr(identity, "parameter", None)
+            if feature is not None and isinstance(parameter, str):
+                satisfied.add((feature, parameter))
+                record_measurement_carrier(
+                    carrier_index, name, feature, parameter, "structured_note"
+                )
         annotation = registry.named(name)
         representation = getattr(annotation, "hole_representation", None)
         representation_reason = getattr(annotation, "hole_representation_reason", None)
@@ -634,6 +653,7 @@ def _index_hole_evidence(registry) -> _HoleEvidence:
             if feature is None or parameter is None:
                 continue
             placed.add((feature, parameter))
+            record_measurement_carrier(carrier_index, name, feature, parameter, "measurement")
             record_representation(feature, parameter)
             if parameter == "bore.diameter":
                 diameter_features.add(feature)
@@ -654,17 +674,19 @@ def _index_hole_evidence(registry) -> _HoleEvidence:
             if requirement == "grouping.count" and not shared_count_agrees:
                 continue
             requirement_counts[(feature, requirement)].add(int(count))
+            count_names[(feature, requirement, int(count))].add(name)
             record_representation(feature, requirement)
         for feature in diameter_features:
             for requirement in getattr(annotation, "covers_hole_requirements", ()):
                 if (feature, requirement) in explicit_keys:
                     continue
                 requirement_counts[(feature, requirement)].add(1)
+                count_names[(feature, requirement, 1)].add(name)
                 record_representation(feature, requirement)
             if (feature, "grouping.count") not in explicit_keys:
-                requirement_counts[(feature, "grouping.count")].add(
-                    int(getattr(annotation, "covers_count", 1) or 1)
-                )
+                count = int(getattr(annotation, "covers_count", 1) or 1)
+                requirement_counts[(feature, "grouping.count")].add(count)
+                count_names[(feature, "grouping.count", count)].add(name)
             record_representation(feature, "grouping.count")
         for fact in getattr(annotation, "covers_hole_locations", ()):
             decoded = _decode_hole_location_fact(fact)
@@ -672,11 +694,15 @@ def _index_hole_evidence(registry) -> _HoleEvidence:
                 continue
             feature, parameter, point = decoded
             if getattr(feature, "kind", None) in {"hole", "pattern"}:
-                locations[(feature, parameter)].add(_normalised_location(feature, point))
+                normalized = _normalised_location(feature, point)
+                locations[(feature, parameter)].add(normalized)
+                location_names[(feature, parameter, normalized)].add(name)
                 record_representation(feature, parameter)
         for feature, point, view in getattr(annotation, "covers_hole_centers", ()):
             if getattr(feature, "kind", None) in {"hole", "pattern"}:
-                centers[feature].add((_normalised_location(feature, point), view))
+                normalized = _normalised_location(feature, point)
+                centers[feature].add((normalized, view))
+                center_names[(feature, normalized, view)].add(name)
     dropped = {
         (feature, parameter)
         for issue in registry.issues
@@ -708,6 +734,10 @@ def _index_hole_evidence(registry) -> _HoleEvidence:
         centers,
         representations,
         unmarked_representations,
+        count_names,
+        location_names,
+        center_names,
+        carrier_index,
     )
 
 
@@ -727,7 +757,9 @@ def _placed_representation(evidence, features, parameter, state):
     return next(iter(markers))
 
 
-def _structured_locations_placed(evidence, features, parameter: str, turned_axis_centers) -> bool:
+def _structured_locations_placed(
+    evidence, features, parameter: str, turned_axis_centers, *, names=None
+) -> bool:
     if parameter.startswith("location_pattern.location."):
         for feature in features:
             if getattr(feature, "pattern", None) == "bolt_circle":
@@ -738,8 +770,12 @@ def _structured_locations_placed(evidence, features, parameter: str, turned_axis
                 # the rest. Fine member addressing does not make every member's absolute
                 # position a separate physical requirement for a pattern.
                 valid = {_normalised_location(feature, point) for point in _members(feature)}
-            if not valid.intersection(evidence.locations.get((feature, parameter), ())):
+            carried = valid.intersection(evidence.locations.get((feature, parameter), ()))
+            if not carried:
                 return False
+            if names is not None:
+                for point in carried:
+                    names.update(evidence.location_names.get((feature, parameter, point), ()))
         return bool(features)
     expected = {
         (feature, point) for feature in features for point in _location_members(feature, parameter)
@@ -757,19 +793,69 @@ def _structured_locations_placed(evidence, features, parameter: str, turned_axis
                 continue
             if _member_coaxial_with_turned_profile(feature, point, turned_axis_centers):
                 covered.add((feature, point))
+                if names is not None and (feature, point) in expected:
+                    names.update(evidence.center_names.get((feature, point, view), ()))
+    if names is not None:
+        for feature, point in expected & covered:
+            names.update(evidence.location_names.get((feature, parameter, point), ()))
     return bool(expected) and expected <= covered
 
 
-def _synthetic_placed(evidence, features, parameter: str, member_count: int) -> bool:
+def _synthetic_placed(
+    evidence, features, parameter: str, member_count: int, *, names=None
+) -> bool:
     if parameter == "bore.through":
+        if names is not None:
+            for feature in features:
+                for count in evidence.requirement_counts.get((feature, parameter), ()):
+                    names.update(evidence.count_names.get((feature, parameter, count), ()))
         return any((feature, parameter) in evidence.requirement_counts for feature in features)
     if parameter != "grouping.count":
         return False
     expected = {feature: len(_members(feature)) for feature in features}
-    return sum(expected.values()) == member_count and all(
+    carried = sum(expected.values()) == member_count and all(
         count in evidence.requirement_counts.get((feature, parameter), ())
         for feature, count in expected.items()
     )
+    if carried and names is not None:
+        for feature, count in expected.items():
+            names.update(evidence.count_names.get((feature, parameter, count), ()))
+    return carried
+
+
+def _hole_carriers(outcome, evidence, registry_index, turned_axis_centers):
+    features, parameter = outcome.features, outcome.parameter_id
+    names: set[str] = set()
+    if parameter.startswith(
+        ("location.location.", "location_pattern.location.", "location_off_axis.")
+    ):
+        if not _structured_locations_placed(
+            evidence, features, parameter, turned_axis_centers, names=names
+        ):
+            names.clear()
+        carriers = [RequirementCarrier(name, "physical_location") for name in sorted(names)]
+    elif parameter in {"bore.through", "grouping.count"}:
+        if not _synthetic_placed(evidence, features, parameter, outcome.member_count, names=names):
+            names.clear()
+        carriers = [RequirementCarrier(name, "physical_requirement") for name in sorted(names)]
+    else:
+        carriers = list(
+            exact_measurement_carriers(
+                registry_index, ((feature, _evidence_parameter(parameter)) for feature in features)
+            )
+        )
+    satisfaction = _satisfaction_parameter(parameter)
+    if satisfaction is not None:
+        satisfied = [(feature, satisfaction) in evidence.satisfied for feature in features]
+        if (all(satisfied) if "location" in parameter else any(satisfied)) and features:
+            carriers.extend(
+                carrier
+                for carrier in exact_measurement_carriers(
+                    registry_index, ((feature, satisfaction) for feature in features)
+                )
+                if carrier.kind == "structured_note"
+            )
+    return tuple(dict.fromkeys(carriers))
 
 
 def _state(features, parameter, *, member_count, evidence_index, suppressed, turned_axis_centers):
@@ -1160,7 +1246,15 @@ def hole_requirement_outcomes(
             )
             for parameter in ("countersink.diameter", "countersink.angle")
         )
-    return outcomes
+    return [
+        replace(
+            outcome,
+            carriers=_hole_carriers(
+                outcome, evidence_index, evidence_index.carrier_index, turned_axis_centers
+            ),
+        )
+        for outcome in outcomes
+    ]
 
 
 def lint_hole_leader_targets(

--- a/src/draftwright/linting/oriented_slot_coverage.py
+++ b/src/draftwright/linting/oriented_slot_coverage.py
@@ -10,8 +10,13 @@ from typing import Literal
 from quiddity import OrientedSlot, RecognitionResult
 
 from draftwright.feature_identity import is_exact_oriented_slot_feature
-from draftwright.linting._registry import satisfaction_ids, satisfaction_of
+from draftwright.linting._registry import (
+    satisfaction_ids,
+    satisfaction_of,
+    with_measurement_carriers,
+)
 from draftwright.linting.issues import LintIssue, is_placement_drop
+from draftwright.measurement_support import RequirementCarrier
 from draftwright.oriented_slot_contract import (
     oriented_slot_provider_key,
     standalone_oriented_slots,
@@ -37,6 +42,7 @@ class OrientedSlotRequirementOutcome:
     requirement_count: int = 1
     features: tuple = ()
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
+    carriers: tuple[RequirementCarrier, ...] = field(default=(), kw_only=True)
 
 
 def _real(value, *, name: str, positive: bool = False) -> float:
@@ -262,7 +268,7 @@ def oriented_slot_requirement_outcomes(
             )
             for parameter_id in parameter_ids
         )
-    return outcomes
+    return with_measurement_carriers(outcomes, registry)
 
 
 def lint_oriented_slot_coverage(

--- a/src/draftwright/linting/pad_coverage.py
+++ b/src/draftwright/linting/pad_coverage.py
@@ -18,7 +18,11 @@ from typing import Literal
 from quiddity import RecognitionResult
 
 from draftwright._core import _decode_hole_location_fact
-from draftwright.linting._registry import satisfaction_ids, satisfaction_of
+from draftwright.linting._registry import (
+    RequirementCarrierEvidence,
+    satisfaction_ids,
+    satisfaction_of,
+)
 from draftwright.linting.issues import (
     UNJOINED_PARAMETER_ID,
     LintIssue,
@@ -26,7 +30,7 @@ from draftwright.linting.issues import (
     requirement_subject,
 )
 from draftwright.location_contract import datum_location_exclusion
-from draftwright.measurement_support import RequirementExclusion
+from draftwright.measurement_support import RequirementCarrier, RequirementExclusion
 
 _PAD_LOCATION_DATUM_COINCIDENT_CODE = "pad_location_coincident_with_datum"
 _PAD_PLANE_AXES = {"x": ("y", "z"), "y": ("z", "x"), "z": ("x", "y")}
@@ -53,6 +57,7 @@ class PadRequirementOutcome:
     features: tuple = ()
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
     intrinsic_exclusion: RequirementExclusion | None = field(default=None, kw_only=True)
+    carriers: tuple[RequirementCarrier, ...] = field(default=(), kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -199,7 +204,7 @@ def _is_location(parameter: str) -> bool:
     return parameter.startswith("location_pad.")
 
 
-def _index_evidence(registry):
+def _index_evidence(registry, *, carriers=None):
     placed = {
         (measurement.feature, measurement.parameter)
         for name in registry.names()
@@ -215,6 +220,10 @@ def _index_evidence(registry):
             feature, parameter, point = decoded
             if getattr(feature, "kind", None) == "pad":
                 locations[(feature, parameter)].add(_point(point))
+                if carriers is not None:
+                    carriers.locations[(feature, parameter, _point(point))].append(
+                        RequirementCarrier(name, "physical_location")
+                    )
     satisfied = {
         (identity.feature, identity.parameter)
         for identity in satisfaction_ids(registry)
@@ -250,20 +259,33 @@ def _state(
     inapplicable,
     dropped,
     registry,
+    carriers=None,
 ):
     evidence_parameter = _evidence_parameter(parameter)
     if (feature, parameter) in inapplicable:
         return "inapplicable"
-    if _is_location(parameter):
-        if point in locations.get((feature, parameter), ()):
-            return "placed"
-        if (feature, parameter) in placed:
-            return "placed"
-        if (feature, "location") in satisfied:
-            return "satisfied_by_structured_note"
-    elif (feature, parameter) in placed:
+    location = _is_location(parameter)
+    point_placed = location and point in locations.get((feature, parameter), ())
+    exact_placed = (feature, parameter) in placed
+    note_parameter = "location" if location else parameter
+    note_satisfied = (feature, note_parameter) in satisfied
+    if carriers is not None:
+        carriers.accept(
+            feature,
+            parameter,
+            "placed",
+            parameters=(parameter,) if exact_placed else (),
+            physical=carriers.locations[(feature, parameter, point)] if point_placed else (),
+        )
+        carriers.accept(
+            feature,
+            parameter,
+            "satisfied_by_structured_note",
+            parameters=(note_parameter,) if note_satisfied else (),
+        )
+    if point_placed or exact_placed:
         return "placed"
-    elif (feature, parameter) in satisfied:
+    if note_satisfied:
         return "satisfied_by_structured_note"
     if (feature, evidence_parameter) in suppressed:
         return "suppressed"
@@ -309,7 +331,8 @@ def pad_requirement_outcomes(
                 # A malformed IR record cannot establish correspondence.
                 continue
 
-    placed, locations, satisfied, dropped = _index_evidence(registry)
+    carriers = RequirementCarrierEvidence(registry)
+    placed, locations, satisfied, dropped = _index_evidence(registry, carriers=carriers)
     suppressed = {
         (omission.feature, omission.parameter_id)
         for omission in omissions
@@ -355,6 +378,7 @@ def pad_requirement_outcomes(
                     inapplicable=inapplicable,
                     dropped=dropped,
                     registry=registry,
+                    carriers=carriers,
                 ),
                 features=(feature,),
                 source_records=(source,),
@@ -362,7 +386,7 @@ def pad_requirement_outcomes(
             )
             for parameter in parameter_ids
         )
-    return outcomes
+    return carriers.attach(outcomes)
 
 
 def lint_pad_coverage(

--- a/src/draftwright/linting/pad_coverage.py
+++ b/src/draftwright/linting/pad_coverage.py
@@ -25,6 +25,8 @@ from draftwright.linting.issues import (
     is_placement_drop,
     requirement_subject,
 )
+from draftwright.location_contract import datum_location_exclusion
+from draftwright.measurement_support import RequirementExclusion
 
 _PAD_LOCATION_DATUM_COINCIDENT_CODE = "pad_location_coincident_with_datum"
 _PAD_PLANE_AXES = {"x": ("y", "z"), "y": ("z", "x"), "z": ("x", "y")}
@@ -50,6 +52,7 @@ class PadRequirementOutcome:
     requirement_count: int = 1
     features: tuple = ()
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
+    intrinsic_exclusion: RequirementExclusion | None = field(default=None, kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -280,6 +283,8 @@ def pad_requirement_outcomes(
     features,
     registry,
     omissions=(),
+    *,
+    datum=None,
 ) -> list[PadRequirementOutcome]:
     """Follow every recognised raised-pad requirement to its semantic outcome."""
     if recognition is None:
@@ -353,6 +358,7 @@ def pad_requirement_outcomes(
                 ),
                 features=(feature,),
                 source_records=(source,),
+                intrinsic_exclusion=datum_location_exclusion(feature, source, parameter, datum),
             )
             for parameter in parameter_ids
         )

--- a/src/draftwright/linting/paired_ramp_step_coverage.py
+++ b/src/draftwright/linting/paired_ramp_step_coverage.py
@@ -14,8 +14,13 @@ from typing import Literal
 
 from quiddity import PairedRampStep, RecognitionResult
 
-from draftwright.linting._registry import satisfaction_ids, satisfaction_of
+from draftwright.linting._registry import (
+    satisfaction_ids,
+    satisfaction_of,
+    with_measurement_carriers,
+)
 from draftwright.linting.issues import LintIssue, is_placement_drop
+from draftwright.measurement_support import RequirementCarrier
 
 PairedRampRequirementState = Literal[
     "placed",
@@ -37,6 +42,7 @@ class PairedRampRequirementOutcome:
     requirement_count: int = 1
     features: tuple = ()
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
+    carriers: tuple[RequirementCarrier, ...] = field(default=(), kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -191,7 +197,7 @@ def paired_ramp_step_requirement_outcomes(
                     source_records=(source,),
                 )
             )
-    return outcomes
+    return with_measurement_carriers(outcomes, registry)
 
 
 def lint_paired_ramp_step_coverage(

--- a/src/draftwright/linting/plate_coverage.py
+++ b/src/draftwright/linting/plate_coverage.py
@@ -24,17 +24,16 @@ from draftwright.linting.issues import (
     is_placement_drop,
     requirement_subject,
 )
+from draftwright.measurement_support import RequirementAlternative
 from draftwright.plate_correspondence import (
     _between,
     _depth_axis,
     _envelope,
-    _envelope_owned_dependencies,
-    _polygonal_boss_dependencies,
     _rounded,
     _same,
-    _slot_pattern_dependencies,
-    _step_level_dependencies,
     plate_center,
+    plate_dependency_alternatives,
+    plate_dependency_supports,
     plate_key,
     plate_span,
 )
@@ -52,6 +51,12 @@ Point = tuple[float, float, float]
 
 
 @dataclass(frozen=True)
+class PlateExclusion:
+    reason_code: Literal["polygonal_boss_owns_supporting_slab", "slot_pattern_owns_material_web"]
+    source_records: tuple[object, ...] = field(repr=False, compare=False)
+
+
+@dataclass(frozen=True)
 class PlateRequirementOutcome:
     """The observable engine outcome of one physical slab-thickness requirement."""
 
@@ -61,7 +66,14 @@ class PlateRequirementOutcome:
     requirement_count: int = 1
     features: tuple = ()
     dependencies: tuple[tuple[object, str], ...] = ()
+    catalog_parameter_id: str = field(default="thickness.length", kw_only=True)
+    intrinsic_exclusion: PlateExclusion | None = field(default=None, kw_only=True)
+    dependency_alternatives: tuple[RequirementAlternative, ...] = field(default=(), kw_only=True)
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
+
+    @property
+    def intrinsically_inapplicable(self) -> bool:
+        return self.intrinsic_exclusion is not None
 
 
 def _parameter_id(feature, source) -> str | None:
@@ -337,23 +349,15 @@ def _shares_one_solid(membership, source, boss) -> bool:
         return False
 
 
-def _alternate_dependencies(
-    source,
-    features,
-    counts,
-    satisfied,
-) -> tuple[tuple[object, str], ...]:
-    for establish in (
-        _envelope_owned_dependencies,
-        _step_level_dependencies,
-        _polygonal_boss_dependencies,
-        _slot_pattern_dependencies,
-    ):
-        if (dependencies := establish(source, features)) and _dependencies_are_evidenced(
-            dependencies, counts, satisfied
-        ):
-            return dependencies
-    return ()
+def _alternate_dependencies(alternatives, counts, satisfied) -> tuple[tuple[object, str], ...]:
+    return next(
+        (
+            recipe.measurements
+            for recipe in alternatives
+            if _dependencies_are_evidenced(recipe.measurements, counts, satisfied)
+        ),
+        (),
+    )
 
 
 def _without_provider_owned_ir(recognition, features, validation_cache=None) -> tuple:
@@ -439,17 +443,17 @@ def _dependencies_are_evidenced(dependencies, counts, satisfied) -> bool:
     )
 
 
-def _recognition_owner_supersedes_plate(
+def _intrinsic_plate_exclusion(
     source,
     recognition,
     features,
     membership=None,
     validation_cache=None,
-) -> bool:
+) -> PlateExclusion | None:
     """Exact aggregate ownership keeps derived Plate fragments out of a second denominator."""
     envelope = _envelope(features)
     if envelope is None:
-        return False
+        return None
     try:
         axis = str(source.axis)
         index = "xyz".index(axis)
@@ -474,7 +478,7 @@ def _recognition_owner_supersedes_plate(
                 and source_interval[1] == envelope_interval[1]
             )
             if (supports_below or supports_above) and _shares_one_solid(membership, source, boss):
-                return True
+                return PlateExclusion("polygonal_boss_owns_supporting_slab", (boss,))
 
         for pattern in recognition.slot_patterns:
             slots = tuple(pattern.slots)
@@ -517,10 +521,12 @@ def _recognition_owner_supersedes_plate(
             if cursor < pattern_interval[1]:
                 material.append((cursor, pattern_interval[1]))
             if source_interval in material:
-                return True
+                # SlotArray is a derived grouping; the accepted occurrences are its
+                # exact Slot members, as in the slot requirement ledger's source set.
+                return PlateExclusion("slot_pattern_owns_material_web", slots)
     except (AttributeError, TypeError, ValueError):
-        return False
-    return False
+        return None
+    return None
 
 
 def _derived_opposite_wall_dependencies(features, feature) -> tuple[tuple[object, str], ...]:
@@ -667,9 +673,13 @@ def plate_requirement_outcomes(
         feature: dependencies
         for feature in features
         if (dependencies := _derived_opposite_wall_dependencies(features, feature))
-        and all(dependency in evidenced for dependency in dependencies)
     }
-    inapplicable = {(feature, "thickness.length") for feature in derived_dependencies}
+    carried_dependencies = {
+        feature: dependencies
+        for feature, dependencies in derived_dependencies.items()
+        if all(dependency in evidenced for dependency in dependencies)
+    }
+    inapplicable = {(feature, "thickness.length") for feature in carried_dependencies}
     membership = _SolidMembership(part) if part is not None else None
     pattern_validations: dict[int, object | None] = {}
     alternate_features = _without_provider_owned_ir(recognition, features, pattern_validations)
@@ -681,33 +691,38 @@ def plate_requirement_outcomes(
         )
         parameter = _parameter_id(feature, source_record) if feature is not None else None
         if parameter is None:
-            recognised_owner = _recognition_owner_supersedes_plate(
+            exclusion = _intrinsic_plate_exclusion(
                 source_record,
                 recognition,
                 features,
                 membership,
                 pattern_validations,
             )
-            dependencies = _alternate_dependencies(
-                source_record,
-                alternate_features,
-                placed_counts,
-                satisfied,
-            )
-            if dependencies or recognised_owner:
+            alternatives = plate_dependency_alternatives(source_record, alternate_features)
+            dependencies = _alternate_dependencies(alternatives, placed_counts, satisfied)
+            if dependencies or exclusion is not None:
                 outcomes.append(
                     PlateRequirementOutcome(
                         at,
                         "thickness.length",
                         "inapplicable",
                         dependencies=dependencies,
+                        intrinsic_exclusion=exclusion,
+                        dependency_alternatives=alternatives,
                         source_records=(source_record,),
                     )
                 )
                 continue
             outcomes.append(
                 PlateRequirementOutcome(
-                    at, UNJOINED_PARAMETER_ID, "unverifiable", source_records=(source_record,)
+                    at,
+                    UNJOINED_PARAMETER_ID,
+                    "unverifiable",
+                    catalog_parameter_id=(
+                        "thickness.length" if key is not None else UNJOINED_PARAMETER_ID
+                    ),
+                    dependency_alternatives=alternatives,
+                    source_records=(source_record,),
                 )
             )
             continue
@@ -726,7 +741,19 @@ def plate_requirement_outcomes(
                     registry=registry,
                 ),
                 features=(feature,),
-                dependencies=derived_dependencies.get(feature, ()),
+                dependencies=carried_dependencies.get(feature, ()),
+                dependency_alternatives=(
+                    (
+                        RequirementAlternative(
+                            derived_dependencies[feature],
+                            plate_dependency_supports(
+                                source_record, derived_dependencies[feature]
+                            ),
+                        ),
+                    )
+                    if feature in derived_dependencies
+                    else ()
+                ),
                 source_records=(source_record,),
             )
         )

--- a/src/draftwright/linting/plate_coverage.py
+++ b/src/draftwright/linting/plate_coverage.py
@@ -17,14 +17,18 @@ from typing import Literal
 
 from quiddity import RecognitionResult
 
-from draftwright.linting._registry import satisfaction_ids, satisfaction_of
+from draftwright.linting._registry import (
+    satisfaction_ids,
+    satisfaction_of,
+    with_measurement_carriers,
+)
 from draftwright.linting.issues import (
     UNJOINED_PARAMETER_ID,
     LintIssue,
     is_placement_drop,
     requirement_subject,
 )
-from draftwright.measurement_support import RequirementAlternative
+from draftwright.measurement_support import RequirementAlternative, RequirementCarrier
 from draftwright.plate_correspondence import (
     _between,
     _depth_axis,
@@ -74,6 +78,8 @@ class PlateRequirementOutcome:
     @property
     def intrinsically_inapplicable(self) -> bool:
         return self.intrinsic_exclusion is not None
+
+    carriers: tuple[RequirementCarrier, ...] = field(default=(), kw_only=True)
 
 
 def _parameter_id(feature, source) -> str | None:
@@ -757,7 +763,7 @@ def plate_requirement_outcomes(
                 source_records=(source_record,),
             )
         )
-    return outcomes
+    return with_measurement_carriers(outcomes, registry)
 
 
 def lint_plate_coverage(

--- a/src/draftwright/linting/pocket_coverage.py
+++ b/src/draftwright/linting/pocket_coverage.py
@@ -15,7 +15,11 @@ from typing import Literal
 from quiddity import RecognitionResult, SectionRecess
 
 from draftwright._core import _decode_hole_location_fact
-from draftwright.linting._registry import satisfaction_ids, satisfaction_of
+from draftwright.linting._registry import (
+    RequirementCarrierEvidence,
+    satisfaction_ids,
+    satisfaction_of,
+)
 from draftwright.linting.issues import (
     UNJOINED_PARAMETER_ID,
     LintIssue,
@@ -23,7 +27,7 @@ from draftwright.linting.issues import (
     requirement_subject,
 )
 from draftwright.location_contract import datum_location_exclusion
-from draftwright.measurement_support import RequirementExclusion
+from draftwright.measurement_support import RequirementCarrier, RequirementExclusion
 from draftwright.section_recess_contract import (
     pocket_mouth_key,
     recesses_with_kind,
@@ -55,6 +59,7 @@ class PocketRequirementOutcome:
     features: tuple = ()
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
     intrinsic_exclusion: RequirementExclusion | None = field(default=None, kw_only=True)
+    carriers: tuple[RequirementCarrier, ...] = field(default=(), kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -148,7 +153,7 @@ def _is_location(parameter: str) -> bool:
     return parameter.startswith("location_pocket.")
 
 
-def _index_evidence(registry):
+def _index_evidence(registry, *, carriers=None):
     placed = {
         (measurement.feature, measurement.parameter)
         for name in registry.names()
@@ -164,6 +169,10 @@ def _index_evidence(registry):
             feature, parameter, point = decoded
             if getattr(feature, "kind", None) == "pocket":
                 locations[(feature, parameter)].add(_point(point))
+                if carriers is not None:
+                    carriers.locations[(feature, parameter, _point(point))].append(
+                        RequirementCarrier(name, "physical_location")
+                    )
     satisfied = {
         (identity.feature, identity.parameter)
         for identity in satisfaction_ids(registry)
@@ -199,20 +208,33 @@ def _state(
     inapplicable,
     dropped,
     registry,
+    carriers=None,
 ):
     evidence_parameter = _evidence_parameter(parameter)
     if (feature, parameter) in inapplicable:
         return "inapplicable"
-    if _is_location(parameter):
-        if point in locations.get((feature, parameter), ()):
-            return "placed"
-        if (feature, parameter) in placed:
-            return "placed"
-        if (feature, "location") in satisfied:
-            return "satisfied_by_structured_note"
-    elif (feature, parameter) in placed:
+    location = _is_location(parameter)
+    point_placed = location and point in locations.get((feature, parameter), ())
+    exact_placed = (feature, parameter) in placed
+    note_parameter = "location" if location else parameter
+    note_satisfied = (feature, note_parameter) in satisfied
+    if carriers is not None:
+        carriers.accept(
+            feature,
+            parameter,
+            "placed",
+            parameters=(parameter,) if exact_placed else (),
+            physical=carriers.locations[(feature, parameter, point)] if point_placed else (),
+        )
+        carriers.accept(
+            feature,
+            parameter,
+            "satisfied_by_structured_note",
+            parameters=(note_parameter,) if note_satisfied else (),
+        )
+    if point_placed or exact_placed:
         return "placed"
-    elif (feature, parameter) in satisfied:
+    if note_satisfied:
         return "satisfied_by_structured_note"
     if (feature, evidence_parameter) in suppressed:
         return "suppressed"
@@ -268,7 +290,8 @@ def pocket_requirement_outcomes(
         if getattr(feature, "kind", None) == "pocket":
             ir_by_key[_key(feature)].append(feature)
 
-    placed, locations, satisfied, dropped = _index_evidence(registry)
+    carriers = RequirementCarrierEvidence(registry)
+    placed, locations, satisfied, dropped = _index_evidence(registry, carriers=carriers)
     suppressed = {
         (omission.feature, omission.parameter_id)
         for omission in omissions
@@ -333,6 +356,7 @@ def pocket_requirement_outcomes(
                     inapplicable=inapplicable,
                     dropped=dropped,
                     registry=registry,
+                    carriers=carriers,
                 ),
                 features=(feature,),
                 source_records=(source,),
@@ -345,7 +369,7 @@ def pocket_requirement_outcomes(
             )
             for parameter in parameter_ids
         )
-    return outcomes
+    return carriers.attach(outcomes)
 
 
 def lint_pocket_coverage(

--- a/src/draftwright/linting/pocket_coverage.py
+++ b/src/draftwright/linting/pocket_coverage.py
@@ -22,6 +22,8 @@ from draftwright.linting.issues import (
     is_placement_drop,
     requirement_subject,
 )
+from draftwright.location_contract import datum_location_exclusion
+from draftwright.measurement_support import RequirementExclusion
 from draftwright.section_recess_contract import (
     pocket_mouth_key,
     recesses_with_kind,
@@ -52,6 +54,7 @@ class PocketRequirementOutcome:
     requirement_count: int = 1
     features: tuple = ()
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
+    intrinsic_exclusion: RequirementExclusion | None = field(default=None, kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -233,6 +236,8 @@ def pocket_requirement_outcomes(
     features,
     registry,
     omissions=(),
+    *,
+    datum=None,
 ) -> list[PocketRequirementOutcome]:
     """Follow every recognised lone-pocket requirement to its semantic outcome."""
     if recognition is None:
@@ -295,7 +300,13 @@ def pocket_requirement_outcomes(
             if section_recess_fields(source)[1]["edge_anchored"]:
                 outcomes.extend(
                     PocketRequirementOutcome(
-                        at, parameter, "inapplicable", source_records=(source,)
+                        at,
+                        parameter,
+                        "inapplicable",
+                        source_records=(source,),
+                        intrinsic_exclusion=RequirementExclusion(
+                            "pocket_edge_anchored", (source,)
+                        ),
                     )
                     for parameter in (
                         "location_pocket.location.x",
@@ -325,6 +336,12 @@ def pocket_requirement_outcomes(
                 ),
                 features=(feature,),
                 source_records=(source,),
+                intrinsic_exclusion=(
+                    RequirementExclusion("pocket_edge_anchored", (source,))
+                    if _is_location(parameter)
+                    and section_recess_fields(source)[1]["edge_anchored"]
+                    else datum_location_exclusion(feature, source, parameter, datum)
+                ),
             )
             for parameter in parameter_ids
         )

--- a/src/draftwright/linting/pocket_pattern_coverage.py
+++ b/src/draftwright/linting/pocket_pattern_coverage.py
@@ -17,13 +17,18 @@ from typing import Literal
 from quiddity import RecognitionResult, SectionRecess, SectionRecessArray, SectionRecessGrid
 
 from draftwright._core import _decode_hole_location_fact
-from draftwright.linting._registry import satisfaction_ids, satisfaction_of
+from draftwright.linting._registry import (
+    RequirementCarrierEvidence,
+    satisfaction_ids,
+    satisfaction_of,
+)
 from draftwright.linting.issues import (
     UNJOINED_PARAMETER_ID,
     LintIssue,
     is_placement_drop,
     requirement_subject,
 )
+from draftwright.measurement_support import RequirementCarrier
 from draftwright.section_recess_contract import (
     distinct_section_recess_patterns,
     pocket_mouth_key,
@@ -54,6 +59,7 @@ class PocketPatternRequirementOutcome:
     members: tuple[tuple[float, float, float], ...] = ()
     features: tuple = ()
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
+    carriers: tuple[RequirementCarrier, ...] = field(default=(), kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -225,7 +231,7 @@ def _evidence_parameter(parameter: str) -> str:
     return parameter
 
 
-def _index_evidence(registry):
+def _index_evidence(registry, *, carriers=None):
     placed = {
         (measurement.feature, measurement.parameter)
         for name in registry.names()
@@ -239,6 +245,10 @@ def _index_evidence(registry):
         count = getattr(annotation, "covers_count", None)
         if getattr(owner, "kind", None) == "pocket_pattern" and isinstance(count, int):
             counts[owner].add(count)
+            if carriers is not None:
+                carriers.counts[(owner, count)].append(
+                    RequirementCarrier(name, "physical_requirement")
+                )
         for fact in getattr(annotation, "covers_hole_locations", ()):
             decoded = _decode_hole_location_fact(fact)
             if decoded is None:
@@ -246,6 +256,10 @@ def _index_evidence(registry):
             feature, parameter, point = decoded
             if getattr(feature, "kind", None) == "pocket_pattern":
                 locations[(feature, parameter)].add(_point(point))
+                if carriers is not None:
+                    carriers.locations[(feature, parameter, _point(point))].append(
+                        RequirementCarrier(name, "physical_location")
+                    )
     satisfied = {
         (identity.feature, identity.parameter)
         for identity in satisfaction_ids(registry)
@@ -275,13 +289,42 @@ def _state(
     suppressed,
     dropped,
     registry,
+    carriers=None,
 ):
     evidence_parameter = _evidence_parameter(parameter)
-    if parameter == "grouping.count":
-        if counts.get(feature) == {member_count}:
-            return "placed"
-        if (feature, parameter) in satisfied:
-            return "satisfied_by_structured_note"
+    grouping = parameter == "grouping.count"
+    location = parameter.startswith("location_pocket_pattern.location.")
+    count_placed = grouping and counts.get(feature) == {member_count}
+    point_placed = location and point in locations.get((feature, parameter), ())
+    exact_placed = not grouping and not location and (feature, parameter) in placed
+    note_parameters = ("location", evidence_parameter) if location else (parameter,)
+    satisfied_parameters = tuple(item for item in note_parameters if (feature, item) in satisfied)
+    if carriers is not None:
+        physical = (
+            carriers.counts[(feature, member_count)]
+            if count_placed
+            else carriers.locations[(feature, parameter, point)]
+            if point_placed
+            else ()
+        )
+        carriers.accept(
+            feature,
+            parameter,
+            "placed",
+            parameters=(parameter,) if exact_placed else (),
+            physical=physical,
+        )
+        carriers.accept(
+            feature,
+            parameter,
+            "satisfied_by_structured_note",
+            parameters=satisfied_parameters,
+        )
+    if count_placed or point_placed or exact_placed:
+        return "placed"
+    if satisfied_parameters:
+        return "satisfied_by_structured_note"
+    if grouping:
         size_ids = {
             "pocket_width.length",
             "pocket_length.length",
@@ -292,15 +335,6 @@ def _state(
             return "suppressed"
         if size_ids & {item for owner, item in dropped if owner == feature}:
             return "dropped"
-    elif parameter.startswith("location_pocket_pattern.location."):
-        if point in locations.get((feature, parameter), ()):
-            return "placed"
-        if (feature, "location") in satisfied or (feature, evidence_parameter) in satisfied:
-            return "satisfied_by_structured_note"
-    elif (feature, parameter) in placed:
-        return "placed"
-    elif (feature, parameter) in satisfied:
-        return "satisfied_by_structured_note"
     if (feature, evidence_parameter) in suppressed:
         return "suppressed"
     if (feature, parameter) in dropped or (feature, evidence_parameter) in dropped:
@@ -355,7 +389,8 @@ def pocket_pattern_requirement_outcomes(
         if getattr(feature, "kind", None) == "pocket_pattern":
             ir_by_key[pocket_pattern_key(feature)].append(feature)
 
-    placed, locations, counts, satisfied, dropped = _index_evidence(registry)
+    carriers = RequirementCarrierEvidence(registry)
+    placed, locations, counts, satisfied, dropped = _index_evidence(registry, carriers=carriers)
     suppressed = {
         (omission.feature, omission.parameter_id)
         for omission in omissions
@@ -400,6 +435,7 @@ def pocket_pattern_requirement_outcomes(
                     suppressed=suppressed,
                     dropped=dropped,
                     registry=registry,
+                    carriers=carriers,
                 ),
                 members=members,
                 features=(feature,),
@@ -407,7 +443,7 @@ def pocket_pattern_requirement_outcomes(
             )
             for parameter in parameter_ids
         )
-    return outcomes
+    return carriers.attach(outcomes)
 
 
 def lint_pocket_pattern_coverage(

--- a/src/draftwright/linting/polygonal_boss_coverage.py
+++ b/src/draftwright/linting/polygonal_boss_coverage.py
@@ -18,13 +18,18 @@ from typing import Literal
 
 from quiddity import PolygonalBoss, RecognitionResult
 
-from draftwright.linting._registry import satisfaction_ids, satisfaction_of
+from draftwright.linting._registry import (
+    satisfaction_ids,
+    satisfaction_of,
+    with_measurement_carriers,
+)
 from draftwright.linting.issues import (
     UNJOINED_PARAMETER_ID,
     LintIssue,
     is_placement_drop,
     requirement_subject,
 )
+from draftwright.measurement_support import RequirementCarrier
 
 PolygonalBossRequirementState = Literal[
     "placed",
@@ -48,6 +53,7 @@ class PolygonalBossRequirementOutcome:
     requirement_count: int = 1
     features: tuple = ()
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
+    carriers: tuple[RequirementCarrier, ...] = field(default=(), kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -354,7 +360,7 @@ def polygonal_boss_requirement_outcomes(
             )
             for parameter in parameter_ids
         )
-    return outcomes
+    return with_measurement_carriers(outcomes, registry)
 
 
 def lint_polygonal_boss_coverage(

--- a/src/draftwright/linting/polygonal_stock_coverage.py
+++ b/src/draftwright/linting/polygonal_stock_coverage.py
@@ -19,13 +19,18 @@ from typing import Literal
 
 from quiddity import PolygonalStock, RecognitionResult
 
-from draftwright.linting._registry import satisfaction_ids, satisfaction_of
+from draftwright.linting._registry import (
+    satisfaction_ids,
+    satisfaction_of,
+    with_measurement_carriers,
+)
 from draftwright.linting.issues import (
     UNJOINED_PARAMETER_ID,
     LintIssue,
     is_placement_drop,
     requirement_subject,
 )
+from draftwright.measurement_support import RequirementCarrier
 
 PolygonalStockState = Literal[
     "placed",
@@ -56,6 +61,8 @@ _SUPPORT_TRANSVERSE_MODEL_TOLERANCE = 0.2
 @dataclass(frozen=True)
 class PolygonalStockOutcome:
     """The observable engine outcome of one whole-stock measurement."""
+
+    carriers: tuple[RequirementCarrier, ...] = field(default=(), kw_only=True)
 
     source_at: Point | None
     parameter_id: str
@@ -415,7 +422,7 @@ def polygonal_stock_outcomes(
                 source_records=(source,),
             )
         ]
-    return [
+    outcomes = [
         PolygonalStockOutcome(
             at,
             parameter,
@@ -433,6 +440,7 @@ def polygonal_stock_outcomes(
         )
         for parameter in parameter_ids
     ]
+    return with_measurement_carriers(outcomes, registry)
 
 
 def lint_polygonal_stock_coverage(

--- a/src/draftwright/linting/rectangular_blind_slot_coverage.py
+++ b/src/draftwright/linting/rectangular_blind_slot_coverage.py
@@ -17,8 +17,13 @@ from typing import Literal
 
 from quiddity import RecognitionResult, SectionRecess
 
-from draftwright.linting._registry import satisfaction_ids, satisfaction_of
+from draftwright.linting._registry import (
+    satisfaction_ids,
+    satisfaction_of,
+    with_measurement_carriers,
+)
 from draftwright.linting.issues import LintIssue, is_placement_drop
+from draftwright.measurement_support import RequirementCarrier
 from draftwright.section_recess_contract import recesses_with_kind, section_recess_fields
 
 RectangularBlindSlotRequirementState = Literal[
@@ -47,6 +52,7 @@ class RectangularBlindSlotRequirementOutcome:
     requirement_count: int = 1
     features: tuple = ()
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
+    carriers: tuple[RequirementCarrier, ...] = field(default=(), kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -299,7 +305,7 @@ def rectangular_blind_slot_requirement_outcomes(
                     source_records=(source,),
                 )
             )
-    return outcomes
+    return with_measurement_carriers(outcomes, registry)
 
 
 def lint_rectangular_blind_slot_coverage(

--- a/src/draftwright/linting/requirements.py
+++ b/src/draftwright/linting/requirements.py
@@ -36,6 +36,64 @@ from draftwright.linting.slot_coverage import slot_requirement_outcomes
 from draftwright.linting.through_step_coverage import through_step_requirement_outcomes
 from draftwright.linting.turned_step_coverage import turned_step_requirement_outcomes
 
+# Source-family coverage of this collector, independent of which outcomes survived
+# projection. Parameter grammars remain exclusively in their existing producers.
+REQUIREMENT_SOURCE_FAMILIES = frozenset(
+    {
+        "section_recesses",
+        "chamfers",
+        "blends",
+        "channels",
+        "circular_blind_steps",
+        "fillets",
+        "paired_ramp_steps",
+        "through_steps",
+        "turned_steps",
+        "flats",
+        "grooves",
+        "holes",
+        "hole_patterns",
+        "oriented_slots",
+        "pads",
+        "plates",
+        "polygonal_bosses",
+        "polygonal_stock",
+        "pockets",
+        "pocket_patterns",
+        "rectangular_blind_slots",
+        "round_bottom_blind_slots",
+        "slots",
+        "slot_patterns",
+    }
+)
+
+
+def requirement_source_census(evidence, ownership):
+    """Exact accepted records whose families have a physical requirement ledger."""
+    if ownership.evidence is not evidence:
+        raise ValueError("requirement census needs the same ownership authority")
+    required = []
+    for reference in evidence.features:
+        family = evidence.family(reference)
+        if family not in REQUIREMENT_SOURCE_FAMILIES:
+            continue
+        binding = ownership.binding_for(reference)
+        reason = binding.reason_code if binding is not None else None
+        # Exact conversion-owned absorption proofs account for these records in a
+        # different physical grammar; they do not acquire another parameter ledger.
+        if (family, reason) in {
+            ("section_recesses", "channel_step_level_owner"),
+            ("turned_steps", "turned_step_groove_owner"),
+        }:
+            continue
+        if family == "section_recesses" and ownership.status(reference) == "unexpectedly_missing":
+            # An unresolved accepted recess has no established drafting grammar.
+            # Its source and missing-owner disposition remain in the occurrence
+            # report and cannot earn credit or a bounded-clear result.
+            continue
+        required.append((reference, evidence.record(reference)))
+    return tuple(required)
+
 
 def recognized_requirement_outcomes(
     recognition,
@@ -47,6 +105,7 @@ def recognized_requirement_outcomes(
     part=None,
     evidence=None,
     ownership=None,
+    datum=None,
 ) -> Mapping[str, tuple[Any, ...]]:
     """Return typed physical-requirement ledgers shared by lint and reports.
 
@@ -82,7 +141,7 @@ def recognized_requirement_outcomes(
         "oriented_slots": oriented_slot_requirement_outcomes(
             recognition, features, registry, omissions
         ),
-        "pads": pad_requirement_outcomes(recognition, features, registry, omissions),
+        "pads": pad_requirement_outcomes(recognition, features, registry, omissions, datum=datum),
         "plates": plate_requirement_outcomes(
             recognition, features, registry, omissions, part=part
         ),
@@ -90,7 +149,9 @@ def recognized_requirement_outcomes(
             recognition, features, registry, omissions
         ),
         "polygonal_stock": polygonal_stock_outcomes(recognition, features, registry, omissions),
-        "pockets": pocket_requirement_outcomes(recognition, features, registry, omissions),
+        "pockets": pocket_requirement_outcomes(
+            recognition, features, registry, omissions, datum=datum
+        ),
         "pocket_patterns": pocket_pattern_requirement_outcomes(
             recognition, features, registry, omissions
         ),

--- a/src/draftwright/linting/round_bottom_blind_slot_coverage.py
+++ b/src/draftwright/linting/round_bottom_blind_slot_coverage.py
@@ -17,8 +17,13 @@ from typing import Literal
 
 from quiddity import RecognitionResult, SectionRecess
 
-from draftwright.linting._registry import satisfaction_ids, satisfaction_of
+from draftwright.linting._registry import (
+    satisfaction_ids,
+    satisfaction_of,
+    with_measurement_carriers,
+)
 from draftwright.linting.issues import LintIssue, is_placement_drop
+from draftwright.measurement_support import RequirementCarrier
 from draftwright.section_recess_contract import recesses_with_kind, section_recess_fields
 
 RoundBottomBlindSlotRequirementState = Literal[
@@ -47,6 +52,7 @@ class RoundBottomBlindSlotRequirementOutcome:
     requirement_count: int = 1
     features: tuple = ()
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
+    carriers: tuple[RequirementCarrier, ...] = field(default=(), kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -305,7 +311,7 @@ def round_bottom_blind_slot_requirement_outcomes(
                     source_records=(source,),
                 )
             )
-    return outcomes
+    return with_measurement_carriers(outcomes, registry)
 
 
 def lint_round_bottom_blind_slot_coverage(

--- a/src/draftwright/linting/slot_coverage.py
+++ b/src/draftwright/linting/slot_coverage.py
@@ -14,8 +14,13 @@ from typing import Literal
 
 from quiddity import RecognitionResult
 
-from draftwright.linting._registry import satisfaction_ids, satisfaction_of
+from draftwright.linting._registry import (
+    satisfaction_ids,
+    satisfaction_of,
+    with_measurement_carriers,
+)
 from draftwright.linting.issues import UNJOINED_PARAMETER_ID, LintIssue, requirement_subject
+from draftwright.measurement_support import RequirementCarrier
 
 SlotRequirementState = Literal[
     "placed",
@@ -44,6 +49,7 @@ class SlotRequirementOutcome:
     requirement_count: int = 1
     features: tuple = ()
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
+    carriers: tuple[RequirementCarrier, ...] = field(default=(), kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -328,7 +334,7 @@ def slot_requirement_outcomes(
             )
             for parameter in parameter_ids
         )
-    return outcomes
+    return with_measurement_carriers(outcomes, registry)
 
 
 def lint_slot_coverage(

--- a/src/draftwright/linting/through_step_coverage.py
+++ b/src/draftwright/linting/through_step_coverage.py
@@ -19,6 +19,7 @@ from draftwright.linting._registry import satisfaction_ids, satisfaction_of
 from draftwright.linting.evidence import compiled_values, rendered_numbers
 from draftwright.linting.issues import LintIssue, is_placement_drop
 from draftwright.linting.structural import _label_reading
+from draftwright.measurement_support import MeasurementSupport
 
 ThroughStepRequirementState = Literal[
     "placed",
@@ -41,32 +42,10 @@ class ThroughStepRequirementOutcome:
     requirement_count: int = 1
     features: tuple = ()
     measurement_ids: tuple[tuple[object, str], ...] = ()
+    dependency_alternatives: tuple[tuple[MeasurementSupport, ...], ...] = field(
+        default=(), kw_only=True
+    )
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
-
-
-@dataclass(frozen=True)
-class _LegacyTerm:
-    """One exact member of a legacy dimension grammar.
-
-    ``DimensionId`` deliberately addresses an entire correlated ladder, so it cannot by
-    itself distinguish (for example) a 10 mm step rung from a 15 mm rung.  The physical
-    interval retained here selects the exact compiled member and prevents another member of
-    the same ladder from receiving credit for a through-step leg.
-    """
-
-    feature: object
-    parameter_id: str
-    axis: str
-    lo: float
-    hi: float
-
-    @property
-    def identity(self) -> tuple[object, str]:
-        return (self.feature, self.parameter_id)
-
-    @property
-    def value(self) -> float:
-        return abs(self.hi - self.lo)
 
 
 def _rounded(value) -> float:
@@ -147,11 +126,13 @@ def _source_leg_intervals(source) -> tuple[tuple[str, float, float], ...]:
     return tuple(intervals)
 
 
-def _legacy_owner_plans(source, features) -> dict[str, list[tuple[_LegacyTerm, ...]]]:
+def _legacy_owner_plans(source, features) -> dict[str, list[tuple[MeasurementSupport, ...]]]:
     """Alternative measurement identities that prove each physical source leg."""
     parameters = _parameter_ids(source)
     legs = dict(zip(parameters, _source_leg_intervals(source), strict=True))
-    plans: dict[str, list[tuple[_LegacyTerm, ...]]] = {parameter: [] for parameter in parameters}
+    plans: dict[str, list[tuple[MeasurementSupport, ...]]] = {
+        parameter: [] for parameter in parameters
+    }
     envelope = next(
         (candidate for candidate in features if getattr(candidate, "kind", None) == "envelope"),
         None,
@@ -170,7 +151,9 @@ def _legacy_owner_plans(source, features) -> dict[str, list[tuple[_LegacyTerm, .
             owner = (feature.axis, *sorted((feature.lo, feature.hi)))
             for parameter, leg in legs.items():
                 if _matches(owner, leg):
-                    plans[parameter].append((_LegacyTerm(feature, "thickness.length", *owner),))
+                    plans[parameter].append(
+                        (MeasurementSupport(feature, "thickness.length", *owner),)
+                    )
                 if envelope is not None:
                     axis = feature.axis
                     bound_lo = envelope.bbox_min["xyz".index(axis)]
@@ -184,8 +167,8 @@ def _legacy_owner_plans(source, features) -> dict[str, list[tuple[_LegacyTerm, .
                     if any(_matches(complement, leg) for complement in complements):
                         plans[parameter].append(
                             (
-                                _LegacyTerm(feature, "thickness.length", *owner),
-                                _LegacyTerm(
+                                MeasurementSupport(feature, "thickness.length", *owner),
+                                MeasurementSupport(
                                     envelope,
                                     envelope_parameters[axis],
                                     axis,
@@ -207,14 +190,14 @@ def _legacy_owner_plans(source, features) -> dict[str, list[tuple[_LegacyTerm, .
                 for parameter, leg in legs.items():
                     if _matches(direct, leg):
                         plans[parameter].append(
-                            (_LegacyTerm(feature, "step_height.length", *direct),)
+                            (MeasurementSupport(feature, "step_height.length", *direct),)
                         )
                     if complement is not None and _matches(complement, leg):
                         assert envelope is not None
                         plans[parameter].append(
                             (
-                                _LegacyTerm(feature, "step_height.length", *direct),
-                                _LegacyTerm(
+                                MeasurementSupport(feature, "step_height.length", *direct),
+                                MeasurementSupport(
                                     envelope,
                                     envelope_parameters["z"],
                                     "z",
@@ -236,14 +219,14 @@ def _legacy_owner_plans(source, features) -> dict[str, list[tuple[_LegacyTerm, .
                 for parameter, leg in legs.items():
                     if _matches(direct, leg):
                         plans[parameter].append(
-                            (_LegacyTerm(feature, "step_position.length", *direct),)
+                            (MeasurementSupport(feature, "step_position.length", *direct),)
                         )
                     if complement is not None and _matches(complement, leg):
                         assert envelope is not None
                         plans[parameter].append(
                             (
-                                _LegacyTerm(feature, "step_position.length", *direct),
-                                _LegacyTerm(
+                                MeasurementSupport(feature, "step_position.length", *direct),
+                                MeasurementSupport(
                                     envelope,
                                     envelope_parameters[axis],
                                     axis,
@@ -285,7 +268,9 @@ def _has_parameters(feature, expected: tuple[str, str]) -> bool:
         return False
 
 
-def _interval_matches(term: _LegacyTerm, span) -> bool:
+def _interval_matches(term: MeasurementSupport, span) -> bool:
+    if term.axis not in ("x", "y", "z") or term.lo is None or term.hi is None:
+        return False
     try:
         if span is None or len(span) != 2:
             return False
@@ -304,11 +289,11 @@ def _interval_matches(term: _LegacyTerm, span) -> bool:
     return abs(lo - term.lo) < 0.5 and abs(hi - term.hi) < 0.5
 
 
-def _span_matches(term: _LegacyTerm, approved) -> bool:
+def _span_matches(term: MeasurementSupport, approved) -> bool:
     return _interval_matches(term, getattr(approved, "span", None))
 
 
-def _term_values(term: _LegacyTerm, approved_by_id) -> frozenset[float]:
+def _term_values(term: MeasurementSupport, approved_by_id) -> frozenset[float]:
     """Compiler-approved labels for the exact correlated member named by *term*."""
     entries = (
         tuple(
@@ -518,7 +503,7 @@ def through_step_requirement_outcomes(
     # be judged on the legacy proof itself, not on the richer recogniser record key: legacy
     # dimensions encode the section intervals but not necessarily the run anchor, so two
     # differently anchored sources can otherwise reuse the same two pieces of ink.
-    legacy_plans: dict[int, dict[str, list[tuple[_LegacyTerm, ...]]]] = {}
+    legacy_plans: dict[int, dict[str, list[tuple[MeasurementSupport, ...]]]] = {}
     legacy_signature_counts: dict[tuple, int] = defaultdict(int)
     for index, (source, _key, record_parameters) in enumerate(keyed_sources):
         if record_parameters is None or source.axis not in ("x", "y"):
@@ -562,6 +547,7 @@ def through_step_requirement_outcomes(
                             for alternative in plans[parameter]
                             for term in alternative
                         ),
+                        dependency_alternatives=tuple(plans[parameter]),
                         source_records=(source,),
                     )
                     for parameter in expected

--- a/src/draftwright/linting/through_step_coverage.py
+++ b/src/draftwright/linting/through_step_coverage.py
@@ -9,17 +9,22 @@ from __future__ import annotations
 
 import math
 from collections import defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from typing import Literal
 
 from quiddity import RecognitionResult, ThroughStep
 
 from draftwright._geometry import _fmt
-from draftwright.linting._registry import satisfaction_ids, satisfaction_of
+from draftwright.linting._registry import (
+    exact_measurement_carriers,
+    measurement_carrier_index,
+    satisfaction_ids,
+    satisfaction_of,
+)
 from draftwright.linting.evidence import compiled_values, rendered_numbers
 from draftwright.linting.issues import LintIssue, is_placement_drop
 from draftwright.linting.structural import _label_reading
-from draftwright.measurement_support import MeasurementSupport
+from draftwright.measurement_support import MeasurementSupport, RequirementCarrier
 
 ThroughStepRequirementState = Literal[
     "placed",
@@ -46,6 +51,7 @@ class ThroughStepRequirementOutcome:
         default=(), kw_only=True
     )
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
+    carriers: tuple[RequirementCarrier, ...] = field(default=(), kw_only=True)
 
 
 def _rounded(value) -> float:
@@ -598,7 +604,18 @@ def through_step_requirement_outcomes(
                     source_records=(source,),
                 )
             )
-    return outcomes
+    index = measurement_carrier_index(registry)
+    # Alternate support needs complete interval/value proofs, not the flattened IDs.
+    # Document evaluation supplies those proofs through DocumentSupportProof.
+    return [
+        replace(
+            outcome,
+            carriers=()
+            if outcome.dependency_alternatives
+            else exact_measurement_carriers(index, outcome.measurement_ids),
+        )
+        for outcome in outcomes
+    ]
 
 
 def lint_through_step_coverage(

--- a/src/draftwright/linting/turned_step_coverage.py
+++ b/src/draftwright/linting/turned_step_coverage.py
@@ -17,9 +17,13 @@ from typing import Literal
 
 from quiddity import RecognitionResult, TurnedProfile, TurnedProfileKey
 
-from draftwright.linting._registry import satisfaction_ids, satisfaction_of
+from draftwright.linting._registry import (
+    satisfaction_ids,
+    satisfaction_of,
+    with_measurement_carriers,
+)
 from draftwright.linting.issues import UNJOINED_PARAMETER_ID, is_placement_drop
-from draftwright.measurement_support import MeasurementSupport
+from draftwright.measurement_support import MeasurementSupport, RequirementCarrier
 from draftwright.recognition_frame import (
     AmbiguousTurnedOwnershipError,
     groove_owns_turned_step_band,
@@ -56,6 +60,7 @@ class TurnedStepRequirementOutcome:
     representation_parameter: str | None = None
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
     representation_alternatives: tuple[MeasurementSupport, ...] = field(default=(), kw_only=True)
+    carriers: tuple[RequirementCarrier, ...] = field(default=(), kw_only=True)
 
 
 def _number(value, *, digits: int | None = 6) -> float:
@@ -527,4 +532,4 @@ def turned_step_requirement_outcomes(
                     representation_alternatives=alternatives,
                 )
             )
-    return outcomes
+    return with_measurement_carriers(outcomes, registry)

--- a/src/draftwright/linting/turned_step_coverage.py
+++ b/src/draftwright/linting/turned_step_coverage.py
@@ -19,6 +19,7 @@ from quiddity import RecognitionResult, TurnedProfile, TurnedProfileKey
 
 from draftwright.linting._registry import satisfaction_ids, satisfaction_of
 from draftwright.linting.issues import UNJOINED_PARAMETER_ID, is_placement_drop
+from draftwright.measurement_support import MeasurementSupport
 from draftwright.recognition_frame import (
     AmbiguousTurnedOwnershipError,
     groove_owns_turned_step_band,
@@ -54,6 +55,7 @@ class TurnedStepRequirementOutcome:
     representation_feature: object | None = None
     representation_parameter: str | None = None
     source_records: tuple[object, ...] = field(default=(), repr=False, compare=False, kw_only=True)
+    representation_alternatives: tuple[MeasurementSupport, ...] = field(default=(), kw_only=True)
 
 
 def _number(value, *, digits: int | None = 6) -> float:
@@ -475,7 +477,8 @@ def turned_step_requirement_outcomes(
             representation = feature
             representation_parameter = parameter
             state = evidence_state(feature, parameter)
-            if parameter == "step.diameter" and state == "missing":
+            alternatives: tuple[MeasurementSupport, ...] = ()
+            if parameter == "step.diameter":
                 # A part-global OD can stand in for one profile's unique largest band only when
                 # axis line + diameter identify exactly one physical occurrence. It carries no
                 # axial span or profile token, so equal disjoint bands must keep their native
@@ -499,8 +502,9 @@ def turned_step_requirement_outcomes(
                 rotational_matches = rotational_by_key.get((key[0], key[1], key[3]), ())
                 if is_unique_profile_maximum and globally_unique and len(rotational_matches) == 1:
                     alternate = rotational_matches[0]
+                    alternatives = (MeasurementSupport(alternate, "od.diameter"),)
                     alternate_state = evidence_state(alternate, "od.diameter")
-                    if alternate_state in {
+                    if state == "missing" and alternate_state in {
                         "placed",
                         "satisfied_by_structured_note",
                         "suppressed",
@@ -520,6 +524,7 @@ def turned_step_requirement_outcomes(
                     representation_feature=representation,
                     representation_parameter=representation_parameter,
                     source_records=(source,),
+                    representation_alternatives=alternatives,
                 )
             )
     return outcomes

--- a/src/draftwright/location_contract.py
+++ b/src/draftwright/location_contract.py
@@ -1,0 +1,56 @@
+"""Shared datum-reference and coincidence rules for pocket and pad locations."""
+
+from __future__ import annotations
+
+from math import isfinite
+
+from draftwright.measurement_support import RequirementExclusion
+
+
+def pocket_location_reference(feature, datum_at):
+    """Retain the planner's centre/near-end reference selection exactly."""
+    point = list(feature.frame.origin)
+    index = "xyz".index(feature.long_axis)
+    point[index] = (
+        feature.lo if abs(feature.lo - datum_at[index]) <= 1e-6 else (feature.lo + feature.hi) / 2
+    )
+    point["xyz".index(feature.width_axis)] = feature.w_center
+    return tuple(point)
+
+
+def coincident_location_axes(feature, span):
+    """Existing compiler applicability, without expanding the Z-pad grammar."""
+    kind, axis = feature.kind, feature.frame.axis
+    if kind not in {"pad", "pocket"} or (kind == "pad" and axis == "z"):
+        return ()
+    axes = ("x", "y") if axis == "z" else (feature.long_axis, feature.width_axis)
+    return tuple(
+        measured
+        for measured in axes
+        if isfinite(span[0]["xyz".index(measured)])
+        and isfinite(span[1]["xyz".index(measured)])
+        and abs(span[1]["xyz".index(measured)] - span[0]["xyz".index(measured)]) <= 1e-6
+    )
+
+
+def datum_location_exclusion(feature, source, parameter, datum):
+    """Retain coincidence proof before authored filtering, without inspecting ink."""
+    if datum is None or getattr(datum, "id", None) != "datum_xy":
+        return None
+    try:
+        reference = (
+            pocket_location_reference(feature, datum.at)
+            if feature.kind == "pocket"
+            else tuple(feature.frame.origin)
+        )
+        span = (tuple(datum.at), reference)
+        prefix = "location_pocket.location" if feature.kind == "pocket" else "location_pad"
+        if parameter not in {
+            f"{prefix}.{axis}" for axis in coincident_location_axes(feature, span)
+        }:
+            return None
+        return RequirementExclusion(
+            "location_coincident_with_common_datum", (source,), datum, span
+        )
+    except (AttributeError, IndexError, TypeError, ValueError, OverflowError):
+        return None

--- a/src/draftwright/measurement_support.py
+++ b/src/draftwright/measurement_support.py
@@ -1,0 +1,45 @@
+"""Run-local measurement witnesses issued by physical requirement producers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class MeasurementSupport:
+    """An exact owner and optional interval or location-member restriction."""
+
+    feature: object
+    parameter_id: str
+    axis: str | None = None
+    lo: float | None = None
+    hi: float | None = None
+    location_point: tuple[float, float, float] | None = None
+
+    @property
+    def identity(self) -> tuple[object, str]:
+        return self.feature, self.parameter_id
+
+    @property
+    def value(self) -> float:
+        if self.lo is None or self.hi is None:
+            raise ValueError("this measurement support has no interval")
+        return abs(self.hi - self.lo)
+
+
+@dataclass(frozen=True)
+class RequirementAlternative:
+    """A conjunction with both legacy local identities and exact carrying witnesses."""
+
+    measurements: tuple[tuple[object, str], ...]
+    supports: tuple[MeasurementSupport, ...]
+
+
+@dataclass(frozen=True)
+class RequirementExclusion:
+    """A source-owned rule, optionally scoped to an exact common location datum."""
+
+    reason_code: str
+    source_records: tuple[object, ...]
+    datum: object | None = None
+    span: tuple | None = None

--- a/src/draftwright/measurement_support.py
+++ b/src/draftwright/measurement_support.py
@@ -43,3 +43,11 @@ class RequirementExclusion:
     source_records: tuple[object, ...]
     datum: object | None = None
     span: tuple | None = None
+
+
+@dataclass(frozen=True)
+class RequirementCarrier:
+    """A named annotation accepted by a physical requirement producer."""
+
+    annotation: str
+    kind: str

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -53,6 +53,7 @@ from dataclasses import dataclass, field, replace
 from typing import Any, Literal
 
 from draftwright._geometry import _fmt, _fmt_angle
+from draftwright.location_contract import coincident_location_axes
 from draftwright.model.ir import (
     AngularReference,
     EnvelopeFeature,
@@ -1390,11 +1391,12 @@ def _compile_locations(model: PartModel) -> tuple[list[ApprovedDimension], list[
             # site that consumed it would have printed an empty label the moment it read
             # `value_text` (#925). The Z-normal ladder below is the remaining exception and
             # is listed as such.
+            coincident = coincident_location_axes(feature, span)
             for meas in (feature.long_axis, feature.width_axis):
                 index = "xyz".index(meas)
                 value = abs(span[1][index] - span[0][index])
                 parameter_id = f"{pd.param.role}.{meas}"
-                if value <= 1e-6:
+                if meas in coincident:
                     omissions.append(
                         Omission(
                             feature,
@@ -1422,10 +1424,11 @@ def _compile_locations(model: PartModel) -> tuple[list[ApprovedDimension], list[
                 )
             continue
         if isinstance(feature, PocketFeature) and axis == "z":
+            coincident = coincident_location_axes(feature, span)
             for measured_axis in ("x", "y"):
                 index = "xyz".index(measured_axis)
                 value = abs(span[1][index] - span[0][index])
-                if value <= 1e-6:
+                if measured_axis in coincident:
                     omissions.append(
                         Omission(
                             feature,

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -268,6 +268,21 @@ class ApprovedDimension:
     equivalent_ids: tuple[DimensionId, ...] = ()
 
     @property
+    def is_location_measurement(self) -> bool:
+        """Location intent includes the existing length-valued off-axis members."""
+        return self.kind == "location" or self.location_member is not None
+
+    @property
+    def physical_location_component(self) -> str | None:
+        """The physical ledger spelling, separate from the finer member selector."""
+        if not self.is_location_measurement or self.discriminator not in {"x", "y", "z"}:
+            return None
+        feature = self.id.feature if self.id is not None else None
+        if isinstance(feature, HoleFeature) and self.axis != "z":
+            return f"{self.role}.{self.discriminator}"
+        return f"{self.role}.location.{self.discriminator}"
+
+    @property
     def measurement_ids(self) -> tuple[DimensionId, ...]:
         return ((self.id,) if self.id is not None else ()) + self.equivalent_ids
 

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass, replace
 from typing import Any, Literal
 
 from draftwright._geometry import _EDGE_ON, _END_ON, HoleRef, _fmt_angle
+from draftwright.location_contract import pocket_location_reference
 from draftwright.model.ir import (
     PLACEMENT_SIDES,
     PLACEMENT_VIEWS,
@@ -1027,12 +1028,7 @@ def plan_locations(model: PartModel) -> list[PlannedDimension]:
             # the length callout fully defines the long position: printing half the
             # length as a datum-to-centre offset is redundant and opaque (a datum-starting
             # 62.1 mm pocket otherwise acquires a seemingly arbitrary 31.1 mm mark).
-            ref_point = list(f.frame.origin)
-            long_index = "xyz".index(f.long_axis)
-            datum_coord = (dx, dy, dz)[long_index]
-            ref_point[long_index] = f.lo if abs(f.lo - datum_coord) <= 1e-6 else (f.lo + f.hi) / 2
-            ref_point["xyz".index(f.width_axis)] = f.w_center
-            ref = (ref_point[0], ref_point[1], ref_point[2])
+            ref = pocket_location_reference(f, datum.at)
             refs.append((ref, role, f, None, None))
         else:
             refs.append((f.frame.origin, role, f, None, None))

--- a/src/draftwright/plate_correspondence.py
+++ b/src/draftwright/plate_correspondence.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from collections import Counter
+
+from draftwright.measurement_support import MeasurementSupport, RequirementAlternative
+
 Point = tuple[float, float, float]
 
 
@@ -316,3 +320,84 @@ def plate_owner_dependencies(source, features) -> tuple[tuple[object, str], ...]
         if dependencies := establish(source, features):
             return dependencies
     return ()
+
+
+def plate_dependency_supports(source, dependencies) -> tuple[MeasurementSupport, ...]:
+    """Retain the exact correlated members used by an established Plate recipe.
+
+    The correspondence predicates select the recipe. This projection retains its
+    member witnesses before a local ledger discards them into coarse DimensionIds.
+    Missing witness data leaves the recipe unproved for document reconciliation.
+    """
+    supports: list[MeasurementSupport] = []
+    seen = set()
+    counts = Counter((id(feature), parameter) for feature, parameter in dependencies)
+    try:
+        for feature, parameter in dependencies:
+            identity = (id(feature), parameter)
+            if identity in seen:
+                continue
+            seen.add(identity)
+            if getattr(feature, "kind", None) == "step_level":
+                axis = str(source.axis)
+                index = "xyz".index(axis)
+                if parameter == "step_height.length" and axis == "z":
+                    datum = float(feature.base)
+                    targets = [
+                        float(level)
+                        for level in feature.levels
+                        if _rounded(level) in {_rounded(source.lo), _rounded(source.hi)}
+                        and not _same(level, datum)
+                    ]
+                elif parameter == "step_position.length" and axis in ("x", "y"):
+                    datum = float(feature.datum[index])
+                    targets = [
+                        float(position)
+                        for shoulder_axis, position in feature.shoulders
+                        if str(shoulder_axis) == axis
+                    ]
+                else:
+                    return ()
+                if len(targets) != counts[identity]:
+                    return ()
+                supports.extend(
+                    MeasurementSupport(
+                        feature, parameter, axis, min(datum, target), max(datum, target)
+                    )
+                    for target in targets
+                )
+            elif ".location." in parameter:
+                axis = parameter.rsplit(".", 1)[-1]
+                if axis not in ("x", "y", "z") or getattr(feature, "kind", None) != "slot_pattern":
+                    return ()
+                # The existing slot-pattern grammar locates its centre; pitch and slot
+                # size in this same conjunction establish the repeated cuts.
+                supports.append(
+                    MeasurementSupport(
+                        feature, parameter, axis, location_point=tuple(feature.frame.origin)
+                    )
+                )
+            else:
+                # A unique scalar parameter needs no correlated-member selection. Its
+                # compiled value and engineering meaning are verified at the carrying sheet.
+                matching = [p for p in feature.parameters() if p.parameter_id == parameter]
+                if len(matching) != 1 or counts[identity] != 1:
+                    return ()
+                supports.append(MeasurementSupport(feature, parameter))
+    except (AttributeError, IndexError, TypeError, ValueError):
+        return ()
+    return tuple(supports)
+
+
+def plate_dependency_alternatives(source, features) -> tuple[RequirementAlternative, ...]:
+    """All producer-permitted conjunctions, independent of current annotation ink."""
+    return tuple(
+        RequirementAlternative(dependencies, plate_dependency_supports(source, dependencies))
+        for establish in (
+            _envelope_owned_dependencies,
+            _step_level_dependencies,
+            _polygonal_boss_dependencies,
+            _slot_pattern_dependencies,
+        )
+        if (dependencies := establish(source, features))
+    )

--- a/src/draftwright/reporting.py
+++ b/src/draftwright/reporting.py
@@ -45,6 +45,7 @@ class RequirementSnapshot:
     dimension_plan: object
     part: object
     outcomes: Mapping[str, tuple[Any, ...]]
+    lint: Mapping | None = None
 
 
 @dataclass(frozen=True, eq=False)
@@ -405,6 +406,7 @@ class DocumentEvaluation:
     conflicts: tuple
     registry: object
     annotation_refs: Mapping
+    members: tuple
 
 
 def evaluate_document_requirements(catalog, model, part, members, claims) -> DocumentEvaluation:
@@ -498,7 +500,7 @@ def evaluate_document_requirements(catalog, model, part, members, claims) -> Doc
             state = "uncovered"
         evaluated.append(DocumentRequirementEvaluation(requirement, state, local, proofs, current))
     return DocumentEvaluation(
-        tuple(evaluated), tuple(claims), conflicts, registry, annotation_refs
+        tuple(evaluated), tuple(claims), conflicts, registry, annotation_refs, tuple(members)
     )
 
 
@@ -614,17 +616,9 @@ def _outcome_records(outcome: object) -> tuple[object, ...]:
 
 
 def _outcome_measurements(outcome: object) -> tuple[tuple[object, str], ...]:
-    explicit = tuple(getattr(outcome, "measurement_ids", ()))
-    if explicit:
-        return explicit
-    representation = getattr(outcome, "representation_feature", None)
-    representation_parameter = getattr(outcome, "representation_parameter", None)
-    if representation is not None and isinstance(representation_parameter, str):
-        return ((representation, representation_parameter),)
-    parameter = getattr(outcome, "parameter_id", None)
-    if not isinstance(parameter, str) or parameter == "?":
-        return ()
-    return tuple((feature, parameter) for feature in getattr(outcome, "features", ()))
+    from draftwright.linting._registry import requirement_measurements
+
+    return requirement_measurements(outcome)
 
 
 # Private: read only by the two `_annotation_*` helpers below. A published name is a
@@ -669,6 +663,23 @@ def _annotation_names(index: _AnnotationIndex, outcome: object) -> list[str]:
         if candidate is not None and candidate[0] is feature:
             result.update(candidate[1])
     return sorted(result)
+
+
+def _profile_source(evidence, profile, profile_ids, support_ids):
+    source = profile.source
+    try:
+        if evidence.planar_outer_profile(source.face) is not source:
+            raise ValueError("profile does not belong to this evidence run")
+        for index in (profile.first_index, profile.second_index):
+            evidence.profile_edge(source, index)
+    except (AttributeError, TypeError, ValueError, IndexError) as exc:
+        raise ReportUnavailableError("profile requirement has no exact issued source") from exc
+    profile_id = profile_ids.setdefault(id(source), f"profile:{len(profile_ids) + 1}")
+    pair_ids = [
+        support_ids.setdefault((id(source), index), f"support:{len(support_ids) + 1}")
+        for index in (profile.first_index, profile.second_index)
+    ]
+    return {"kind": "planar_outer_profile", "profile_id": profile_id, "support_ids": pair_ids}
 
 
 def _requirements(
@@ -752,28 +763,7 @@ def _requirements(
                     raise ReportUnavailableError(
                         "profile requirement has conflicting source kinds"
                     )
-                source = profile.source
-                try:
-                    if evidence.planar_outer_profile(source.face) is not source:
-                        raise ValueError("profile does not belong to this evidence run")
-                    for index in (profile.first_index, profile.second_index):
-                        evidence.profile_edge(source, index)
-                except (AttributeError, TypeError, ValueError, IndexError) as exc:
-                    raise ReportUnavailableError(
-                        "profile requirement has no exact issued source"
-                    ) from exc
-                # Allocate document IDs on first use; no opaque reference or
-                # provider topology/support index is serialized.
-                profile_id = profile_ids.setdefault(id(source), f"profile:{len(profile_ids) + 1}")
-                pair_ids = [
-                    support_ids.setdefault((id(source), index), f"support:{len(support_ids) + 1}")
-                    for index in (profile.first_index, profile.second_index)
-                ]
-                profile_source = {
-                    "kind": "planar_outer_profile",
-                    "profile_id": profile_id,
-                    "support_ids": pair_ids,
-                }
+                profile_source = _profile_source(evidence, profile, profile_ids, support_ids)
             if not source_records and profile_source is None:
                 raise ReportUnavailableError(
                     f"recognized requirement family {family!r} has no exact source records"
@@ -1084,6 +1074,400 @@ def drawing_report(
     }
 
 
+def _engineering_meaning(meaning):
+    from draftwright.fits import FitClass
+
+    value, tolerance, span, axis, discriminator, member, angular = meaning
+    if isinstance(tolerance, FitClass):
+        tolerance = {
+            "kind": "fit",
+            "code": tolerance.code,
+            "lower": tolerance.lower,
+            "upper": tolerance.upper,
+        }
+    return {
+        "value": value,
+        "tolerance": tolerance,
+        "span": span,
+        "axis": axis,
+        "discriminator": discriminator,
+        "location_member": member,
+        "angular_reference": angular,
+    }
+
+
+def _document_intents(model, owner_id):
+    def projected(items):
+        return [
+            {
+                "owner_id": owner_id(item.feature),
+                "role": item.role,
+                "discriminator": item.discriminator,
+                "member": item.member,
+                "display_decimals": item.display_decimals,
+                "view": item.view,
+                "side": item.side,
+            }
+            for item in items
+        ]
+
+    return {
+        "source": "automatic" if model.authored_dimensions is None else "authored",
+        "authored": None
+        if model.authored_dimensions is None
+        else projected(model.authored_dimensions),
+        "requested": projected(model.requested_dimensions),
+    }
+
+
+def _document_views(constraints, owner_id):
+    from dataclasses import asdict, replace
+
+    def projected(item):
+        target = item.spec.target
+        if target is not None and target[0] == "feature":
+            target = ("owner", owner_id(target[1]))
+        return asdict(replace(item, spec=replace(item.spec, target=target)))
+
+    return {
+        "principal_source": constraints.principal_source,
+        "derived_source": constraints.derived_source,
+        "principals": [projected(item) for item in constraints.principals],
+        "added_principals": [projected(item) for item in constraints.added_principals],
+        "derived": [projected(item) for item in constraints.derived],
+        "added_derived": [projected(item) for item in constraints.added_derived],
+        "relations": [asdict(item) for item in constraints.relations],
+        "pins": [asdict(item) for item in constraints.pins],
+    }
+
+
+def document_report(
+    *, catalog, evaluation, model, source, run_options, member_recipes, resolved
+) -> dict[str, object]:
+    """Project one schema-v4 document read; no report-local identity survives this value.
+
+    Carrier attribution is producer-owned. A missing producer projection stays explicit
+    and prevents bounded clearance; ordinary owner/parameter associations are not proof.
+    """
+    if len(evaluation.requirements) != len(catalog.requirements) or any(
+        row.requirement is not expected
+        for row, expected in zip(evaluation.requirements, catalog.requirements, strict=True)
+    ):
+        raise ReportUnavailableError("document evaluation lost its exact catalog")
+    occurrences, _unused, occurrence_summary = project_occurrences(
+        catalog.evidence, catalog.ownership, model
+    )
+    occurrence_ids = {
+        id(catalog.evidence.record(reference)): (catalog.evidence.record(reference), item["id"])
+        for reference, item in zip(catalog.evidence.features, occurrences, strict=True)
+    }
+    owners = _feature_ids(model)
+
+    def owner_id(feature):
+        candidate = owners.get(id(feature))
+        if candidate is None or candidate[0] is not feature:
+            raise ReportUnavailableError("document claim has no exact common owner")
+        return candidate[1]["id"]
+
+    members = evaluation.members
+    sheet_ids = {
+        name: f"sheet:{index + 1}" for index, (name, _snapshot, _rows) in enumerate(members)
+    }
+    if not sheet_ids or len(sheet_ids) != len(members):
+        raise ReportUnavailableError("document member identities are absent or repeated")
+    refs = set(evaluation.annotation_refs.values())
+
+    def annotation_ref(sheet, name):
+        if sheet not in sheet_ids or (sheet, name) not in refs:
+            raise ReportUnavailableError("document evidence refers to an absent member annotation")
+        return {"sheet_id": sheet_ids[sheet], "annotation": name}
+
+    def combined_ref(name):
+        if name not in evaluation.annotation_refs:
+            raise ReportUnavailableError("requirement carrier names an absent annotation")
+        return annotation_ref(*evaluation.annotation_refs[name])
+
+    claims: list[dict[str, Any]] = []
+    claim_ids = {}
+    for snapshot in evaluation.claims:
+        for claim in snapshot.claims:
+            key = f"claim:{len(claims) + 1}"
+            claim_ids[id(claim)] = key
+            claims.append(
+                {
+                    "id": key,
+                    **annotation_ref(claim.sheet, claim.annotation),
+                    "owner_id": owner_id(claim.owner),
+                    "parameter_id": claim.parameter,
+                    "address": claim.address,
+                    "meaning": _engineering_meaning(claim.meaning),
+                    "rendered": claim.rendered,
+                    "verification": "confirmed-within-measurement-verifier-scope",
+                }
+            )
+
+    def claim_id(claim):
+        result = claim_ids.get(id(claim))
+        if result is None:
+            raise ReportUnavailableError("document proof refers to an absent confirmed claim")
+        return result
+
+    conflicts = [
+        {
+            "code": "conflicting_engineering_meanings",
+            "claim_ids": [claim_id(claim) for claim in conflict.claims],
+        }
+        for conflict in evaluation.conflicts
+    ]
+    unknown = [
+        {**annotation_ref(sheet, annotation), "reason_code": reason}
+        for snapshot in evaluation.claims
+        for sheet, annotation, reason in snapshot.unknown
+    ]
+    requirements: list[dict[str, Any]] = []
+    profile_ids: dict[int, str] = {}
+    support_ids: dict[tuple[int, int], str] = {}
+    attributed_by_occurrence: dict[str, list[str]] = {item["id"]: [] for item in occurrences}
+    for evaluated in evaluation.requirements:
+        row = evaluated.requirement
+        if evaluated.state not in {
+            "placed",
+            "satisfied_by_structured_note",
+            "dependency-derived",
+            "inapplicable",
+            "unresolved",
+            "uncovered",
+        }:
+            raise ReportUnavailableError("document requirement has an invalid evaluation state")
+        key = f"requirement:{len(requirements) + 1}"
+        source_ids = [
+            _exact_occurrence_id(record, occurrence_ids) for record in row.source_records
+        ]
+        local = [
+            {
+                "sheet_id": sheet_ids[name],
+                "state": getattr(outcome, "state", "unsupported"),
+                "reason_code": _REQUIREMENT_REASON.get(
+                    getattr(outcome, "state", "unsupported"), "source_owned_inapplicability"
+                ),
+            }
+            for name, outcome in evaluated.local
+        ]
+        proofs = [
+            {
+                "alternative": proof.alternative,
+                "supports": [
+                    [claim_id(claim) for claim in carriers] for carriers in proof.carriers
+                ],
+                "distinct_witnesses": [claim_id(claim) for claim in proof.witnesses],
+            }
+            for proof in evaluated.dependencies
+        ]
+        # Populated by each existing ledger's acceptance point. Until a producer
+        # supplies it, retain the absence instead of guessing from annotation names.
+        carriers = getattr(evaluated.combined.outcome, "carriers", None)
+        attributed = carriers is not None
+        carrying = (
+            []
+            if carriers is None
+            else [
+                {**combined_ref(carrier.annotation), "evidence_kind": carrier.kind}
+                for carrier in carriers
+            ]
+        )
+        if evaluated.state == "dependency-derived":
+            attributed = bool(proofs)
+            carrying = []
+        elif evaluated.state not in {"placed", "satisfied_by_structured_note"}:
+            attributed = True
+            carrying = []
+        elif not carrying:
+            attributed = False
+        result = {
+            "id": key,
+            "family": row.family,
+            "occurrence_ids": source_ids,
+            "owner_ids": [owner_id(feature) for feature in row.features],
+            "parameter_id": row.parameter_id,
+            "requirement_count": row.requirement_count,
+            "requirement_count_known": row.requirement_count_known,
+            "state": evaluated.state,
+            "coverage_credit": int(
+                evaluated.state in {"placed", "satisfied_by_structured_note", "dependency-derived"}
+            ),
+            "local_outcomes": local,
+            "carrying_annotations": carrying,
+            "carrier_attribution": "available" if attributed else "unavailable",
+            "dependency_proofs": proofs,
+            "intrinsic_exclusion": None
+            if row.intrinsic_exclusion is None
+            else {
+                "reason_code": row.intrinsic_exclusion.reason_code,
+                "occurrence_ids": [
+                    _exact_occurrence_id(record, occurrence_ids)
+                    for record in row.intrinsic_exclusion.source_records
+                ],
+                "span": getattr(row.intrinsic_exclusion, "span", None),
+            },
+        }
+        if row.source_profile is not None:
+            result["profile_source"] = _profile_source(
+                catalog.evidence, row.source_profile, profile_ids, support_ids
+            )
+        requirements.append(result)
+        for identity in source_ids:
+            attributed_by_occurrence[identity].append(key)
+    for occurrence in occurrences:
+        identities = attributed_by_occurrence[occurrence["id"]]
+        occurrence["requirements"] = {
+            "coverage": "ledger" if identities else "not-projected",
+            "ids": identities,
+        }
+
+    sheets = []
+    for name, snapshot, _rows in members:
+        if snapshot.lint is None or name not in resolved or name not in member_recipes:
+            raise ReportUnavailableError(f"document sheet {name!r} lacks lint or run options")
+        options = {
+            key: str(value) if isinstance(value, PathLike) else value
+            for key, value in member_recipes[name]["options"].items()
+        }
+        sheets.append(
+            {
+                "id": sheet_ids[name],
+                "name": name,
+                "options": options,
+                "resolved": resolved[name],
+                "dimension_intents": _document_intents(snapshot.model, owner_id),
+                "view_intents": _document_views(member_recipes[name]["views"], owner_id),
+                "table_intents": member_recipes[name]["tables"],
+                "lint": snapshot.lint,
+            }
+        )
+
+    def axis_summary(axis):
+        values = [sheet["lint"].get("quality", {}).get(axis, {}) for sheet in sheets]
+        unavailable = [
+            sheet["id"]
+            for sheet, value in zip(sheets, values, strict=True)
+            if not value.get("available", False)
+        ]
+        affected = [
+            sheet["id"]
+            for sheet, value in zip(sheets, values, strict=True)
+            if value.get("raw_issues", 0)
+        ]
+        return {
+            "status": "needs-attention"
+            if affected
+            else "unassessed"
+            if unavailable
+            else "clear-within-lint-scope",
+            "affected_sheets": affected,
+            "unassessed_sheets": unavailable,
+        }
+
+    layout = axis_summary("legibility")
+    fidelity = {
+        **axis_summary("fidelity"),
+        "conflicts": conflicts,
+        "unknown_claims": unknown,
+        "scope": "verified-measurement-claims-and-member-fidelity-lint",
+        "unassessed_scope": [
+            "authored-note-prose",
+            "manufacturing-intent",
+            "engineering-content-without-typed-verified-claims",
+        ],
+    }
+    if conflicts or unknown:
+        fidelity["status"] = "needs-attention"
+    unknown_counts = sum(not row["requirement_count_known"] for row in requirements)
+    applicable = [row for row in requirements if row["state"] != "inapplicable"]
+    denominator = sum(
+        row["requirement_count"] for row in applicable if row["requirement_count_known"]
+    )
+    credit = sum(row["coverage_credit"] for row in applicable)
+    unresolved = [row["id"] for row in applicable if not row["coverage_credit"]]
+    unattributed = [row["id"] for row in applicable if row["carrier_attribution"] == "unavailable"]
+    coverage = {
+        "scope": "accepted-occurrences-and-profile-requirements",
+        "known_requirement_count": denominator,
+        "unknown_cardinality_rows": unknown_counts,
+        "credited_requirements": credit,
+        "audited_score": credit / denominator if denominator and not unknown_counts else None,
+        "uncovered_or_unresolved": unresolved,
+        "unattributed_carriers": unattributed,
+        "excludes": ["unrecognised-geometry", "manufacturing-readiness"],
+    }
+    unresolved_occurrences = [
+        item["id"]
+        for item in occurrences
+        if item["disposition"] in _ATTENTION_DISPOSITIONS
+        or item["requirements"]["coverage"] == "not-projected"
+    ]
+    attention = bool(
+        unresolved
+        or unattributed
+        or unknown_counts
+        or unresolved_occurrences
+        or conflicts
+        or unknown
+    )
+    attention = (
+        attention
+        or layout["status"] != "clear-within-lint-scope"
+        or fidelity["status"] != "clear-within-lint-scope"
+    )
+    report = {
+        "schema": REPORT_SCHEMA,
+        "schema_version": 4,
+        "scope": "document",
+        "status": "needs-attention" if attention else "bounded-clear",
+        "producer": producer(),
+        "source": source,
+        "run_options": run_options,
+        "outputs": {},
+        "recognition": {
+            "identity_scope": "document-local",
+            "occurrences": occurrences,
+            "owners": [owner for _feature, owner in owners.values()],
+            "requirements": requirements,
+            "summary": occurrence_summary,
+            "unresolved_occurrences": unresolved_occurrences,
+        },
+        "sheets": sheets,
+        "claims": claims,
+        "assessment": {
+            "coverage": coverage,
+            "layout": layout,
+            "fidelity": fidelity,
+            "manufacturing": {"status": "unassessed", "readiness": "not-certified"},
+        },
+        "replay": {
+            "identity_lifetime": "this-report-only",
+            "source_snapshot": "immutable-step-bytes",
+            "member_reads": "live-at-report-call",
+            "requires": "source-recipe-and-current-inventory-assertions",
+            "durable_feature_identity": False,
+            "serialized_declaration_scope": [
+                "dimension-selection",
+                "view-constraints",
+                "table-text",
+            ],
+            "source_recipe_required_for": [
+                "feature-decorations",
+                "gdt",
+                "authored-notes",
+                "measured-dimensions",
+                "member-pmi-declarations",
+                "live-edits",
+            ],
+            "script_deserialization": False,
+        },
+    }
+    return cast(dict[str, object], json_value(report))
+
+
 def write_json_document(report: Mapping[str, object], path: str | PathLike[str]) -> str:
     """Atomically write one strict, deterministic UTF-8 JSON document.
 
@@ -1146,6 +1530,7 @@ __all__ = [
     "build_requirement_catalog",
     "match_requirement_catalog",
     "drawing_report",
+    "document_report",
     # The shared occurrence projector (#1461). Three schema'd public documents are built
     # from these — the drawing report, the STEP inspection document, and the sidecar the
     # script emitter writes — so their shape is a contract, not an implementation detail.

--- a/src/draftwright/reporting.py
+++ b/src/draftwright/reporting.py
@@ -6,7 +6,10 @@ import json
 import os
 from collections import Counter
 from collections.abc import Mapping
+from dataclasses import dataclass
 from importlib.metadata import version as distribution_version
+from math import isfinite
+from numbers import Real
 from os import PathLike
 from pathlib import Path
 from tempfile import NamedTemporaryFile
@@ -23,6 +26,369 @@ if TYPE_CHECKING:
 
 REPORT_SCHEMA = "draftwright-report"
 REPORT_SCHEMA_VERSION = 3
+
+
+@dataclass(frozen=True)
+class RequirementSnapshot:
+    """Live typed report inputs captured through the drawing's existing ledger pass.
+
+    This is run-local evidence, not a serialized document or an independent build.
+    Callers serialize edits and reads; mutable drawing objects are not frozen by it.
+    """
+
+    evidence: RecognitionEvidence
+    ownership: RecognitionOwnership
+    model: PartModel
+    source: str | PathLike[str] | None
+    registry: object
+    omissions: tuple
+    dimension_plan: object
+    part: object
+    outcomes: Mapping[str, tuple[Any, ...]]
+
+
+@dataclass(frozen=True, eq=False)
+class CatalogRequirement:
+    """A source-owned obligation retained before any member's ink is evaluated."""
+
+    family: str
+    source_records: tuple[object, ...]
+    source_profile: object | None
+    parameter_id: str | None
+    requirement_count: int
+    requirement_count_known: bool
+    features: tuple[object, ...]
+    members: tuple
+    dependency_alternatives: tuple
+    intrinsic_exclusion: object | None
+    unsupported: bool = False
+    representation_alternatives: tuple = ()
+    outcome: object | None = None
+
+
+@dataclass(frozen=True, eq=False)
+class RequirementCatalog:
+    """One run's typed denominator; these references are never persistence IDs."""
+
+    evidence: object
+    ownership: object
+    features: tuple[object, ...]
+    families: tuple[str, ...]
+    requirements: tuple[CatalogRequirement, ...]
+
+
+def build_requirement_catalog(
+    *, evidence, ownership, model, part, requirement_outcomes=None
+) -> RequirementCatalog:
+    """Use the existing ledger producers and strict source projection before authoring."""
+    from draftwright.linting.requirements import (
+        REQUIREMENT_SOURCE_FAMILIES,
+        recognized_requirement_outcomes,
+        requirement_source_census,
+    )
+    from draftwright.registry import AnnotationRegistry
+
+    evidence, ownership, model = validate_report_inputs(evidence, ownership, model)
+    registry = AnnotationRegistry()
+    outcomes = requirement_outcomes
+    if outcomes is None:
+        outcomes = recognized_requirement_outcomes(
+            evidence.result,
+            tuple(model.features),
+            registry,
+            (),
+            part=part,
+            evidence=evidence,
+            ownership=ownership,
+            datum=next((datum for datum in model.datums if datum.id == "datum_xy"), None),
+        )
+    if set(outcomes) != REQUIREMENT_SOURCE_FAMILIES | {"outer_profile_angles"}:
+        raise ReportUnavailableError("catalog requirement family roster changed")
+    # Reuse the strict projection's authority, profile-denominator, source-set and
+    # unsupported-disposition checks. The typed rows below come from the producers;
+    # serialized IDs, annotation rows and local coverage counts are not their input.
+    project_occurrences(
+        evidence,
+        ownership,
+        model,
+        registry=registry,
+        part=part,
+        requirement_outcomes=outcomes,
+    )
+    records = tuple(evidence.record(reference) for reference in evidence.features)
+    record_order = {id(record): index for index, record in enumerate(records)}
+    feature_order = {id(feature): feature for feature in model.features}
+    if any(
+        feature_order.get(id(feature)) is not feature
+        for binding in ownership.bindings
+        for feature in binding.features
+    ):
+        raise ReportUnavailableError("catalog lost an exact conversion-time physical owner")
+    entries = []
+    keys = set()
+    projected_records: set[int] = set()
+    for family, rows in outcomes.items():
+        for row in rows:
+            sources_by_id = {id(record): record for record in _outcome_records(row)}
+            sources = tuple(
+                sorted(sources_by_id.values(), key=lambda record: record_order[id(record)])
+            )
+            profile = getattr(row, "source_profile", None)
+            parameter = getattr(row, "catalog_parameter_id", row.parameter_id)
+            count = getattr(row, "requirement_count", 1)
+            known = getattr(row, "requirement_count_known", True)
+            if (
+                type(parameter) is not str
+                or not parameter
+                or type(count) is not int
+                or count < 1
+                or type(known) is not bool
+                or (parameter != "?" and count != 1)
+            ):
+                raise ReportUnavailableError(
+                    "invalid source-owned catalog identity or cardinality"
+                )
+            source_key = tuple(id(record) for record in sources)
+            profile_key = (
+                (id(profile.source), profile.first_index, profile.second_index)
+                if profile is not None
+                else None
+            )
+            key = (family, source_key, profile_key, parameter)
+            if key in keys:
+                raise ReportUnavailableError(
+                    "ambiguous duplicate source-owned catalog requirement"
+                )
+            keys.add(key)
+            projected_records.update(source_key)
+            features = tuple(getattr(row, "features", ()))
+            if any(feature_order.get(id(feature)) is not feature for feature in features):
+                raise ReportUnavailableError("catalog requirement has a foreign physical owner")
+            alternatives = tuple(getattr(row, "dependency_alternatives", ()))
+            _validate_catalog_supports(alternatives, feature_order)
+            representations = tuple(getattr(row, "representation_alternatives", ()))
+            _validate_catalog_supports(tuple((term,) for term in representations), feature_order)
+            exclusion = getattr(row, "intrinsic_exclusion", None)
+            if exclusion is not None:
+                for record in exclusion.source_records:
+                    index = record_order.get(id(record))
+                    if index is None or records[index] is not record:
+                        raise ReportUnavailableError(
+                            "catalog exclusion has foreign source evidence"
+                        )
+                datum = getattr(exclusion, "datum", None)
+                if datum is not None and not any(datum is item for item in model.datums):
+                    raise ReportUnavailableError("catalog exclusion has a foreign datum")
+            entries.append(
+                CatalogRequirement(
+                    family,
+                    sources,
+                    profile,
+                    None if parameter == "?" else parameter,
+                    count,
+                    known,
+                    features,
+                    tuple(getattr(row, "members", ())),
+                    alternatives,
+                    exclusion,
+                    row.state == "unsupported",
+                    representations,
+                    row,
+                )
+            )
+    for reference, record in requirement_source_census(evidence, ownership):
+        if (
+            ownership.status(reference) not in {"unsupported", "deferred", "evidence_only"}
+            and id(record) not in projected_records
+        ):
+            raise ReportUnavailableError("recognized requirement source has no ledger outcome")
+    for reference, record in zip(evidence.features, records, strict=True):
+        if ownership.status(reference) == "unsupported" and id(record) not in projected_records:
+            entries.append(
+                CatalogRequirement(
+                    evidence.family(reference),
+                    (record,),
+                    None,
+                    None,
+                    1,
+                    True,
+                    (),
+                    (),
+                    (),
+                    None,
+                    True,
+                )
+            )
+    return RequirementCatalog(
+        evidence, ownership, tuple(model.features), tuple(outcomes), tuple(entries)
+    )
+
+
+def _validate_catalog_supports(alternatives, feature_order):
+    from draftwright.measurement_support import MeasurementSupport, RequirementAlternative
+
+    for alternative in alternatives:
+        if isinstance(alternative, RequirementAlternative):
+            identities, terms = alternative.measurements, alternative.supports
+        else:
+            terms = tuple(alternative)
+            if any(not isinstance(term, MeasurementSupport) for term in terms):
+                raise ReportUnavailableError("catalog dependency has an invalid support type")
+            identities = tuple(term.identity for term in terms)
+        if not identities:
+            raise ReportUnavailableError("catalog dependency has an empty conjunction")
+        for feature, parameter in identities:
+            if (
+                feature_order.get(id(feature)) is not feature
+                or type(parameter) is not str
+                or not parameter
+            ):
+                raise ReportUnavailableError("catalog dependency has a foreign physical owner")
+        for term in terms:
+            if (
+                not isinstance(term, MeasurementSupport)
+                or feature_order.get(id(term.feature)) is not term.feature
+                or not any(
+                    owner is term.feature and parameter == term.parameter_id
+                    for owner, parameter in identities
+                )
+            ):
+                raise ReportUnavailableError("catalog support has a foreign or unrelated owner")
+            interval = term.lo is not None or term.hi is not None
+            point = term.location_point
+            if (
+                term.axis not in {None, "x", "y", "z"}
+                or (
+                    interval
+                    and (
+                        term.axis is None
+                        or term.lo is None
+                        or term.hi is None
+                        or not _finite_support_number(term.lo)
+                        or not _finite_support_number(term.hi)
+                        or term.lo > term.hi
+                    )
+                )
+                or (
+                    point is not None
+                    and (
+                        term.axis is None
+                        or type(point) is not tuple
+                        or len(point) != 3
+                        or not all(_finite_support_number(value) for value in point)
+                    )
+                )
+            ):
+                raise ReportUnavailableError("catalog support has an invalid physical witness")
+        if terms:
+            required = Counter((id(owner), parameter) for owner, parameter in identities)
+            for (owner_id, parameter), count in required.items():
+                witnesses = {
+                    (term.axis, term.lo, term.hi, term.location_point)
+                    for term in terms
+                    if id(term.feature) == owner_id and term.parameter_id == parameter
+                }
+                if len(witnesses) < count:
+                    raise ReportUnavailableError(
+                        "catalog dependency lost a distinct measurement witness"
+                    )
+
+
+def _finite_support_number(value):
+    try:
+        return not isinstance(value, bool) and isinstance(value, Real) and isfinite(value)
+    except (OverflowError, TypeError, ValueError):
+        return False
+
+
+def _catalog_key(row):
+    profile = row.source_profile
+    return (
+        row.family,
+        frozenset(id(record) for record in row.source_records),
+        (id(profile.source), profile.first_index, profile.second_index)
+        if profile is not None
+        else None,
+        row.parameter_id,
+    )
+
+
+def _support_signature(term):
+    return (
+        id(term.feature),
+        term.parameter_id,
+        term.axis,
+        term.lo,
+        term.hi,
+        term.location_point,
+    )
+
+
+def _alternative_signature(alternative):
+    from draftwright.measurement_support import RequirementAlternative
+
+    if isinstance(alternative, RequirementAlternative):
+        identities, terms = alternative.measurements, alternative.supports
+    else:
+        terms = tuple(alternative)
+        identities = tuple(term.identity for term in terms)
+    return (
+        frozenset(Counter((id(owner), parameter) for owner, parameter in identities).items()),
+        frozenset(Counter(_support_signature(term) for term in terms).items()),
+    )
+
+
+def _catalog_shape(row):
+    exclusion = row.intrinsic_exclusion
+    return (
+        row.requirement_count,
+        row.requirement_count_known,
+        frozenset(Counter(id(feature) for feature in row.features).items()),
+        row.members,
+        frozenset(_alternative_signature(recipe) for recipe in row.dependency_alternatives),
+        frozenset(_support_signature(term) for term in row.representation_alternatives),
+        (
+            exclusion.reason_code,
+            frozenset(id(record) for record in exclusion.source_records),
+            id(getattr(exclusion, "datum", None)),
+            getattr(exclusion, "span", None),
+        )
+        if exclusion is not None
+        else None,
+        row.unsupported,
+    )
+
+
+def match_requirement_catalog(
+    expected: RequirementCatalog, actual: RequirementCatalog
+) -> tuple[CatalogRequirement, ...]:
+    """Align live outcomes to the sealed source catalog, refusing a changed denominator.
+
+    Both catalogs retain their exact objects. Object addresses here are temporary index
+    keys into those strongly held, validated references, never exported identities.
+    Local evidence states and selected representations deliberately do not define shape.
+    """
+    if actual.evidence is not expected.evidence or actual.ownership is not expected.ownership:
+        raise ReportUnavailableError("document member has a different recognition authority")
+    if set(actual.families) != set(expected.families):
+        raise ReportUnavailableError("document member changed the requirement family roster")
+    expected_by_key = {_catalog_key(row): row for row in expected.requirements}
+    actual_by_key = {_catalog_key(row): row for row in actual.requirements}
+    if (
+        len(expected_by_key) != len(expected.requirements)
+        or len(actual_by_key) != len(actual.requirements)
+        or expected_by_key.keys() != actual_by_key.keys()
+    ):
+        raise ReportUnavailableError("document member changed source-owned requirement identities")
+    aligned = []
+    for key, baseline in expected_by_key.items():
+        current = actual_by_key[key]
+        if _catalog_shape(current) != _catalog_shape(baseline):
+            raise ReportUnavailableError("document member changed source-owned requirement shape")
+        aligned.append(current)
+    return tuple(aligned)
+
+
 _DISPOSITIONS = (
     "represented",
     "absorbed",
@@ -656,8 +1022,13 @@ def write_json_document(report: Mapping[str, object], path: str | PathLike[str])
 __all__ = [
     "REPORT_SCHEMA",
     "REPORT_SCHEMA_VERSION",
+    "CatalogRequirement",
     "JsonValue",
+    "RequirementCatalog",
+    "RequirementSnapshot",
     "ReportUnavailableError",
+    "build_requirement_catalog",
+    "match_requirement_catalog",
     "drawing_report",
     # The shared occurrence projector (#1461). Three schema'd public documents are built
     # from these — the drawing report, the STEP inspection document, and the sidecar the

--- a/src/draftwright/reporting.py
+++ b/src/draftwright/reporting.py
@@ -389,6 +389,119 @@ def match_requirement_catalog(
     return tuple(aligned)
 
 
+@dataclass(frozen=True)
+class DocumentRequirementEvaluation:
+    requirement: CatalogRequirement
+    state: str
+    local: tuple
+    dependencies: tuple
+    combined: CatalogRequirement
+
+
+@dataclass(frozen=True)
+class DocumentEvaluation:
+    requirements: tuple[DocumentRequirementEvaluation, ...]
+    claims: tuple
+    conflicts: tuple
+    registry: object
+    annotation_refs: Mapping
+
+
+def evaluate_document_requirements(catalog, model, part, members, claims) -> DocumentEvaluation:
+    """Read shared physical ledgers over all member ink, retaining local outcomes.
+
+    The temporary registry holds the exact existing annotations. It does not add ink
+    to a drawing, merge models, recognize geometry, or use a sheet's score as evidence.
+    """
+    from types import SimpleNamespace
+
+    from draftwright.document_evidence import document_conflicts, document_support_proofs
+    from draftwright.linting.requirements import recognized_requirement_outcomes
+    from draftwright.registry import AnnotationRegistry
+
+    registry = AnnotationRegistry()
+    annotation_refs = {}
+    for index, (name, snapshot, _aligned) in enumerate(members):
+        for annotation in sorted(snapshot.registry.names()):
+            reference = f"{index}:{annotation}"
+            annotation_refs[reference] = (name, annotation)
+            registry.add(
+                snapshot.registry.named(annotation),
+                reference,
+                snapshot.registry.view_of(annotation),
+                feature=snapshot.registry.feature_of(annotation),
+                measurement=snapshot.registry.measurement_of(annotation),
+                satisfaction=snapshot.registry.satisfaction_of(annotation),
+            )
+    # Existing ledger verification reads approved values from these four collections.
+    # Each entry keeps its actual member compiler authority; nothing is recompiled here.
+    plan = SimpleNamespace(
+        **{
+            field: tuple(
+                item
+                for _name, snapshot, _aligned in members
+                for item in getattr(snapshot.dimension_plan, field, ())
+            )
+            for field in ("groups", "ladders", "locations", "contingencies")
+        }
+    )
+    outcomes = recognized_requirement_outcomes(
+        catalog.evidence.result,
+        tuple(model.features),
+        registry,
+        (),
+        dimension_plan=plan,
+        part=part,
+        evidence=catalog.evidence,
+        ownership=catalog.ownership,
+        datum=next((datum for datum in model.datums if datum.id == "datum_xy"), None),
+    )
+    combined = build_requirement_catalog(
+        evidence=catalog.evidence,
+        ownership=catalog.ownership,
+        model=model,
+        part=part,
+        requirement_outcomes=outcomes,
+    )
+    aligned = match_requirement_catalog(catalog, combined)
+    conflicts = document_conflicts(claims)
+    evaluated = []
+    for index, (requirement, current) in enumerate(
+        zip(catalog.requirements, aligned, strict=True)
+    ):
+        local = tuple((name, rows[index].outcome) for name, _snapshot, rows in members)
+        proofs = document_support_proofs(requirement.dependency_alternatives, claims, conflicts)
+        observed = getattr(current.outcome, "state", None)
+        # A local direct representation remains direct even when the union makes a
+        # producer's conditional alternative applicable (notably opposite plates).
+        local_states = {getattr(outcome, "state", None) for _name, outcome in local}
+        if (
+            requirement.unsupported
+            or not requirement.requirement_count_known
+            or requirement.parameter_id is None
+        ):
+            state = "unresolved"
+        elif requirement.intrinsic_exclusion is not None:
+            state = "inapplicable"
+        elif "placed" in local_states and current.features:
+            state = "placed"
+        elif current.features and observed == "placed":
+            state = "placed"
+        elif current.features and (
+            "satisfied_by_structured_note" in local_states
+            or observed == "satisfied_by_structured_note"
+        ):
+            state = "satisfied_by_structured_note"
+        elif proofs:
+            state = "dependency-derived"
+        else:
+            state = "uncovered"
+        evaluated.append(DocumentRequirementEvaluation(requirement, state, local, proofs, current))
+    return DocumentEvaluation(
+        tuple(evaluated), tuple(claims), conflicts, registry, annotation_refs
+    )
+
+
 _DISPOSITIONS = (
     "represented",
     "absorbed",
@@ -1023,6 +1136,9 @@ __all__ = [
     "REPORT_SCHEMA",
     "REPORT_SCHEMA_VERSION",
     "CatalogRequirement",
+    "DocumentEvaluation",
+    "DocumentRequirementEvaluation",
+    "evaluate_document_requirements",
     "JsonValue",
     "RequirementCatalog",
     "RequirementSnapshot",

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -53,7 +53,7 @@ from __future__ import annotations
 import inspect
 import math
 import warnings
-from collections.abc import MutableSequence
+from collections.abc import Callable, MutableSequence, Sequence
 from dataclasses import replace
 from typing import TYPE_CHECKING, Literal, cast
 
@@ -62,6 +62,7 @@ from draftwright._geometry import _solids_body
 from draftwright._warnings import SoftDeprecationWarning
 from draftwright.builder import _coerce_model, build_drawing, detect_part_model
 from draftwright.compose import _est_table_size
+from draftwright.document_input import DocumentInput
 from draftwright.fits import fit_class
 from draftwright.model import DimensionParameterId, Feature
 from draftwright.model import angle as _angle
@@ -250,7 +251,7 @@ class _FeatureView(MutableSequence):
     instead of detectable.
     """
 
-    __slots__ = ("_entries", "_next_token")
+    __slots__ = ("_entries", "_next_token", "validate_change")
 
     def __init__(self, entries: list) -> None:
         self._entries = entries
@@ -261,6 +262,11 @@ class _FeatureView(MutableSequence):
         # process-wide counter would make those keys depend on how many other sheets
         # happened to be built first.
         self._next_token = 0
+        self.validate_change: Callable[[Sequence], None] | None = None
+
+    def _validate(self, values):
+        if self.validate_change is not None:
+            self.validate_change(values)
 
     def _mint(self) -> int:
         token = self._next_token
@@ -290,6 +296,11 @@ class _FeatureView(MutableSequence):
         # references fail loudly instead. To reorder while keeping identity, use
         # `reverse()` / `sort()`, which move whole entries. Internal rebuilding goes
         # through `_rebind`, which is the only path that preserves a token.
+        current = list(self)
+        if isinstance(i, slice):
+            value = list(value)
+        current[i] = value
+        self._validate(current)
         if isinstance(i, slice):
             self._entries[i] = [(self._mint(), f) for f in value]
             return
@@ -301,16 +312,34 @@ class _FeatureView(MutableSequence):
         The only identity-preserving write. Used by the size verbs, whose frozen
         dataclasses are replaced wholesale on every `.depth()` / `.cbore()` / `.thread()`.
         """
+        current = list(self)
+        current[index] = feature
+        self._validate(current)
         self._entries[index] = (self._entries[index][0], feature)
 
     def __delitem__(self, i) -> None:
+        current = list(self)
+        del current[i]
+        self._validate(current)
         del self._entries[i]
+
+    def clear(self) -> None:
+        self._validate([])
+        self._entries.clear()
 
     def __len__(self) -> int:
         return len(self._entries)
 
     def insert(self, i, value) -> None:
+        current = list(self)
+        current.insert(i, value)
+        self._validate(current)
         self._entries.insert(i, (self._mint(), value))
+
+    def extend(self, values) -> None:
+        values = list(values)
+        self._validate([*self, *values])
+        self._entries.extend((self._mint(), value) for value in values)
 
     # Reordering must move ENTRIES, not values. `MutableSequence` implements `reverse`
     # in terms of `__setitem__`, which here keeps each slot's token — right for a size
@@ -1091,6 +1120,7 @@ class Sheet:
         # list moves each token with its feature instead of stranding references.
         self._entries: list[tuple[int, object]] = []
         self._features = _FeatureView(self._entries)
+        self._document_input: DocumentInput | None = None
         # P2a ± tolerances, keyed by (feature index, ParamKind) so a handle survives a later
         # feature replacement (e.g. hole().depth()); materialized to (feature, kind) at build.
         self._tolerances: dict = {}
@@ -1179,6 +1209,24 @@ class Sheet:
         ):
             if _v is not None:
                 self._opts[_k] = _v
+
+    def _bind_document(self, source) -> None:
+        if self._entries or self._document_input is not None:
+            raise ValueError("document binding requires a new empty Sheet")
+        source.validate(self._part, source.initial_features())
+        self._features.extend(source.initial_features())
+        self._document_input = source
+        self._features.validate_change = source.validate_features
+
+    def _snapshot_for_document(self):
+        from copy import deepcopy
+
+        if self._document_input is None:
+            raise ValueError("only a bound document Sheet has common input authority")
+        source = self._document_input
+        source.validate(self._part, self._features)
+        shared = (source, self._part, *source.features)
+        return deepcopy(self, {id(value): value for value in shared})
 
     @classmethod
     def from_part(cls, part, **opts) -> Sheet:
@@ -1607,6 +1655,8 @@ class Sheet:
             for i, f in enumerate(self._features):
                 if f is ref:  # identity — an EQUAL feature from elsewhere is not this one
                     return self._token_at(i)
+            if self._document_input is not None:
+                raise ValueError(f"{verb}: use an exact feature from this document's inventory")
             return None  # a Feature this sheet does not manage
         return None  # build123d geometry, or something else entirely
 
@@ -2420,6 +2470,8 @@ class Sheet:
 
     def _prepare(self) -> None:
         """Resolve deferred GD&T state before handing features to the engine."""
+        if self._document_input is not None:
+            self._document_input.validate(self._part, self._features)
         self._materialize_gdt()
         self._validate_datums()
 
@@ -3023,6 +3075,11 @@ class Sheet:
             )
         return cut_y
 
+    def _build_model_input(self):
+        if self._document_input is not None:
+            return self._document_input.model(self._features)
+        return self._features
+
     def model(self):
         """The IR the engine will draw (detection skipped) — for inspection. Wraps the
         declared features into a :class:`PartModel` **without** rendering a drawing (#453):
@@ -3039,7 +3096,7 @@ class Sheet:
         self._prepare()
         self._check_dimension_source()
         return _coerce_model(
-            self._features,
+            self._build_model_input(),
             _solids_body(self._part),
             self._decorations(),
             self._requested_dimensions(),
@@ -3102,7 +3159,8 @@ class Sheet:
         try:
             return build_drawing(
                 self._part,
-                model=self._features,
+                model=self._build_model_input(),
+                _document_input=self._document_input,
                 decorations=self._decorations(
                     section_request,
                     suppress_auto_sections=self._derived_view_source == "authored",

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -1218,6 +1218,16 @@ class Sheet:
         self._document_input = source
         self._features.validate_change = source.validate_features
 
+    def _document_recipe(self):
+        """Snapshot options, view intent and ordinary tables before a member build."""
+        from copy import deepcopy
+
+        return {
+            "options": deepcopy(self._opts),
+            "views": self.view_constraints,
+            "tables": deepcopy(self._tables),
+        }
+
     def _snapshot_for_document(self):
         from copy import deepcopy
 

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -89,6 +89,8 @@ _LAYERS: dict[str, int] = {
     # Shared pure Plate-record/final-IR correspondence predicates. Both model assembly and
     # completeness lint consume them without either layer importing the other.
     "plate_correspondence": 0,
+    "measurement_support": 0,
+    "location_contract": 0,
     "profile_angles": 0,
     "angular_geometry": 0,
     "recogniser_policy": 0,
@@ -108,6 +110,7 @@ _LAYERS: dict[str, int] = {
     "model": 0,  # the ADR 1 (was 0008) IR waist — depends only on rank-0 leaves (guarded below too)
     # 1 — the shared drawing/layout primitives
     "_core": 1,
+    "document_input": 1,
     # 2 — core-consumers: depend on _core, sit below the stages
     "linting": 2,
     # Schema-v1 projection over explicitly supplied finished-build state. It consumes linting's
@@ -130,6 +133,7 @@ _LAYERS: dict[str, int] = {
     # 7 — the user-facing surfaces
     "make_drawing": 7,
     "sheet": 7,
+    "document": 7,
     "sheet_emit": 7,
     # Developer-only pytest/runner support. It patches the user-facing builder bindings at
     # runtime and is therefore a top-layer consumer, never an engine dependency.
@@ -481,6 +485,8 @@ _MODEL_MAY_IMPORT = {
     "recognition_frame",
     "oriented_slot_contract",
     "section_recess_contract",
+    # Shared pure pocket/pad datum geometry used by both compiler and ledger producers.
+    "location_contract",
     # ADR 3 (was 0017 Amendment 12): detect records exact run-local occurrence→IR ownership at the
     # conversion site. The leaf ledger depends on neither the model nor any upper stage.
     "recognition_ownership",

--- a/tests/test_import_boundaries.py
+++ b/tests/test_import_boundaries.py
@@ -116,6 +116,7 @@ _LAYERS: dict[str, int] = {
     # Schema-v1 projection over explicitly supplied finished-build state. It consumes linting's
     # recognition-owned typed requirement ledgers but never reaches through Drawing internals.
     "reporting": 2,
+    "document_evidence": 2,
     "pmi": 2,
     "export": 2,
     "repair": 2,

--- a/tests/test_issue_1373_plate_completeness_evidence.py
+++ b/tests/test_issue_1373_plate_completeness_evidence.py
@@ -429,6 +429,43 @@ def test_exact_overlapping_family_owners_do_not_create_a_second_plate_denominato
     )
     assert len(slot_outcomes) == 5
     assert {outcome.state for outcome in slot_outcomes} == {"inapplicable"}
+    from draftwright.plate_correspondence import plate_dependency_alternatives
+
+    recipes = [
+        recipe
+        for source in slot_recognition.plates
+        for recipe in plate_dependency_alternatives(source, slot_drawing.model().features)
+        if any(getattr(owner, "kind", None) == "slot_pattern" for owner, _ in recipe.measurements)
+    ]
+    assert recipes
+    owner = next(
+        feature for feature in slot_drawing.model().features if feature.kind == "slot_pattern"
+    )
+    centre = tuple(owner.frame.origin)
+    assert centre not in owner.members
+    claims = slot_drawing.measurement_snapshot().claims
+    for recipe in recipes:
+        locations = [term for term in recipe.supports if term.location_point is not None]
+        assert len(locations) == 2
+        assert {term.axis for term in locations} == {"x", "y"}
+        assert {term.location_point for term in locations} == {centre}
+        assert all(term.feature is owner for term in locations)
+        assert any(term.parameter_id == "pitch.length" for term in recipe.supports)
+        for term in locations:
+            carrying = [
+                claim
+                for claim in claims
+                if claim.owner is owner and claim.parameter == term.parameter_id
+            ]
+            assert carrying
+            assert any((term.parameter_id, centre) in claim.witnesses[1] for claim in carrying)
+    (pattern,) = slot_recognition.slot_patterns
+    for outcome in slot_outcomes:
+        assert outcome.intrinsically_inapplicable
+        assert outcome.intrinsic_exclusion.reason_code == "slot_pattern_owns_material_web"
+        retained = outcome.intrinsic_exclusion.source_records
+        assert len(retained) == len(pattern.slots)
+        assert all(a is b for a, b in zip(retained, pattern.slots, strict=True))
 
     boss_part = Box(100, 80, 10, align=(Align.CENTER, Align.CENTER, Align.CENTER)) + (
         Pos(13, -7, 5) * Rot(0, 0, 11) * extrude(RegularPolygon(20, 6), 30)
@@ -443,6 +480,10 @@ def test_exact_overlapping_family_owners_do_not_create_a_second_plate_denominato
         boss_recognition, envelope_only, AnnotationRegistry(), part=boss_part
     )
     assert boss_outcome.state == "inapplicable"
+    assert boss_outcome.intrinsically_inapplicable
+    assert boss_outcome.intrinsic_exclusion.reason_code == "polygonal_boss_owns_supporting_slab"
+    (retained_boss,) = boss_outcome.intrinsic_exclusion.source_records
+    assert retained_boss is boss_recognition.polygonal_bosses[0]
 
     malformed = replace(boss_recognition, polygonal_bosses=(object(),))
     (failed_closed,) = plate_requirement_outcomes(
@@ -990,11 +1031,9 @@ def test_provider_hexagon_invariant_does_not_narrow_public_owner_geometry() -> N
     from math import cos, pi, sin
 
     from draftwright import build_drawing
-    from draftwright.linting.plate_coverage import (
-        _polygonal_boss_dependencies,
-        _without_provider_owned_ir,
-    )
+    from draftwright.linting.plate_coverage import _without_provider_owned_ir
     from draftwright.model import polygonal_boss
+    from draftwright.plate_correspondence import _polygonal_boss_dependencies
 
     part = Box(100, 80, 10, align=(Align.CENTER, Align.CENTER, Align.CENTER)) + (
         Pos(0, 0, 5) * extrude(RegularPolygon(10, 8), 20)
@@ -1139,6 +1178,30 @@ def test_step_level_alternate_must_land_before_plate_intervals_are_inapplicable(
     assert len(complete) == len(missing) == 2
     assert {outcome.state for outcome in complete} == {"inapplicable"}
     assert {outcome.state for outcome in missing} == {"unverifiable"}
+    for carried, absent in zip(complete, missing, strict=True):
+        assert carried.source_records[0] is absent.source_records[0]
+        assert carried.catalog_parameter_id == absent.catalog_parameter_id == "thickness.length"
+        assert carried.parameter_id != absent.parameter_id
+        assert not carried.intrinsically_inapplicable and not absent.intrinsically_inapplicable
+        assert carried.dependency_alternatives == absent.dependency_alternatives
+        assert len(absent.dependency_alternatives) == 1
+        terms = absent.dependency_alternatives[0].measurements
+        assert [parameter for _, parameter in terms] == [
+            "depth.length",
+            "step_position.length",
+            "step_position.length",
+        ]
+        assert terms[1][0] is terms[2][0]
+        supports = absent.dependency_alternatives[0].supports
+        assert len(supports) == 3
+        assert supports[0].identity == terms[0]
+        rungs = supports[1:]
+        assert all(term.axis == "y" and term.lo == -30 for term in rungs)
+        assert sorted(term.hi for term in rungs) == [-10, 10]
+        assert all(term.feature is terms[1][0] for term in rungs)
+        assert all(
+            any(owner is feature for feature in drawing.model().features) for owner, _ in terms
+        )
 
 
 def test_derived_plate_drawing_credit_requires_verified_dependency_ink() -> None:
@@ -1156,6 +1219,21 @@ def test_derived_plate_drawing_credit_requires_verified_dependency_ink() -> None
             for identity in drawing.registry.measurement_of(name)
         )
     )
+    from draftwright.linting.plate_coverage import plate_requirement_outcomes
+    from draftwright.registry import AnnotationRegistry
+
+    carried = plate_requirement_outcomes(recognition, drawing.model().features, drawing.registry)
+    absent = plate_requirement_outcomes(
+        recognition, drawing.model().features, AnnotationRegistry()
+    )
+    assert [row.state for row in carried].count("inapplicable") == 1
+    assert {row.state for row in absent} == {"missing"}
+    derived = [row for row in absent if row.dependency_alternatives]
+    assert len(derived) == 1 and len(derived[0].dependency_alternatives[0].supports) == 3
+    for before, after in zip(carried, absent, strict=True):
+        assert before.dependency_alternatives == after.dependency_alternatives
+        assert before.source_records[0] is after.source_records[0]
+        assert not after.intrinsically_inapplicable
     drawing.registry.named(name).label = "999"
 
     outcomes = _plate_drawing_outcomes(tuple(recognition.plates), drawing)

--- a/tests/test_issue_1374_turned_step_completeness_evidence.py
+++ b/tests/test_issue_1374_turned_step_completeness_evidence.py
@@ -277,6 +277,7 @@ def test_global_od_cannot_multiply_across_disjoint_coaxial_profiles(framed: bool
     assert not [
         outcome for outcome in largest if outcome.representation_parameter == "od.diameter"
     ]
+    assert all(not outcome.representation_alternatives for outcome in largest)
     assert len(
         {outcome.representation_feature for outcome in largest if outcome.state == "placed"}
     ) == sum(outcome.state == "placed" for outcome in largest)
@@ -307,6 +308,13 @@ def test_native_step_diameter_evidence_precedes_global_od_alternate() -> None:
             if outcome.parameter_id == "step.diameter" and step in outcome.features
         )
 
+    empty = diameter_outcome(AnnotationRegistry())
+    assert empty.state == "missing"
+    assert len(empty.representation_alternatives) == 1
+    support = empty.representation_alternatives[0]
+    assert support.feature is rotational
+    assert support.parameter_id == "od.diameter"
+
     direct = AnnotationRegistry()
     direct.add(
         object(),
@@ -319,10 +327,14 @@ def test_native_step_diameter_evidence_precedes_global_od_alternate() -> None:
         "placed",
         step,
     )
+    assert (
+        diameter_outcome(direct).representation_alternatives == empty.representation_alternatives
+    )
 
     omission = SimpleNamespace(feature=step, parameter_id="step.diameter", authored=True)
     suppressed = diameter_outcome(AnnotationRegistry(), (omission,))
     assert (suppressed.state, suppressed.representation_feature) == ("suppressed", step)
+    assert suppressed.representation_alternatives == empty.representation_alternatives
 
     dropped_registry = AnnotationRegistry()
     dropped_registry.record_issue(
@@ -335,6 +347,7 @@ def test_native_step_diameter_evidence_precedes_global_od_alternate() -> None:
     )
     dropped = diameter_outcome(dropped_registry)
     assert (dropped.state, dropped.representation_feature) == ("dropped", step)
+    assert dropped.representation_alternatives == empty.representation_alternatives
 
     alternate = AnnotationRegistry()
     alternate.add(
@@ -349,6 +362,7 @@ def test_native_step_diameter_evidence_precedes_global_od_alternate() -> None:
         "placed",
         rotational,
     )
+    assert alternate_outcome.representation_alternatives == empty.representation_alternatives
 
 
 def test_turned_step_ledger_tracks_two_requirements_per_physical_band() -> None:

--- a/tests/test_issue_1382_through_step_semantics.py
+++ b/tests/test_issue_1382_through_step_semantics.py
@@ -749,6 +749,13 @@ def test_remaining_ladder_rungs_cannot_cover_removed_exact_legacy_members() -> N
     drawing.lint()  # populate the declared build's one recognition aggregate
     assert drawing.scale == 1
     assert "dim_detail_a_step0" in drawing.annotations(), drawing.annotations()
+    before = through_step_requirement_outcomes(
+        drawing.recognition(),
+        drawing.model().features,
+        drawing.registry,
+        plan=compile_dimensions(drawing.model()),
+    )
+    assert {row.state for row in before} == {"inapplicable"}
     drawing.remove("dim_detail_a_step0")
     drawing.remove("dim_shoulder_x1")
 
@@ -761,6 +768,16 @@ def test_remaining_ladder_rungs_cannot_cover_removed_exact_legacy_members() -> N
     )
 
     assert [outcome.state for outcome in outcomes] == ["missing", "missing"]
+    for carried, missing in zip(before, outcomes, strict=True):
+        assert carried.source_records[0] is missing.source_records[0]
+        assert carried.dependency_alternatives == missing.dependency_alternatives
+        assert missing.dependency_alternatives
+        for alternative in missing.dependency_alternatives:
+            assert alternative
+            for term in alternative:
+                assert term.axis in "xyz" and term.hi > term.lo
+                assert term.identity in missing.measurement_ids
+                assert any(owner is term.feature for owner in drawing.model().features)
     assert {
         issue.code for issue in drawing.lint() if issue.code.startswith("through_step_requirement")
     } == {"through_step_requirement_missing"}

--- a/tests/test_issue_1542_applicability.py
+++ b/tests/test_issue_1542_applicability.py
@@ -132,3 +132,25 @@ def test_synthetic_local_omission_cannot_manufacture_datum_proof(common):
     }
     current = project(missing, analysis, outcomes=fabricated)
     assert not any(row.intrinsic_exclusion is not None for row in current.requirements)
+
+
+@pytest.mark.parametrize("damage", ["foreign_source", "foreign_datum"])
+def test_exclusion_must_retain_exact_common_source_and_datum(common, damage):
+    _, model, analysis, _, _ = common
+    outcomes = dict(live_outcomes(model, analysis))
+    family, index, original = next(
+        (family, index, row)
+        for family, rows in outcomes.items()
+        for index, row in enumerate(rows)
+        if getattr(row, "intrinsic_exclusion", None) is not None
+    )
+    proof = original.intrinsic_exclusion
+    if damage == "foreign_source":
+        changed = replace(proof, source_records=(replace(proof.source_records[0]),))
+    else:
+        changed = replace(proof, datum=replace(proof.datum))
+    rows = list(outcomes[family])
+    rows[index] = replace(original, intrinsic_exclusion=changed)
+    outcomes[family] = tuple(rows)
+    with pytest.raises(ReportUnavailableError, match="catalog exclusion has (a )?foreign"):
+        project(model, analysis, outcomes=outcomes)

--- a/tests/test_issue_1542_applicability.py
+++ b/tests/test_issue_1542_applicability.py
@@ -1,0 +1,134 @@
+"""Shared datum applicability survives authored filtering and retains exact authority."""
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+from build123d import Box, Pos
+
+from draftwright.builder import _detect_part_model_analysis
+from draftwright.linting.requirements import recognized_requirement_outcomes
+from draftwright.model.compiled import compile_dimensions
+from draftwright.registry import AnnotationRegistry
+from draftwright.reporting import (
+    ReportUnavailableError,
+    build_requirement_catalog,
+    match_requirement_catalog,
+)
+
+
+@pytest.fixture(scope="module", params=("pad", "pocket"))
+def common(request):
+    source = (
+        Path(__file__).parent / "fixtures/evaluation/pad-x-positive.step"
+        if request.param == "pad"
+        else Box(60, 40, 20) - Pos(0, 0, 8) * Box(10, 12, 6)
+    )
+    model, analysis = _detect_part_model_analysis(source)
+    feature = next(feature for feature in model.features if feature.kind == request.param)
+    datum = next(datum for datum in model.datums if datum.id == "datum_xy")
+    at = list(datum.at)
+    index = "xyz".index(feature.long_axis)
+    at[index] = feature.frame.origin[index] if request.param == "pad" else feature.lo
+    datum = replace(datum, at=tuple(at))
+    model = replace(model, datums=[datum])
+    return request.param, model, analysis, feature, datum
+
+
+def project(model, analysis, *, outcomes=None):
+    return build_requirement_catalog(
+        evidence=analysis.recognition_evidence,
+        ownership=analysis.recognition_ownership,
+        model=model,
+        part=analysis.part,
+        requirement_outcomes=outcomes,
+    )
+
+
+def live_outcomes(model, analysis, *, extra_omissions=()):
+    plan = compile_dimensions(model)
+    return recognized_requirement_outcomes(
+        analysis.recognition,
+        model.features,
+        AnnotationRegistry(),
+        (*plan.diagnostics, *extra_omissions),
+        part=analysis.part,
+        evidence=analysis.recognition_evidence,
+        ownership=analysis.recognition_ownership,
+        dimension_plan=plan,
+        datum=next((datum for datum in model.datums if datum.id == "datum_xy"), None),
+    )
+
+
+def test_datum_proof_survives_authored_suppression(common):
+    kind, model, analysis, feature, datum = common
+    catalog = project(model, analysis)
+    proof_rows = [
+        row
+        for row in catalog.requirements
+        if row.intrinsic_exclusion is not None
+        and row.intrinsic_exclusion.reason_code == "location_coincident_with_common_datum"
+    ]
+    assert len(proof_rows) == 1
+    expected = proof_rows[0]
+    proof = expected.intrinsic_exclusion
+    assert proof.datum is datum
+    assert proof.source_records[0] is expected.source_records[0]
+    assert proof.span[0] == datum.at
+    if kind == "pocket":
+        assert not feature.edge_anchored
+        assert proof.span[1]["xyz".index(feature.long_axis)] == feature.lo
+    states = []
+    for current in (model, replace(model, authored_dimensions=())):
+        aligned = match_requirement_catalog(
+            catalog, project(current, analysis, outcomes=live_outcomes(current, analysis))
+        )
+        row = next(
+            row
+            for row in aligned
+            if row.parameter_id == expected.parameter_id and row.family == expected.family
+        )
+        assert row.intrinsic_exclusion.datum is datum
+        assert row.intrinsic_exclusion.span == proof.span
+        states.append(row.outcome.state)
+    assert states == ["inapplicable", "suppressed"]
+
+
+@pytest.mark.parametrize("missing", (False, True))
+def test_changed_or_missing_common_datum_cannot_keep_exclusion(common, missing):
+    _, model, analysis, _, datum = common
+    baseline = project(model, analysis)
+    moved = replace(datum, at=tuple(value + 3 for value in datum.at))
+    changed = replace(model, datums=[] if missing else [moved])
+    current = project(changed, analysis)
+    assert not any(
+        row.intrinsic_exclusion is not None
+        and row.intrinsic_exclusion.reason_code == "location_coincident_with_common_datum"
+        for row in current.requirements
+    )
+    with pytest.raises(ReportUnavailableError, match="requirement shape"):
+        match_requirement_catalog(baseline, current)
+
+
+def test_synthetic_local_omission_cannot_manufacture_datum_proof(common):
+    _, model, analysis, _, _ = common
+    original = live_outcomes(model, analysis)
+    target = next(
+        row
+        for rows in original.values()
+        for row in rows
+        if row.intrinsic_exclusion is not None
+        and row.intrinsic_exclusion.reason_code == "location_coincident_with_common_datum"
+    )
+    missing = replace(model, datums=[])
+    fabricated = {
+        family: tuple(
+            replace(row, state="inapplicable")
+            if row.parameter_id == target.parameter_id and row.features == target.features
+            else row
+            for row in rows
+        )
+        for family, rows in live_outcomes(missing, analysis).items()
+    }
+    current = project(missing, analysis, outcomes=fabricated)
+    assert not any(row.intrinsic_exclusion is not None for row in current.requirements)

--- a/tests/test_issue_1542_catalog.py
+++ b/tests/test_issue_1542_catalog.py
@@ -280,6 +280,79 @@ def test_groove_floor_absorption_does_not_demand_a_second_step_ledger():
     assert any(row.family == "grooves" for row in catalog.requirements)
 
 
+@pytest.fixture(scope="module")
+def shoulder_intake():
+    _, model, analysis = detect_intake("shoulders")
+    return model, analysis
+
+
+@pytest.mark.parametrize("parameter", [None, "", 7])
+def test_catalog_rejects_invalid_canonical_producer_parameter(shoulder_intake, parameter):
+    model, analysis = shoulder_intake
+    outcomes = dict(outcomes_for(model, analysis))
+    first, *rest = outcomes["plates"]
+    outcomes["plates"] = (replace(first, catalog_parameter_id=parameter), *rest)
+    with pytest.raises(ReportUnavailableError, match="identity or cardinality"):
+        project_outcomes(model, analysis, outcomes)
+
+
+def test_catalog_rejects_a_duplicate_requirement_from_one_producer(shoulder_intake):
+    model, analysis = shoulder_intake
+    outcomes = dict(outcomes_for(model, analysis))
+    first, *rest = outcomes["plates"]
+    outcomes["plates"] = (first, first, *rest)
+    with pytest.raises(ReportUnavailableError, match="duplicate source-owned"):
+        project_outcomes(model, analysis, outcomes)
+
+
+@pytest.mark.parametrize("damage", ["invalid_type", "empty", "foreign_identity"])
+def test_catalog_refuses_unowned_or_empty_dependency_conjunctions(shoulder_intake, damage):
+    model, analysis = shoulder_intake
+    outcomes = dict(outcomes_for(model, analysis))
+    first, *rest = outcomes["plates"]
+    (recipe,) = first.dependency_alternatives
+    if damage == "invalid_type":
+        changed = ("not a measurement support",)
+        reason = "invalid support type"
+    elif damage == "empty":
+        changed = replace(recipe, measurements=(), supports=())
+        reason = "empty conjunction"
+    else:
+        (owner, parameter), *others = recipe.measurements
+        changed = replace(recipe, measurements=((replace(owner), parameter), *others))
+        reason = "foreign physical owner"
+    outcomes["plates"] = (replace(first, dependency_alternatives=(changed,)), *rest)
+    with pytest.raises(ReportUnavailableError, match=reason):
+        project_outcomes(model, analysis, outcomes)
+
+
+def test_lost_physical_witnesses_cannot_keep_the_sealed_catalog_shape(shoulder_intake):
+    model, analysis = shoulder_intake
+    expected = catalog_for(model, analysis)
+    outcomes = dict(outcomes_for(model, analysis))
+    first, *rest = outcomes["plates"]
+    (recipe,) = first.dependency_alternatives
+    assert recipe.supports
+    outcomes["plates"] = (
+        replace(first, dependency_alternatives=(replace(recipe, supports=()),)),
+        *rest,
+    )
+    actual = project_outcomes(model, analysis, outcomes)
+    with pytest.raises(ReportUnavailableError, match="requirement shape"):
+        match_requirement_catalog(expected, actual)
+
+
+@pytest.mark.parametrize("damage", ["evidence", "ownership", "families"])
+def test_catalog_comparison_refuses_changed_authority_or_family_roster(shoulder_intake, damage):
+    model, analysis = shoulder_intake
+    expected = catalog_for(model, analysis)
+    changed = replace(
+        expected, **{damage: expected.families[:-1] if damage == "families" else object()}
+    )
+    with pytest.raises(ReportUnavailableError, match="recognition authority|family roster"):
+        match_requirement_catalog(expected, changed)
+
+
 @pytest.mark.parametrize(
     "damage",
     (

--- a/tests/test_issue_1542_catalog.py
+++ b/tests/test_issue_1542_catalog.py
@@ -1,0 +1,330 @@
+"""The document denominator exists before member placement and keeps source witnesses."""
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+from build123d import Box, Cylinder, Pos
+from quiddity import HoleSpec
+
+from draftwright.builder import _detect_part_model_analysis
+from draftwright.reporting import (
+    ReportUnavailableError,
+    build_requirement_catalog,
+    match_requirement_catalog,
+)
+
+
+@pytest.fixture(scope="module", params=("holes", "u_channel", "shoulders"))
+def intake(request):
+    return detect_intake(request.param)
+
+
+def detect_intake(kind):
+    if kind == "holes":
+        part = Box(60, 40, 20) - Pos(-15, 0, 0) * Cylinder(2, 30)
+        part -= Pos(15, 0, 8) * Cylinder(2, 4)
+    elif kind == "u_channel":
+        part = Path(__file__).parent / "fixtures/evaluation/plate-u-additive.step"
+    else:
+        part = Box(80, 60, 30) - Pos(0, 0, 7.5) * Box(80, 20, 15)
+    model, analysis = _detect_part_model_analysis(part)
+    return kind, model, analysis
+
+
+def catalog_for(model, analysis):
+    return build_requirement_catalog(
+        evidence=analysis.recognition_evidence,
+        ownership=analysis.recognition_ownership,
+        model=model,
+        part=analysis.part,
+    )
+
+
+def outcomes_for(model, analysis, registry=None):
+    from draftwright.linting.requirements import recognized_requirement_outcomes
+    from draftwright.registry import AnnotationRegistry
+
+    return recognized_requirement_outcomes(
+        analysis.recognition_evidence.result,
+        model.features,
+        registry if registry is not None else AnnotationRegistry(),
+        (),
+        part=analysis.part,
+        evidence=analysis.recognition_evidence,
+        ownership=analysis.recognition_ownership,
+    )
+
+
+def project_outcomes(model, analysis, outcomes):
+    return build_requirement_catalog(
+        evidence=analysis.recognition_evidence,
+        ownership=analysis.recognition_ownership,
+        model=model,
+        part=analysis.part,
+        requirement_outcomes=outcomes,
+    )
+
+
+def test_live_catalog_joins_by_source_and_parameter_despite_reordered_rows(intake):
+    _, model, analysis = intake
+    baseline = catalog_for(model, analysis)
+    outcomes = outcomes_for(model, analysis)
+    reordered = {family: tuple(reversed(rows)) for family, rows in reversed(outcomes.items())}
+    live = project_outcomes(model, analysis, reordered)
+    aligned = match_requirement_catalog(baseline, live)
+    assert len(aligned) == len(baseline.requirements)
+    for original, current in zip(baseline.requirements, aligned, strict=True):
+        assert original.parameter_id == current.parameter_id
+        assert len(original.source_records) == len(current.source_records)
+        assert all(a is b for a, b in zip(original.source_records, current.source_records))
+
+
+@pytest.mark.parametrize("kind", ("holes", "u_channel"))
+def test_member_cannot_erase_one_parameter_while_retaining_its_source(kind):
+    _, model, analysis = detect_intake(kind)
+    baseline = catalog_for(model, analysis)
+    outcomes = dict(outcomes_for(model, analysis))
+    family, rows = next(
+        (family, rows)
+        for family, rows in outcomes.items()
+        if len(rows) > 1
+        and rows[0].source_records
+        and any(other.source_records == rows[0].source_records for other in rows[1:])
+    )
+    outcomes[family] = rows[1:]
+    live = project_outcomes(model, analysis, outcomes)
+    # The original occurrence remains represented, so the whole-source census alone
+    # cannot detect this loss. The sealed parameter denominator must reject it.
+    assert len(live.requirements) == len(baseline.requirements) - 1
+    with pytest.raises(ReportUnavailableError, match="requirement identities"):
+        match_requirement_catalog(baseline, live)
+
+
+def test_local_evidence_state_does_not_remove_a_catalog_requirement(intake):
+    _, model, analysis = intake
+    baseline = catalog_for(model, analysis)
+    outcomes = outcomes_for(model, analysis)
+    locally_inapplicable = {
+        family: tuple(
+            replace(row, state="inapplicable") if row.state != "unsupported" else row
+            for row in rows
+        )
+        for family, rows in outcomes.items()
+    }
+    live = project_outcomes(model, analysis, locally_inapplicable)
+    aligned = match_requirement_catalog(baseline, live)
+    assert len(aligned) == len(baseline.requirements)
+    assert all(row.intrinsic_exclusion is None for row in aligned)
+
+
+def test_preink_catalog_keeps_complete_source_groups_and_conditional_obligations(intake):
+    kind, model, analysis = intake
+    catalog = catalog_for(model, analysis)
+    assert catalog.evidence is analysis.recognition_evidence
+    assert catalog.ownership is analysis.recognition_ownership
+    assert len(catalog.families) == 25
+    assert catalog.requirements
+    issued = tuple(catalog.evidence.record(ref) for ref in catalog.evidence.features)
+    for row in catalog.requirements:
+        assert row.source_records or row.source_profile is not None
+        assert all(any(record is source for source in issued) for record in row.source_records)
+        assert type(row.requirement_count_known) is bool
+        assert row.requirement_count > 0
+    if kind == "holes":
+        holes = analysis.recognition.holes
+        assert {HoleSpec.from_hole(hole).bottom == "through" for hole in holes} == {False, True}
+        diameter = [row for row in catalog.requirements if row.parameter_id == "bore.diameter"]
+        assert len(diameter) == 2
+        assert all(len(row.source_records) == 1 for row in diameter)
+        assert diameter[0].source_records[0] is not diameter[1].source_records[0]
+    else:
+        plates = [row for row in catalog.requirements if row.family == "plates"]
+        assert len(plates) == (3 if kind == "u_channel" else 2)
+        assert {row.parameter_id for row in plates} == {"thickness.length"}
+        derived = [row for row in plates if row.dependency_alternatives]
+        assert len(derived) == (1 if kind == "u_channel" else 2)
+        assert all(row.intrinsic_exclusion is None for row in plates)
+        assert all(recipe.supports for row in derived for recipe in row.dependency_alternatives)
+
+
+def test_catalog_refuses_equal_clone_conversion_owners(intake):
+    _, model, analysis = intake
+    first = next(
+        binding.features[0]
+        for binding in analysis.recognition_ownership.bindings
+        if binding.features
+    )
+    clone = replace(first)
+    assert clone == first and clone is not first
+    with pytest.raises(ReportUnavailableError, match="conversion-time"):
+        catalog_for(
+            replace(
+                model,
+                features=[clone if feature is first else feature for feature in model.features],
+            ),
+            analysis,
+        )
+
+
+def test_catalog_rejects_foreign_source_records_before_storing_authority(intake, monkeypatch):
+    from draftwright.linting import requirements
+
+    _, model, analysis = intake
+    original = requirements.recognized_requirement_outcomes
+    changed = []
+
+    def substitute(*args, **kwargs):
+        rows = dict(original(*args, **kwargs))
+        for family, outcomes in rows.items():
+            for index, outcome in enumerate(outcomes):
+                if outcome.source_records:
+                    source = outcome.source_records[0]
+                    clone = replace(source)
+                    assert clone == source and clone is not source
+                    altered = replace(outcome, source_records=(clone, *outcome.source_records[1:]))
+                    rows[family] = (*outcomes[:index], altered, *outcomes[index + 1 :])
+                    changed.append(source)
+                    return rows
+        raise AssertionError("fixture emitted no exact source records")
+
+    monkeypatch.setattr(requirements, "recognized_requirement_outcomes", substitute)
+    with pytest.raises(ReportUnavailableError, match="evidence authority"):
+        catalog_for(model, analysis)
+    assert changed
+
+
+@pytest.mark.parametrize("remove_family", (False, True))
+def test_catalog_refuses_an_erased_nonempty_ledger(intake, monkeypatch, remove_family):
+    from draftwright.linting import requirements
+
+    _, model, analysis = intake
+    original = requirements.recognized_requirement_outcomes
+    changed = []
+
+    def erase(*args, **kwargs):
+        rows = dict(original(*args, **kwargs))
+        family = next(
+            name for name, values in rows.items() if values and name != "outer_profile_angles"
+        )
+        assert rows[family]
+        changed.append(family)
+        if remove_family:
+            del rows[family]
+        else:
+            rows[family] = ()
+        return rows
+
+    monkeypatch.setattr(requirements, "recognized_requirement_outcomes", erase)
+    with pytest.raises(ReportUnavailableError, match="family roster|no ledger outcome"):
+        catalog_for(model, analysis)
+    assert changed
+
+
+def test_catalog_rejects_foreign_and_collapsed_dependency_witnesses(monkeypatch):
+    from draftwright.linting import requirements
+
+    model, analysis = _detect_part_model_analysis(
+        Box(80, 60, 30) - Pos(0, 0, 7.5) * Box(80, 20, 15)
+    )
+    original = requirements.recognized_requirement_outcomes
+    calls = []
+    mode = "foreign"
+
+    def damage(*args, **kwargs):
+        rows = dict(original(*args, **kwargs))
+        first, *rest = rows["plates"]
+        (recipe,) = first.dependency_alternatives
+        envelope, left, right = recipe.supports
+        assert left.feature is right.feature and left.hi != right.hi
+        if mode == "foreign":
+            clone = replace(left.feature)
+            assert clone == left.feature and clone is not left.feature
+            altered = replace(left, feature=clone)
+            supports = (envelope, altered, right)
+        else:
+            supports = (envelope, left, left)
+        calls.append(mode)
+        rows["plates"] = (
+            replace(first, dependency_alternatives=(replace(recipe, supports=supports),)),
+            *rest,
+        )
+        return rows
+
+    monkeypatch.setattr(requirements, "recognized_requirement_outcomes", damage)
+    with pytest.raises(ReportUnavailableError, match="foreign or unrelated owner"):
+        catalog_for(model, analysis)
+    mode = "collapsed"
+    with pytest.raises(ReportUnavailableError, match="distinct measurement witness"):
+        catalog_for(model, analysis)
+    assert calls == ["foreign", "collapsed"]
+
+
+def test_groove_floor_absorption_does_not_demand_a_second_step_ledger():
+    source = Path(__file__).parent / "fixtures/evaluation/groove-lone-y.step"
+    model, analysis = _detect_part_model_analysis(source)
+    catalog = catalog_for(model, analysis)
+    bindings = [
+        binding
+        for binding in analysis.recognition_ownership.bindings
+        if binding.reason_code == "turned_step_groove_owner"
+    ]
+    assert bindings
+    for binding in bindings:
+        record = analysis.recognition_evidence.record(binding.occurrence)
+        assert not any(
+            any(source is record for source in row.source_records)
+            for row in catalog.requirements
+            if row.family == "turned_steps"
+        )
+    assert any(row.family == "grooves" for row in catalog.requirements)
+
+
+@pytest.mark.parametrize(
+    "damage",
+    (
+        {"lo": float("nan")},
+        {"hi": float("inf")},
+        {"lo": True},
+        {"hi": None},
+        {"axis": None},
+        {"axis": "u"},
+        {"lo": 99},
+        {"location_point": (0, float("nan"), 0)},
+        {"location_point": (0, 1)},
+    ),
+)
+def test_catalog_refuses_malformed_physical_dependency_witnesses(damage):
+    _, model, analysis = detect_intake("shoulders")
+    outcomes = dict(outcomes_for(model, analysis))
+    first, *rest = outcomes["plates"]
+    (recipe,) = first.dependency_alternatives
+    envelope, left, right = recipe.supports
+    damaged = replace(left, **damage)
+    outcomes["plates"] = (
+        replace(
+            first, dependency_alternatives=(replace(recipe, supports=(envelope, damaged, right)),)
+        ),
+        *rest,
+    )
+    with pytest.raises(ReportUnavailableError, match="invalid physical witness"):
+        project_outcomes(model, analysis, outcomes)
+
+
+@pytest.mark.parametrize("erase", (False, True))
+def test_live_catalog_refuses_changed_dependency_rule_or_interval(erase):
+    _, model, analysis = detect_intake("shoulders")
+    baseline = catalog_for(model, analysis)
+    outcomes = dict(outcomes_for(model, analysis))
+    first, *rest = outcomes["plates"]
+    (recipe,) = first.dependency_alternatives
+    envelope, left, right = recipe.supports
+    alternatives = (
+        ()
+        if erase
+        else (replace(recipe, supports=(envelope, replace(left, hi=left.hi + 1), right)),)
+    )
+    outcomes["plates"] = (replace(first, dependency_alternatives=alternatives), *rest)
+    live = project_outcomes(model, analysis, outcomes)
+    with pytest.raises(ReportUnavailableError, match="requirement shape"):
+        match_requirement_catalog(baseline, live)

--- a/tests/test_issue_1542_catalog_families.py
+++ b/tests/test_issue_1542_catalog_families.py
@@ -48,15 +48,19 @@ _CASES = (
 )
 
 
+def family_part(case):
+    _family, source, factory = case
+    if factory is not None:
+        return getattr(import_module(source), factory)()
+    if source is not None:
+        return Path(__file__).parent / "fixtures/evaluation" / source
+    return extrude(RegularPolygon(30, 3), amount=4)
+
+
 @pytest.fixture(scope="module", params=_CASES, ids=[case[0] for case in _CASES])
 def family_intake(request):
-    family, source, factory = request.param
-    if factory is not None:
-        part = getattr(import_module(source), factory)()
-    elif source is not None:
-        part = Path(__file__).parent / "fixtures/evaluation" / source
-    else:
-        part = extrude(RegularPolygon(30, 3), amount=4)
+    family = request.param[0]
+    part = family_part(request.param)
     model, analysis = _detect_part_model_analysis(part)
     return family, model, analysis
 

--- a/tests/test_issue_1542_catalog_families.py
+++ b/tests/test_issue_1542_catalog_families.py
@@ -1,0 +1,126 @@
+"""Nonempty source catalogs for every current family survive member intent changes."""
+
+from dataclasses import replace
+from importlib import import_module
+from pathlib import Path
+
+import pytest
+from build123d import RegularPolygon, extrude
+
+from draftwright.builder import _detect_part_model_analysis
+from draftwright.linting.requirements import recognized_requirement_outcomes
+from draftwright.model.compiled import compile_dimensions
+from draftwright.registry import AnnotationRegistry
+from draftwright.reporting import (
+    ReportUnavailableError,
+    build_requirement_catalog,
+    match_requirement_catalog,
+)
+
+# Reuse each family's existing real geometric reproducer. The roster assertion below
+# requires an explicit nonempty example when the shared collector gains a family.
+_CASES = (
+    ("chamfers", "chamfer-planar-z.step", None),
+    ("fillets", "fillet-planar-z.step", None),
+    ("flats", "flat-lone-d.step", None),
+    ("grooves", "groove-lone-z.step", None),
+    ("hole_patterns", "pattern-grid.step", None),
+    ("holes", "blind-hole.step", None),
+    ("pads", "pad-x-positive.step", None),
+    ("plates", "plate-t-yz.step", None),
+    ("pockets", "pocket-lone.step", None),
+    ("pocket_patterns", "pocket-pattern-linear.step", None),
+    ("polygonal_bosses", "polygonal-boss-x.step", None),
+    ("polygonal_stock", "polygonal-stock-x.step", None),
+    ("through_steps", "plate-t-yz.step", None),
+    ("turned_steps", "turned-step-axis-x.step", None),
+    ("channels", "plate-u-additive.step", None),
+    ("oriented_slots", "test_issue_1432_oriented_slot_semantics", "_part"),
+    ("blends", "test_issue_1433_blend_semantics", "_single_blend"),
+    ("paired_ramp_steps", "test_issue_1382_paired_ramp_semantics", "_paired_ramp_part"),
+    ("circular_blind_steps", "test_issue_1382_circular_blind_step_semantics", "_part"),
+    ("round_bottom_blind_slots", "test_issue_1421_round_bottom_blind_slot_completeness", "_part"),
+    ("rectangular_blind_slots", "test_issue_1421_rectangular_blind_slot_completeness", "_part"),
+    ("slots", "test_slot_completeness", "_off_centre_slot"),
+    ("slot_patterns", "test_slot_completeness", "_slot_row"),
+    ("section_recesses", "test_issue_1438_report_projection", "_passage_part"),
+    ("outer_profile_angles", None, None),
+)
+
+
+@pytest.fixture(scope="module", params=_CASES, ids=[case[0] for case in _CASES])
+def family_intake(request):
+    family, source, factory = request.param
+    if factory is not None:
+        part = getattr(import_module(source), factory)()
+    elif source is not None:
+        part = Path(__file__).parent / "fixtures/evaluation" / source
+    else:
+        part = extrude(RegularPolygon(30, 3), amount=4)
+    model, analysis = _detect_part_model_analysis(part)
+    return family, model, analysis
+
+
+def _catalog(model, analysis, outcomes=None):
+    return build_requirement_catalog(
+        evidence=analysis.recognition_evidence,
+        ownership=analysis.recognition_ownership,
+        model=model,
+        part=analysis.part,
+        requirement_outcomes=outcomes,
+    )
+
+
+def _outcomes(model, analysis):
+    return recognized_requirement_outcomes(
+        analysis.recognition,
+        model.features,
+        AnnotationRegistry(),
+        compile_dimensions(model).diagnostics,
+        part=analysis.part,
+        evidence=analysis.recognition_evidence,
+        ownership=analysis.recognition_ownership,
+        datum=next((datum for datum in model.datums if datum.id == "datum_xy"), None),
+    )
+
+
+def test_all_current_families_have_a_nonempty_stable_document_catalog(family_intake):
+    family, model, analysis = family_intake
+    baseline = _catalog(model, analysis)
+    assert set(baseline.families) == {case[0] for case in _CASES}
+    required = [row for row in baseline.requirements if row.family == family]
+    assert required, f"{family} reproducer no longer exercises its requirement ledger"
+    empty = replace(model, authored_dimensions=())
+    current = _catalog(empty, analysis, _outcomes(empty, analysis))
+    assert len(match_requirement_catalog(baseline, current)) == len(baseline.requirements)
+    if family == "slot_patterns":
+        records = tuple(
+            analysis.recognition_evidence.record(ref)
+            for ref in analysis.recognition_evidence.features
+        )
+        exclusions = [
+            row.intrinsic_exclusion for row in baseline.requirements if row.family == "plates"
+        ]
+        assert exclusions and all(exclusion is not None for exclusion in exclusions)
+        for exclusion in exclusions:
+            assert exclusion.reason_code == "slot_pattern_owns_material_web"
+            assert len(exclusion.source_records) == 4
+            assert all(
+                any(source is record for record in records) for source in exclusion.source_records
+            )
+
+
+def test_member_cannot_erase_supported_family_obligations(family_intake):
+    family, model, analysis = family_intake
+    baseline = _catalog(model, analysis)
+    outcomes = dict(_outcomes(model, analysis))
+    outcomes[family] = ()
+    if family == "section_recesses":
+        # The accepted unsupported occurrence independently synthesizes its opaque
+        # obligation even when this producer emits no row. It must not disappear.
+        current = _catalog(model, analysis, outcomes)
+        aligned = match_requirement_catalog(baseline, current)
+        assert any(row.family == family and row.unsupported for row in aligned)
+    else:
+        with pytest.raises(ReportUnavailableError):
+            match_requirement_catalog(baseline, _catalog(model, analysis, outcomes))

--- a/tests/test_issue_1542_claim_authority.py
+++ b/tests/test_issue_1542_claim_authority.py
@@ -1,0 +1,183 @@
+"""Withdrawn witness authority cannot prove document agreement or dependency coverage."""
+
+from copy import copy
+from dataclasses import replace
+
+import pytest
+from build123d import Box, Cylinder, Pos
+from test_issue_1542_catalog import detect_intake
+
+from draftwright import build_drawing
+from draftwright.document_evidence import bind_document_claims, document_support_proofs
+from draftwright.document_input import DocumentInput
+from draftwright.measurement_support import MeasurementSupport
+from draftwright.plate_correspondence import plate_dependency_alternatives
+
+
+@pytest.fixture(scope="module")
+def located_drawing():
+    drawing = build_drawing(Box(60, 50, 10) - Pos(10, 5, 0) * Cylinder(2, 20))
+    snapshot = drawing.measurement_snapshot()
+    location = next(claim for claim in snapshot.claims if claim.witnesses[1])
+    width = next(claim for claim in snapshot.claims if claim.parameter == "width.length")
+    return drawing, snapshot, location, width
+
+
+@pytest.mark.parametrize(
+    "damage,reason",
+    [
+        ("foreign_owner", "physical_owner_unavailable"),
+        ("missing_meaning", "compiled_meaning_unavailable"),
+        ("old_meaning_shape", "compiled_meaning_unavailable"),
+        ("malformed_span", "span_witness_invalid"),
+        ("wrong_span", "span_meaning_unbound"),
+        ("missing_approvals", "location_meaning_unbound"),
+        ("nonfinite_point", "location_witness_invalid"),
+        ("wrong_point", "location_meaning_unbound"),
+        ("wrong_component", "location_meaning_unbound"),
+        ("missing_reference_span", "location_meaning_unbound"),
+        ("absent_registry", "bound_claim_unconfirmed"),
+    ],
+)
+def test_damaged_or_detached_measurement_witness_remains_unknown(located_drawing, damage, reason):
+    drawing, snapshot, location, width = located_drawing
+    variants = {
+        "foreign_owner": replace(width, owner=replace(width.owner)),
+        "missing_meaning": replace(width, meaning=()),
+        "old_meaning_shape": replace(width, meaning=((30, None),)),
+        "malformed_span": replace(width, witnesses=((1, 2), ())),
+        "wrong_span": replace(width, witnesses=(((100, 0, 0), (130, 0, 0)), ())),
+        "missing_approvals": replace(location, approved=()),
+        "nonfinite_point": replace(
+            location, witnesses=(None, ((location.witnesses[1][0][0], (float("nan"), 0, 0)),))
+        ),
+        "wrong_point": replace(
+            location, witnesses=(None, ((location.witnesses[1][0][0], (1000, 1000, 0)),))
+        ),
+        "wrong_component": replace(
+            location,
+            witnesses=(
+                None,
+                (
+                    (
+                        "location_other.location."
+                        + location.witnesses[1][0][0].rsplit(".", 1)[-1],
+                        location.witnesses[1][0][1],
+                    ),
+                ),
+            ),
+        ),
+        "missing_reference_span": replace(
+            location,
+            witnesses=(None, ()),
+            meaning=tuple((*entry[:2], None, *entry[3:]) for entry in location.meaning),
+        ),
+        "absent_registry": location,
+    }
+    claim = variants[damage]
+    result = bind_document_claims(
+        "damaged",
+        replace(snapshot, claims=(claim,), unknown=()),
+        None if damage == "absent_registry" else drawing.registry,
+    )
+    assert not result.claims
+    assert result.unknown == (("damaged", claim.annotation, reason),)
+
+
+def test_real_slot_pattern_dependency_requires_the_exact_location_point_and_axis():
+    part = Box(60, 180, 20)
+    for y in (-45, -15, 15, 45):
+        part -= Pos(0, y, 0) * Box(30, 8, 20)
+    drawing = build_drawing(part)
+    bound = bind_document_claims("slots", drawing.measurement_snapshot(), drawing.registry)
+    recipes = [
+        recipe
+        for plate in drawing.recognition().plates
+        for recipe in plate_dependency_alternatives(plate, drawing.model().features)
+        if any(term.location_point is not None for term in recipe.supports)
+    ]
+    assert recipes and not bound.unknown
+    recipe = recipes[0]
+    assert document_support_proofs((recipe,), (bound,), ())
+    checked = 0
+    for term in recipe.supports:
+        if term.location_point is None:
+            continue
+        carrying = tuple(
+            claim
+            for claim in bound.claims
+            if claim.owner is term.feature and claim.parameter == term.parameter_id
+        )
+        assert carrying
+        single = replace(bound, claims=carrying)
+        assert document_support_proofs(((term,),), (single,), ())
+        wrong_point = tuple(
+            value + (axis == term.axis)
+            for axis, value in zip("xyz", term.location_point, strict=True)
+        )
+        assert not document_support_proofs(
+            ((replace(term, location_point=wrong_point),),), (single,), ()
+        )
+        assert not document_support_proofs(
+            ((replace(term, axis="y" if term.axis == "x" else "x"),),), (single,), ()
+        )
+        scalar = replace(single, claims=tuple(replace(claim, address=()) for claim in carrying))
+        assert not document_support_proofs(((term,),), (scalar,), ())
+        checked += 1
+    assert checked == 2
+
+
+@pytest.fixture(scope="module")
+def intake():
+    _, model, analysis = detect_intake("holes")
+    return model, analysis
+
+
+@pytest.mark.parametrize(
+    "damage",
+    [
+        "not_raw",
+        "no_evidence",
+        "no_ownership",
+        "foreign_result",
+        "foreign_evidence",
+        "foreign_model_type",
+        "duplicate_owner",
+    ],
+)
+def test_document_intake_requires_one_raw_authority_and_unique_owners(intake, damage):
+    model, analysis = intake
+    changes = {
+        "not_raw": {"recognition_frame_decision": {"status": "reoriented"}},
+        "no_evidence": {"recognition_evidence": None},
+        "no_ownership": {"recognition_ownership": None},
+        "foreign_result": {"recognition": copy(analysis.recognition)},
+        "foreign_evidence": {"recognition_evidence": copy(analysis.recognition_evidence)},
+        "foreign_model_type": {"model": None},
+        "duplicate_owner": {
+            "model": replace(model, features=[*model.features, model.features[0]])
+        },
+    }
+    source = DocumentInput(analysis, "fixture.step", b"owned snapshot")
+    assert source.features
+    with pytest.raises(ValueError):
+        DocumentInput(replace(analysis, **changes[damage]), "fixture.step", b"owned snapshot")
+
+
+def test_equal_copy_of_working_solid_does_not_acquire_document_authority(intake):
+    _, analysis = intake
+    source = DocumentInput(analysis, "fixture.step", b"owned snapshot")
+    source.validate(analysis.part, source.features)
+    with pytest.raises(ValueError, match="working solid"):
+        source.validate(copy(analysis.part), source.features)
+
+
+def test_axis_only_support_uses_physical_measurement_axis(located_drawing):
+    drawing, snapshot, location, _width = located_drawing
+    bound = bind_document_claims(
+        "locations", replace(snapshot, claims=(location,), unknown=()), drawing.registry
+    )
+    assert bound.claims and not bound.unknown
+    term = MeasurementSupport(location.owner, location.parameter, axis="z")
+    assert document_support_proofs(((term,),), (bound,), ())
+    assert not document_support_proofs(((replace(term, axis="x"),),), (bound,), ())

--- a/tests/test_issue_1542_document.py
+++ b/tests/test_issue_1542_document.py
@@ -1,0 +1,203 @@
+"""Shared source membership and per-sheet builds retain one conversion authority."""
+
+from dataclasses import replace
+
+import pytest
+from build123d import Box, Cylinder, export_step
+
+from draftwright import (
+    BuildCancelled,
+    Document,
+    DocumentBuildError,
+    Sheet,
+    observe_build,
+)
+from draftwright import analysis as analysis_module
+from draftwright import recognition_cache as cache_module
+from draftwright.model.ir import Note
+
+
+@pytest.fixture(scope="module")
+def source(tmp_path_factory):
+    path = tmp_path_factory.mktemp("document") / "hole.step"
+    export_step(Box(30, 20, 5) - Cylinder(2, 10), path)
+    return path
+
+
+def authored_member(document, name):
+    sheet = document.sheet(name, detail_view=False).authored_dimensions().authored_views()
+    for view in ("front", "plan", "side"):
+        sheet.view(view)
+    return sheet
+
+
+def test_members_and_live_reports_reuse_one_exact_recognition(source, monkeypatch):
+    calls = []
+    original = analysis_module.build_recognition_evidence
+
+    def counted(*args, **kwargs):
+        evidence = original(*args, **kwargs)
+        calls.append(evidence)
+        return evidence
+
+    monkeypatch.setattr(analysis_module, "build_recognition_evidence", counted)
+    monkeypatch.setattr(cache_module, "build_recognition_evidence", counted)
+    document = Document.from_part(source)
+    hole = next(feature for feature in document.features if feature.kind == "hole")
+    first = authored_member(document, "diameter")
+    first.dimension(hole, "bore.diameter")
+    second = authored_member(document, "locations")
+    second.dimension(hole, "location")
+    result = document.build()
+    drawings = result.sheets
+    members = result._project_members()
+    assert len(members) == 2
+    assert all(len(rows) == len(result._catalog.requirements) for _, _, rows in members)
+    assert {
+        row.outcome.state
+        for _, _, rows in members
+        for row in rows
+        if row.parameter_id == "bore.diameter"
+    } == {"placed", "suppressed"}
+    assert len(calls) == 1
+    for drawing in drawings.values():
+        assert drawing.recognition_evidence() is calls[0]
+        assert all(
+            any(member is owner for member in drawing.model().features)
+            for owner in document.features
+        )
+        assert drawing.recognition_ownership() is drawings["diameter"].recognition_ownership()
+        drawing.report()
+    drawing = drawings["diameter"]
+    before = drawing.report()["recognition"]["requirements"]
+    row = next(item for item in before if item["parameter_id"] == "bore.diameter")
+    assert row["state"] == "placed" and row["annotations"]
+    drawing.remove(row["annotations"][0])
+    assert all(
+        row.outcome.state != "placed"
+        for _, _, rows in result._project_members()
+        for row in rows
+        if row.parameter_id == "bore.diameter"
+    )
+    after = drawing.report()["recognition"]["requirements"]
+    assert len(after) == len(before)
+    assert (
+        next(item for item in after if item["parameter_id"] == "bore.diameter")["state"]
+        != "placed"
+    )
+    assert len(calls) == 1
+
+
+def test_sealed_members_reject_physical_mutation_before_changing_anything(source):
+    document = Document.from_part(source)
+    sheet = authored_member(document, "features")
+    hole = next(feature for feature in document.features if feature.kind == "hole")
+    handle = sheet.of(hole)
+    clone = replace(hole)
+    assert clone == hole and clone is not hole
+    note = Note(frame=hole.frame, text="REVIEW", view="plan", side="right", origin=hole)
+    initial = tuple(sheet.features)
+    for mutation in (
+        lambda: sheet.features.append(clone),
+        lambda: sheet.features.extend((note, clone)),
+        lambda: sheet.features.__setitem__(slice(None), [clone]),
+        lambda: sheet.features.__delitem__(0),
+        lambda: handle.depth(6),
+        lambda: sheet.add(clone),
+        lambda: sheet.control(clone).position(0.1, to="A"),
+    ):
+        with pytest.raises(ValueError, match="document|sealed"):
+            mutation()
+        assert len(sheet.features) == len(initial)
+        assert all(a is b for a, b in zip(initial, sheet.features))
+    sheet.dimension(handle, "bore.diameter")
+    handle.tolerance(0.02).note("REVIEW")
+    with_note = tuple(sheet.features)
+    assert len(with_note) > len(initial)
+    with pytest.raises(ValueError, match="sealed"):
+        sheet.features.clear()
+    assert len(sheet.features) == len(with_note)
+    assert all(a is b for a, b in zip(with_note, sheet.features))
+    built = sheet.build()
+    assert built.recognition_ownership() is not None
+    assert hole in built.model().features
+
+
+def test_foreign_member_handles_remain_foreign_and_plain_sheets_keep_editing(source):
+    document = Document.from_part(source)
+    first, second = authored_member(document, "a"), authored_member(document, "b")
+    hole = next(feature for feature in document.features if feature.kind == "hole")
+    with pytest.raises(ValueError, match="different Sheet"):
+        second.dimension(first.of(hole), "bore.diameter")
+    second.dimension(hole, "bore.diameter")
+    plain = Sheet(Box(30, 20, 5)).authored_dimensions()
+    declared = plain.hole(diameter=4, depth=5, at=(0, 0, 0), axis="z")
+    declared.depth(6)
+    assert plain.features[0].depth == 6
+    plain.features.clear()
+    assert not plain.features
+
+
+def test_document_names_failure_and_returns_no_partial_result(source):
+    document = Document.from_part(source)
+    document.sheet("unconfigured")
+    with pytest.raises(DocumentBuildError, match="unconfigured") as failure:
+        document.build()
+    assert failure.value.sheet_name == "unconfigured"
+    assert isinstance(failure.value.__cause__, ValueError)
+    with pytest.raises(ValueError, match="duplicate"):
+        document.sheet("unconfigured")
+
+
+def test_cancellation_names_member_without_publishing_completed_child(source):
+    document = Document.from_part(source)
+    authored_member(document, "cancelled")
+    with observe_build(lambda _event: None) as control:
+        control.cancel()
+        with pytest.raises(BuildCancelled) as failure:
+            document.build()
+    assert failure.value.diagnostic["sheet"] == "cancelled"
+    assert failure.value.completed_result is None
+
+
+def test_member_intents_are_snapshotted_before_any_member_build(source):
+    document = Document.from_part(source)
+    first = authored_member(document, "first")
+    second = authored_member(document, "second")
+    hole = next(feature for feature in document.features if feature.kind == "hole")
+    first.dimension(hole, "bore.diameter")
+    changed = []
+
+    def observe(event):
+        if event.phase == "started" and event.stage == ("document sheet first",):
+            second.dimension(hole, "bore.diameter")
+            changed.append(True)
+
+    with observe_build(observe):
+        result = document.build()
+    assert changed == [True]
+    rows = result.sheets["second"].report()["recognition"]["requirements"]
+    assert (
+        next(row for row in rows if row["parameter_id"] == "bore.diameter")["state"]
+        == "suppressed"
+    )
+    assert second.model().authored_dimensions
+
+
+@pytest.mark.parametrize("clone", (False, True))
+def test_live_document_refuses_lost_or_replaced_physical_members(source, clone):
+    from draftwright import ReportUnavailableError
+
+    document = Document.from_part(source)
+    authored_member(document, "damaged")
+    result = document.build()
+    drawing = result.sheets["damaged"]
+    features = drawing.model().features
+    hole = next(feature for feature in features if feature.kind == "hole")
+    index = next(index for index, feature in enumerate(features) if feature is hole)
+    if clone:
+        features[index] = replace(hole)
+    else:
+        del features[index]
+    with pytest.raises(ReportUnavailableError, match="damaged.*sealed"):
+        result._project_members()

--- a/tests/test_issue_1542_document_claims.py
+++ b/tests/test_issue_1542_document_claims.py
@@ -1,0 +1,242 @@
+"""Document agreement uses exact interval/member witnesses and approved engineering meaning."""
+
+from dataclasses import replace
+
+import pytest
+from build123d import Box, Cylinder, Pos, export_step
+
+from draftwright import Document, ReportUnavailableError, build_drawing
+from draftwright.audit import compare_measurements
+from draftwright.document_evidence import bind_document_claims, document_conflicts
+
+
+@pytest.fixture(scope="module")
+def hole_source(tmp_path_factory):
+    path = tmp_path_factory.mktemp("document-claims") / "hole.step"
+    export_step(Box(30, 20, 5) - Cylinder(2, 10), path)
+    return path
+
+
+def member(document, name):
+    sheet = document.sheet(name, detail_view=False).authored_dimensions().authored_views()
+    for view in ("front", "plan", "side"):
+        sheet.view(view)
+    return sheet
+
+
+def bound(sheet, drawing):
+    return bind_document_claims(sheet, drawing.measurement_snapshot(), drawing.registry)
+
+
+@pytest.mark.parametrize("aspects", ((0.02, 0.05), (0.02, 0.02), ("class", "deviation")))
+def test_confirmed_diameter_tolerances_conflict_but_fit_display_does_not(hole_source, aspects):
+    document = Document.from_part(hole_source)
+    hole = next(feature for feature in document.features if feature.kind == "hole")
+    for name, aspect in zip(("first", "second"), aspects, strict=True):
+        sheet = member(document, name)
+        sheet.dimension(hole, "bore.diameter")
+        if isinstance(aspect, str):
+            sheet.of(hole).fit("H7", show=aspect)
+        else:
+            sheet.of(hole).tolerance(aspect)
+    result = document.build()
+    result._project_members()
+    snapshots = tuple(bound(name, drawing) for name, drawing in result.sheets.items())
+    assert all(not snapshot.unknown for snapshot in snapshots)
+    assert all(len(snapshot.claims) == 1 for snapshot in snapshots)
+    assert all(snapshot.claims[0].owner is hole for snapshot in snapshots)
+    conflicts = document_conflicts(snapshots)
+    if aspects == (0.02, 0.05):
+        assert len(conflicts) == 1
+        assert {claim.sheet for claim in conflicts[0].claims} == {"first", "second"}
+        assert {claim.meaning[1] for claim in conflicts[0].claims} == {0.02, 0.05}
+    else:
+        assert not conflicts
+    if isinstance(aspects[0], str):
+        first, second = (drawing.measurement_snapshot() for drawing in result.sheets.values())
+        assert first.claims[0].meaning != second.claims[0].meaning
+        assert compare_measurements(first, second)["status"] == "changed"
+        assert snapshots[0].claims[0].meaning == snapshots[1].claims[0].meaning
+        assert snapshots[0].claims[0].rendered != snapshots[1].claims[0].rendered
+
+
+@pytest.fixture(scope="module")
+def shoulders():
+    return build_drawing(Box(80, 60, 30) - Pos(0, 0, 7.5) * Box(80, 20, 15))
+
+
+def test_equal_coarse_claim_bags_bind_to_distinct_shoulder_intervals(shoulders):
+    snapshot = shoulders.measurement_snapshot()
+    claims = tuple(claim for claim in snapshot.claims if claim.parameter == "step_position.length")
+    assert len(claims) == 2 and claims[0].meaning == claims[1].meaning
+    first, second = (
+        bind_document_claims(
+            name, replace(snapshot, claims=(claim,), unknown=()), shoulders.registry
+        )
+        for name, claim in zip(("first", "second"), claims, strict=True)
+    )
+    assert not first.unknown and not second.unknown
+    assert {first.claims[0].meaning[0], second.claims[0].meaning[0]} == {20, 40}
+    assert first.claims[0].address != second.claims[0].address
+    assert not document_conflicts((first, second))
+
+
+def test_wrong_interval_cannot_borrow_sibling_label_confirmation(shoulders):
+    snapshot = shoulders.measurement_snapshot()
+    first, second = (
+        claim for claim in snapshot.claims if claim.parameter == "step_position.length"
+    )
+    altered = replace(first, witnesses=second.witnesses)
+    narrowed = bind_document_claims(
+        "damaged", replace(snapshot, claims=(altered,), unknown=()), shoulders.registry
+    )
+    assert not narrowed.claims
+    assert narrowed.unknown == (("damaged", first.annotation, "bound_claim_unconfirmed"),)
+
+
+def test_missing_witness_cannot_choose_one_of_multiple_approved_intervals(shoulders):
+    snapshot = shoulders.measurement_snapshot()
+    claim = next(claim for claim in snapshot.claims if claim.parameter == "step_position.length")
+    altered = replace(claim, witnesses=())
+    narrowed = bind_document_claims(
+        "damaged", replace(snapshot, claims=(altered,), unknown=()), shoulders.registry
+    )
+    assert not narrowed.claims
+    assert narrowed.unknown == (("damaged", claim.annotation, "measurement_meaning_ambiguous"),)
+
+
+def test_equal_pocket_offsets_keep_their_own_measured_axes():
+    drawing = build_drawing(Box(50, 50, 30) - Pos(10, 10, 12) * Box(22, 14, 10))
+    snapshot = drawing.measurement_snapshot()
+    coarse = tuple(
+        claim for claim in snapshot.claims if claim.parameter == "location_pocket.location"
+    )
+    assert len(coarse) == 2 and coarse[0].meaning == coarse[1].meaning
+    narrowed = bind_document_claims(
+        "pocket", replace(snapshot, claims=coarse, unknown=()), drawing.registry
+    )
+    assert not narrowed.unknown
+    assert len(narrowed.claims) == 2
+    assert {claim.address[1] for claim in narrowed.claims} == {
+        "location_pocket.location.x",
+        "location_pocket.location.y",
+    }
+    assert all(claim.meaning[3] == "z" for claim in narrowed.claims)
+    assert not document_conflicts((narrowed,))
+
+
+def test_member_cannot_change_layout_datum_to_evade_agreement(hole_source):
+    document = Document.from_part(hole_source)
+    member(document, "changed")
+    result = document.build()
+    model = result.sheets["changed"].model()
+    original = next(datum for datum in model.datums if datum.id == "datum_xy")
+    index = next(index for index, datum in enumerate(model.datums) if datum is original)
+    model.datums[index] = replace(original, at=tuple(value + 1 for value in original.at))
+    with pytest.raises(ReportUnavailableError, match="changed.*datum is sealed"):
+        result._project_members()
+
+
+def test_unequal_pocket_offset_cannot_borrow_sibling_axis_confirmation():
+    drawing = build_drawing(Box(60, 50, 30) - Pos(10, 5, 12) * Box(22, 14, 10))
+    snapshot = drawing.measurement_snapshot()
+    coarse = tuple(
+        claim for claim in snapshot.claims if claim.parameter == "location_pocket.location"
+    )
+    first = next(claim for claim in coarse if claim.witnesses[1][0][0].endswith(".x"))
+    second = next(claim for claim in coarse if claim.witnesses[1][0][0].endswith(".y"))
+    assert first.meaning == second.meaning
+    assert first.rendered != second.rendered
+    clean = bind_document_claims(
+        "pocket", replace(snapshot, claims=coarse, unknown=()), drawing.registry
+    )
+    assert not clean.unknown and len(clean.claims) == 2
+    changed = replace(first, witnesses=second.witnesses)
+    narrowed = bind_document_claims(
+        "damaged", replace(snapshot, claims=(changed,), unknown=()), drawing.registry
+    )
+    assert not narrowed.claims
+    assert narrowed.unknown == (("damaged", first.annotation, "bound_claim_unconfirmed"),)
+
+
+def test_unique_compiled_span_keeps_address_without_optional_rendered_witness():
+    drawing = build_drawing(Box(30, 20, 10))
+    snapshot = drawing.measurement_snapshot()
+    claim = next(claim for claim in snapshot.claims if claim.parameter == "width.length")
+    assert len(claim.meaning) == 1 and claim.witnesses[0]
+    first = bind_document_claims(
+        "first", replace(snapshot, claims=(claim,), unknown=()), drawing.registry
+    )
+    without = replace(claim, witnesses=(None, ()))
+    second = bind_document_claims(
+        "second", replace(snapshot, claims=(without,), unknown=()), drawing.registry
+    )
+    assert not first.unknown and not second.unknown
+    assert first.claims[0].address == second.claims[0].address
+    changed = replace(second.claims[0], meaning=(30.0, 0.02, *second.claims[0].meaning[2:]))
+    conflicts = document_conflicts((first, replace(second, claims=(changed,))))
+    assert len(conflicts) == 1
+
+
+@pytest.mark.parametrize("coarse", (False, True))
+def test_location_witness_removal_keeps_fine_identity_and_exposes_coarse_uncertainty(coarse):
+    part = Box(60, 50, 30 if coarse else 10)
+    part -= Pos(10, 5, 12) * Box(22, 14, 10) if coarse else Pos(10, 5, 0) * Cylinder(2, 20)
+    drawing = build_drawing(part)
+    snapshot = drawing.measurement_snapshot()
+    original = next(claim for claim in snapshot.claims if claim.witnesses[1])
+    before = bind_document_claims(
+        "before", replace(snapshot, claims=(original,), unknown=()), drawing.registry
+    )
+    assert not before.unknown
+    annotation = drawing.registry.named(original.annotation)
+    annotation.covers_hole_locations = ()
+    changed_snapshot = drawing.measurement_snapshot()
+    changed = next(
+        claim
+        for claim in changed_snapshot.claims
+        if claim.annotation == original.annotation and claim.parameter == original.parameter
+    )
+    after = bind_document_claims(
+        "after", replace(changed_snapshot, claims=(changed,), unknown=()), drawing.registry
+    )
+    if coarse:
+        assert not after.claims
+        assert after.unknown == (("after", original.annotation, "location_component_unavailable"),)
+    else:
+        assert not after.unknown
+        assert after.claims[0].address == before.claims[0].address
+        assert after.claims[0].meaning == before.claims[0].meaning
+
+
+@pytest.mark.parametrize(
+    "axis,at,rotation", (("x", (0, -10, -5), (0, 90, 0)), ("y", (-15, 0, -5), (90, 0, 0)))
+)
+def test_off_axis_locations_keep_compiler_component_with_or_without_rider(axis, at, rotation):
+    drawing = build_drawing(Box(60, 50, 30) - Pos(*at) * Cylinder(2, 80, rotation=rotation))
+    snapshot = drawing.measurement_snapshot()
+    locations = tuple(
+        claim for claim in snapshot.claims if claim.parameter.startswith("location_off_axis")
+    )
+    assert locations
+    for claim in locations:
+        assert all(item.is_location_measurement for item in claim.approved)
+        assert all(item.kind == "length" for item in claim.approved)
+        first = bind_document_claims(
+            "first", replace(snapshot, claims=(claim,), unknown=()), drawing.registry
+        )
+        assert not first.unknown and first.claims
+        component = first.claims[0].address[1]
+        assert component in {"location_off_axis.x", "location_off_axis.y", "location_off_axis.z"}
+        drawing.registry.named(claim.annotation).covers_hole_locations = ()
+        changed_snapshot = drawing.measurement_snapshot()
+        changed = next(
+            item
+            for item in changed_snapshot.claims
+            if item.annotation == claim.annotation and item.parameter == claim.parameter
+        )
+        second = bind_document_claims(
+            "second", replace(changed_snapshot, claims=(changed,), unknown=()), drawing.registry
+        )
+        assert not second.unknown
+        assert first.claims[0].address == second.claims[0].address

--- a/tests/test_issue_1542_document_claims.py
+++ b/tests/test_issue_1542_document_claims.py
@@ -24,6 +24,27 @@ def member(document, name):
     return sheet
 
 
+@pytest.mark.parametrize("name", ["", "  ", None, 4])
+def test_document_refuses_empty_or_nontext_sheet_names(hole_source, name):
+    document = Document.from_part(hole_source)
+    with pytest.raises(ValueError, match="nonempty name"):
+        document.sheet(name)
+
+
+def test_document_cannot_build_without_a_member(hole_source):
+    with pytest.raises(ValueError, match="at least one sheet"):
+        Document.from_part(hole_source).build()
+
+
+def test_document_names_the_member_whose_intent_snapshot_is_incomplete(hole_source):
+    from draftwright.document import DocumentBuildError
+
+    document = Document.from_part(hole_source)
+    document.sheet("incomplete").authored_views().view("front")
+    with pytest.raises(DocumentBuildError, match="incomplete"):
+        document.build()
+
+
 def bound(sheet, drawing):
     return bind_document_claims(sheet, drawing.measurement_snapshot(), drawing.registry)
 
@@ -58,6 +79,11 @@ def test_confirmed_diameter_tolerances_conflict_but_fit_display_does_not(hole_so
         assert compare_measurements(first, second)["status"] == "changed"
         assert snapshots[0].claims[0].meaning == snapshots[1].claims[0].meaning
         assert snapshots[0].claims[0].rendered != snapshots[1].claims[0].rendered
+        report = result.report()
+        assert not report["assessment"]["fidelity"]["conflicts"]
+        first_fit, second_fit = (claim["meaning"]["tolerance"] for claim in report["claims"])
+        assert first_fit == second_fit
+        assert first_fit["kind"] == "fit" and first_fit["code"] == "H7"
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_issue_1542_document_coverage.py
+++ b/tests/test_issue_1542_document_coverage.py
@@ -1,0 +1,244 @@
+"""Shared coverage retains the denominator and proves complete dependency recipes."""
+
+from dataclasses import replace
+from pathlib import Path
+
+from build123d import Box, Cylinder, Pos, export_step
+
+from draftwright import Document, build_drawing
+from draftwright.document_evidence import (
+    bind_document_claims,
+    document_conflicts,
+    document_support_proofs,
+)
+from draftwright.measurement_support import MeasurementSupport, RequirementAlternative
+
+
+def member(document, name):
+    sheet = document.sheet(name, detail_view=False).authored_dimensions().authored_views()
+    for view in ("front", "plan", "side"):
+        sheet.view(view)
+    return sheet
+
+
+def test_shared_coverage_survives_move_and_repetition_but_not_removal(tmp_path):
+    path = tmp_path / "hole.step"
+    export_step(Box(30, 20, 5) - Cylinder(2, 10), path)
+    document = Document.from_part(path)
+    hole = next(feature for feature in document.features if feature.kind == "hole")
+    member(document, "first").dimension(hole, "bore.diameter")
+    member(document, "second").dimension(hole, "bore.diameter")
+    result = document.build()
+    initial = result._evaluate()
+    row = next(
+        row for row in initial.requirements if row.requirement.parameter_id == "bore.diameter"
+    )
+    assert row.state == "placed"
+    assert len(initial.claims) == 2
+    assert not initial.conflicts
+    first, second = result.sheets.values()
+    names = [claim.annotation for claim in initial.claims[0].claims if claim.owner is hole]
+    for name in names:
+        first.remove(name)
+    moved = result._evaluate()
+    row = next(
+        row for row in moved.requirements if row.requirement.parameter_id == "bore.diameter"
+    )
+    assert row.state == "placed"
+    assert dict(row.local)["first"].state != "placed"
+    assert dict(row.local)["second"].state == "placed"
+    for claim in moved.claims[1].claims:
+        if claim.owner is hole:
+            second.remove(claim.annotation)
+    removed = result._evaluate()
+    row = next(
+        row for row in removed.requirements if row.requirement.parameter_id == "bore.diameter"
+    )
+    assert row.state == "uncovered"
+    for changed in (moved, removed):
+        assert len(changed.requirements) == len(initial.requirements)
+        assert all(
+            before.requirement is after.requirement
+            for before, after in zip(initial.requirements, changed.requirements, strict=True)
+        )
+
+
+def test_dependency_conjunction_requires_each_exact_confirmed_interval():
+    drawing = build_drawing(Box(80, 60, 30) - Pos(0, 0, 7.5) * Box(80, 20, 15))
+    snapshot = drawing.measurement_snapshot()
+    coarse = tuple(claim for claim in snapshot.claims if claim.parameter == "step_position.length")
+    snapshots = tuple(
+        bind_document_claims(
+            name, replace(snapshot, claims=(claim,), unknown=()), drawing.registry
+        )
+        for name, claim in zip(("first", "second"), coarse, strict=True)
+    )
+    assert len(snapshots) == 2 and all(not item.unknown for item in snapshots)
+    supports = tuple(
+        MeasurementSupport(
+            claim.owner,
+            claim.parameter,
+            axis="y",
+            lo=min(point[1] for point in claim.witnesses[0]),
+            hi=max(point[1] for point in claim.witnesses[0]),
+        )
+        for claim in coarse
+    )
+    recipe = RequirementAlternative(tuple(term.identity for term in supports), supports)
+    proofs = document_support_proofs((recipe,), snapshots, ())
+    assert len(proofs) == 1
+    assert [{claim.sheet for claim in carriers} for carriers in proofs[0].carriers] == [
+        {"first"},
+        {"second"},
+    ]
+    assert not document_support_proofs((recipe,), snapshots[:1], ())
+    # Empty rich witnesses and incomplete branches cannot become vacuous coverage.
+    assert not document_support_proofs((replace(recipe, supports=()),), snapshots, ())
+    absent = replace(supports[0], lo=200, hi=220)
+    wrong_axis = replace(supports[1], axis="x")
+    alternatives = ((supports[0], absent), (supports[1], wrong_axis))
+    assert not document_support_proofs(alternatives, snapshots, ())
+    # A different confirmed engineering claim on one interval blocks derived credit;
+    # direct ink and both conflicting sides remain inspectable.
+    claim = snapshots[0].claims[0]
+    other = replace(
+        claim, sheet="conflicting", meaning=(claim.meaning[0], 0.02, *claim.meaning[2:])
+    )
+    conflicting = (*snapshots, replace(snapshots[0], claims=(other,)))
+    conflicts = document_conflicts(conflicting)
+    assert len(conflicts) == 1
+    assert not document_support_proofs((recipe,), conflicting, conflicts)
+    # Only actual confirmed claims establish prerequisites; derived outcomes aren't inputs.
+    unknown = replace(
+        snapshots[0], claims=(), unknown=(("first", claim.annotation, "unconfirmed"),)
+    )
+    assert not document_support_proofs((recipe,), (unknown, snapshots[1]), ())
+
+
+def test_repeating_one_interval_cannot_fill_two_nearby_support_terms():
+    from draftwright.document_evidence import DocumentClaim, DocumentClaimSnapshot
+
+    owner = object()
+    span = ((0.0, 0.0, 0.0), (0.0, 20.0, 0.0))
+    claim = DocumentClaim(
+        "a",
+        owner,
+        "step.length",
+        "first",
+        ("span", span),
+        (20.0, None, span, "y", None, None, None),
+        (),
+        (span, ()),
+    )
+    other = replace(claim, sheet="b", annotation="repeat")
+    support = MeasurementSupport(owner, "step.length", "y", 0.0, 20.0)
+    adjacent = replace(support, hi=20.2)
+    snapshots = (DocumentClaimSnapshot((claim, other), ()),)
+    assert not document_support_proofs(((support, adjacent),), snapshots, ())
+    next_span = (span[0], (0.0, 20.2, 0.0))
+    distinct = replace(
+        claim,
+        annotation="second",
+        address=("span", next_span),
+        meaning=(20.2, None, next_span, "y", None, None, None),
+        witnesses=(next_span, ()),
+    )
+    proven = document_support_proofs(
+        ((support, adjacent),), (DocumentClaimSnapshot((claim, other, distinct), ()),), ()
+    )
+    assert len(proven) == 1
+    assert len({item.address for item in proven[0].witnesses}) == 2
+
+
+def test_u_channel_prerequisites_split_across_sheets_and_live_loss():
+    source = Path(__file__).parent / "fixtures/evaluation/plate-u-additive.step"
+    document = Document.from_part(source)
+    conditional = next(
+        row for row in document._catalog.requirements if row.dependency_alternatives
+    )
+    (recipe,) = conditional.dependency_alternatives
+    assert len(recipe.supports) == 3
+    for index, support in enumerate(recipe.supports):
+        member(document, str(index)).dimension(support.feature, support.parameter_id)
+    result = document.build()
+    before = result._evaluate()
+    target = next(row for row in before.requirements if row.requirement is conditional)
+    assert target.state == "dependency-derived"
+    assert len(target.dependencies) == 1
+    assert {claim.sheet for claim in target.dependencies[0].witnesses} == {"0", "1", "2"}
+    assert all(outcome.state == "suppressed" for _name, outcome in target.local)
+    carrier = next(claim for claim in target.dependencies[0].witnesses if claim.sheet == "1")
+    drawing = result.sheets["1"]
+    label = drawing.registry.named(carrier.annotation).label
+    drawing.registry.named(carrier.annotation).label = "999"
+    unconfirmed = result._evaluate()
+    target = next(row for row in unconfirmed.requirements if row.requirement is conditional)
+    assert target.state == "uncovered" and not target.dependencies
+    assert any(snapshot.unknown for snapshot in unconfirmed.claims)
+    drawing.registry.named(carrier.annotation).label = label
+    assert (
+        next(
+            row for row in result._evaluate().requirements if row.requirement is conditional
+        ).state
+        == "dependency-derived"
+    )
+    drawing.remove(carrier.annotation)
+    removed = result._evaluate()
+    target = next(row for row in removed.requirements if row.requirement is conditional)
+    assert target.state == "uncovered" and not target.dependencies
+    assert len(removed.requirements) == len(before.requirements)
+
+
+def test_native_plate_does_not_become_derived_when_other_sheets_carry_prerequisites():
+    source = Path(__file__).parent / "fixtures/evaluation/plate-u-additive.step"
+    document = Document.from_part(source)
+    conditional = next(
+        row for row in document._catalog.requirements if row.dependency_alternatives
+    )
+    (recipe,) = conditional.dependency_alternatives
+    for index, support in enumerate(recipe.supports):
+        member(document, str(index)).dimension(support.feature, support.parameter_id)
+    (owner,) = conditional.features
+    member(document, "direct").dimension(owner, conditional.parameter_id)
+    result = document.build()
+    target = next(row for row in result._evaluate().requirements if row.requirement is conditional)
+    assert target.state == "placed"
+    assert target.dependencies
+    assert dict(target.local)["direct"].state == "placed"
+
+
+def test_grouped_hole_locations_need_all_members_across_sheets(tmp_path):
+    part = Box(80, 60, 10)
+    for x, y in ((-20, -15), (20, 15)):
+        part -= Pos(x, y, 0) * Cylinder(2, 20)
+    path = tmp_path / "group.step"
+    export_step(part, path)
+    document = Document.from_part(path)
+    hole = next(feature for feature in document.features if feature.kind == "hole")
+    assert hole.count == 2
+    for index in (0, 1):
+        sheet = member(document, str(index))
+        for axis in ("x", "y"):
+            sheet.dimension(hole, "location", member=index, axis=axis)
+    result = document.build()
+    before = result._evaluate()
+    locations = [
+        row
+        for row in before.requirements
+        if row.requirement.family == "holes"
+        and row.requirement.parameter_id.startswith("location")
+    ]
+    assert locations and all(row.state == "placed" for row in locations)
+    assert all(all(outcome.state != "placed" for _, outcome in row.local) for row in locations)
+    snapshot = before.claims[1]
+    claim = next(claim for claim in snapshot.claims if claim.parameter.endswith(".x"))
+    result.sheets["1"].remove(claim.annotation)
+    after = result._evaluate()
+    changed = [
+        row
+        for row in after.requirements
+        if row.requirement.family == "holes"
+        and row.requirement.parameter_id.startswith("location")
+    ]
+    assert len(changed) == len(locations)
+    assert any(row.state == "uncovered" for row in changed)

--- a/tests/test_issue_1542_document_report.py
+++ b/tests/test_issue_1542_document_report.py
@@ -1,0 +1,389 @@
+"""Public document reports keep common authority, independent assessments and live evidence."""
+
+import hashlib
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+from build123d import Box, Cylinder, export_step
+from jsonschema.validators import validator_for
+from test_issue_1542_catalog_families import _CASES, family_part
+
+from draftwright import Document, ReportUnavailableError
+
+
+def member(document, name):
+    sheet = document.sheet(name, detail_view=False).authored_dimensions().authored_views()
+    for view in ("front", "plan", "side"):
+        sheet.view(view)
+    return sheet
+
+
+def hole_document(tmp_path, tolerances=(0.02, 0.05)):
+    path = tmp_path / "hole.step"
+    export_step(Box(30, 20, 5) - Cylinder(2, 10), path)
+    raw = path.read_bytes()
+    document = Document.from_part(path)
+    hole = next(feature for feature in document.features if feature.kind == "hole")
+    for index, tolerance in enumerate(tolerances):
+        sheet = member(document, str(index))
+        sheet.dimension(hole, "bore.diameter")
+        sheet.of(hole).tolerance(tolerance)
+    return document, path, raw
+
+
+def test_report_conflict_keeps_both_confirmed_values_and_one_coverage_credit(tmp_path):
+    document, path, raw = hole_document(tmp_path)
+    path.unlink()
+    result = document.build()
+    report = result.report()
+    assert report["schema"] == "draftwright-report"
+    assert report["schema_version"] == 4 and report["scope"] == "document"
+    assert report["source"]["sha256"] == hashlib.sha256(raw).hexdigest()
+    assert report["run_options"] == {"pmi": "off", "frame": "raw"}
+    assert report["recognition"]["identity_scope"] == "document-local"
+    assert report["replay"]["identity_lifetime"] == "this-report-only"
+    assert report["assessment"]["manufacturing"]["readiness"] == "not-certified"
+    row = next(
+        row
+        for row in report["recognition"]["requirements"]
+        if row["parameter_id"] == "bore.diameter"
+    )
+    assert row["state"] == "placed" and row["coverage_credit"] == 1
+    assert [local["state"] for local in row["local_outcomes"]] == ["placed", "placed"]
+    conflicts = report["assessment"]["fidelity"]["conflicts"]
+    assert len(conflicts) == 1 and report["status"] == "needs-attention"
+    claims = {claim["id"]: claim for claim in report["claims"]}
+    disputed = [claims[key] for key in conflicts[0]["claim_ids"]]
+    assert {claim["meaning"]["tolerance"] for claim in disputed} == {0.02, 0.05}
+    assert len({claim["owner_id"] for claim in disputed}) == 1
+    assert len({claim["sheet_id"] for claim in disputed}) == 2
+    assert all(
+        sheet["lint"]["quality"]["fidelity"]["raw_issues"] == 0 for sheet in report["sheets"]
+    )
+    assert all(sheet["dimension_intents"]["source"] == "authored" for sheet in report["sheets"])
+    json.dumps(report, allow_nan=False)
+    assert all(drawing.report()["schema_version"] == 3 for drawing in result.sheets.values())
+
+
+def test_returned_document_is_detached_and_fresh_reads_lose_removed_credit(tmp_path):
+    document, _path, _raw = hole_document(tmp_path, (0.02, 0.02))
+    result = document.build()
+    before = result.report()
+    saved = json.dumps(before, sort_keys=True)
+    for drawing in result.sheets.values():
+        for claim in drawing.measurement_snapshot().claims:
+            if claim.parameter == "bore.diameter":
+                drawing.remove(claim.annotation)
+    after = result.report()
+    assert json.dumps(before, sort_keys=True) == saved
+    previous = before["recognition"]["requirements"]
+    current = after["recognition"]["requirements"]
+    assert [(row["id"], row["occurrence_ids"], row["parameter_id"]) for row in previous] == [
+        (row["id"], row["occurrence_ids"], row["parameter_id"]) for row in current
+    ]
+    row = next(row for row in current if row["parameter_id"] == "bore.diameter")
+    assert row["state"] == "uncovered" and row["coverage_credit"] == 0
+    assert not after["claims"]
+
+
+def test_ordinary_carriers_and_dependency_witnesses_name_existing_sheets_and_ink():
+    document = Document.from_part(
+        Path(__file__).parent / "fixtures/evaluation/plate-u-additive.step"
+    )
+    conditional = next(
+        row for row in document._catalog.requirements if row.dependency_alternatives
+    )
+    (recipe,) = conditional.dependency_alternatives
+    for index, support in enumerate(recipe.supports):
+        member(document, str(index)).dimension(support.feature, support.parameter_id)
+    result = document.build()
+    report = result.report()
+    sheets = {row["id"]: result.sheets[row["name"]] for row in report["sheets"]}
+    claims = {row["id"]: row for row in report["claims"]}
+    derived = [
+        row
+        for row in report["recognition"]["requirements"]
+        if row["state"] == "dependency-derived"
+    ]
+    assert len(derived) == 1
+    assert derived[0]["carrier_attribution"] == "available"
+    assert not derived[0]["carrying_annotations"]
+    (proof,) = derived[0]["dependency_proofs"]
+    assert len(proof["distinct_witnesses"]) == 3
+    assert len({claims[key]["sheet_id"] for key in proof["distinct_witnesses"]}) == 3
+    placed = [row for row in report["recognition"]["requirements"] if row["state"] == "placed"]
+    assert placed and all(row["carrying_annotations"] for row in placed)
+    for row in placed:
+        assert row["carrier_attribution"] == "available"
+        for carrier in row["carrying_annotations"]:
+            assert carrier["annotation"] in sheets[carrier["sheet_id"]].annotations()
+            assert carrier["evidence_kind"] == "measurement"
+
+
+def test_writer_is_explicit_strict_and_preserves_destination_on_failure(tmp_path, monkeypatch):
+    import draftwright.reporting as reporting
+
+    document, _path, _raw = hole_document(tmp_path)
+    result = document.build()
+    output = tmp_path / "report.json"
+    result.write_report(output)
+    first = output.read_bytes()
+    assert json.loads(first)["schema_version"] == 4
+
+    def fail_replace(*_args):
+        raise OSError("replace failed")
+
+    monkeypatch.setattr(reporting.os, "replace", fail_replace)
+    with pytest.raises(OSError, match="replace failed"):
+        result.write_report(output)
+    assert output.read_bytes() == first
+    assert not list(tmp_path.glob(".draftwright-*"))
+
+
+def test_public_report_refuses_changed_exact_member_without_overwriting_report(tmp_path):
+    document, _path, _raw = hole_document(tmp_path)
+    result = document.build()
+    output = tmp_path / "report.json"
+    result.write_report(output)
+    original = output.read_bytes()
+    features = result.sheets["0"].model().features
+    index = next(i for i, feature in enumerate(features) if feature.kind == "hole")
+    features[index] = replace(features[index])
+    with pytest.raises(ReportUnavailableError, match="document sheet.*(sealed|matches nothing)"):
+        result.write_report(output)
+    assert output.read_bytes() == original
+
+
+@pytest.mark.parametrize("case", _CASES, ids=[case[0] for case in _CASES])
+def test_every_family_projects_live_carriers_and_preserves_catalog_after_removal(case, tmp_path):
+    source = family_part(case)
+    if not isinstance(source, Path):
+        path = tmp_path / "part.step"
+        export_step(source, path)
+        source = path
+    document = Document.from_part(source)
+    document.sheet("drawing", detail_view=False).auto_dimensions().auto_views()
+    result = document.build()
+    before = result.report()
+    schema = json.loads(
+        (
+            Path(__file__).parents[1] / "docs/reference/draftwright-report-v4.schema.json"
+        ).read_text()
+    )
+    validator_for(schema).check_schema(schema)
+    validator_for(schema)(schema).validate(before)
+    rows = before["recognition"]["requirements"]
+    family = [row for row in rows if row["family"] == case[0]]
+    assert family, "the public report must retain this source family's requirements"
+    direct = [row for row in family if row["state"] in {"placed", "satisfied_by_structured_note"}]
+    if case[0] not in {"section_recesses", "through_steps"}:
+        assert direct, "this positive fixture must exercise actual carrier attribution"
+    drawing = result.sheets["drawing"]
+    for row in direct:
+        assert row["carrier_attribution"] == "available", row
+        assert row["carrying_annotations"], row
+        assert all(
+            carrier["annotation"] in drawing.annotations()
+            for carrier in row["carrying_annotations"]
+        )
+    for name in tuple(drawing.annotations()):
+        drawing.remove(name)
+    after = result.report()
+
+    def identity(row):
+        return (
+            row["id"],
+            row["family"],
+            row["occurrence_ids"],
+            row["parameter_id"],
+            row["requirement_count"],
+            row["requirement_count_known"],
+        )
+
+    assert [identity(row) for row in after["recognition"]["requirements"]] == [
+        identity(row) for row in rows
+    ]
+    assert not any(row["coverage_credit"] for row in after["recognition"]["requirements"])
+    assert not after["claims"]
+    assert after["status"] == "needs-attention"
+
+
+def test_mixed_axis_operations_move_live_without_substitution_or_denominator_drift(tmp_path):
+    from build123d import Pos, Rot
+
+    path = tmp_path / "mixed.step"
+    part = Box(40, 30, 20) - Pos(-10, 0, 0) * Cylinder(2, 30)
+    part -= Pos(15, 5, 3) * Rot(0, 90, 0) * Cylinder(2, 10)
+    export_step(part, path)
+    document = Document.from_part(path)
+    holes = [feature for feature in document.features if feature.kind == "hole"]
+    assert len(holes) == 2
+    through = next(feature for feature in holes if feature.through)
+    blind = next(feature for feature in holes if not feature.through)
+    assert through.frame.axis == "z" and blind.frame.axis == "x"
+    assert through.diameter == blind.diameter == 4
+    assert blind.depth == 10
+    member(document, "through").dimension(through, "bore.diameter")
+    sockets = member(document, "blind")
+    sockets.dimension(blind, "bore.diameter")
+    sockets.dimension(blind, "bore.depth")
+    # A live callout respects authored omissions; declare the destination intent first.
+    sockets.dimension(through, "bore.diameter")
+    sockets.notes(["REVIEW ONLY"], number=False)
+    result = document.build()
+    destination = result.sheets["blind"]
+    destination.drop(through)
+    before = result.report()
+    diameter_rows = [
+        row
+        for row in before["recognition"]["requirements"]
+        if row["parameter_id"] == "bore.diameter"
+    ]
+    assert len(diameter_rows) == 2 and all(row["coverage_credit"] == 1 for row in diameter_rows)
+    assert len({tuple(row["owner_ids"]) for row in diameter_rows}) == 2
+    assert not before["assessment"]["fidelity"]["conflicts"]
+    view_intents = before["sheets"][1]["view_intents"]
+    assert view_intents["principal_source"] == "authored"
+    assert [item["spec"]["name"] for item in view_intents["principals"]] == [
+        "front",
+        "plan",
+        "side",
+    ]
+    assert before["sheets"][1]["table_intents"][0]["rows"][-1] == ["REVIEW ONLY"]
+    first, second = result.sheets.values()
+    original = next(
+        claim.annotation for claim in first.measurement_snapshot().claims if claim.owner is through
+    )
+    moved_name = second.callout(through)
+    assert moved_name in second.annotations()
+    first.remove(original)
+    moved = result.report()
+    assert not moved["assessment"]["fidelity"]["conflicts"]
+    assert [row["coverage_credit"] for row in moved["recognition"]["requirements"]] == [
+        row["coverage_credit"] for row in before["recognition"]["requirements"]
+    ]
+    second.remove(moved_name)
+    after = result.report()
+    assert [
+        (row["id"], row["occurrence_ids"], row["parameter_id"])
+        for row in after["recognition"]["requirements"]
+    ] == [
+        (row["id"], row["occurrence_ids"], row["parameter_id"])
+        for row in before["recognition"]["requirements"]
+    ]
+    remaining = [
+        row
+        for row in after["recognition"]["requirements"]
+        if row["parameter_id"] == "bore.diameter"
+    ]
+    assert sorted(row["coverage_credit"] for row in remaining) == [0, 1]
+
+
+def test_actual_through_step_conjunctions_span_members_and_reject_wrong_support(tmp_path):
+    from build123d import Pos, Rot
+
+    path = tmp_path / "through-step.step"
+    export_step(Rot(90, 0, 0) * (Box(40, 30, 20) - Pos(15, 10, 0) * Box(20, 20, 30)), path)
+    document = Document.from_part(path)
+    steps = member(document, "steps")
+    overall = member(document, "overall")
+    rows = [row for row in document._catalog.requirements if row.family == "through_steps"]
+    assert len(rows) == 2
+    for row in rows:
+        (alternative,) = row.dependency_alternatives
+        assert len(alternative) == 2
+        first, second = alternative
+        assert first.feature.kind == "step_level" and second.feature.kind == "envelope"
+        steps.dimension(first.feature, first.parameter_id)
+        overall.dimension(second.feature, second.parameter_id)
+    result = document.build()
+    before = result.report()
+    carried = [
+        row for row in before["recognition"]["requirements"] if row["family"] == "through_steps"
+    ]
+    assert all(row["state"] == "dependency-derived" for row in carried)
+    claims = {claim["id"]: claim for claim in before["claims"]}
+    for row in carried:
+        (proof,) = row["dependency_proofs"]
+        assert len(proof["distinct_witnesses"]) == 2
+        assert {claims[key]["sheet_id"] for key in proof["distinct_witnesses"]} == {
+            "sheet:1",
+            "sheet:2",
+        }
+    drawing = result.sheets["steps"]
+    height = next(
+        claim
+        for claim in drawing.measurement_snapshot().claims
+        if claim.parameter == "step_height.length"
+    )
+    annotation = drawing.registry.named(height.annotation)
+    original = annotation.label
+    assert original != "999"
+    annotation.label = "999"
+    wrong = result.report()
+    damaged = [
+        row for row in wrong["recognition"]["requirements"] if row["family"] == "through_steps"
+    ]
+    assert sorted(row["state"] for row in damaged) == ["dependency-derived", "uncovered"]
+    assert wrong["assessment"]["fidelity"]["unknown_claims"]
+    annotation.label = original
+    assert all(
+        row["state"] == "dependency-derived"
+        for row in result.report()["recognition"]["requirements"]
+        if row["family"] == "through_steps"
+    )
+    drawing.remove(height.annotation)
+    removed = result.report()
+    assert [
+        (row["id"], row["parameter_id"]) for row in removed["recognition"]["requirements"]
+    ] == [(row["id"], row["parameter_id"]) for row in before["recognition"]["requirements"]]
+    assert sorted(
+        row["state"]
+        for row in removed["recognition"]["requirements"]
+        if row["family"] == "through_steps"
+    ) == ["dependency-derived", "uncovered"]
+
+
+@pytest.mark.parametrize("source_less", (False, True))
+def test_producer_unknown_cardinality_never_becomes_a_known_clean_denominator(
+    monkeypatch, source_less
+):
+    from draftwright.linting import requirements
+
+    original = requirements.recognized_requirement_outcomes
+
+    def unknown_count(*args, **kwargs):
+        outcomes = dict(original(*args, **kwargs))
+        first, *rest = outcomes["grooves"]
+        assert first.source_records and first.requirement_count_known
+        outcomes["grooves"] = (
+            replace(
+                first,
+                parameter_id="?",
+                requirement_count=1,
+                requirement_count_known=False,
+                source_records=() if source_less else first.source_records,
+            ),
+            *rest,
+        )
+        return outcomes
+
+    monkeypatch.setattr(requirements, "recognized_requirement_outcomes", unknown_count)
+    source = Path(__file__).parent / "fixtures/evaluation/groove-lone-z.step"
+    if source_less:
+        with pytest.raises(ReportUnavailableError, match="no exact source"):
+            Document.from_part(source)
+        return
+    document = Document.from_part(source)
+    document.sheet("drawing", detail_view=False).auto_dimensions().auto_views()
+    report = document.build().report()
+    unknown = [
+        row for row in report["recognition"]["requirements"] if not row["requirement_count_known"]
+    ]
+    assert len(unknown) == 1 and unknown[0]["state"] == "unresolved"
+    assert unknown[0]["coverage_credit"] == 0
+    coverage = report["assessment"]["coverage"]
+    assert coverage["unknown_cardinality_rows"] == 1 and coverage["audited_score"] is None
+    assert report["status"] == "needs-attention"

--- a/tests/test_issue_1542_report_authority.py
+++ b/tests/test_issue_1542_report_authority.py
@@ -1,0 +1,142 @@
+"""A report must refuse broken references rather than serialize a plausible smaller graph."""
+
+from dataclasses import replace
+
+import pytest
+from test_issue_1542_document_report import hole_document
+
+from draftwright.reporting import ReportUnavailableError, document_report
+
+
+@pytest.fixture(scope="module")
+def report_inputs(tmp_path_factory):
+    import draftwright.document as document_module
+
+    document, _path, _raw = hole_document(tmp_path_factory.mktemp("report-authority"))
+    result = document.build()
+    captured = {}
+
+    def capture(**kwargs):
+        captured.update(kwargs)
+        return document_report(**kwargs)
+
+    with pytest.MonkeyPatch.context() as patch:
+        patch.setattr(document_module, "document_report", capture)
+        report = result.report()
+    assert report["claims"] and report["assessment"]["fidelity"]["conflicts"]
+    assert len(captured["evaluation"].members) == 2
+    return captured
+
+
+@pytest.mark.parametrize("change", ["missing", "equal_clone"])
+def test_report_requires_its_exact_complete_catalog(report_inputs, change):
+    evaluation = report_inputs["evaluation"]
+    first, *rest = evaluation.requirements
+    rows = (
+        tuple(rest)
+        if change == "missing"
+        else (replace(first, requirement=replace(first.requirement)), *rest)
+    )
+    with pytest.raises(ReportUnavailableError, match="exact catalog"):
+        document_report(**{**report_inputs, "evaluation": replace(evaluation, requirements=rows)})
+
+
+@pytest.mark.parametrize("change", ["foreign_owner", "absent_sheet", "absent_annotation"])
+def test_claim_references_must_resolve_within_the_document(report_inputs, change):
+    evaluation = report_inputs["evaluation"]
+    snapshot, *others = evaluation.claims
+    claim, *rest = snapshot.claims
+    if change == "foreign_owner":
+        changed = replace(claim, owner=replace(claim.owner))
+    elif change == "absent_sheet":
+        changed = replace(claim, sheet="absent")
+    else:
+        changed = replace(claim, annotation="absent")
+    altered = replace(evaluation, claims=(replace(snapshot, claims=(changed, *rest)), *others))
+    with pytest.raises(
+        ReportUnavailableError, match="exact common owner|absent member annotation"
+    ):
+        document_report(**{**report_inputs, "evaluation": altered})
+
+
+@pytest.mark.parametrize("members", ["empty", "duplicate"])
+def test_report_cannot_lose_or_duplicate_member_identity(report_inputs, members):
+    evaluation = report_inputs["evaluation"]
+    changed = () if members == "empty" else (evaluation.members[0], evaluation.members[0])
+    with pytest.raises(ReportUnavailableError, match="member identities"):
+        document_report(**{**report_inputs, "evaluation": replace(evaluation, members=changed)})
+
+
+def test_conflict_cannot_refer_to_an_unpublished_equal_claim(report_inputs):
+    evaluation = report_inputs["evaluation"]
+    conflict, *rest = evaluation.conflicts
+    first, *others = conflict.claims
+    changed = replace(conflict, claims=(replace(first), *others))
+    with pytest.raises(ReportUnavailableError, match="absent confirmed claim"):
+        document_report(
+            **{**report_inputs, "evaluation": replace(evaluation, conflicts=(changed, *rest))}
+        )
+
+
+def test_producer_carrier_cannot_name_absent_ink(report_inputs):
+    evaluation = report_inputs["evaluation"]
+    index, row = next(
+        (i, row)
+        for i, row in enumerate(evaluation.requirements)
+        if getattr(row.combined.outcome, "carriers", ()) and row.state == "placed"
+    )
+    outcome = row.combined.outcome
+    carrier, *rest = outcome.carriers
+    outcome = replace(outcome, carriers=(replace(carrier, annotation="absent"), *rest))
+    changed = replace(row, combined=replace(row.combined, outcome=outcome))
+    rows = list(evaluation.requirements)
+    rows[index] = changed
+    with pytest.raises(ReportUnavailableError, match="carrier names an absent"):
+        document_report(
+            **{**report_inputs, "evaluation": replace(evaluation, requirements=tuple(rows))}
+        )
+
+
+@pytest.mark.parametrize("change", ["invalid_state", "unattributed_placed"])
+def test_report_distinguishes_invalid_state_from_missing_carrier_attribution(
+    report_inputs, change
+):
+    evaluation = report_inputs["evaluation"]
+    index, row = next(
+        (i, row) for i, row in enumerate(evaluation.requirements) if row.state == "placed"
+    )
+    rows = list(evaluation.requirements)
+    if change == "invalid_state":
+        rows[index] = replace(row, state="complete")
+        with pytest.raises(ReportUnavailableError, match="invalid evaluation state"):
+            document_report(
+                **{**report_inputs, "evaluation": replace(evaluation, requirements=tuple(rows))}
+            )
+    else:
+        rows[index] = replace(
+            row, combined=replace(row.combined, outcome=replace(row.combined.outcome, carriers=()))
+        )
+        report = document_report(
+            **{**report_inputs, "evaluation": replace(evaluation, requirements=tuple(rows))}
+        )
+        emitted = report["recognition"]["requirements"][index]
+        assert emitted["carrier_attribution"] == "unavailable"
+        assert emitted["carrying_annotations"] == []
+        assert report["status"] == "needs-attention"
+
+
+@pytest.mark.parametrize("missing", ["lint", "resolved", "recipe"])
+def test_report_requires_member_lint_and_replay_inputs(report_inputs, missing):
+    kwargs = dict(report_inputs)
+    evaluation = kwargs["evaluation"]
+    name, snapshot, rows = evaluation.members[0]
+    if missing == "lint":
+        kwargs["evaluation"] = replace(
+            evaluation,
+            members=((name, replace(snapshot, lint=None), rows), *evaluation.members[1:]),
+        )
+    else:
+        key = "resolved" if missing == "resolved" else "member_recipes"
+        kwargs[key] = {k: v for k, v in kwargs[key].items() if k != name}
+    with pytest.raises(ReportUnavailableError, match="lacks lint or run options"):
+        document_report(**kwargs)

--- a/tests/test_issue_1542_requirement_carriers.py
+++ b/tests/test_issue_1542_requirement_carriers.py
@@ -1,0 +1,213 @@
+"""Carrier names follow accepted evidence without changing requirement outcomes."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from build123d import Box, Cylinder, Pos, RegularPolygon, Rot, extrude
+
+from draftwright import build_drawing
+from draftwright.document_evidence import bind_document_claims, document_support_proofs
+from draftwright.model.compiled import DimensionId
+
+FIXTURES = Path(__file__).parent / "fixtures/evaluation"
+
+
+def _carriers(outcome):
+    return {(carrier.annotation, carrier.kind) for carrier in outcome.carriers}
+
+
+def test_through_step_alternates_use_confirmed_proofs_not_registered_names():
+    part = Rot(90, 0, 0) * (Box(40, 30, 20) - Pos(15, 10, 0) * Box(20, 20, 30))
+    drawing = build_drawing(part)
+    outcomes = drawing.requirement_snapshot().outcomes["through_steps"]
+    assert len(outcomes) == 2
+    assert all(row.state == "inapplicable" and row.dependency_alternatives for row in outcomes)
+    assert all(not row.carriers for row in outcomes)
+    snapshot = bind_document_claims("before", drawing.measurement_snapshot(), drawing.registry)
+    proofs = tuple(
+        document_support_proofs(row.dependency_alternatives, (snapshot,), ()) for row in outcomes
+    )
+    assert all(proofs), "The fixture must first prove both complete physical legs"
+    names = {
+        claim.annotation
+        for alternatives in proofs
+        for proof in alternatives
+        for claim in proof.witnesses
+    }
+    assert names
+    for name in names:
+        annotation = drawing.registry.named(name)
+        assert annotation.label != "999"
+        annotation.label = "999"
+
+    damaged = drawing.requirement_snapshot().outcomes["through_steps"]
+    assert len(damaged) == len(outcomes)
+    assert all(row.state == "missing" and not row.carriers for row in damaged)
+    snapshot = bind_document_claims("after", drawing.measurement_snapshot(), drawing.registry)
+    assert snapshot.unknown
+    assert all(
+        not document_support_proofs(row.dependency_alternatives, (snapshot,), ())
+        for row in damaged
+    )
+
+
+def test_native_through_step_keeps_every_direct_carrier():
+    drawing = build_drawing(Box(40, 30, 20) - Pos(15, 10, 0) * Box(20, 20, 30))
+    rows = drawing.requirement_snapshot().outcomes["through_steps"]
+    assert len(rows) == 2
+    for row in rows:
+        assert row.state == "placed" and not row.dependency_alternatives
+        assert row.carriers
+        for carrier in row.carriers:
+            assert carrier.kind == "measurement"
+            assert any(
+                identity.feature is row.features[0] and identity.parameter == row.parameter_id
+                for identity in drawing.registry.measurement_of(carrier.annotation)
+            )
+
+
+@pytest.mark.parametrize(
+    "fixture,family,kind,prefix,aliases",
+    (
+        ("pad-z-positive.step", "pads", "pad", "location_pad.", ("location",)),
+        ("pocket-lone.step", "pockets", "pocket", "location_pocket.", ("location",)),
+        (
+            "pocket-pattern-linear.step",
+            "pocket_patterns",
+            "pocket_pattern",
+            "location_pocket_pattern.",
+            ("location", "location_pocket_pattern.location"),
+        ),
+    ),
+)
+def test_locations_retain_physical_ink_and_every_valid_note_alias(
+    fixture, family, kind, prefix, aliases
+):
+    drawing = build_drawing(FIXTURES / fixture)
+    owner = next(feature for feature in drawing.model().features if feature.kind == kind)
+    original = {
+        row.parameter_id: row
+        for row in drawing.requirement_snapshot().outcomes[family]
+        if row.parameter_id.startswith(prefix)
+    }
+    assert len(original) == 2
+    assert all(row.state == "placed" and row.carriers for row in original.values())
+    expected_notes = set()
+    for index, parameter in enumerate(aliases):
+        name = f"location_note_{index}"
+        drawing.registry.add(
+            SimpleNamespace(),
+            name,
+            "plan",
+            feature=owner,
+            satisfaction=DimensionId(owner, parameter),
+        )
+        expected_notes.add((name, "structured_note"))
+
+    both = {
+        row.parameter_id: row
+        for row in drawing.requirement_snapshot().outcomes[family]
+        if row.parameter_id in original
+    }
+    for parameter, row in both.items():
+        assert row.state == "placed"
+        assert _carriers(row) == _carriers(original[parameter]) | expected_notes
+    for name in {carrier.annotation for row in original.values() for carrier in row.carriers}:
+        drawing.remove(name)
+    remaining = [
+        row
+        for row in drawing.requirement_snapshot().outcomes[family]
+        if row.parameter_id in original
+    ]
+    assert len(remaining) == 2
+    assert all(row.state == "satisfied_by_structured_note" for row in remaining)
+    assert all(_carriers(row) == expected_notes for row in remaining)
+
+
+def test_pocket_pattern_count_keeps_note_and_rejects_conflicting_printed_quantity():
+    drawing = build_drawing(FIXTURES / "pocket-pattern-linear.step")
+    owner = next(
+        feature for feature in drawing.model().features if feature.kind == "pocket_pattern"
+    )
+
+    def count_outcome():
+        return next(
+            row
+            for row in drawing.requirement_snapshot().outcomes["pocket_patterns"]
+            if row.parameter_id == "grouping.count"
+        )
+
+    original = count_outcome()
+    assert original.state == "placed" and original.carriers
+    drawing.registry.add(
+        SimpleNamespace(),
+        "count_note",
+        "plan",
+        feature=owner,
+        satisfaction=DimensionId(owner, "grouping.count"),
+    )
+    assert _carriers(count_outcome()) == _carriers(original) | {("count_note", "structured_note")}
+    drawing.registry.add(SimpleNamespace(covers_count=99), "wrong_count", "plan", feature=owner)
+    conflicted = count_outcome()
+    assert conflicted.state == "satisfied_by_structured_note"
+    assert _carriers(conflicted) == {("count_note", "structured_note")}
+
+
+def test_hole_carriers_exclude_wrong_quantities_and_unrelated_member_points():
+    part = Box(80, 60, 10)
+    for x, y in ((-20, -15), (20, 15)):
+        part -= Pos(x, y, 0) * Cylinder(2, 20)
+    drawing = build_drawing(part)
+    owner = next(feature for feature in drawing.model().features if feature.kind == "hole")
+    assert owner.count == 2
+    parameters = {"grouping.count", "location.location.x", "location.location.y"}
+    original = {
+        row.parameter_id: row
+        for row in drawing.requirement_snapshot().outcomes["holes"]
+        if row.parameter_id in parameters
+    }
+    assert set(original) == parameters
+    assert all(row.state == "placed" and row.carriers for row in original.values())
+    drawing.registry.add(
+        SimpleNamespace(covers_count=99, covers_hole_requirements=("grouping.count",)),
+        "wrong_count",
+        "plan",
+        feature=owner,
+        measurement=DimensionId(owner, "bore.diameter"),
+    )
+    drawing.registry.add(
+        SimpleNamespace(covers_hole_locations=((owner, "location.location.x", (999, 999, 5)),)),
+        "wrong_point",
+        "plan",
+        feature=owner,
+    )
+    for row in drawing.requirement_snapshot().outcomes["holes"]:
+        if row.parameter_id in original:
+            assert row.state == "placed"
+            assert _carriers(row) == _carriers(original[row.parameter_id])
+
+
+def test_profile_angle_carrier_requires_angular_annotation_type():
+    drawing = build_drawing(extrude(RegularPolygon(30, 3), amount=4))
+    original = next(
+        row
+        for row in drawing.requirement_snapshot().outcomes["outer_profile_angles"]
+        if row.state == "placed"
+    )
+    assert original.carriers
+    owner = original.features[0]
+    drawing.registry.add(
+        SimpleNamespace(),
+        "not_an_angle",
+        "plan",
+        feature=owner,
+        measurement=DimensionId(owner, original.parameter_id),
+    )
+    current = next(
+        row
+        for row in drawing.requirement_snapshot().outcomes["outer_profile_angles"]
+        if any(feature is owner for feature in row.features)
+    )
+    assert current.state == "placed"
+    assert _carriers(current) == _carriers(original)

--- a/tests/test_sheet_identity_invariant.py
+++ b/tests/test_sheet_identity_invariant.py
@@ -41,9 +41,9 @@ import pickle
 from pathlib import Path
 
 import pytest
-from build123d import Box, Cylinder, Pos
+from build123d import Box, Cylinder, Pos, export_step
 
-from draftwright import Sheet
+from draftwright import Document, Sheet
 from draftwright.model import Frame, HoleFeature
 
 _SRC = Path(__file__).resolve().parent.parent / "src" / "draftwright" / "sheet.py"
@@ -676,6 +676,11 @@ _STATE_CARRYING_FEATURE_REFS = frozenset(
     }
 )
 
+#: Exact common owners cannot be deleted/replaced. Their separate scenario below tests
+#: reorder and authoring while the document lifecycle tests exercise atomic refusals.
+_STATE_CARRYING_SEALED_FEATURE_REFS = frozenset({"_document_input"})
+
+
 #: `Sheet` state that stores no feature reference, so a reorder cannot affect it.
 _STATE_WITHOUT_FEATURE_REFS = frozenset(
     {
@@ -742,7 +747,11 @@ def test_every_sheet_state_field_is_classified():
     that is what the invariant is actually about. A new field forces a classification, and
     classifying it as reference-carrying forces a scenario via the test below.
     """
-    assert _sheet_state_fields() == _STATE_CARRYING_FEATURE_REFS | _STATE_WITHOUT_FEATURE_REFS, (
+    assert _sheet_state_fields() == (
+        _STATE_CARRYING_FEATURE_REFS
+        | _STATE_CARRYING_SEALED_FEATURE_REFS
+        | _STATE_WITHOUT_FEATURE_REFS
+    ), (
         "Sheet grew or lost state — classify each new field as carrying feature references "
         "(and give it a scenario in _SCENARIOS) or not carrying them"
     )
@@ -761,6 +770,29 @@ def test_every_reference_carrying_state_field_is_exercised():
         f"no scenario populates {sorted(_STATE_CARRYING_FEATURE_REFS - reached)} — a reference "
         "stored there would not be covered by the reorder matrix"
     )
+
+
+def test_sealed_reference_state_preserves_common_owners_across_reorder(tmp_path):
+    path = tmp_path / "common.step"
+    export_step(_part(), path)
+    document = Document.from_part(path)
+    sheet = document.sheet("features").authored_dimensions()
+    reached = {field for field in _STATE_CARRYING_SEALED_FEATURE_REFS if getattr(sheet, field)}
+    assert reached == _STATE_CARRYING_SEALED_FEATURE_REFS
+    holes = [feature for feature in document.features if feature.kind == "hole"]
+    assert len(holes) == 2 and holes[0] is not holes[1]
+    handle = sheet.of(holes[0])
+    sheet.dimension(handle, "bore.diameter")
+    before = _canonical_sheet(sheet)
+    order = _order(sheet)
+    sheet.features.reverse()
+    assert _order(sheet) != order
+    assert _canonical_sheet(sheet) == before
+    handle.tolerance(0.02)
+    model = sheet.model()
+    assert all(any(feature is owner for feature in model.features) for owner in document.features)
+    assert len(model.decorations) == 1
+    assert next(iter(model.decorations))[0] is holes[0]
 
 
 def test_dimension_intent_verb_roster_is_closed():


### PR DESCRIPTION
Dimensions distributed across separate sheets now share one recognition-owned requirement inventory through `Document.from_part(...).sheet(...)`. The document builds each member through the existing compiler and placement engine, then reconciles live evidence without joining independent reports by numbers or coordinates.

Repeated measurements earn one requirement credit. A confirmed ±0.02 claim on one sheet and ±0.05 on another retains both claims as a document fidelity conflict. Existing physical dependency recipes can use confirmed prerequisites on different sheets; missing, conflicting or incorrect support loses derived credit while preserving the obligation.

The common input seals exact physical owners and retains the original STEP bytes. Schema-v4 document reports include source/options, member intent and outcomes, actual carrier/proof references, separate coverage/layout/fidelity/manufacturing assessments, and explicit replay limits. Single-sheet reports retain schema v3. Public API documentation includes an executed two-sheet example; typed schedules and the complete frame canary remain #1543 and #1544.

Validation:
- Full `BASE_REF=6c52939682671bc37faa6ac4ae883140b0a7d9cc scripts/pr-check --full` passed on the tree committed as `7e1bf0ad`: 8,276 passed, 5 skipped, 13 xfailed; 96.08% overall coverage and 97% changed-line coverage. Static checks and strict documentation build passed.
- The published predecessor failed Codecov patch coverage because partially covered branches count as misses there. Added authority-refusal regressions and removed a reviewed unreachable empty-approval guard. The fresh local XML has 1,152 fully covered changed lines out of 1,210 (95.21%) when counting partial branches as misses; hosted CI remains the authority for its check. No coverage threshold or configuration changed.
- Independent Google-style review against all five ADRs and the complete #1542 acceptance criteria: no substantive findings. The final coverage increment independently passed 114 tests and killed three actual guard-removal mutations; prior full review exercised all 25 current requirement families.
- Regressions cover exact ownership and datum sealing, failures/cancellation, live removal and movement, conflicting tolerances, fit display equivalence, per-member location addresses, complete interval dependency proofs, carrier count/point/type predicates, unknown cardinality, and atomic report writes.
- Named runtime mutations restoring rejected carrier behavior and single-channel note omission fail their regression tests. Claim-address, witness-multiplicity and conflict mutations also fail their named guards.
- The exact documented example exported both member PDFs/SVGs and wrote the v4 report.

Fixes #1542. Part of #1529; follows the merged design in #1535.
