### PR TITLE
Add compiler-owned feature schedules with verified cell coverage

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -286,7 +286,7 @@ IR, generation, and drawing code must not depend on benchmark expectations or sc
   and the original analysis for reuse through the existing builder.
 - **`document.py`** — rank-7 explicit document facade. It takes one STEP snapshot, binds member
   Sheets to the common source, and builds them through the existing pipeline with named failures.
-  Live member snapshots reach `reporting.py` for schema-v4 coverage, carrier attribution and
+  Live member snapshots reach `reporting.py` for document coverage, carrier attribution and
   engineering conflict assessment; ordinary Drawing reports retain schema v3.
 - **`inspection.py`** — the rank-7 public read-only STEP inspection surface (`inspect_step`).
   It hashes one immutable source-byte snapshot, drives the shared one-run

--- a/docs/reference/document.md
+++ b/docs/reference/document.md
@@ -48,9 +48,11 @@ the member through `DocumentBuildError.sheet_name`; cancellation names it in
 
 ## Read the document report
 
-`result.report()` returns schema version **4**, with `scope: "document"`. The schema is published as
-[`draftwright-report-v4.schema.json`](draftwright-report-v4.schema.json). Individual
-`Drawing.report()` calls retain version 3. The document report contains:
+`result.report()` uses `scope: "document"`. Ordinary documents return schema version **4**
+([schema](draftwright-report-v4.schema.json)). A document with a declared feature schedule returns
+version **5** ([schema](draftwright-report-v5.schema.json)), including when the table could not be
+placed or was removed. Individual `Drawing.report()` calls retain version 3. The document report
+contains:
 
 - One source hash, recognition inventory and physical requirement catalog. Repeated annotations
   receive at most one coverage credit for each obligation.
@@ -67,6 +69,55 @@ the member through `DocumentBuildError.sheet_name`; cancellation names it in
 unknown cardinality, unconfirmed claims and unresolved dispositions remain explicit.
 Manufacturing readiness is unassessed. Free-text notes do not acquire measurement authority.
 
+## Feature schedules
+
+A schedule declares measurements through exact feature owners and canonical parameter IDs.
+The compiler supplies the values and their formatting; the existing table placement path fits
+and places the result. The `location` selector expands the feature's addressable member
+coordinates. Discover supported parameters with `sheet.of(feature).dimension_ids()` and member
+selectors with `sheet.dimension_options(feature, "location")["location_components"]` when choosing only some components.
+
+```python
+from pathlib import Path
+from draftwright import Document
+
+package = Document.from_part("part.step")
+features = [feature for feature in package.features if feature.kind == "hole"]
+assert features, "select recognized hole operations before building this recipe"
+sheet = package.sheet("features", page="A3", detail_view=False).authored_views()
+sheet.view("front")
+sheet.view("plan")
+sheet.schedule(
+    [(feature, ("bore.diameter", "location")) for feature in features],
+    name="holes",
+    prefer="br",
+)
+result = package.build()
+Path("out").mkdir(exist_ok=True)
+result.sheets["features"].export("out/features", formats=("pdf", "svg"))
+result.write_report("out/document.json")
+```
+
+This example declares hole diameter and location cells; other requirements remain in the
+report. A schedule selects an authored dimension set. Add ordinary `sheet.dimension(...)`
+statements when the same measurement should also appear beside a view. Schedules do not mix
+with `auto_dimensions()` or augmenting `add_dimension(...)` intent. A table-only measurement
+requires no leader view; an ordinary dimension still needs a view that can show it.
+
+Each measured cell retains its exact owner and parameter, plus a one-based data-row index
+(the header is row zero) and a zero-based column index. V5 claims, carrying annotations and
+cell-specific uncertainties include these addresses. Ordinary annotations and uncertainties
+without a recoverable cell use `cell: null`. Header, owner, axis and quantity context are part
+of cell verification. Changing a nominal, tolerance or relevant context withdraws the affected
+proof; equal numbers elsewhere in the table cannot replace it.
+
+Use `result.sheets["features"].remove("holes")` to remove the whole table. If a schedule also
+contains other features, `drop(feature)` refuses to remove only that feature's rows; change the
+source recipe and rebuild.
+Failed placement reports the scheduled measurements without silently shrinking the table's
+text. Structured notes earn only their explicitly declared satisfaction; descriptive table
+cells and ordinary prose earn no dimensional credit.
+
 ## Edits, persistence and replay
 
 Member Drawings remain editable through their public verbs. Read `result.report()` again after
@@ -82,10 +133,10 @@ and requires its parent directory to exist. Export remains explicit, per member.
 The source hash identifies the retained STEP bytes. Report-local owner, occurrence, sheet,
 requirement and claim IDs expire with that report; they are not reusable feature handles.
 The report records member build options, dimension selection, view constraints, ordinary table
-text and resolved layout decisions. Preserve your source recipe for decorations, GD&T,
+text and resolved layout decisions. V5 also records the captured feature-schedule selectors,
+using report-local owner IDs. Preserve your source recipe for decorations, GD&T,
 feature-linked notes, measured dimensions, member PMI declarations and live edits. Replaying a recipe means loading the source and selecting
 current exact features with operation/cardinality assertions. It never means deserializing old
 IDs or treating an independently built Drawing or PDF as common authority.
 
-Typed feature schedules and the complete two-sheet frame recipe are tracked separately in
-#1543 and #1544.
+The complete two-sheet frame recipe and real-part canary are tracked in #1544.

--- a/docs/reference/draftwright-report-v5.schema.json
+++ b/docs/reference/draftwright-report-v5.schema.json
@@ -1,0 +1,1257 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://draftwright.dev/schema/draftwright-report-v5.schema.json",
+  "title": "Draftwright common-source document report v5",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema",
+    "schema_version",
+    "scope",
+    "status",
+    "producer",
+    "source",
+    "run_options",
+    "outputs",
+    "recognition",
+    "sheets",
+    "claims",
+    "assessment",
+    "replay"
+  ],
+  "properties": {
+    "schema": {
+      "const": "draftwright-report"
+    },
+    "schema_version": {
+      "const": 5
+    },
+    "scope": {
+      "const": "document"
+    },
+    "status": {
+      "enum": [
+        "needs-attention",
+        "bounded-clear"
+      ]
+    },
+    "producer": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "draftwright",
+        "quiddity"
+      ],
+      "properties": {
+        "draftwright": {
+          "type": "string",
+          "minLength": 1
+        },
+        "quiddity": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "kind",
+        "name",
+        "sha256"
+      ],
+      "properties": {
+        "kind": {
+          "const": "step"
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sha256": {
+          "type": "string",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      }
+    },
+    "run_options": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "pmi",
+        "frame"
+      ],
+      "properties": {
+        "pmi": {
+          "enum": [
+            "off",
+            "report",
+            "annotate"
+          ]
+        },
+        "frame": {
+          "const": "raw"
+        }
+      }
+    },
+    "outputs": {
+      "type": "object"
+    },
+    "recognition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "identity_scope",
+        "occurrences",
+        "owners",
+        "requirements",
+        "summary",
+        "unresolved_occurrences"
+      ],
+      "properties": {
+        "identity_scope": {
+          "const": "document-local"
+        },
+        "occurrences": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/occurrence"
+          }
+        },
+        "owners": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/owner"
+          }
+        },
+        "requirements": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/requirement"
+          }
+        },
+        "summary": {
+          "$ref": "#/$defs/summary"
+        },
+        "unresolved_occurrences": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "sheets": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/sheet"
+      }
+    },
+    "claims": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/claim"
+      }
+    },
+    "assessment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "coverage",
+        "layout",
+        "fidelity",
+        "manufacturing"
+      ],
+      "properties": {
+        "coverage": {
+          "$ref": "#/$defs/coverage"
+        },
+        "layout": {
+          "$ref": "#/$defs/axis_assessment"
+        },
+        "fidelity": {
+          "$ref": "#/$defs/fidelity"
+        },
+        "manufacturing": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "status",
+            "readiness"
+          ],
+          "properties": {
+            "status": {
+              "const": "unassessed"
+            },
+            "readiness": {
+              "const": "not-certified"
+            }
+          }
+        }
+      }
+    },
+    "replay": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "identity_lifetime",
+        "source_snapshot",
+        "member_reads",
+        "requires",
+        "durable_feature_identity",
+        "serialized_declaration_scope",
+        "source_recipe_required_for",
+        "script_deserialization"
+      ],
+      "properties": {
+        "identity_lifetime": {
+          "const": "this-report-only"
+        },
+        "source_snapshot": {
+          "const": "immutable-step-bytes"
+        },
+        "member_reads": {
+          "const": "live-at-report-call"
+        },
+        "requires": {
+          "const": "source-recipe-and-current-inventory-assertions"
+        },
+        "durable_feature_identity": {
+          "const": false
+        },
+        "serialized_declaration_scope": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "source_recipe_required_for": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "script_deserialization": {
+          "const": false
+        }
+      }
+    }
+  },
+  "$defs": {
+    "owner": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "kind"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "kind": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "occurrence": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "family",
+        "record_type",
+        "record_schema_version",
+        "record",
+        "disposition",
+        "reason_code",
+        "tracking",
+        "owners",
+        "requirements"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "family": {
+          "type": "string",
+          "minLength": 1
+        },
+        "record_type": {
+          "type": "string",
+          "minLength": 1
+        },
+        "record_schema_version": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "record": {
+          "type": "object"
+        },
+        "disposition": {
+          "enum": [
+            "represented",
+            "absorbed",
+            "unsupported",
+            "deferred",
+            "evidence_only",
+            "unexpectedly_missing"
+          ]
+        },
+        "reason_code": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tracking": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "owners": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/owner"
+          }
+        },
+        "requirements": {
+          "$ref": "#/$defs/requirement_refs"
+        }
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "total",
+        "represented",
+        "absorbed",
+        "unsupported",
+        "deferred",
+        "evidence_only",
+        "unexpectedly_missing"
+      ],
+      "properties": {
+        "total": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "represented": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "absorbed": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "unsupported": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "deferred": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "evidence_only": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "unexpectedly_missing": {
+          "type": "integer",
+          "minimum": 0
+        }
+      }
+    },
+    "requirement_refs": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "coverage",
+        "ids"
+      ],
+      "properties": {
+        "coverage": {
+          "enum": [
+            "ledger",
+            "not-projected",
+            "not-applicable",
+            "deferred",
+            "unavailable"
+          ]
+        },
+        "ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "uniqueItems": true
+        }
+      }
+    },
+    "annotation_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sheet_id",
+        "annotation"
+      ],
+      "properties": {
+        "sheet_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "annotation": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "carrier": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sheet_id",
+        "annotation",
+        "evidence_kind",
+        "cell"
+      ],
+      "properties": {
+        "sheet_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "annotation": {
+          "type": "string",
+          "minLength": 1
+        },
+        "evidence_kind": {
+          "enum": [
+            "measurement",
+            "structured_note",
+            "angular_measurement",
+            "physical_location",
+            "physical_requirement"
+          ]
+        },
+        "cell": {
+          "$ref": "#/$defs/cell"
+        }
+      }
+    },
+    "local_outcome": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "sheet_id",
+        "state",
+        "reason_code"
+      ],
+      "properties": {
+        "sheet_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "state": {
+          "type": "string",
+          "minLength": 1
+        },
+        "reason_code": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    },
+    "proof": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "alternative",
+        "supports",
+        "distinct_witnesses"
+      ],
+      "properties": {
+        "alternative": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "supports": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "distinct_witnesses": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "requirement": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "family",
+        "occurrence_ids",
+        "owner_ids",
+        "parameter_id",
+        "requirement_count",
+        "requirement_count_known",
+        "state",
+        "coverage_credit",
+        "local_outcomes",
+        "carrying_annotations",
+        "carrier_attribution",
+        "dependency_proofs",
+        "intrinsic_exclusion"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "family": {
+          "type": "string",
+          "minLength": 1
+        },
+        "occurrence_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "owner_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "parameter_id": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "minLength": 1
+        },
+        "requirement_count": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "requirement_count_known": {
+          "type": "boolean"
+        },
+        "state": {
+          "enum": [
+            "placed",
+            "satisfied_by_structured_note",
+            "dependency-derived",
+            "inapplicable",
+            "unresolved",
+            "uncovered"
+          ]
+        },
+        "coverage_credit": {
+          "enum": [
+            0,
+            1
+          ]
+        },
+        "local_outcomes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/local_outcome"
+          }
+        },
+        "carrying_annotations": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/carrier"
+          }
+        },
+        "carrier_attribution": {
+          "enum": [
+            "available",
+            "unavailable"
+          ]
+        },
+        "dependency_proofs": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/proof"
+          }
+        },
+        "intrinsic_exclusion": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "reason_code",
+                "occurrence_ids",
+                "span"
+              ],
+              "properties": {
+                "reason_code": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "occurrence_ids": {
+                  "type": "array",
+                  "items": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                },
+                "span": {}
+              }
+            }
+          ]
+        },
+        "profile_source": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "kind",
+            "profile_id",
+            "support_ids"
+          ],
+          "properties": {
+            "kind": {
+              "const": "planar_outer_profile"
+            },
+            "profile_id": {
+              "type": "string",
+              "pattern": "^profile:[1-9][0-9]*$"
+            },
+            "support_ids": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "uniqueItems": true,
+              "items": {
+                "type": "string",
+                "pattern": "^support:[1-9][0-9]*$"
+              }
+            }
+          }
+        }
+      }
+    },
+    "meaning": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "value",
+        "tolerance",
+        "span",
+        "axis",
+        "discriminator",
+        "location_member",
+        "angular_reference"
+      ],
+      "properties": {
+        "value": {
+          "type": [
+            "number",
+            "null"
+          ]
+        },
+        "tolerance": {},
+        "span": {},
+        "axis": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "discriminator": {},
+        "location_member": {},
+        "angular_reference": {}
+      }
+    },
+    "claim": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "sheet_id",
+        "annotation",
+        "owner_id",
+        "parameter_id",
+        "address",
+        "meaning",
+        "rendered",
+        "verification",
+        "cell"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "sheet_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "annotation": {
+          "type": "string",
+          "minLength": 1
+        },
+        "owner_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "parameter_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "address": {
+          "type": "array",
+          "items": {}
+        },
+        "meaning": {
+          "$ref": "#/$defs/meaning"
+        },
+        "rendered": {
+          "type": "array",
+          "items": {}
+        },
+        "verification": {
+          "const": "confirmed-within-measurement-verifier-scope"
+        },
+        "cell": {
+          "$ref": "#/$defs/cell"
+        }
+      }
+    },
+    "dimension_intent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "owner_id",
+        "role",
+        "discriminator",
+        "member",
+        "display_decimals",
+        "view",
+        "side"
+      ],
+      "properties": {
+        "owner_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "role": {
+          "type": "string",
+          "minLength": 1
+        },
+        "discriminator": {},
+        "member": {},
+        "display_decimals": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "view": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "side": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "dimension_intents": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source",
+        "authored",
+        "requested"
+      ],
+      "properties": {
+        "source": {
+          "enum": [
+            "authored",
+            "automatic"
+          ]
+        },
+        "authored": {
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/$defs/dimension_intent"
+              }
+            }
+          ]
+        },
+        "requested": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/dimension_intent"
+          }
+        }
+      }
+    },
+    "view_intents": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "principal_source",
+        "derived_source",
+        "principals",
+        "added_principals",
+        "derived",
+        "added_derived",
+        "relations",
+        "pins"
+      ],
+      "properties": {
+        "principal_source": {
+          "enum": [
+            null,
+            "authored",
+            "automatic"
+          ]
+        },
+        "derived_source": {
+          "enum": [
+            null,
+            "authored",
+            "automatic"
+          ]
+        },
+        "principals": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "added_principals": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "derived": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "added_derived": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "relations": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        },
+        "pins": {
+          "type": "array",
+          "items": {
+            "type": "object"
+          }
+        }
+      }
+    },
+    "sheet": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "id",
+        "name",
+        "options",
+        "resolved",
+        "dimension_intents",
+        "view_intents",
+        "table_intents",
+        "lint",
+        "schedule_intents"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "options": {
+          "type": "object"
+        },
+        "resolved": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "scale",
+            "page_mm",
+            "scale_decision",
+            "view_decision"
+          ],
+          "properties": {
+            "scale": {
+              "type": "number"
+            },
+            "page_mm": {
+              "type": "array",
+              "minItems": 2,
+              "maxItems": 2,
+              "items": {
+                "type": "number"
+              }
+            },
+            "scale_decision": {},
+            "view_decision": {}
+          }
+        },
+        "dimension_intents": {
+          "$ref": "#/$defs/dimension_intents"
+        },
+        "view_intents": {
+          "$ref": "#/$defs/view_intents"
+        },
+        "table_intents": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "rows",
+              "prefer",
+              "name",
+              "block_cols"
+            ],
+            "properties": {
+              "rows": {
+                "type": "array",
+                "items": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "prefer": {
+                "type": "string",
+                "minLength": 1
+              },
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "block_cols": {}
+            }
+          }
+        },
+        "lint": {
+          "type": "object"
+        },
+        "schedule_intents": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/schedule_intent"
+          }
+        }
+      }
+    },
+    "axis_assessment": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "affected_sheets",
+        "unassessed_sheets"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "needs-attention",
+            "unassessed",
+            "clear-within-lint-scope"
+          ]
+        },
+        "affected_sheets": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "unassessed_sheets": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "fidelity": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "status",
+        "affected_sheets",
+        "unassessed_sheets",
+        "conflicts",
+        "unknown_claims",
+        "scope",
+        "unassessed_scope"
+      ],
+      "properties": {
+        "status": {
+          "enum": [
+            "needs-attention",
+            "unassessed",
+            "clear-within-lint-scope"
+          ]
+        },
+        "affected_sheets": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "unassessed_sheets": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "conflicts": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "code",
+              "claim_ids"
+            ],
+            "properties": {
+              "code": {
+                "const": "conflicting_engineering_meanings"
+              },
+              "claim_ids": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        },
+        "unknown_claims": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "sheet_id",
+              "annotation",
+              "reason_code",
+              "cell"
+            ],
+            "properties": {
+              "sheet_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "annotation": {
+                "type": "string",
+                "minLength": 1
+              },
+              "reason_code": {
+                "type": "string",
+                "minLength": 1
+              },
+              "cell": {
+                "$ref": "#/$defs/cell"
+              }
+            }
+          }
+        },
+        "scope": {
+          "const": "verified-measurement-claims-and-member-fidelity-lint"
+        },
+        "unassessed_scope": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "coverage": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "scope",
+        "known_requirement_count",
+        "unknown_cardinality_rows",
+        "credited_requirements",
+        "audited_score",
+        "uncovered_or_unresolved",
+        "unattributed_carriers",
+        "excludes"
+      ],
+      "properties": {
+        "scope": {
+          "const": "accepted-occurrences-and-profile-requirements"
+        },
+        "known_requirement_count": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "unknown_cardinality_rows": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "credited_requirements": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "audited_score": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "minimum": 0,
+          "maximum": 1
+        },
+        "uncovered_or_unresolved": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "unattributed_carriers": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "excludes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        }
+      }
+    },
+    "cell": {
+      "anyOf": [
+        {
+          "type": "null"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "row",
+            "column"
+          ],
+          "properties": {
+            "row": {
+              "type": "integer",
+              "minimum": 1
+            },
+            "column": {
+              "type": "integer",
+              "minimum": 0
+            }
+          }
+        }
+      ]
+    },
+    "schedule_intent": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "prefer",
+        "rows"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "prefer": {
+          "type": "string",
+          "minLength": 1
+        },
+        "rows": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "owner_id",
+              "parameters"
+            ],
+            "properties": {
+              "owner_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "parameters": {
+                "type": "array",
+                "minItems": 1,
+                "uniqueItems": true,
+                "items": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -126,6 +126,20 @@ resolved wording, machining specifications and placement constraints agree; orig
 owners and measurement identities remain separate. Removing one owner of a shared callout
 rebuilds the survivors through the placement solver.
 
+## Feature schedules
+
+`sheet.schedule([(feature, ("bore.diameter", "location"))], name="holes")` declares a measured
+table through the same IR/compiler as ordinary dimensions. Features may be fluent handles or
+exact owned IR objects. Values, tolerances, units and through/blind wording come from the
+compiler. `location` expands the addressable member coordinates; explicit canonical IDs select
+individual components. Use `prefer="tr"`, `"tl"`, `"br"` or `"bl"` to rank the existing table
+placement candidates.
+
+Schedules establish authored dimension intent. Add `sheet.dimension(...)` declarations when a
+measurement should also appear beside a view. Ordinary `table(...)` text has no measurement
+authority. See [shared drawing documents](document.md#feature-schedules) for an executable
+recipe, verified cell evidence and the document report contract.
+
 ## Grooves on coaxial bodies
 
 When different turned bodies share an axis line, give their steps distinct `profile_group`

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -20,7 +20,6 @@ import re
 from bisect import bisect_left, bisect_right
 from collections.abc import Callable
 from dataclasses import dataclass
-from decimal import Decimal
 from pathlib import Path
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Literal
@@ -63,6 +62,7 @@ from draftwright._geometry import (  # noqa: F401
     HoleRef,
     _axis_letter,
     _fmt,
+    _fmt_tolerance,
     _xyz,
 )
 from draftwright.fits import FitClass
@@ -110,6 +110,7 @@ def place_annotation(
     feature=None,
     measurement=None,
     satisfaction=None,
+    cells=(),
 ):
     """The annotation-placement primitive (#817): register *obj* under *name* — replacing any
     prior object of that name (dropped from the render list *items*) so a name maps to one
@@ -126,7 +127,7 @@ def place_annotation(
         items.remove(displaced)
     annotate(obj, name)
     items.append(obj)
-    registry.add(obj, name, view, feature, measurement, satisfaction)
+    registry.add(obj, name, view, feature, measurement, satisfaction, cells=cells)
     return obj
 
 
@@ -357,15 +358,7 @@ def _tol_suffix(tolerance, draft) -> str:
     if isinstance(tolerance, FitClass):
         return tolerance.suffix()
 
-    def magnitude(value):
-        decimal = Decimal(str(value))
-        precision = max(draft.decimal_precision, -int(decimal.as_tuple().exponent))
-        return f"{decimal:.{precision}f}"
-
-    if isinstance(tolerance, (int, float)):
-        return f" ±{magnitude(tolerance)}"
-    lo, hi = tolerance
-    return f" +{magnitude(hi)} -{magnitude(lo)}"
+    return _fmt_tolerance(tolerance, draft.decimal_precision)
 
 
 def _tag_sequence(n):

--- a/src/draftwright/_geometry.py
+++ b/src/draftwright/_geometry.py
@@ -588,6 +588,29 @@ def _fmt(v: float, decimals: int | None = None) -> str:
     return str(r) if abs(v - r) < 1e-6 else f"{v:.1f}"
 
 
+def _fmt_tolerance(tolerance, decimal_precision: int = 1) -> str:
+    """Shared numeric tolerance suffix, preserving every authored deviation digit."""
+    if tolerance is None:
+        return ""
+
+    def magnitude(value):
+        decimal = Decimal(str(value))
+        precision = max(decimal_precision, -int(decimal.as_tuple().exponent))
+        return f"{decimal:.{precision}f}"
+
+    if isinstance(tolerance, (int, float)):
+        return f" ±{magnitude(tolerance)}"
+    lo, hi = tolerance
+    return f" +{magnitude(hi)} -{magnitude(lo)}"
+
+
+def _fmt_chamfer(leg_text, leg, other_leg, angle) -> str:
+    """Shared chamfer form: equal 45-degree legs use C, asymmetric legs state the angle."""
+    if abs(leg - other_leg) < 0.05 and abs(angle - 45.0) < 0.5:
+        return f"C{leg_text}"
+    return f"{leg_text} × {_fmt(angle)}°"
+
+
 def _fmt_angle(value, decimals=None, tolerance=None) -> str:
     """Complete angular text shared by footprint sizing and compilation.
 

--- a/src/draftwright/analysis.py
+++ b/src/draftwright/analysis.py
@@ -57,13 +57,15 @@ from draftwright.compose import (
     _build_zones,
     _est_hole_table_sizes,
     _est_planned_bore_callout_width,
+    _est_table_size,
     _layout_geometry,
     _measure_strips,
     choose_scale,
 )
+from draftwright.model.compiled import compile_dimensions
 from draftwright.model.detect import _build_part_model_from_recognition
 from draftwright.model.ir import Datum, GrooveFeature, PartModel, StepFeature, StepLevelFeature
-from draftwright.model.planner import plan_dimensions
+from draftwright.model.planner import annotation_groups, plan_dimensions
 from draftwright.progress import observed_stage
 from draftwright.recognition_cache import _result_from_evidence
 from draftwright.recognition_frame import (
@@ -1134,6 +1136,12 @@ def _analyse(
         strip_sizing_model,
         planned_views=third_angle_view_names() if _views is None else _views,
     )
+    schedule_tables = (
+        compile_dimensions(strip_sizing_model, groups=sizing_groups).schedules
+        if strip_sizing_model.schedules
+        else ()
+    )
+    sizing_groups = annotation_groups(strip_sizing_model, sizing_groups)
     bore_callout_width = _est_planned_bore_callout_width(
         sizing_groups, _draft_est, font_size=_FONT_SIZE, pad_around_text=_pad_around_text
     )
@@ -1150,7 +1158,17 @@ def _analyse(
     layout_table_sizes = _est_hole_table_sizes(
         sizing_model, bb, font_size=_FONT_SIZE, pad_around_text=_pad_around_text
     )
-    layout_required_tables = tuple(_required_tables)
+    layout_required_tables = tuple(_required_tables) + tuple(
+        (
+            _est_table_size(
+                tuple(tuple(cell.text for cell in row) for row in schedule.rows),
+                font_size=_FONT_SIZE,
+                pad_around_text=_pad_around_text,
+            ),
+            schedule.prefer,
+        )
+        for schedule in schedule_tables
+    )
     planned_iso_scale = _planned_iso_scale(_view_constraints)
 
     # Choose scale/page, iterating so the reserved step corridor matches the

--- a/src/draftwright/annotations/from_model.py
+++ b/src/draftwright/annotations/from_model.py
@@ -64,6 +64,7 @@ from draftwright._core import (
 )
 from draftwright._geometry import (
     _blend_profile_arcs,
+    _fmt_chamfer,
     _segment_clips_box,
     _straight_blend_faces,
     _turned_profile_site,
@@ -1961,12 +1962,10 @@ def _chamfer_label(leg_text, leg, ch) -> str:
     while *leg* is the number the equal-leg comparison needs. The feature supplies only the
     geometric form discriminators (``leg2``/``angle``), and a ``ChamferFeature`` stays pure
     data (ADR 3 (was 0013 §7))."""
-    if abs(leg - ch.leg2) < 0.05 and abs(ch.angle - 45.0) < 0.5:
-        return f"C{leg_text}"
     # `ch.angle` is a FORM discriminator, not a planned parameter — `ChamferFeature.
     # parameters()` emits only the leg — so it has no approved text to consume. That is the
     # IR gap `_FACTS` records, and it is why this line stays in the provenance budget.
-    return f"{leg_text} × {_fmt(ch.angle)}°"
+    return _fmt_chamfer(leg_text, leg, ch.leg2, ch.angle)
 
 
 # ── Shared machined-feature leader-callout pass (#637) ──────────────────────────────────

--- a/src/draftwright/annotations/orchestrator.py
+++ b/src/draftwright/annotations/orchestrator.py
@@ -115,7 +115,9 @@ from draftwright.model import (
 from draftwright.model.callout import resolved_through_indicator
 from draftwright.model.compiled import compile_dimensions, resolve_feature
 from draftwright.model.detect import _build_part_model_from_recognition
+from draftwright.model.planner import annotation_groups
 from draftwright.progress import stage
+from draftwright.registry import MeasurementCell
 from draftwright.repair import reconcile_witness_labels
 from draftwright.view_plan import ViewConstraints
 
@@ -551,6 +553,7 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
     # ladder, the shoulders and the detail escalation each hold a separately
     # derived decision — three chances to disagree about one drawing.
     _compiled = compile_dimensions(_model, groups=_groups)
+    _groups = annotation_groups(_model, _groups)
     for omission in _compiled.diagnostics:
         if omission.code != "step_position_coincident_with_datum":
             continue
@@ -905,6 +908,20 @@ def _auto_annotate(dwg, a: Analysis, *, detail_view: bool = False):
         # every hole — runs last so the table avoids every placed annotation
         # including the title block and projection symbol (#93/#1517).
         _maybe_tabulate_holes(dwg, a, ctx=ctx, plan=_compiled)
+        for schedule in _compiled.schedules:
+            cells = tuple(
+                MeasurementCell(schedule.name, ri, ci, cell.measurement.id)
+                for ri, row in enumerate(schedule.rows)
+                for ci, cell in enumerate(row)
+                if cell.measurement is not None and cell.measurement.id is not None
+            )
+            dwg.add_table(
+                tuple(tuple(cell.text for cell in row) for row in schedule.rows),
+                name=schedule.name,
+                prefer=schedule.prefer,
+                _source_id=f"schedule:{schedule.name}",
+                _cells=cells,
+            )
 
     run_stages(
         {

--- a/src/draftwright/audit.py
+++ b/src/draftwright/audit.py
@@ -42,6 +42,16 @@ class MeasurementClaim:
     rendered: tuple
     witnesses: tuple = ()
     approved: tuple = field(default=(), repr=False, compare=False, kw_only=True)
+    cell: tuple[int, int] | None = field(default=None, kw_only=True)
+
+
+@dataclass(frozen=True)
+class MeasurementCellUncertainty:
+    """An unconfirmed measured cell; its table-level unknown remains compatible."""
+
+    annotation: str
+    cell: tuple[int, int]
+    reason: str
 
 
 @dataclass(frozen=True)
@@ -51,6 +61,7 @@ class MeasurementSnapshot:
     owners: tuple
     claims: tuple[MeasurementClaim, ...]
     unknown: tuple[tuple[str, str], ...] = ()
+    cell_unknown: tuple[MeasurementCellUncertainty, ...] = field(default=(), kw_only=True)
 
 
 def compare_measurements(before, after, *, feature_pairs=()) -> dict:

--- a/src/draftwright/compose.py
+++ b/src/draftwright/compose.py
@@ -62,6 +62,7 @@ from draftwright.model.callout import hole_callout_batches, hole_callout_suffix
 from draftwright.model.ir import authored_dimension_target_view
 from draftwright.model.planner import (
     angular_pattern_label,
+    annotation_groups,
     authored_location_omitted,
     plan_dimensions,
 )
@@ -521,7 +522,7 @@ def _compose_anno_boxes(
         # compose path also serves read-only inspection. Share the complete text
         # formatter so small authored tolerances reserve their actual footprint.
         # Each curved footprint grows only the sides it actually reaches.
-        for group in plan_dimensions(model):
+        for group in annotation_groups(model, plan_dimensions(model)):
             if group.feature.kind != "angle":
                 continue
             shared_label = angular_pattern_label(group)
@@ -623,7 +624,7 @@ def _compose_anno_boxes(
         if feature.kind in ("boss", "polygonal_boss", "polygonal_stock")
         and feature.frame.axis in ("x", "y")
     ]
-    for group in plan_dimensions(model) if axial_features else ():
+    for group in annotation_groups(model, plan_dimensions(model)) if axial_features else ():
         feature = group.feature
         if feature.kind not in ("boss", "polygonal_boss", "polygonal_stock"):
             continue
@@ -683,12 +684,13 @@ def _compose_anno_boxes(
         # provides the complete requirement for a bounded facing corridor.
         full_depth = _STRIP_GAP + above * (1 + _STRIP_SPACING / (font_size + 2 * pad_around_text))
         boxes.append(AnnoBox("plan_location_above", full_depth))
+    ordinary_model = replace(model, schedules=()) if model.schedules else model
     rear_locations = sum(
         len(feature.members or (feature.frame.origin,))
         for feature in model.features
         if feature.kind in {"hole", "pattern"}
         and feature.frame.axis == "y"
-        and not authored_location_omitted(model, feature)
+        and not authored_location_omitted(ordinary_model, feature)
     )
     rear_height = any(
         group.feature.kind == "envelope"
@@ -699,7 +701,7 @@ def _compose_anno_boxes(
             and dimension.side != "left"
             for dimension in group.dims
         )
-        for group in plan_dimensions(model)
+        for group in annotation_groups(model, plan_dimensions(model))
     )
     if rear_tiers := rear_locations + int(rear_height):
         tier = font_size + 2 * pad_around_text

--- a/src/draftwright/document_evidence.py
+++ b/src/draftwright/document_evidence.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from math import isfinite
 from numbers import Real
 from types import SimpleNamespace
 
 from draftwright._core import _decode_hole_location_fact
+from draftwright.audit import MeasurementCellUncertainty
 from draftwright.fits import FitClass
 from draftwright.linting.evidence import verify_measurement_claims
 from draftwright.registry import AnnotationRegistry
@@ -25,12 +26,16 @@ class DocumentClaim:
     meaning: tuple
     rendered: tuple
     witnesses: tuple
+    cell: tuple[int, int] | None = None
 
 
 @dataclass(frozen=True)
 class DocumentClaimSnapshot:
     claims: tuple[DocumentClaim, ...]
     unknown: tuple[tuple[str, str, str], ...]
+    cell_unknown: tuple[tuple[str, MeasurementCellUncertainty], ...] = field(
+        default=(), kw_only=True
+    )
 
 
 @dataclass(frozen=True)
@@ -164,6 +169,11 @@ def _bind_claim(claim):
 
 
 def _narrowed_claim_confirmed(claim, address, meaning, registry):
+    if claim.cell is not None:
+        # The snapshot already verified this exact table cell against its one
+        # approval. Sending it through the legacy numeric-pool verifier would
+        # discard that evidence address and weaken the proof.
+        return len(claim.approved) == len(claim.meaning) == 1
     location_axis = address[1].rsplit(".", 1)[-1] if address and address[0] == "location" else None
     if len(_normalised_meanings(claim)) == 1 and location_axis is None:
         return True
@@ -222,10 +232,15 @@ def bind_document_claims(sheet, snapshot, registry=None) -> DocumentClaimSnapsho
                 meaning,
                 claim.rendered,
                 claim.witnesses,
+                claim.cell,
             )
             for address, meaning in bindings
         )
-    return DocumentClaimSnapshot(tuple(claims), tuple(dict.fromkeys(unknown)))
+    return DocumentClaimSnapshot(
+        tuple(claims),
+        tuple(dict.fromkeys(unknown)),
+        cell_unknown=tuple((sheet, item) for item in snapshot.cell_unknown),
+    )
 
 
 def document_conflicts(snapshots) -> tuple[DocumentConflict, ...]:

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -1353,7 +1353,12 @@ class Drawing:
         """
         from copy import deepcopy
 
-        from draftwright.audit import _FURNITURE, MeasurementClaim, MeasurementSnapshot
+        from draftwright.audit import (
+            _FURNITURE,
+            MeasurementCellUncertainty,
+            MeasurementClaim,
+            MeasurementSnapshot,
+        )
         from draftwright.linting.evidence import compiled_values, verify_measurement_claims
         from draftwright.linting.structural import dimension_path_measurement
         from draftwright.model.compiled import compile_dimensions
@@ -1363,9 +1368,11 @@ class Drawing:
             return MeasurementSnapshot((), (), (("", "model_unavailable"),))
         plan = compile_dimensions(model)
         values = compiled_values(plan)
+        schedules = {schedule.name: schedule for schedule in plan.schedules}
         outcomes = verify_measurement_claims(self.registry, plan)
         claims = []
         unknown = []
+        cell_unknown = []
         for name, type_name in self.annotations().items():
             if type_name in _FURNITURE:
                 continue
@@ -1378,6 +1385,72 @@ class Drawing:
             identities = self.registry.measurement_of(name)
             if not identities:
                 unknown.append((name, "measurement_identity_unavailable"))
+            cells = self.registry.cells_of(name)
+            if cells:
+                for reference in cells:
+                    identity = reference.measurement
+                    address = (reference.row, reference.column)
+                    evidence = [
+                        item
+                        for item in outcomes
+                        if item.annotation == name
+                        and item.cell == address
+                        and item.measurement is not None
+                        and getattr(item.measurement, "feature", None) is identity.feature
+                        and item.parameter_id == identity.parameter
+                    ]
+                    if not evidence or any(item.state != "confirmed" for item in evidence):
+                        unknown.append((name, "compiled_claim_unconfirmed"))
+                        cell_unknown.append(
+                            MeasurementCellUncertainty(name, address, "compiled_claim_unconfirmed")
+                        )
+                        continue
+                    schedule = schedules[reference.schedule]
+                    approved_cell = schedule.rows[reference.row][reference.column]
+                    item = approved_cell.measurement
+                    # Verification has bound the actual cell to this exact approval.
+                    # Other cells sharing a coarse ID cannot enlarge its meaning.
+                    assert item is not None
+                    rows = annotation.table_rows
+                    claims.append(
+                        MeasurementClaim(
+                            identity.feature,
+                            identity.parameter,
+                            name,
+                            (
+                                (
+                                    item.value,
+                                    deepcopy(item.tolerance),
+                                    item.span,
+                                    item.axis,
+                                    item.discriminator,
+                                    item.location_member,
+                                    item.angular_reference.measurement_key
+                                    if item.angular_reference is not None
+                                    else None,
+                                ),
+                            ),
+                            (
+                                str(rows[reference.row][reference.column]),
+                                str(rows[0][reference.column]),
+                                tuple(
+                                    (column, str(rows[reference.row][column]))
+                                    for column, cell in enumerate(schedule.rows[reference.row])
+                                    if cell.measurement is None
+                                ),
+                            ),
+                            approved=(item,),
+                            cell=address,
+                        )
+                    )
+                # Retain unsliced claims as uncertainty, just as the common verifier
+                # does. No successful neighbour grants them an implicit address.
+                if any(
+                    item.annotation == name and item.cell is None and item.state != "confirmed"
+                    for item in outcomes
+                ):
+                    unknown.append((name, "compiled_claim_unconfirmed"))
+                continue
             for identity in identities:
                 approved = tuple(
                     item
@@ -1444,7 +1517,12 @@ class Drawing:
                         approved=approved,
                     )
                 )
-        return MeasurementSnapshot(tuple(model.features), tuple(claims), tuple(unknown))
+        return MeasurementSnapshot(
+            tuple(model.features),
+            tuple(claims),
+            tuple(unknown),
+            cell_unknown=tuple(cell_unknown),
+        )
 
     @property
     def solve_trace(self):
@@ -1623,7 +1701,7 @@ class Drawing:
         )
 
     # -- annotations ----------------------------------------------------------
-    def _add(self, obj, name=None, view=None, feature=None, measurement=None):
+    def _add(self, obj, name=None, view=None, feature=None, measurement=None, *, cells=()):
         """Register an annotation so lint and export include it; returns ``obj``. The
         annotation-placement **primitive** (#817) — private, because the public door is the
         placement verbs (:meth:`callout`/:meth:`dimension`/:meth:`note`/:meth:`add_table`/…) and
@@ -1644,6 +1722,7 @@ class Drawing:
             view,
             feature,
             measurement,
+            cells=cells,
         )
 
     @deprecated(
@@ -1684,8 +1763,18 @@ class Drawing:
 
         Use a feature from :meth:`model`: ``dwg.drop(dwg.model().features[0])``. Removing
         a feature's callout/centre-mark/size-dims is a page-level edit; call
-        :func:`finalize_drawing` afterwards (when available) to recompose the sheet."""
+        :func:`finalize_drawing` afterwards (when available) to recompose the sheet.
+        A measured schedule shared by other features requires editing its declared
+        rows and rebuilding; partial removal refuses before changing any ink."""
         names = self._registry.names_for_feature(feature)
+        for name in names:
+            if any(
+                cell.measurement.feature is not feature for cell in self._registry.cells_of(name)
+            ):
+                raise ValueError(
+                    f"schedule {name!r} also measures other features; edit its declared "
+                    "rows and rebuild, or remove the whole table explicitly by name"
+                )
         survivors: list = []
         for name in names:
             for owner in getattr(self._registry.named(name), "source_features", ()):
@@ -3558,7 +3647,14 @@ class Drawing:
         return name
 
     def add_table(
-        self, rows, *, prefer="tr", name="table", block_cols=None, _source_id: str | None = None
+        self,
+        rows,
+        *,
+        prefer="tr",
+        name="table",
+        block_cols=None,
+        _source_id: str | None = None,
+        _cells=(),
     ):
         """Add a generic data table in the preferred available sheet region (#93/#1145).
 
@@ -3575,6 +3671,8 @@ class Drawing:
         """
         if not rows:
             return None
+        if _cells and name in self._registry:
+            raise ValueError(f"measured schedule name {name!r} already belongs to an annotation")
         table = _build_table(rows, self.draft, block_cols=block_cols)
         # Keep the rows the table draws, so its content is readable back off the annotation
         # (#1217). A table renders as compound geometry with no `label`, so without this a
@@ -3582,6 +3680,8 @@ class Drawing:
         # claims it carries are exactly the ones coverage relies on when the engine withdraws
         # the individual callouts. Mirrors `gear_requirement_rows`.
         table.table_rows = tuple(tuple(str(cell) for cell in row) for row in rows)
+        if _cells:
+            table.measurement_schedule = _cells[0].schedule
         table.table_block_cols = block_cols
         w, h = table.table_size
         a = self._analysis
@@ -3633,10 +3733,23 @@ class Drawing:
                         f"{measured}; {detail}"
                     ),
                     source_ids=(_source_id,) if _source_id is not None else (),
+                    measurement_ids=tuple(cell.measurement for cell in _cells),
                 )
             )
             return None
-        return self._add(table.locate(Location((pos[0], pos[1], 0))), name)
+        placed = table.locate(Location((pos[0], pos[1], 0)))
+        if not _cells:
+            return self._add(placed, name)
+        snapshot = self._registry.snapshot()
+        items = list(self.items)
+        issues = self._registry.issues
+        try:
+            return self._add(placed, name, cells=_cells)
+        except BaseException:
+            self.items[:] = items
+            self._registry.restore(snapshot)
+            self._registry.restore_issues(issues)
+            raise
 
     def _hole_spec_groups(self, view):
         """Ordered ``(tag, [holes], count)`` spec-groups of *view*'s holes (tags A, B,
@@ -4037,6 +4150,23 @@ class Drawing:
                 prof_kw = {}
             if recognition is None:
                 recognition = self._build.ensure_recognition(working_part)
+            model = self._part_model
+            if model is not None:
+                # Every annotation's measurement claims, resolved against what it renders
+                # (#1217). Coverage believes these claims; this is the only thing that
+                # checks them. Cheap — pure Python over the IR and the registry, no
+                # geometry — and it needs the compiled plan because the value an annotation
+                # SHOULD show is the compiler's, never a renderer's own formatting
+                # (ADR 4 (was 0016 Amendment 1)).
+                from draftwright.model.compiled import compile_dimensions
+
+                dimension_plan = compile_dimensions(model)
+                issues += lint_claimed_representations(self._registry, dimension_plan)
+            else:
+                dimension_plan = None
+            from draftwright.linting.schedule_evidence import verified_schedule_registry
+
+            physical_registry = verified_schedule_registry(self._registry, dimension_plan)
             issues += lint_angular_supports(
                 self.items,
                 registry=self._registry,
@@ -4066,7 +4196,7 @@ class Drawing:
                 # is one decision rather than two that can disagree. `prof_kw` is empty only
                 # where detect also falls back to the aggregate.
                 **({"turned_profiles": prof_kw["profiles"]} if "profiles" in prof_kw else {}),
-                registry=self._registry,
+                registry=physical_registry,
                 # Counts belong to lint_hole_coverage's operation/ownership ledger.
                 check_hole_counts=False,
             )
@@ -4074,29 +4204,17 @@ class Drawing:
                 working_part,
                 self,
                 assembly=self.assembly,
+                registry=physical_registry,
                 recognition=recognition,
                 **prof_kw,
             )
-            model = self._part_model
-            if model is not None:
-                # Every annotation's measurement claims, resolved against what it renders
-                # (#1217). Coverage believes these claims; this is the only thing that
-                # checks them. Cheap — pure Python over the IR and the registry, no
-                # geometry — and it needs the compiled plan because the value an annotation
-                # SHOULD show is the compiler's, never a renderer's own formatting
-                # (ADR 4 (was 0016 Amendment 1)).
-                from draftwright.model.compiled import compile_dimensions
-
-                dimension_plan = compile_dimensions(model)
-                issues += lint_claimed_representations(self._registry, dimension_plan)
-            else:
-                dimension_plan = None
             if model is not None:
                 issues += lint_boss_height_coverage(
                     working_part,
                     self,
                     getattr(model, "features", ()),
                     assembly=self.assembly,
+                    registry=physical_registry,
                     omissions=self._build.omissions,
                 )
             issues += lint_location_coverage(
@@ -4107,11 +4225,13 @@ class Drawing:
                 holes=holes,
                 patterns=patterns,
                 profiled_bores=profiled_bores,
+                registry=physical_registry,
             )
             issues += lint_prismatic_coverage(
                 working_part,
                 self,
                 assembly=self.assembly,
+                registry=physical_registry,
                 pads=pads,
                 section_recesses=recognition.section_recesses,
                 bbox=a.bb if a is not None else None,
@@ -4122,7 +4242,7 @@ class Drawing:
                 working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
-                registry=self._registry,
+                registry=physical_registry,
                 omissions=self._build.omissions,
                 assembly=self.assembly,
             )
@@ -4130,7 +4250,7 @@ class Drawing:
                 working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
-                registry=self._registry,
+                registry=physical_registry,
                 omissions=self._build.omissions,
                 assembly=self.assembly,
             )
@@ -4138,7 +4258,7 @@ class Drawing:
                 working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
-                registry=self._registry,
+                registry=physical_registry,
                 omissions=self._build.omissions,
                 assembly=self.assembly,
             )
@@ -4169,7 +4289,7 @@ class Drawing:
                 self.items,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
-                registry=self._registry,
+                registry=physical_registry,
                 dropped_profiles=self._coverage.dropped_profiles,
                 dropped_profile_evidence=self._coverage.dropped_profile_evidence,
                 assembly=self.assembly,
@@ -4178,7 +4298,7 @@ class Drawing:
                 working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
-                registry=self._registry,
+                registry=physical_registry,
                 omissions=self._build.omissions,
                 assembly=self.assembly,
             )
@@ -4186,7 +4306,7 @@ class Drawing:
                 working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
-                registry=self._registry,
+                registry=physical_registry,
                 omissions=self._build.omissions,
                 assembly=self.assembly,
             )
@@ -4194,7 +4314,7 @@ class Drawing:
                 working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
-                registry=self._registry,
+                registry=physical_registry,
                 omissions=self._build.omissions,
                 assembly=self.assembly,
             )
@@ -4202,12 +4322,12 @@ class Drawing:
                 working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
-                registry=self._registry,
+                registry=physical_registry,
                 omissions=self._build.omissions,
                 assembly=self.assembly,
             )
             issues += lint_blend_leader_targets(
-                registry=self._registry,
+                registry=physical_registry,
                 cylinders=cyls,
                 project=self.at,
                 evidence=self._build.recognition_evidence,
@@ -4217,7 +4337,7 @@ class Drawing:
                 working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
-                registry=self._registry,
+                registry=physical_registry,
                 omissions=self._build.omissions,
                 assembly=self.assembly,
             )
@@ -4225,7 +4345,7 @@ class Drawing:
                 working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
-                registry=self._registry,
+                registry=physical_registry,
                 omissions=self._build.omissions,
                 assembly=self.assembly,
             )
@@ -4233,7 +4353,7 @@ class Drawing:
                 working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
-                registry=self._registry,
+                registry=physical_registry,
                 omissions=self._build.omissions,
                 assembly=self.assembly,
             )
@@ -4241,7 +4361,7 @@ class Drawing:
                 working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
-                registry=self._registry,
+                registry=physical_registry,
                 omissions=self._build.omissions,
                 assembly=self.assembly,
             )
@@ -4249,7 +4369,7 @@ class Drawing:
                 working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
-                registry=self._registry,
+                registry=physical_registry,
                 omissions=self._build.omissions,
                 assembly=self.assembly,
             )
@@ -4257,7 +4377,7 @@ class Drawing:
                 working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
-                registry=self._registry,
+                registry=physical_registry,
                 omissions=self._build.omissions,
                 assembly=self.assembly,
             )
@@ -4265,7 +4385,7 @@ class Drawing:
                 working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
-                registry=self._registry,
+                registry=physical_registry,
                 omissions=self._build.omissions,
                 assembly=self.assembly,
                 plan=dimension_plan,
@@ -4274,7 +4394,7 @@ class Drawing:
                 working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
-                registry=self._registry,
+                registry=physical_registry,
                 omissions=self._build.omissions,
                 assembly=self.assembly,
             )
@@ -4282,7 +4402,7 @@ class Drawing:
                 working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
-                registry=self._registry,
+                registry=physical_registry,
                 omissions=self._build.omissions,
                 assembly=self.assembly,
                 project=self.at,
@@ -4294,7 +4414,7 @@ class Drawing:
                 working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
-                registry=self._registry,
+                registry=physical_registry,
                 omissions=self._build.omissions,
                 assembly=self.assembly,
             )
@@ -4302,7 +4422,7 @@ class Drawing:
                 working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
-                registry=self._registry,
+                registry=physical_registry,
                 omissions=self._build.omissions,
                 assembly=self.assembly,
             )
@@ -4310,7 +4430,7 @@ class Drawing:
                 working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
-                registry=self._registry,
+                registry=physical_registry,
                 omissions=self._build.omissions,
                 assembly=self.assembly,
             )
@@ -4318,13 +4438,13 @@ class Drawing:
                 working_part,
                 recognition=recognition,
                 features=getattr(model, "features", ()) if model is not None else (),
-                registry=self._registry,
+                registry=physical_registry,
                 omissions=self._build.omissions,
                 assembly=self.assembly,
             )
             issues += lint_declared_gear_coverage(
                 features=getattr(model, "features", ()) if model is not None else (),
-                registry=self._registry,
+                registry=physical_registry,
                 profiles=getattr(recognition, "repeating_radial_profiles", None),
                 assembly=self.assembly,
             )

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -4178,7 +4178,7 @@ class Drawing:
                 self._build.recognition_evidence,
                 self._build.recognition_ownership,
                 getattr(self._part_model, "features", ()),
-                self._registry,
+                physical_registry,
                 self._build.omissions,
             )
             profiled_bores = list(recognition.double_d_bores)

--- a/src/draftwright/linting/_registry.py
+++ b/src/draftwright/linting/_registry.py
@@ -53,12 +53,24 @@ def requirement_measurements(outcome) -> tuple[tuple[object, str], ...]:
     return tuple((feature, parameter) for feature in getattr(outcome, "features", ()))
 
 
+def cell_approvals_of(registry, name) -> tuple:
+    """Read verified cell evidence only from the physical registry projection."""
+    reader = getattr(registry, "cell_approvals_of", None)
+    return tuple(reader(name)) if callable(reader) else ()
+
+
 def measurement_carrier_index(registry):
     """Preserve names alongside the registry's exact measurement/satisfaction axes."""
     result: dict[tuple[int, str], tuple[object, list[RequirementCarrier]]] = {}
     if registry is None:
         return result
     for name in sorted(registry.names()):
+        measured_cells: dict = {}
+        for reference, _approval in cell_approvals_of(registry, name):
+            identity = reference.measurement
+            measured_cells.setdefault((id(identity.feature), identity.parameter), []).append(
+                reference
+            )
         for kind, identities in (
             ("measurement", registry.measurement_of(name)),
             ("structured_note", satisfaction_of(registry, name)),
@@ -68,16 +80,22 @@ def measurement_carrier_index(registry):
                     getattr(identity, "feature", None),
                     getattr(identity, "parameter", None),
                 )
-                record_measurement_carrier(result, name, feature, parameter, kind)
+                cells = (
+                    measured_cells.get((id(feature), parameter), ())
+                    if kind == "measurement"
+                    else ()
+                )
+                for cell in cells or (None,):
+                    record_measurement_carrier(result, name, feature, parameter, kind, cell=cell)
     return result
 
 
-def record_measurement_carrier(index, name, feature, parameter, kind):
+def record_measurement_carrier(index, name, feature, parameter, kind, *, cell=None):
     """Retain a name alongside already-read identity fields without rereading the claim."""
     if feature is not None and isinstance(parameter, str):
         entry = index.setdefault((id(feature), parameter), (feature, []))
         if entry[0] is feature:
-            carrier = RequirementCarrier(name, kind)
+            carrier = RequirementCarrier(name, kind, cell)
             if carrier not in entry[1]:
                 entry[1].append(carrier)
 

--- a/src/draftwright/linting/angular.py
+++ b/src/draftwright/linting/angular.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 
 from build123d import GeomType
 
+from draftwright.linting._registry import cell_approvals_of
 from draftwright.linting.issues import LintIssue
 from draftwright.measurement_support import RequirementCarrier
 from draftwright.profile_angles import (
@@ -507,6 +508,12 @@ def profile_angle_requirement_outcomes(evidence, ownership, features, registry, 
                 for name in sorted(registry.names())
                 if hasattr(registry.named(name), "angular_points")
                 and any(matches_id(identity) for identity in registry.measurement_of(name))
+            )
+            measured += tuple(
+                RequirementCarrier(name, "angular_measurement", reference)
+                for name in sorted(registry.names())
+                for reference, cell in cell_approvals_of(registry, name)
+                if cell.measurement.kind == "angle" and matches_id(reference.measurement)
             )
             satisfied = tuple(
                 RequirementCarrier(name, "structured_note")

--- a/src/draftwright/linting/coverage.py
+++ b/src/draftwright/linting/coverage.py
@@ -50,7 +50,7 @@ from draftwright._core import (
     _fmt,
     _xyz,
 )
-from draftwright.linting._registry import annotation_owner, satisfaction_ids
+from draftwright.linting._registry import annotation_owner, cell_approvals_of, satisfaction_ids
 from draftwright.linting.issues import LintIssue
 from draftwright.linting.pocket_pattern_coverage import pocket_pattern_requirement_outcomes
 from draftwright.linting.profiled_bore_coverage import profiled_bore_key
@@ -432,6 +432,14 @@ def lint_feature_coverage(
             value = float(parameter.value)
             mentioned.add(value)
             provide(value, getattr(feature, "count", 1), feature)
+    if registry is not None:
+        for name in registry.names():
+            for reference, cell in cell_approvals_of(registry, name):
+                approved = cell.measurement
+                if approved.kind == "diameter" and approved.role != "bolt_circle":
+                    feature = reference.measurement.feature
+                    mentioned.add(float(approved.value))
+                    provide(approved.value, getattr(feature, "count", 1), feature)
     for ann in annotations:
         if isinstance(ann, TitleBlock):
             continue
@@ -496,6 +504,7 @@ def lint_location_coverage(
     holes=None,
     patterns=None,
     profiled_bores=None,
+    registry=None,
 ) -> list:
     """Report holes with no **centre mark** or no **locating dimension**.
 
@@ -539,7 +548,7 @@ def lint_location_coverage(
     marks: dict[str, list] = {}
     dim_verts: dict[str, list] = {}
     structured_locations: set[tuple[object, str, HoleRef]] = set()
-    registry = getattr(dwg, "registry", None)
+    registry = registry if registry is not None else getattr(dwg, "registry", None)
     satisfied_locations = {
         identity.feature
         for identity in satisfaction_ids(registry)
@@ -553,9 +562,11 @@ def lint_location_coverage(
         # A placed table carries the same feature/member/axis facts as a dimension,
         # even when it is sheet furniture with no view. Read that shared evidence
         # independently of the annotation's presentation type.
+        named = getattr(registry, "named", None)
+        evidence_annotation = named(name) if callable(named) else ann
         decoded = tuple(
             parsed
-            for fact in getattr(ann, "covers_hole_locations", ())
+            for fact in getattr(evidence_annotation, "covers_hole_locations", ())
             if (parsed := _decode_hole_location_fact(fact)) is not None
         )
         # Structured evidence is authoritative: a wrong feature/axis tag must not
@@ -1355,6 +1366,7 @@ def lint_prismatic_coverage(
     tol: float = 0.6,
     features=(),
     recognition=None,
+    registry=None,
 ) -> list:
     """Report undefined prismatic features.
 
@@ -1366,7 +1378,8 @@ def lint_prismatic_coverage(
         assembly = len(part.solids()) > 1
     severity: Literal["info", "warning"] = "info" if assembly else "warning"
     pairs_by_view: dict[str, list] = {}
-    registry = getattr(dwg, "registry", None)
+    if registry is None:
+        registry = getattr(dwg, "registry", None)
     placed_ids = (
         {identity for name in registry.names() for identity in registry.measurement_of(name)}
         if registry is not None
@@ -1446,45 +1459,43 @@ def lint_prismatic_coverage(
             # Legacy Z-normal drawings may predate structured satisfaction authority, so
             # retain the geometric fallback for their footprint/location marks. The local
             # pad height is new compiler-owned evidence and must retain its exact identity.
+            size_x = satisfied(owner, "pad_length.length")
+            size_y = satisfied(owner, "pad_width.length")
+            located_x = location_note_satisfied(owner) or (
+                abs(pad.x0 - bb.min.X) <= tol or abs(pad.x1 - bb.max.X) <= tol
+            )
+            located_y = location_note_satisfied(owner) or (
+                abs(pad.y0 - bb.min.Y) <= tol or abs(pad.y1 - bb.max.Y) <= tol
+            )
             yc = (pad.y0 + pad.y1) / 2
             xc = (pad.x0 + pad.x1) / 2
-            x0, _, *_ = dwg.at("plan", pad.x0, yc, pad.z1)
-            x1, _, *_ = dwg.at("plan", pad.x1, yc, pad.z1)
-            xc_page, _, *_ = dwg.at("plan", xc, yc, pad.z1)
-            _, y0, *_ = dwg.at("plan", xc, pad.y0, pad.z1)
-            _, y1, *_ = dwg.at("plan", xc, pad.y1, pad.z1)
-            bx0, _, *_ = dwg.at("plan", bb.min.X, yc, pad.z1)
-            bx1, _, *_ = dwg.at("plan", bb.max.X, yc, pad.z1)
-            sy0, _, *_ = dwg.at("side", xc, pad.y0, pad.z1)
-            sy1, _, *_ = dwg.at("side", xc, pad.y1, pad.z1)
-            syc, _, *_ = dwg.at("side", xc, yc, pad.z1)
-            sby0, _, *_ = dwg.at("side", xc, bb.min.Y, pad.z1)
-            sby1, _, *_ = dwg.at("side", xc, bb.max.Y, pad.z1)
-            ps = pairs("plan")
-            size_x = _pair_covers(ps, 0, x0, x1, tol, owner=owner) or satisfied(
-                owner, "pad_length.length"
-            )
-            size_y = _pair_covers(ps, 1, y0, y1, tol, owner=owner) or satisfied(
-                owner, "pad_width.length"
-            )
-            located_x = location_note_satisfied(owner) or (
-                abs(pad.x0 - bb.min.X) <= tol
-                or abs(pad.x1 - bb.max.X) <= tol
-                or any(
+            if "plan" in dwg.views and not (size_x and size_y and located_x):
+                x0, _, *_ = dwg.at("plan", pad.x0, yc, pad.z1)
+                x1, _, *_ = dwg.at("plan", pad.x1, yc, pad.z1)
+                xc_page, _, *_ = dwg.at("plan", xc, yc, pad.z1)
+                _, y0, *_ = dwg.at("plan", xc, pad.y0, pad.z1)
+                _, y1, *_ = dwg.at("plan", xc, pad.y1, pad.z1)
+                bx0, _, *_ = dwg.at("plan", bb.min.X, yc, pad.z1)
+                bx1, _, *_ = dwg.at("plan", bb.max.X, yc, pad.z1)
+                ps = pairs("plan")
+                size_x |= _pair_covers(ps, 0, x0, x1, tol, owner=owner)
+                size_y |= _pair_covers(ps, 1, y0, y1, tol, owner=owner)
+                located_x |= any(
                     _pair_covers(ps, 0, edge, bound, tol)
                     for edge in (bx0, bx1)
                     for bound in (x0, x1, xc_page)
                 )
-            )
-            located_y = location_note_satisfied(owner) or (
-                abs(pad.y0 - bb.min.Y) <= tol
-                or abs(pad.y1 - bb.max.Y) <= tol
-                or any(
+            if "side" in dwg.views and not located_y:
+                sy0, _, *_ = dwg.at("side", xc, pad.y0, pad.z1)
+                sy1, _, *_ = dwg.at("side", xc, pad.y1, pad.z1)
+                syc, _, *_ = dwg.at("side", xc, yc, pad.z1)
+                sby0, _, *_ = dwg.at("side", xc, bb.min.Y, pad.z1)
+                sby1, _, *_ = dwg.at("side", xc, bb.max.Y, pad.z1)
+                located_y |= any(
                     _pair_covers(pairs("side"), 0, edge, bound, tol)
                     for edge in (sby0, sby1)
                     for bound in (sy0, sy1, syc)
                 )
-            )
             height = satisfied(owner, "pad_height.length")
             if not (size_x and size_y and height and located_x and located_y):
                 undefined += 1
@@ -1587,24 +1598,24 @@ def lint_prismatic_coverage(
         view = _END_ON.get(pocket["axis"], "plan")
         x, y, z = pocket["origin"]
         if pocket["axis"] == "z":
-            datum_plan, target_plan = (
-                dwg.at("plan", bb.min.X, y, z),
-                dwg.at("plan", x, y, z),
-            )
-            datum_side, target_side = (
-                dwg.at("side", x, bb.min.Y, z),
-                dwg.at("side", x, y, z),
-            )
-            covered_x = abs(x - centre.X) <= 1.0 or _pair_covers(
-                pairs("plan"), 0, datum_plan[0], target_plan[0], tol
-            )
-            covered_y = abs(y - centre.Y) <= 1.0 or _pair_covers(
-                pairs("side"), 0, datum_side[0], target_side[0], tol
-            )
+            covered_x = abs(x - centre.X) <= 1.0
+            covered_y = abs(y - centre.Y) <= 1.0
+            if "plan" in dwg.views and not covered_x:
+                datum_plan, target_plan = (
+                    dwg.at("plan", bb.min.X, y, z),
+                    dwg.at("plan", x, y, z),
+                )
+                covered_x = _pair_covers(pairs("plan"), 0, datum_plan[0], target_plan[0], tol)
+            if "side" in dwg.views and not covered_y:
+                datum_side, target_side = (
+                    dwg.at("side", x, bb.min.Y, z),
+                    dwg.at("side", x, y, z),
+                )
+                covered_y = _pair_covers(pairs("side"), 0, datum_side[0], target_side[0], tol)
             if not (covered_x and covered_y):
                 unlocated += 1
             continue
-        ps = pairs(view)
+        ps = pairs(view) if view in dwg.views else []
         # A datum-starting pocket needs no redundant long-axis centre dimension: the
         # coincident edge plus the length callout defines it. Ordinary inset pockets
         # retain their established centre-location scheme. Keep critique on the same
@@ -1628,23 +1639,31 @@ def lint_prismatic_coverage(
                 (target_world["z"], centre.Z, bb.min.Z),
             ),
         }[view]
-        datum_page = dwg.at(view, bb.min.X, bb.min.Y, bb.min.Z)
-        target_page = dwg.at(
-            view,
-            target_world["x"],
-            target_world["y"],
-            target_world["z"],
+        datum_page = dwg.at(view, bb.min.X, bb.min.Y, bb.min.Z) if view in dwg.views else None
+        target_page = (
+            dwg.at(
+                view,
+                target_world["x"],
+                target_world["y"],
+                target_world["z"],
+            )
+            if view in dwg.views
+            else None
         )
         covered = []
         for axis, (coord, mid, datum) in enumerate(coordinates):
             symmetric = abs(coord - mid) <= 1.0
             datum_coincident = abs(coord - datum) <= tol
-            witnessed = _pair_covers(
-                ps,
-                axis,
-                datum_page[axis],
-                target_page[axis],
-                tol,
+            witnessed = (
+                datum_page is not None
+                and target_page is not None
+                and _pair_covers(
+                    ps,
+                    axis,
+                    datum_page[axis],
+                    target_page[axis],
+                    tol,
+                )
             )
             covered.append(symmetric or datum_coincident or witnessed)
         if not all(covered):
@@ -1999,13 +2018,14 @@ def _lint_one_axial_profile(
     recognition,
     sibling_profiles=(),
     profile_label="",
+    registry=None,
 ) -> list:
     """Report missing axial coverage for one body-local turned profile.
 
     A turned part can have every diameter called out yet be unmanufacturable: with
     no shoulder located, the lengths are unknown (the drive-screw gap). A complete
-    chain dimensions all ``n`` steps; coverage is counted from placed drawing witnesses or
-    placed structured-note provenance joined to the same physical spans, not a build-time
+    chain dimensions all ``n`` steps; coverage is counted from placed drawing witnesses,
+    verified schedule cells or structured-note provenance joined to the same physical spans, not a build-time
     side channel — so it judges any producer. A shortfall yields one
     ``axial_length_missing`` issue.
 
@@ -2020,14 +2040,21 @@ def _lint_one_axial_profile(
     """
     n = len(prof.steps)
     covered_steps = _axial_covered_from_drawing(part, dwg, prof, sibling_profiles=sibling_profiles)
-    registry = getattr(dwg, "registry", None)
+    if registry is None:
+        registry = getattr(dwg, "registry", None)
     placed_ids = (
         {identity for name in registry.names() for identity in registry.measurement_of(name)}
         if registry is not None
         else set()
     )
     satisfied_ids = satisfaction_ids(registry)
-    # Match structured step-length authority back to the recognition-owned physical band by
+    if registry is not None:
+        satisfied_ids |= {
+            reference.measurement
+            for name in registry.names()
+            for reference, _approval in cell_approvals_of(registry, name)
+        }
+    # Match verified cells and structured step-length authority to the recognition-owned band by
     # its axial span. This preserves the denominator and prevents an unrelated declared step
     # from certifying one merely because both share the same role (#1351, ADR 3 (was 0017)).
     axis_index = "xyz".index(prof.axis)
@@ -2142,6 +2169,7 @@ def lint_axial_coverage(
     recognition=None,
     *,
     profiles=_UNSET,
+    registry=None,
 ) -> list:
     """Report every body-local turned profile whose axial chain is incomplete.
 
@@ -2200,18 +2228,21 @@ def lint_axial_coverage(
                 recognition=recognition,
                 sibling_profiles=profiles,
                 profile_label=label,
+                registry=registry,
             )
         )
     return issues
 
 
-def lint_boss_height_coverage(part, dwg, features, assembly=None, omissions=()) -> list:
+def lint_boss_height_coverage(
+    part, dwg, features, assembly=None, omissions=(), *, registry=None
+) -> list:
     """Report modeled boss heights that have no rendered linear dimension (#632).
 
     Coverage is reconciled from the drawing registry's feature provenance, not a
     renderer side channel: a boss is covered only when one of its live annotations
-    is a ``Dimension``. Boss diameter annotations are leaders, so they cannot mask a
-    missing axial height. Bosses without a modeled height retain the historical
+    is a ``Dimension`` or its exact height has verified cell/structured-note evidence.
+    Boss diameter annotations cannot mask a missing axial height. Bosses without a modeled height retain the historical
     diameter-only contract and are outside this check.
 
     A height the compiler **consolidated** onto an overall extent (#1154 — the boss spans
@@ -2233,13 +2264,20 @@ def lint_boss_height_coverage(part, dwg, features, assembly=None, omissions=()) 
         if getattr(feature, "kind", None) == "boss"
         and getattr(feature, "height", None) is not None
     ]
-    registry = getattr(dwg, "registry", None)
+    if registry is None:
+        registry = getattr(dwg, "registry", None)
     placed = (
         {measurement for name in registry.names() for measurement in registry.measurement_of(name)}
         if registry is not None
         else set()
     )
     satisfied = satisfaction_ids(registry)
+    if registry is not None:
+        satisfied |= {
+            reference.measurement
+            for name in registry.names()
+            for reference, _approval in cell_approvals_of(registry, name)
+        }
     conveyed = {
         omission.feature
         for omission in omissions

--- a/src/draftwright/linting/evidence.py
+++ b/src/draftwright/linting/evidence.py
@@ -157,6 +157,7 @@ class ClaimOutcome:
     #: The claim itself, so a consumer can join on the FEATURE as well as the parameter
     #: name. `parameter_id` alone says `bore.diameter` without saying whose (#1217 PR 2).
     measurement: object | None = None
+    cell: tuple[int, int] | None = None
 
 
 def compiled_values(plan) -> dict:
@@ -187,6 +188,11 @@ def compiled_values(plan) -> dict:
     for contingency in getattr(plan, "contingencies", ()):
         for approved in getattr(contingency.fallback, "rungs", ()):
             values[approved.id].append(approved)
+    for schedule in getattr(plan, "schedules", ()):
+        for row in schedule.rows:
+            for cell in row:
+                if cell.measurement is not None:
+                    values[cell.measurement.id].append(cell.measurement)
     return {key: tuple(entries) for key, entries in values.items()}
 
 
@@ -245,10 +251,65 @@ def rendered_numbers(annotation) -> frozenset[float] | None:
     return frozenset(float(match.group()) for text in texts for match in _NUMBER_RE.finditer(text))
 
 
+def _verify_cell_claim(registry, name, reference, schedules):
+    """Bind one actual cell to its compiler approval, never another cell's numbers."""
+    claim = reference.measurement
+    parameter = str(getattr(claim, "parameter", claim))
+    outcome = dict(measurement=claim, cell=(reference.row, reference.column))
+    schedule = schedules.get(reference.schedule)
+    if schedule is None:
+        return ClaimOutcome(name, parameter, "unresolved", **outcome)
+    try:
+        approved_row = schedule.rows[reference.row]
+        approved_cell = approved_row[reference.column]
+    except IndexError:
+        return ClaimOutcome(name, parameter, "unresolved", **outcome)
+    approved = approved_cell.measurement
+    if (
+        approved is None
+        or approved.id is None
+        or approved.id.feature is not getattr(claim, "feature", None)
+        or approved.id.parameter != parameter
+    ):
+        return ClaimOutcome(name, parameter, "unresolved", **outcome)
+    expected = (approved_cell.text,)
+    try:
+        rows = getattr(registry.named(name), "table_rows", None)
+        if rows is None:
+            return ClaimOutcome(name, parameter, "unreadable", expected, **outcome)
+        actual_row = rows[reference.row]
+        rendered = str(actual_row[reference.column])
+        context_matches = (
+            len(actual_row) == len(approved_row)
+            and tuple(str(cell) for cell in rows[0])
+            == tuple(cell.text for cell in schedule.rows[0])
+            and all(
+                cell.measurement is not None or str(actual_row[index]) == cell.text
+                for index, cell in enumerate(approved_row)
+            )
+        )
+    except Exception:
+        return ClaimOutcome(name, parameter, "unreadable", expected, **outcome)
+    return ClaimOutcome(
+        name,
+        parameter,
+        "confirmed" if context_matches and rendered == approved_cell.text else "value_absent",
+        expected,
+        rendered,
+        **outcome,
+    )
+
+
 def verify_measurement_claims(registry, plan, *, location_components=None) -> list[ClaimOutcome]:
     """Resolve every annotation's measurement claims against what it renders.
 
-    **Four limits, all measured rather than reasoned about** (#1218 review found each of them
+    Typed feature schedules bind each registered row/column to one compiler-approved
+    measurement. Exact cell text, headings and row context are checked, including
+    tolerances, through/blind content and quantity. Other numeric cells cannot supply
+    evidence. A missing cell address cannot downgrade a known schedule to the legacy
+    numeric-pool check below. This still reads renderer-recorded text, not exported glyphs.
+
+    **Legacy annotation limits, all measured rather than reasoned about** (#1218 review found each of them
     by relabelling a real drawing and watching this function stay silent):
 
     1. **Presence, not attribution.** It proves the approved value appears among the numbers
@@ -311,6 +372,7 @@ def verify_measurement_claims(registry, plan, *, location_components=None) -> li
     genuinely the drawn content. Verifying export-visible text is #1217's step 5.
     """
     approved = compiled_values(plan)
+    schedules = {schedule.name: schedule for schedule in getattr(plan, "schedules", ())}
     outcomes: list[ClaimOutcome] = []
     # `sorted`, because `registry.names()` is a set: without it the emitted issue ORDER varies
     # run to run on the same drawing (measured: five orderings in five processes), against
@@ -319,6 +381,30 @@ def verify_measurement_claims(registry, plan, *, location_components=None) -> li
     for name in sorted(registry.names()):
         claims = registry.measurement_of(name)
         if not claims:
+            continue
+        cells = getattr(registry, "cells_of", lambda _name: ())(name)
+        if not cells and (
+            name in schedules
+            or getattr(registry.named(name), "measurement_schedule", None) is not None
+        ):
+            outcomes.extend(
+                ClaimOutcome(name, str(claim.parameter), "unresolved", measurement=claim)
+                for claim in claims
+            )
+            continue
+        if cells:
+            outcomes.extend(_verify_cell_claim(registry, name, cell, schedules) for cell in cells)
+            # Any extra unsliced table claim has no evidence address. It must not borrow
+            # a number from a verified neighbour or from a quantity column.
+            for claim in claims:
+                if not any(
+                    cell.measurement.feature is claim.feature
+                    and cell.measurement.parameter == claim.parameter
+                    for cell in cells
+                ):
+                    outcomes.append(
+                        ClaimOutcome(name, str(claim.parameter), "unresolved", measurement=claim)
+                    )
             continue
         numbers = rendered_numbers(registry.named(name))
         shared_angular_labels = tuple(

--- a/src/draftwright/linting/hole_coverage.py
+++ b/src/draftwright/linting/hole_coverage.py
@@ -17,6 +17,7 @@ from quiddity import HoleRecord, HoleSpec, RecognitionResult, countersink_matche
 from draftwright._core import _decode_hole_location_fact, _fmt
 from draftwright._geometry import _END_ON, _is_principal_axis, _projected_edge_distance
 from draftwright.linting._registry import (
+    cell_approvals_of,
     exact_measurement_carriers,
     record_measurement_carrier,
     satisfaction_of,
@@ -560,6 +561,7 @@ class _HoleEvidence:
     location_names: dict = field(default_factory=dict)
     center_names: dict = field(default_factory=dict)
     carrier_index: dict = field(default_factory=dict)
+    physical_carriers: dict = field(default_factory=dict)
 
 
 def _normalised_location(feature, point) -> tuple[float, float, float]:
@@ -597,6 +599,7 @@ def _index_hole_evidence(registry) -> _HoleEvidence:
     placed = set()
     satisfied: set[tuple[object, str]] = set()
     carrier_index: dict = {}
+    physical_carriers: dict = defaultdict(list)
     requirement_counts: dict[tuple[object, str], set[int]] = defaultdict(set)
     locations: dict[tuple[object, str], set[tuple[float, float, float]]] = defaultdict(set)
     centers: dict[object, set[tuple[tuple[float, float, float], str]]] = defaultdict(set)
@@ -608,6 +611,18 @@ def _index_hole_evidence(registry) -> _HoleEvidence:
         defaultdict(set),
     )
     for name in registry.names():
+        measured_cells: dict = defaultdict(list)
+        for reference, cell in cell_approvals_of(registry, name):
+            feature = reference.measurement.feature
+            measured_cells[(id(feature), reference.measurement.parameter)].append(reference)
+            for parameter, count in cell.hole_requirements:
+                physical_carriers[(name, feature, parameter, count)].append(
+                    RequirementCarrier(name, "physical_requirement", reference)
+                )
+            for parameter, point in cell.hole_locations:
+                physical_carriers[
+                    (name, feature, parameter, _normalised_location(feature, point))
+                ].append(RequirementCarrier(name, "physical_location", reference))
         for identity in satisfaction_of(registry, name):
             feature = getattr(identity, "feature", None)
             parameter = getattr(identity, "parameter", None)
@@ -653,7 +668,10 @@ def _index_hole_evidence(registry) -> _HoleEvidence:
             if feature is None or parameter is None:
                 continue
             placed.add((feature, parameter))
-            record_measurement_carrier(carrier_index, name, feature, parameter, "measurement")
+            for reference in measured_cells.get((id(feature), parameter), ()) or (None,):
+                record_measurement_carrier(
+                    carrier_index, name, feature, parameter, "measurement", cell=reference
+                )
             record_representation(feature, parameter)
             if parameter == "bore.diameter":
                 diameter_features.add(feature)
@@ -738,6 +756,7 @@ def _index_hole_evidence(registry) -> _HoleEvidence:
         location_names,
         center_names,
         carrier_index,
+        physical_carriers,
     )
 
 
@@ -757,8 +776,18 @@ def _placed_representation(evidence, features, parameter, state):
     return next(iter(markers))
 
 
+def _retain_physical_carriers(evidence, carriers, names, feature, parameter, value, kind):
+    if carriers is None:
+        return
+    for name in sorted(names):
+        carriers.extend(
+            evidence.physical_carriers.get((name, feature, parameter, value))
+            or (RequirementCarrier(name, kind),)
+        )
+
+
 def _structured_locations_placed(
-    evidence, features, parameter: str, turned_axis_centers, *, names=None
+    evidence, features, parameter: str, turned_axis_centers, *, names=None, carriers=None
 ) -> bool:
     if parameter.startswith("location_pattern.location."):
         for feature in features:
@@ -775,7 +804,17 @@ def _structured_locations_placed(
                 return False
             if names is not None:
                 for point in carried:
-                    names.update(evidence.location_names.get((feature, parameter, point), ()))
+                    accepted = evidence.location_names.get((feature, parameter, point), ())
+                    names.update(accepted)
+                    _retain_physical_carriers(
+                        evidence,
+                        carriers,
+                        accepted,
+                        feature,
+                        parameter,
+                        point,
+                        "physical_location",
+                    )
         return bool(features)
     expected = {
         (feature, point) for feature in features for point in _location_members(feature, parameter)
@@ -794,21 +833,41 @@ def _structured_locations_placed(
             if _member_coaxial_with_turned_profile(feature, point, turned_axis_centers):
                 covered.add((feature, point))
                 if names is not None and (feature, point) in expected:
-                    names.update(evidence.center_names.get((feature, point, view), ()))
+                    accepted = evidence.center_names.get((feature, point, view), ())
+                    names.update(accepted)
+                    if carriers is not None:
+                        carriers.extend(
+                            RequirementCarrier(name, "physical_location")
+                            for name in sorted(accepted)
+                        )
     if names is not None:
         for feature, point in expected & covered:
-            names.update(evidence.location_names.get((feature, parameter, point), ()))
+            accepted = evidence.location_names.get((feature, parameter, point), ())
+            names.update(accepted)
+            _retain_physical_carriers(
+                evidence, carriers, accepted, feature, parameter, point, "physical_location"
+            )
     return bool(expected) and expected <= covered
 
 
 def _synthetic_placed(
-    evidence, features, parameter: str, member_count: int, *, names=None
+    evidence, features, parameter: str, member_count: int, *, names=None, carriers=None
 ) -> bool:
     if parameter == "bore.through":
         if names is not None:
             for feature in features:
                 for count in evidence.requirement_counts.get((feature, parameter), ()):
-                    names.update(evidence.count_names.get((feature, parameter, count), ()))
+                    accepted = evidence.count_names.get((feature, parameter, count), ())
+                    names.update(accepted)
+                    _retain_physical_carriers(
+                        evidence,
+                        carriers,
+                        accepted,
+                        feature,
+                        parameter,
+                        count,
+                        "physical_requirement",
+                    )
         return any((feature, parameter) in evidence.requirement_counts for feature in features)
     if parameter != "grouping.count":
         return False
@@ -819,25 +878,30 @@ def _synthetic_placed(
     )
     if carried and names is not None:
         for feature, count in expected.items():
-            names.update(evidence.count_names.get((feature, parameter, count), ()))
+            accepted = evidence.count_names.get((feature, parameter, count), ())
+            names.update(accepted)
+            _retain_physical_carriers(
+                evidence, carriers, accepted, feature, parameter, count, "physical_requirement"
+            )
     return carried
 
 
 def _hole_carriers(outcome, evidence, registry_index, turned_axis_centers):
     features, parameter = outcome.features, outcome.parameter_id
     names: set[str] = set()
+    carriers: list[RequirementCarrier] = []
     if parameter.startswith(
         ("location.location.", "location_pattern.location.", "location_off_axis.")
     ):
         if not _structured_locations_placed(
-            evidence, features, parameter, turned_axis_centers, names=names
+            evidence, features, parameter, turned_axis_centers, names=names, carriers=carriers
         ):
-            names.clear()
-        carriers = [RequirementCarrier(name, "physical_location") for name in sorted(names)]
+            carriers.clear()
     elif parameter in {"bore.through", "grouping.count"}:
-        if not _synthetic_placed(evidence, features, parameter, outcome.member_count, names=names):
-            names.clear()
-        carriers = [RequirementCarrier(name, "physical_requirement") for name in sorted(names)]
+        if not _synthetic_placed(
+            evidence, features, parameter, outcome.member_count, names=names, carriers=carriers
+        ):
+            carriers.clear()
     else:
         carriers = list(
             exact_measurement_carriers(

--- a/src/draftwright/linting/requirements.py
+++ b/src/draftwright/linting/requirements.py
@@ -31,6 +31,7 @@ from draftwright.linting.rectangular_blind_slot_coverage import (
 from draftwright.linting.round_bottom_blind_slot_coverage import (
     round_bottom_blind_slot_requirement_outcomes,
 )
+from draftwright.linting.schedule_evidence import verified_schedule_registry
 from draftwright.linting.section_recess_coverage import unsupported_section_recess_outcomes
 from draftwright.linting.slot_coverage import slot_requirement_outcomes
 from draftwright.linting.through_step_coverage import through_step_requirement_outcomes
@@ -115,6 +116,8 @@ def recognized_requirement_outcomes(
 
     if evidence is not None and evidence.result is not recognition:
         raise ValueError("requirement evidence and recognition must belong to the same run")
+
+    registry = verified_schedule_registry(registry, dimension_plan)
 
     outcomes: dict[str, list] = {
         "section_recesses": unsupported_section_recess_outcomes(recognition),

--- a/src/draftwright/linting/schedule_evidence.py
+++ b/src/draftwright/linting/schedule_evidence.py
@@ -1,0 +1,96 @@
+"""Verified cell evidence for the existing physical requirement producers.
+
+This is a read-local registry projection, not a requirement inventory or a renderer.
+Only successfully registered cells whose actual content agrees with their compiler
+approval can expose measurements or physical riders. Original drawing state is untouched.
+"""
+
+from __future__ import annotations
+
+from draftwright.linting.evidence import _verify_cell_claim
+from draftwright.registry import AnnotationRegistry
+
+
+class _ScheduleAnnotationEvidence:
+    def __init__(self, annotation, approvals):
+        self._annotation = annotation
+        requirements = {}
+        owners = {}
+        locations: list = []
+        for reference, cell in approvals:
+            feature = reference.measurement.feature
+            owners[id(feature)] = feature
+            for parameter, count in cell.hole_requirements:
+                requirements[(id(feature), parameter)] = (feature, parameter, count)
+            locations.extend(
+                (feature, component, point) for component, point in cell.hole_locations
+            )
+        self.source_features = tuple(owners.values())
+        self.covers_hole_requirements_by_feature = tuple(requirements.values())
+        self.covers_hole_locations = tuple(locations)
+        self.covers_count = sum(
+            count
+            for _feature, parameter, count in requirements.values()
+            if parameter == "grouping.count"
+        )
+        # An unverified stale rider cannot restore a fact withdrawn with its cell.
+        self.covers_hole_requirements = ()
+        self.covers_hole_centers = ()
+        self.covers_hole_representations_by_requirement = ()
+        self.hole_representation = None
+        self.hole_representation_reason = None
+
+    def __getattr__(self, name):
+        return getattr(self._annotation, name)
+
+
+class _VerifiedScheduleRegistry:
+    def __init__(self, registry, plan):
+        self._registry = AnnotationRegistry()
+        self._registry.restore(registry.snapshot())
+        self._registry.restore_issues(registry.issues)
+        self._approvals = {}
+        schedules = {schedule.name: schedule for schedule in getattr(plan, "schedules", ())}
+        for name in sorted(registry.names()):
+            cells = registry.cells_of(name)
+            annotation = registry.named(name)
+            if (
+                not cells
+                and name not in schedules
+                and getattr(annotation, "measurement_schedule", None) is None
+            ):
+                continue
+            approvals = tuple(
+                (reference, schedules[reference.schedule].rows[reference.row][reference.column])
+                for reference in cells
+                if _verify_cell_claim(registry, name, reference, schedules).state == "confirmed"
+            )
+            self._approvals[name] = approvals
+            identity = registry.identity_of(name)
+            identity["measurement"] = ()
+            identity["cells"] = tuple(reference for reference, _cell in approvals)
+            self._registry.add(
+                _ScheduleAnnotationEvidence(annotation, approvals), name, registry.view_of(name)
+            )
+            self._registry.reapply(name, identity)
+
+    def cell_approvals_of(self, name):
+        return self._approvals.get(name, ())
+
+    def __getattr__(self, name):
+        return getattr(self._registry, name)
+
+
+def verified_schedule_registry(registry, plan):
+    """Filter only typed schedule ink; all other registry evidence keeps its contract."""
+    if registry is None or isinstance(registry, _VerifiedScheduleRegistry):
+        return registry
+    cells_of = getattr(registry, "cells_of", None)
+    if not callable(cells_of):
+        return registry
+    if not getattr(plan, "schedules", ()) and not any(
+        cells_of(name) or getattr(registry.named(name), "measurement_schedule", None) is not None
+        for name in registry.names()
+    ):
+        return registry
+    return _VerifiedScheduleRegistry(registry, plan)

--- a/src/draftwright/linting/through_step_coverage.py
+++ b/src/draftwright/linting/through_step_coverage.py
@@ -16,6 +16,7 @@ from quiddity import RecognitionResult, ThroughStep
 
 from draftwright._geometry import _fmt
 from draftwright.linting._registry import (
+    cell_approvals_of,
     exact_measurement_carriers,
     measurement_carrier_index,
     satisfaction_ids,
@@ -405,6 +406,19 @@ def _index_evidence(registry):
     rendered: dict[tuple[object, str], list[tuple[float, object]]] = defaultdict(list)
     for name in registry.names():
         annotation = registry.named(name)
+        cells = cell_approvals_of(registry, name)
+        if cells:
+            for reference, cell in cells:
+                approved = cell.measurement
+                try:
+                    value = float(approved.value_text)
+                except (TypeError, ValueError, OverflowError):
+                    continue
+                if math.isfinite(value):
+                    rendered[
+                        (reference.measurement.feature, reference.measurement.parameter)
+                    ].append((value, approved.span))
+            continue
         label = str(getattr(annotation, "label", "") or "")
         primary = _label_reading(annotation, label) if label else None
         for identity in registry.measurement_of(name):

--- a/src/draftwright/measurement_support.py
+++ b/src/draftwright/measurement_support.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from draftwright.registry import MeasurementCell
+
 
 @dataclass(frozen=True)
 class MeasurementSupport:
@@ -51,3 +53,4 @@ class RequirementCarrier:
 
     annotation: str
     kind: str
+    cell: MeasurementCell | None = None

--- a/src/draftwright/model/__init__.py
+++ b/src/draftwright/model/__init__.py
@@ -81,6 +81,7 @@ from draftwright.model.ir import (
     EnvelopeFeature,
     ExternalSpurGearFeature,
     Feature,
+    FeatureSchedule,
     FilletFeature,
     FlatFeature,
     Frame,
@@ -105,6 +106,7 @@ from draftwright.model.ir import (
     RectangularBlindSlotFeature,
     RotationalFeature,
     RoundBottomBlindSlotFeature,
+    ScheduleRow,
     SlotFeature,
     SlotPatternFeature,
     StepFeature,
@@ -128,6 +130,8 @@ from draftwright.model.planner import (
 from draftwright.view_plan import UncoveredViewRequirement, ViewPlanIncomplete
 
 __all__ = [
+    "FeatureSchedule",
+    "ScheduleRow",
     "AngleFeature",
     "AnglePatternFeature",
     "angle",

--- a/src/draftwright/model/callout.py
+++ b/src/draftwright/model/callout.py
@@ -23,7 +23,7 @@ from dataclasses import dataclass
 
 from draftwright._geometry import _fmt
 from draftwright.model.ir import HoleFeature, PatternFeature, ThreadOperation, ThreadRequirement
-from draftwright.model.planner import DimensionGroup, DimensionId
+from draftwright.model.planner import _SCHEDULE_REPRESENTATION, DimensionGroup, DimensionId
 
 
 def resolved_through_indicator(feature) -> str:
@@ -329,7 +329,10 @@ def _refuse_headless_callout(group: DimensionGroup) -> None:
     # and omitting `bore.diameter` produce neither the 50 mm BCD nor a diagnostic — the
     # requested dimension vanished (#925 review).
     riders: list[str] = []
-    if not authored_omission_in(group):
+    if not authored_omission_in(group) and not any(
+        dimension.suppressed and dimension.reason == _SCHEDULE_REPRESENTATION
+        for dimension in group.dims
+    ):
         hole = feat.member if isinstance(feat, PatternFeature) else feat
         thread = getattr(hole, "thread", None)
         if thread:

--- a/src/draftwright/model/compiled.py
+++ b/src/draftwright/model/compiled.py
@@ -52,10 +52,13 @@ from __future__ import annotations
 from dataclasses import dataclass, field, replace
 from typing import Any, Literal
 
-from draftwright._geometry import _fmt, _fmt_angle
+from draftwright._geometry import _fmt, _fmt_angle, _fmt_chamfer, _fmt_tolerance
+from draftwright.fits import FitClass
 from draftwright.location_contract import coincident_location_axes
+from draftwright.model.callout import resolved_through_indicator
 from draftwright.model.ir import (
     AngularReference,
+    ChamferFeature,
     EnvelopeFeature,
     Feature,
     HoleFeature,
@@ -74,6 +77,7 @@ from draftwright.model.ir import (
 from draftwright.model.planner import (
     _AUTHORED_OMISSION,
     _CONSOLIDATED,
+    CORRELATED_SETS,
     DimensionId,
     _authored_for,
     _decorated,
@@ -82,6 +86,8 @@ from draftwright.model.planner import (
     _request_for,
     _selected_chain_covers_extent,
     angular_pattern_label,
+    annotation_requested,
+    authored_dimension_requests,
     authored_location_axis_omitted,
     authored_location_omitted,
     hole_location_parameter_id,
@@ -91,6 +97,7 @@ from draftwright.model.planner import (
     plan_locations,
     polygonal_stock_conveys_height,
     rotational_od_conveys_height,
+    schedule_row_dimensions,
 )
 
 
@@ -690,6 +697,28 @@ class AddressableIntent:
 
 
 @dataclass(frozen=True)
+class ApprovedScheduleCell:
+    """Compiler-owned text and its optional exact measured meaning.
+
+    Descriptive cells carry no measurement and earn no dimensional coverage.
+    """
+
+    text: str
+    measurement: ApprovedDimension | None = None
+    hole_requirements: tuple[tuple[str, int], ...] = ()
+    hole_locations: tuple[tuple[str, Point], ...] = ()
+
+
+@dataclass(frozen=True)
+class ApprovedSchedule:
+    """A rectangular table ready for the existing measurement/placement path."""
+
+    name: str
+    rows: tuple[tuple[ApprovedScheduleCell, ...], ...]
+    prefer: str
+
+
+@dataclass(frozen=True)
 class RenderableDimensionPlan:
     """Everything approved for drawing, plus what was not and why.
 
@@ -715,6 +744,7 @@ class RenderableDimensionPlan:
     #: addressable because a generated authored script must carry the fallback intent even
     #: when the automatic build did not need to release it.
     contingencies: tuple[ApprovedContingency, ...] = ()
+    schedules: tuple[ApprovedSchedule, ...] = ()
     diagnostics: tuple[Omission, ...] = field(default=())
 
     def of_kind(self, *kinds: str) -> tuple[ApprovedGroup, ...]:
@@ -756,7 +786,7 @@ class RenderableDimensionPlan:
     #: it to cover every such field — so a NEW compiler-owned category cannot be added without
     #: either flowing into generated scripts or being explicitly, visibly excluded (#946).
     #: `diagnostics` is not here: it is what was NOT approved, and has its own contract.
-    _ADDRESSABLE = ("groups", "ladders", "locations", "contingencies")
+    _ADDRESSABLE = ("groups", "ladders", "locations", "contingencies", "schedules")
 
     def addressable(self) -> tuple[AddressableIntent, ...]:
         """Every approved intent, in plan order, as the target a script would name.
@@ -832,6 +862,31 @@ class RenderableDimensionPlan:
             # unregistered kind would let generated scripts lose it. Indexing is deliberately
             # fail-closed, matching the addressability ratchet on the containing plan.
             out.append(AddressableIntent(ladder.ref, _LADDER_ROLE[ladder.kind]))
+        return out
+
+    def _addressable_schedules(self) -> list[AddressableIntent]:
+        out = []
+        for schedule in self.schedules:
+            for row in schedule.rows:
+                for cell in row:
+                    dimension = cell.measurement
+                    if dimension is None:
+                        continue
+                    assert dimension.id is not None
+                    out.append(
+                        AddressableIntent(
+                            dimension.ref,
+                            "location"
+                            if dimension.is_location_measurement
+                            else dimension.id.parameter,
+                            discriminator=dimension.discriminator
+                            if dimension.is_location_measurement
+                            else None,
+                            member=dimension.location_member
+                            if dimension.is_location_measurement
+                            else None,
+                        )
+                    )
         return out
 
     def omitted(self, kind: str) -> tuple[Omission, ...]:
@@ -1759,6 +1814,7 @@ def compile_dimensions(
     # alone cannot protect a model mutated afterward. Recheck at the compiler boundary before
     # any structured-note authority can reach placement or critique (#1351).
     model._validate_structured_note_origins()
+    authored_dimension_requests(model)
     for feature in model.features:
         if (
             isinstance(feature, Note)
@@ -1822,7 +1878,7 @@ def compile_dimensions(
     off_axis, off_axis_omissions = _compile_off_axis_hole_locations(model)
     locations.extend(off_axis)
     location_omissions.extend(off_axis_omissions)
-    return RenderableDimensionPlan(
+    result = RenderableDimensionPlan(
         groups=tuple(groups_out),
         ladders=tuple(ladders),
         locations=tuple(locations),
@@ -1830,6 +1886,223 @@ def compile_dimensions(
         diagnostics=_dedupe_omissions(
             omissions, height_omissions, location_omissions, group_omissions
         ),
+    )
+    return _compile_schedules(model, result) if model.schedules else result
+
+
+def _schedule_cell_text(dimension: ApprovedDimension, feature: Feature) -> str:
+    """Present an approved measurement using the shared dimensional formatters."""
+    if dimension.angular_reference is not None:
+        return dimension.final_label
+    if dimension.kind == "angle":
+        return _fmt_angle(dimension.value, dimension.display_decimals, dimension.tolerance)
+    prefix = {"diameter": "Ø", "radius": "R", "depth": "↓"}.get(dimension.kind, "")
+    tolerance = dimension.tolerance
+    suffix = tolerance.suffix() if isinstance(tolerance, FitClass) else _fmt_tolerance(tolerance)
+    text = f"{prefix}{dimension.value_text}{suffix}"
+    if isinstance(feature, ChamferFeature):
+        return _fmt_chamfer(
+            dimension.value_text + suffix, dimension.value, feature.leg2, feature.angle
+        )
+    hole = feature.member if isinstance(feature, PatternFeature) else feature
+    if isinstance(hole, HoleFeature) and dimension.parameter_id == "bore.diameter":
+        indicator = resolved_through_indicator(feature)
+        if indicator:
+            text += f" {indicator}"
+    return text
+
+
+def _approved_schedule_cell(
+    dimension: ApprovedDimension, feature: Feature
+) -> ApprovedScheduleCell:
+    """Retain the physical riders carried by the already-approved text and row context."""
+    requirements: tuple[tuple[str, int], ...] = ()
+    locations: tuple[tuple[str, Point], ...] = ()
+    if isinstance(feature, (HoleFeature, PatternFeature)):
+        if dimension.id is not None and dimension.id.parameter == "bore.diameter":
+            requirements = (("grouping.count", feature.count),)
+            if resolved_through_indicator(feature):
+                requirements += (("bore.through", 1),)
+        component = dimension.physical_location_component
+        if component is not None and dimension.span is not None:
+            locations = ((component, dimension.span[1]),)
+    return ApprovedScheduleCell(
+        _schedule_cell_text(dimension, feature), dimension, requirements, locations
+    )
+
+
+def _compile_schedules(model: PartModel, plan: RenderableDimensionPlan) -> RenderableDimensionPlan:
+    """Route existing approvals into cells; do not evaluate another set of measurements."""
+    labels = {
+        id(feature): f"{feature.kind}{index + 1}" for index, feature in enumerate(model.features)
+    }
+    scheduled_ids: set[tuple[int, str]] = set()
+    schedules = []
+    for schedule in model.schedules:
+        columns: list[str] = []
+        headings: dict[str, str] = {}
+        content: list[tuple[Feature, object, dict[str, ApprovedDimension]]] = []
+        for source_row in schedule.rows:
+            feature = source_row.feature
+            measurements: dict[object, dict[str, ApprovedDimension]] = {}
+            scalars: dict[str, ApprovedDimension] = {}
+            for request in schedule_row_dimensions(source_row):
+                location = request.role == "location"
+                parameter_id = request.role
+                column = parameter_id
+                if location:
+                    assert request.discriminator is not None
+                    parameter_id = hole_location_parameter_id(
+                        feature,
+                        None if request.member == "centre" else request.member,
+                        request.discriminator,
+                    )
+                    column = f"{request.discriminator.upper()} distance (mm)"
+                if location:
+                    candidates = plan.locations
+                else:
+                    # A correlated identity owns the whole set. A single value under that
+                    # ID cannot become a row by silently taking the first member.
+                    if any(
+                        parameter.parameter_id == parameter_id
+                        and (feature.kind, parameter.role) in CORRELATED_SETS
+                        for parameter in feature.parameters()
+                    ):
+                        raise ValueError(
+                            f"schedule {schedule.name!r}: correlated measurement {parameter_id!r} requires a set representation"
+                        )
+                    candidates = tuple(d for ladder in plan.ladders for d in ladder.rungs)
+                    candidates += tuple(
+                        d for item in plan.contingencies for d in item.fallback.rungs
+                    )
+                    if not any(
+                        d.id is not None
+                        and d.id.feature is feature
+                        and d.id.parameter == parameter_id
+                        for d in candidates
+                    ):
+                        candidates = tuple(d for group in plan.groups for d in group.dims)
+                matches = [
+                    dimension
+                    for dimension in candidates
+                    if dimension.id is not None
+                    and dimension.id.feature is feature
+                    and dimension.id.parameter == parameter_id
+                ]
+                if len(matches) != 1:
+                    raise ValueError(
+                        f"schedule {schedule.name!r}: {parameter_id!r} requires exactly one "
+                        f"approved measurement; found {len(matches)}"
+                    )
+                (dimension,) = matches
+                scheduled_ids.add((id(feature), parameter_id))
+                if column not in columns:
+                    columns.append(column)
+                    unit = "degrees" if dimension.kind == "angle" else "mm"
+                    headings[column] = (
+                        column
+                        if location
+                        else f"{parameter_id.replace('.', ' ').replace('_', ' ').capitalize()} ({unit})"
+                    )
+                if location:
+                    measurements.setdefault(request.member, {})[column] = dimension
+                else:
+                    scalars[column] = dimension
+            if measurements:
+                # A scalar is owned by the group, so it is stated once in a distinct row;
+                # repeating its count/diameter beside each member would change its scope.
+                if scalars:
+                    content.append((feature, None, scalars))
+                content.extend(
+                    (feature, member, values) for member, values in measurements.items()
+                )
+            else:
+                content.append((feature, None, scalars))
+        rows = [
+            tuple(
+                ApprovedScheduleCell(text)
+                for text in (
+                    "Feature",
+                    "Member",
+                    "Axis",
+                    "Qty",
+                    *(headings[column] for column in columns),
+                )
+            )
+        ]
+        for feature, member, values in content:
+            row = [
+                ApprovedScheduleCell(labels[id(feature)]),
+                ApprovedScheduleCell(
+                    "group"
+                    if member is None
+                    else str(member + 1)
+                    if isinstance(member, int)
+                    else str(member)
+                ),
+                ApprovedScheduleCell(feature.frame.axis.upper()),
+                ApprovedScheduleCell(str(getattr(feature, "count", 1)) if member is None else "1"),
+            ]
+            for column in columns:
+                cell_dimension = values.get(column)
+                row.append(
+                    _approved_schedule_cell(cell_dimension, feature)
+                    if cell_dimension is not None
+                    else ApprovedScheduleCell("—")
+                )
+            rows.append(tuple(row))
+        schedules.append(ApprovedSchedule(schedule.name, tuple(rows), schedule.prefer))
+
+    ordinary_model = replace(model, schedules=())
+
+    def ordinary(dimension):
+        identity = dimension.id
+        if identity is None or (id(identity.feature), identity.parameter) not in scheduled_ids:
+            return True
+        feature = identity.feature
+        if dimension.is_location_measurement:
+            if location_datum(feature) == "bbox":
+                bbox: Any = model.bbox
+                datum = (float(bbox.min.X), float(bbox.min.Y), float(bbox.min.Z))
+            else:
+                datum = next(d.at for d in model.datums if d.id == "datum_xy")
+            return any(
+                ("centre" if member is None else member) == dimension.location_member
+                and dimension.discriminator in axes
+                for member, _point, axes in hole_location_references(
+                    ordinary_model, feature, datum
+                )
+            )
+        return any(
+            annotation_requested(model, feature, parameter)
+            for parameter in feature.parameters()
+            if parameter.parameter_id == identity.parameter
+        )
+
+    ladders = tuple(
+        replace(ladder, rungs=tuple(d for d in ladder.rungs if ordinary(d)))
+        for ladder in plan.ladders
+    )
+    contingencies = []
+    inactive = set()
+    for item in plan.contingencies:
+        rungs = tuple(d for d in item.fallback.rungs if ordinary(d))
+        if rungs:
+            contingencies.append(replace(item, fallback=replace(item.fallback, rungs=rungs)))
+        else:
+            inactive.add(id(item.inactive))
+
+    return replace(
+        plan,
+        groups=tuple(
+            replace(group, dims=tuple(d for d in group.dims if ordinary(d)))
+            for group in plan.groups
+        ),
+        ladders=tuple(ladder for ladder in ladders if ladder.rungs),
+        locations=tuple(d for d in plan.locations if ordinary(d)),
+        contingencies=tuple(contingencies),
+        diagnostics=tuple(item for item in plan.diagnostics if id(item) not in inactive),
+        schedules=tuple(schedules),
     )
 
 

--- a/src/draftwright/model/ir.py
+++ b/src/draftwright/model/ir.py
@@ -3427,6 +3427,48 @@ class RequestedDimension:
             )
 
 
+@dataclass(frozen=True)
+class ScheduleRow:
+    """An exact feature and measurement selectors, with no authored numeric content.
+
+    ``location`` expands to addressable member components in the planner. Other
+    selectors are canonical parameter IDs, rather than potentially ambiguous roles.
+    """
+
+    feature: Feature
+    parameters: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if isinstance(self.parameters, str):
+            raise ValueError("schedule parameters must be a sequence of parameter IDs")
+        object.__setattr__(self, "parameters", tuple(self.parameters))
+        if not self.parameters or any(
+            not isinstance(parameter, str) or not parameter.strip()
+            for parameter in self.parameters
+        ):
+            raise ValueError("schedule row requires nonempty parameter IDs")
+        if len(set(self.parameters)) != len(self.parameters):
+            raise ValueError("schedule row repeats a parameter selector")
+
+
+@dataclass(frozen=True)
+class FeatureSchedule:
+    """Authored table representation; the compiler supplies its measured cells."""
+
+    name: str
+    rows: tuple[ScheduleRow, ...]
+    prefer: Literal["tr", "tl", "br", "bl"] = "tr"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.name, str) or not self.name.strip():
+            raise ValueError("schedule requires a nonempty name")
+        object.__setattr__(self, "rows", tuple(self.rows))
+        if not self.rows or any(not isinstance(row, ScheduleRow) for row in self.rows):
+            raise ValueError("schedule requires at least one ScheduleRow")
+        if self.prefer not in ("tr", "tl", "br", "bl"):
+            raise ValueError("schedule prefer must be tr, tl, br or bl")
+
+
 @dataclass
 class PartModel:
     """The whole-part IR: the oriented part plus its features and datums."""
@@ -3455,9 +3497,28 @@ class PartModel:
     # authored set is planned with ``suppressed=True`` and keeps its value, so the group
     # retains its engineering data and a later pass can still see what was left out.
     authored_dimensions: tuple[RequestedDimension, ...] | None = None
+    # Table representations belong to authored intent, not the physical inventory.
+    schedules: tuple[FeatureSchedule, ...] = ()
 
     def __post_init__(self) -> None:
         self._validate_structured_note_origins()
+        self._validate_schedule_origins()
+
+    def _validate_schedule_origins(self) -> None:
+        """Check exact ownership again at planning, since features is mutable."""
+        names: set[str] = set()
+        for schedule in self.schedules:
+            if not isinstance(schedule, FeatureSchedule):
+                raise ValueError("PartModel.schedules requires FeatureSchedule entries")
+            if schedule.name in names:
+                raise ValueError(f"duplicate schedule name {schedule.name!r}")
+            names.add(schedule.name)
+            for row in schedule.rows:
+                if not any(feature is row.feature for feature in self.features):
+                    raise ValueError(
+                        f"schedule {schedule.name!r} row must target the identical feature "
+                        "in PartModel.features"
+                    )
 
     def _validate_structured_note_origins(self) -> None:
         """Require every authority-bearing note to target this exact mutable inventory."""

--- a/src/draftwright/model/planner.py
+++ b/src/draftwright/model/planner.py
@@ -57,6 +57,7 @@ from draftwright.model.ir import (
     RectangularBlindSlotFeature,
     RequestedDimension,
     RoundBottomBlindSlotFeature,
+    ScheduleRow,
     SlotFeature,
     SlotPatternFeature,
     StepLevelFeature,
@@ -72,6 +73,7 @@ from draftwright.view_plan import (
 #: omission, as opposed to a rule-set suppression. Defined here, beside the code that
 #: sets it, and re-exported by `model/compiled.py` so the two cannot drift.
 _AUTHORED_OMISSION = "not in the authored dimension set"
+_SCHEDULE_REPRESENTATION = "selected for a feature schedule"
 
 
 def _is_zero_step_position(value: float) -> bool:
@@ -848,11 +850,123 @@ def location_components(feature) -> list[dict]:
     ]
 
 
+def schedule_row_dimensions(row: ScheduleRow) -> tuple[RequestedDimension, ...]:
+    """Resolve schedule selectors using the existing parameter/member vocabulary.
+
+    This is selection only: values and formatting still enter through the ordinary
+    dimension compiler. A location alias selects physical members; the optional
+    bolt-circle centre remains available by its explicit canonical ID.
+    """
+    feature = row.feature
+    parameters = {parameter.parameter_id: parameter for parameter in feature.parameters()}
+    components = {
+        component["parameter_id"]: component for component in location_components(feature)
+    }
+    requests: list[RequestedDimension] = []
+    selected: set[str] = set()
+    for selector in row.parameters:
+        targets = (
+            tuple(key for key, value in components.items() if value["member"] != "centre")
+            if selector == LOCATION_ROLE
+            else (selector,)
+        )
+        if not targets:
+            raise ValueError(
+                f"schedule location has no addressable member components for {feature.kind}"
+            )
+        for target in targets:
+            if target in selected:
+                raise ValueError(f"schedule row repeats measurement {target!r}")
+            selected.add(target)
+            if target in components and location_role(feature) is not None:
+                component = components[target]
+                requests.append(
+                    RequestedDimension(
+                        feature,
+                        LOCATION_ROLE,
+                        discriminator=component["axis"],
+                        member=component["member"],
+                    )
+                )
+            elif target in parameters and parameters[target].kind != "location":
+                requests.append(RequestedDimension(feature, target))
+            else:
+                raise ValueError(
+                    f"schedule parameter {target!r} is not an addressable canonical "
+                    f"measurement on {feature.kind}; choose from "
+                    f"{sorted(set(parameters) | set(components))}"
+                )
+    return tuple(requests)
+
+
+def authored_dimension_requests(model: PartModel) -> tuple[RequestedDimension, ...] | None:
+    """The authored selection, retaining schedule intent on the original model.
+
+    Ordinary dimensions precede scheduled representations so their explicit display
+    policy remains authoritative when both present the same measurement.
+    """
+    if not model.schedules:
+        return model.authored_dimensions
+    model._validate_schedule_origins()
+    if model.authored_dimensions is None or model.requested_dimensions:
+        raise ValueError("feature schedules require an authored dimension set")
+    return model.authored_dimensions + tuple(
+        request
+        for schedule in model.schedules
+        for row in schedule.rows
+        for request in schedule_row_dimensions(row)
+    )
+
+
+def _selection_model(model: PartModel, selection) -> PartModel:
+    # A pass-local view lets existing selection helpers read the expanded authored set.
+    # The caller's model retains its schedules and is revalidated on the next plan.
+    return (
+        replace(model, authored_dimensions=selection, schedules=()) if model.schedules else model
+    )
+
+
+def annotation_requested(model: PartModel, feature: Feature, parameter) -> bool:
+    """Whether a measurement also has ordinary annotation intent, independent of tables."""
+    return model.authored_dimensions is None or any(
+        _authored_addresses(request, feature, parameter) for request in model.authored_dimensions
+    )
+
+
+def annotation_groups(model: PartModel, groups) -> list[DimensionGroup]:
+    """Ordinary ink projection of one plan, retaining table-only parameters as withheld.
+
+    Sizing and legacy compound-callout consumers use this projection; the compiler
+    receives the complete planned selection to approve both representations once.
+    """
+    if not model.schedules:
+        return list(groups)
+    return [
+        replace(
+            group,
+            units=tuple(
+                replace(
+                    unit,
+                    members=tuple(
+                        dimension
+                        if dimension.suppressed
+                        or annotation_requested(model, group.feature, dimension.param)
+                        else replace(dimension, suppressed=True, reason=_SCHEDULE_REPRESENTATION)
+                        for dimension in unit.members
+                    ),
+                )
+                for unit in group.units
+            ),
+        )
+        for group in groups
+    ]
+
+
 def _location_requests(model: PartModel, feature):
     return tuple(
         request
         for request in (
-            model.authored_dimensions
+            (authored_dimension_requests(model) or ())
             if model.authored_dimensions is not None
             else model.requested_dimensions
         )
@@ -951,6 +1065,7 @@ def plan_locations(model: PartModel) -> list[PlannedDimension]:
     - Everything else is unchanged when no set is authored: every ref survives, so the
       dedup sees the same input it always did.
     """
+    model = _selection_model(model, authored_dimension_requests(model))
     datum = next((d for d in model.datums if d.id == "datum_xy"), None)
     if datum is None:
         # No datum to measure from — but every otherwise-eligible feature still HAD a location
@@ -1130,7 +1245,7 @@ def _authored_for(model, feature, param):
     what differs is what the answer means. `add_dimension` ADDS to the planner's set, so a
     miss leaves the rule set's own decision standing. `dimension` DECLARES the set, so a miss
     is an omission and the measurement is suppressed."""
-    for authored in model.authored_dimensions or ():
+    for authored in authored_dimension_requests(model) or ():
         if _authored_addresses(authored, feature, param):
             return authored
     return None
@@ -1338,7 +1453,7 @@ def _authored_location_for(model, feature):
     Separate from :func:`_authored_for` because a location has no `DimParameter` to match
     against: it is synthesized from the feature and the datum, so the entry names the
     feature and the coarse role and nothing else (see :data:`LOCATION_ROLE`)."""
-    for authored in model.authored_dimensions or ():
+    for authored in authored_dimension_requests(model) or ():
         if authored.feature is feature and authored.role == LOCATION_ROLE:
             return authored
     return None
@@ -1361,7 +1476,7 @@ def _check_authored_targets(model: PartModel) -> None:
     `_request_for`: two equal-valued features are two distinct targets, so structural
     equality would make an authored dimension on one of a pair of identical holes
     ambiguous). What changes is that a miss now says so."""
-    for authored in model.authored_dimensions or ():
+    for authored in authored_dimension_requests(model) or ():
         if authored.role == LOCATION_ROLE and any(
             f is authored.feature and location_role(f) is not None for f in model.features
         ):
@@ -1475,7 +1590,11 @@ def _uncovered_group_requirements(
     uncovered: list[UncoveredViewRequirement] = []
     for group in groups:
         for unit in group.units:
-            approved = [pd for pd in unit.members if not pd.suppressed]
+            approved = [
+                pd
+                for pd in unit.members
+                if not pd.suppressed and annotation_requested(model, group.feature, pd.param)
+            ]
             if not approved:
                 continue
             if isinstance(group.feature, StepLevelFeature) and unit.id == "step_position.length":
@@ -1753,7 +1872,10 @@ def plan_dimensions(model: PartModel, *, planned_views=None) -> list[DimensionGr
     """Plan each feature's parameters into one `DimensionGroup` (anchor + single
     view + planned dims, each carrying its render intent — convention, model-level
     suppression, datum). No cross- or within-feature value de-duplication."""
+    declared_model = model
+    selection = authored_dimension_requests(model)  # validate even without scalar parameters
     _check_intent_policy_conflicts(model)
+    model = _selection_model(model, selection)
     if model.authored_dimensions is not None:
         _check_authored_targets(model)
     groups: list[DimensionGroup] = []
@@ -1827,7 +1949,13 @@ def plan_dimensions(model: PartModel, *, planned_views=None) -> list[DimensionGr
         # Validate the final content: a consolidated height must not reject a
         # supported end-on view requested for the remaining diameter.
         selected_view, selected_side = _group_placement(
-            group.feature, list(group.dims), planned_views
+            group.feature,
+            [
+                pd
+                for pd in group.dims
+                if annotation_requested(declared_model, group.feature, pd.param)
+            ],
+            planned_views,
         )
         groups[index] = replace(
             group,
@@ -1835,8 +1963,15 @@ def plan_dimensions(model: PartModel, *, planned_views=None) -> list[DimensionGr
             side=selected_side,
         )
     if planned_views is not None:
-        uncovered = _uncovered_group_requirements(model, groups, planned_views)
-        uncovered.extend(_uncovered_location_requirements(model, planned_views))
+        uncovered = _uncovered_group_requirements(declared_model, groups, planned_views)
+        uncovered.extend(
+            _uncovered_location_requirements(
+                replace(declared_model, schedules=())
+                if declared_model.schedules
+                else declared_model,
+                planned_views,
+            )
+        )
         if uncovered:
             raise ViewPlanIncomplete(planned_views, uncovered)
     return groups

--- a/src/draftwright/registry.py
+++ b/src/draftwright/registry.py
@@ -29,6 +29,42 @@ draftwright and carries no behaviour beyond the bookkeeping moved out of
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class _MeasurementIdentity(Protocol):
+    @property
+    def feature(self) -> object: ...
+
+    @property
+    def parameter(self) -> str: ...
+
+
+@dataclass(frozen=True)
+class MeasurementCell:
+    """Exact measured cell provenance; numeric content remains in the compiled plan."""
+
+    schedule: str
+    row: int
+    column: int
+    measurement: _MeasurementIdentity
+
+    def __post_init__(self):
+        if not isinstance(self.schedule, str) or not self.schedule:
+            raise ValueError("measurement cell requires a schedule name")
+        if (
+            isinstance(self.row, bool)
+            or not isinstance(self.row, int)
+            or self.row < 1
+            or isinstance(self.column, bool)
+            or not isinstance(self.column, int)
+            or self.column < 0
+        ):
+            raise ValueError("measurement cell requires a data row and nonnegative column")
+        if self.measurement is None:
+            raise ValueError("measurement cell requires a measurement identity")
+
 
 def _as_ids(measurement) -> tuple:
     """Normalise a caller's *measurement* to a tuple of ids (#1002).
@@ -74,6 +110,7 @@ class AnnotationRegistry:
         # would have to be widened again later, and worse, would make the audit's
         # "exact when present" promise false for a callout's other measurements.
         self._anno_measurement: dict = {}
+        self._anno_cells: dict[str, tuple[MeasurementCell, ...]] = {}
         # name -> DimensionIds a placed structured note explicitly satisfies (#1351).
         # Separate from ``_anno_measurement`` because a note carries manufacturing authority
         # without pretending to be dimensional ink; coverage and quality reports must retain
@@ -117,7 +154,11 @@ class AnnotationRegistry:
         `tests/test_audit_differential.py` rather than described here — the prose version of
         that set was wrong when first written (Codex #1002 r1)."""
         ids: tuple = self._anno_measurement.get(name, ())
-        return ids
+        return ids + tuple(cell.measurement for cell in self.cells_of(name))
+
+    def cells_of(self, name) -> tuple[MeasurementCell, ...]:
+        """The registered data-cell addresses of a live measured table."""
+        return self._anno_cells.get(name, ())
 
     def has_measurement(self, identity) -> bool:
         """Whether a live mark carries this exact feature/parameter identity."""
@@ -155,8 +196,10 @@ class AnnotationRegistry:
     def features_of(self, name) -> tuple:
         """Original feature owners of a mark, including shared callout members."""
         primary = self.feature_of(name)
-        owners = (() if primary is None else (primary,)) + tuple(
-            getattr(self._named.get(name), "source_features", ())
+        owners = (
+            (() if primary is None else (primary,))
+            + tuple(getattr(self._named.get(name), "source_features", ()))
+            + tuple(cell.measurement.feature for cell in self.cells_of(name))
         )
         seen = set()
         unique = []
@@ -188,6 +231,7 @@ class AnnotationRegistry:
             "anno_view": dict(self._anno_view),
             "anno_feature": dict(self._anno_feature),
             "anno_measurement": dict(self._anno_measurement),
+            "anno_cells": dict(self._anno_cells),
             "anno_satisfaction": dict(self._anno_satisfaction),
             "pinned": set(self._pinned),
         }
@@ -202,6 +246,8 @@ class AnnotationRegistry:
         self._anno_feature.update(snap.get("anno_feature", {}))
         self._anno_measurement.clear()
         self._anno_measurement.update(snap.get("anno_measurement", {}))
+        self._anno_cells.clear()
+        self._anno_cells.update(snap.get("anno_cells", {}))
         self._anno_satisfaction.clear()
         self._anno_satisfaction.update(snap.get("anno_satisfaction", {}))
         self._pinned.clear()
@@ -226,6 +272,7 @@ class AnnotationRegistry:
             "view": self._anno_view.get(name),
             "feature": self._anno_feature.get(name),
             "measurement": self._anno_measurement.get(name, ()),
+            "cells": self._anno_cells.get(name, ()),
             "satisfaction": self._anno_satisfaction.get(name, ()),
             "pinned": name in self._pinned,
         }
@@ -256,6 +303,11 @@ class AnnotationRegistry:
             self._anno_measurement[name] = ids
         else:
             self._anno_measurement.pop(name, None)
+        cells = tuple(identity.get("cells", ()))
+        if cells:
+            self._anno_cells[name] = cells
+        else:
+            self._anno_cells.pop(name, None)
         satisfactions = _as_ids(identity.get("satisfaction"))
         if satisfactions:
             self._anno_satisfaction[name] = satisfactions
@@ -266,7 +318,7 @@ class AnnotationRegistry:
         else:
             self._pinned.discard(name)
 
-    def add(self, obj, name, view, feature=None, measurement=None, satisfaction=None):
+    def add(self, obj, name, view, feature=None, measurement=None, satisfaction=None, cells=()):
         """Register *obj* under *name* and record its owning *view* (and source *feature*).
 
         Returns the object previously registered under *name* (so the caller can
@@ -300,6 +352,10 @@ class AnnotationRegistry:
                 self._anno_measurement[name] = ids
             else:
                 self._anno_measurement.pop(name, None)
+            if cells:
+                self._anno_cells[name] = tuple(cells)
+            else:
+                self._anno_cells.pop(name, None)
             satisfactions = _as_ids(satisfaction)
             if satisfactions:
                 self._anno_satisfaction[name] = satisfactions
@@ -315,6 +371,7 @@ class AnnotationRegistry:
             self._anno_view.pop(name, None)
             self._anno_feature.pop(name, None)
             self._anno_measurement.pop(name, None)
+            self._anno_cells.pop(name, None)
             self._anno_satisfaction.pop(name, None)
         return obj
 
@@ -328,6 +385,7 @@ class AnnotationRegistry:
         self._anno_view = {n: v for n, v in self._anno_view.items() if n in keep_set}
         self._anno_feature = {n: f for n, f in self._anno_feature.items() if n in keep_set}
         self._anno_measurement = {n: m for n, m in self._anno_measurement.items() if n in keep_set}
+        self._anno_cells = {n: c for n, c in self._anno_cells.items() if n in keep_set}
         self._anno_satisfaction = {
             n: s for n, s in self._anno_satisfaction.items() if n in keep_set
         }

--- a/src/draftwright/reporting.py
+++ b/src/draftwright/reporting.py
@@ -415,6 +415,7 @@ def evaluate_document_requirements(catalog, model, part, members, claims) -> Doc
     The temporary registry holds the exact existing annotations. It does not add ink
     to a drawing, merge models, recognize geometry, or use a sheet's score as evidence.
     """
+    from dataclasses import replace
     from types import SimpleNamespace
 
     from draftwright.document_evidence import document_conflicts, document_support_proofs
@@ -432,10 +433,14 @@ def evaluate_document_requirements(catalog, model, part, members, claims) -> Doc
                 reference,
                 snapshot.registry.view_of(annotation),
                 feature=snapshot.registry.feature_of(annotation),
-                measurement=snapshot.registry.measurement_of(annotation),
+                measurement=snapshot.registry.identity_of(annotation)["measurement"],
                 satisfaction=snapshot.registry.satisfaction_of(annotation),
+                cells=tuple(
+                    replace(cell, schedule=f"{index}:{cell.schedule}")
+                    for cell in snapshot.registry.cells_of(annotation)
+                ),
             )
-    # Existing ledger verification reads approved values from these four collections.
+    # Existing ledger verification reads each member's approved values and cells.
     # Each entry keeps its actual member compiler authority; nothing is recompiled here.
     plan = SimpleNamespace(
         **{
@@ -445,7 +450,12 @@ def evaluate_document_requirements(catalog, model, part, members, claims) -> Doc
                 for item in getattr(snapshot.dimension_plan, field, ())
             )
             for field in ("groups", "ladders", "locations", "contingencies")
-        }
+        },
+        schedules=tuple(
+            replace(schedule, name=f"{index}:{schedule.name}")
+            for index, (_name, snapshot, _aligned) in enumerate(members)
+            for schedule in getattr(snapshot.dimension_plan, "schedules", ())
+        ),
     )
     outcomes = recognized_requirement_outcomes(
         catalog.evidence.result,
@@ -1141,10 +1151,38 @@ def _document_views(constraints, owner_id):
     }
 
 
+def _document_cell(cell):
+    if cell is None:
+        return None
+    if (
+        not isinstance(cell, tuple)
+        or len(cell) != 2
+        or any(isinstance(item, bool) or not isinstance(item, int) for item in cell)
+        or cell[0] < 1
+        or cell[1] < 0
+    ):
+        raise ReportUnavailableError("document evidence has an invalid cell address")
+    return {"row": cell[0], "column": cell[1]}
+
+
+def _document_schedules(schedules, owner_id):
+    return [
+        {
+            "name": schedule.name,
+            "prefer": schedule.prefer,
+            "rows": [
+                {"owner_id": owner_id(row.feature), "parameters": row.parameters}
+                for row in schedule.rows
+            ],
+        }
+        for schedule in schedules
+    ]
+
+
 def document_report(
     *, catalog, evaluation, model, source, run_options, member_recipes, resolved
 ) -> dict[str, object]:
-    """Project one schema-v4 document read; no report-local identity survives this value.
+    """Project a document read; authored schedules select schema v5, otherwise v4.
 
     Carrier attribution is producer-owned. A missing producer projection stays explicit
     and prevents bounded clearance; ordinary owner/parameter associations are not proof.
@@ -1170,6 +1208,11 @@ def document_report(
         return candidate[1]["id"]
 
     members = evaluation.members
+    cell_schema = any(
+        snapshot.model.schedules or member_recipes.get(name, {}).get("schedules")
+        for name, snapshot, _rows in members
+    )
+    member_registries = {name: snapshot.registry for name, snapshot, _rows in members}
     sheet_ids = {
         name: f"sheet:{index + 1}" for index, (name, _snapshot, _rows) in enumerate(members)
     }
@@ -1187,6 +1230,30 @@ def document_report(
             raise ReportUnavailableError("requirement carrier names an absent annotation")
         return annotation_ref(*evaluation.annotation_refs[name])
 
+    def claim_cell(claim):
+        if claim.cell is not None and not any(
+            (reference.row, reference.column) == claim.cell
+            and reference.measurement.feature is claim.owner
+            and reference.measurement.parameter == claim.parameter
+            for reference in member_registries[claim.sheet].cells_of(claim.annotation)
+        ):
+            raise ReportUnavailableError("document claim refers to an absent exact cell")
+        return _document_cell(claim.cell)
+
+    def carrying_ref(carrier):
+        reference: dict[str, Any] = {
+            **combined_ref(carrier.annotation),
+            "evidence_kind": carrier.kind,
+        }
+        if cell_schema:
+            cell = carrier.cell
+            if cell is not None and not any(
+                actual is cell for actual in evaluation.registry.cells_of(carrier.annotation)
+            ):
+                raise ReportUnavailableError("requirement carrier names a foreign cell")
+            reference["cell"] = _document_cell(None if cell is None else (cell.row, cell.column))
+        return reference
+
     claims: list[dict[str, Any]] = []
     claim_ids = {}
     for snapshot in evaluation.claims:
@@ -1203,6 +1270,7 @@ def document_report(
                     "meaning": _engineering_meaning(claim.meaning),
                     "rendered": claim.rendered,
                     "verification": "confirmed-within-measurement-verifier-scope",
+                    **({"cell": claim_cell(claim)} if cell_schema else {}),
                 }
             )
 
@@ -1220,10 +1288,24 @@ def document_report(
         for conflict in evaluation.conflicts
     ]
     unknown = [
-        {**annotation_ref(sheet, annotation), "reason_code": reason}
+        {
+            **annotation_ref(sheet, annotation),
+            "reason_code": reason,
+            **({"cell": None} if cell_schema else {}),
+        }
         for snapshot in evaluation.claims
         for sheet, annotation, reason in snapshot.unknown
     ]
+    if cell_schema:
+        unknown.extend(
+            {
+                **annotation_ref(sheet, item.annotation),
+                "reason_code": item.reason,
+                "cell": _document_cell(item.cell),
+            }
+            for snapshot in evaluation.claims
+            for sheet, item in snapshot.cell_unknown
+        )
     requirements: list[dict[str, Any]] = []
     profile_ids: dict[int, str] = {}
     support_ids: dict[tuple[int, int], str] = {}
@@ -1267,14 +1349,7 @@ def document_report(
         # supplies it, retain the absence instead of guessing from annotation names.
         carriers = getattr(evaluated.combined.outcome, "carriers", None)
         attributed = carriers is not None
-        carrying = (
-            []
-            if carriers is None
-            else [
-                {**combined_ref(carrier.annotation), "evidence_kind": carrier.kind}
-                for carrier in carriers
-            ]
-        )
+        carrying = [] if carriers is None else [carrying_ref(carrier) for carrier in carriers]
         if evaluated.state == "dependency-derived":
             attributed = bool(proofs)
             carrying = []
@@ -1328,6 +1403,8 @@ def document_report(
     for name, snapshot, _rows in members:
         if snapshot.lint is None or name not in resolved or name not in member_recipes:
             raise ReportUnavailableError(f"document sheet {name!r} lacks lint or run options")
+        if cell_schema and "schedules" not in member_recipes[name]:
+            raise ReportUnavailableError(f"document sheet {name!r} lacks schedule intent")
         options = {
             key: str(value) if isinstance(value, PathLike) else value
             for key, value in member_recipes[name]["options"].items()
@@ -1341,6 +1418,15 @@ def document_report(
                 "dimension_intents": _document_intents(snapshot.model, owner_id),
                 "view_intents": _document_views(member_recipes[name]["views"], owner_id),
                 "table_intents": member_recipes[name]["tables"],
+                **(
+                    {
+                        "schedule_intents": _document_schedules(
+                            member_recipes[name]["schedules"], owner_id
+                        )
+                    }
+                    if cell_schema
+                    else {}
+                ),
                 "lint": snapshot.lint,
             }
         )
@@ -1420,7 +1506,7 @@ def document_report(
     )
     report = {
         "schema": REPORT_SCHEMA,
-        "schema_version": 4,
+        "schema_version": 5 if cell_schema else 4,
         "scope": "document",
         "status": "needs-attention" if attention else "bounded-clear",
         "producer": producer(),
@@ -1453,6 +1539,7 @@ def document_report(
                 "dimension-selection",
                 "view-constraints",
                 "table-text",
+                *(["feature-schedules"] if cell_schema else []),
             ],
             "source_recipe_required_for": [
                 "feature-decorations",

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -113,15 +113,18 @@ from draftwright.model.declare import read_countersink as _read_countersink
 from draftwright.model.ir import (
     ControlFrame,
     DatumRef,
+    FeatureSchedule,
     NominalRequirement,
     Note,
     RequestedDimension,
+    ScheduleRow,
     ToleranceDecoration,
 )
 from draftwright.model.planner import LOCATION_ROLE as _LOCATION_ROLE
 from draftwright.model.planner import (
     dimension_placement_options,
     location_components,
+    schedule_row_dimensions,
     validate_dimension_placement,
 )
 from draftwright.model.planner import location_role as _location_role
@@ -1133,6 +1136,7 @@ class Sheet:
         # engine's generic auto-placed Drawing.add_table, AFTER the drawing is built so they sit
         # clear of the views + title block (like the hole table). Each: {rows, prefer, name}.
         self._tables: list = []
+        self._schedules: list[dict] = []
         # ADR 4 (was 0016) augmenting dimension intents (#872), token-keyed for the same reason as
         # `_tolerances`: a handle may be recorded before a later size verb replaces the
         # feature, and a position would then name whatever moved into the slot.
@@ -1219,13 +1223,14 @@ class Sheet:
         self._features.validate_change = source.validate_features
 
     def _document_recipe(self):
-        """Snapshot options, view intent and ordinary tables before a member build."""
+        """Snapshot options, view intent and both table declarations before a member build."""
         from copy import deepcopy
 
         return {
             "options": deepcopy(self._opts),
             "views": self.view_constraints,
             "tables": deepcopy(self._tables),
+            "schedules": self._resolved_schedules(),
         }
 
     def _snapshot_for_document(self):
@@ -2487,6 +2492,32 @@ class Sheet:
 
     # -- corner-block tables (notes / revision / BOM / schedule) --------------
 
+    def schedule(
+        self, rows, *, name: str, prefer: Literal["tr", "tl", "br", "bl"] = "tr"
+    ) -> Sheet:
+        """Declare a measured table from ``(feature, parameter_ids)`` rows.
+
+        ``location`` selects every addressable hole member's transverse distances.
+        Explicit canonical IDs select individual measurements. Values, units and
+        tolerances come from the compiler; the existing table solve owns placement.
+        This declares authored dimension intent, like :meth:`dimension`.
+        """
+        records = []
+        resolved = []
+        for feature, parameters in rows:
+            token = self._feature_token(feature)
+            target = self._features[self._index_of_token(token)]
+            row = ScheduleRow(target, parameters)
+            schedule_row_dimensions(row)
+            resolved.append(row)
+            records.append((token, row.parameters))
+        FeatureSchedule(name, tuple(resolved), prefer)
+        if any(schedule["name"] == name for schedule in self._schedules):
+            raise ValueError(f"duplicate schedule name {name!r}")
+        self._schedules.append({"name": name, "prefer": prefer, "rows": tuple(records)})
+        self._authored_source = True
+        return self
+
     def table(
         self, rows, *, prefer: str = "tr", name: str | None = None, block_cols=None
     ) -> Sheet:
@@ -3085,10 +3116,28 @@ class Sheet:
             )
         return cut_y
 
+    def _resolved_schedules(self):
+        return tuple(
+            FeatureSchedule(
+                entry["name"],
+                tuple(
+                    ScheduleRow(self._features[self._index_of_token(token)], parameters)
+                    for token, parameters in entry["rows"]
+                ),
+                entry["prefer"],
+            )
+            for entry in self._schedules
+        )
+
     def _build_model_input(self):
         if self._document_input is not None:
-            return self._document_input.model(self._features)
-        return self._features
+            model = self._document_input.model(self._features)
+        else:
+            model = self._features
+        if not self._schedules:
+            return model
+        model = _coerce_model(model, _solids_body(self._part), authored=self._authored_set())
+        return replace(model, schedules=self._resolved_schedules())
 
     def model(self):
         """The IR the engine will draw (detection skipped) — for inspection. Wraps the

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -1550,7 +1550,8 @@ def _dimension_block(model, names: dict[int, str], synthesised_envelope=None) ->
     )
     out = [
         "# ── Dimensions ────────────────────────────────────────────────────────────────",
-        "# THIS IS THE COMPLETE SET (ADR 4 (was 0016)). A measurement with no line here is omitted",
+        "# THIS IS THE COMPLETE SET (ADR 4 (was 0016)), including feature schedules below.",
+        "# A measurement with no dimension or schedule declaration is omitted",
         "# deliberately — comment a line out to drop that dimension, add one to declare it.",
         # The role vocabulary was undiscoverable from the artefact: an editor had to guess a
         # string or read the source (#963). Typing narrows it now, but a generated file is
@@ -1597,6 +1598,26 @@ def _dimension_block(model, names: dict[int, str], synthesised_envelope=None) ->
         if display_decimals is not None:
             line += f".format(decimals={display_decimals})"
         out.append(line)
+    return out
+
+
+def _schedule_block(model, names: dict[int, str]) -> list[str]:
+    """Retain authored table representations using the same emitted owner bindings."""
+    if not model.schedules:
+        return []
+    model._validate_schedule_origins()
+    out = ["", "# Feature schedules select measurements; the compiler supplies cell content."]
+    for schedule in model.schedules:
+        out.append("sheet.schedule([")
+        for row in schedule.rows:
+            name = names.get(id(row.feature))
+            if name is None:
+                raise ValueError(
+                    f"emit_sheet_script(): cannot name the {row.feature.kind} carrying "
+                    f"schedule {schedule.name!r}; it has no emitted feature binding"
+                )
+            out.append(f"    ({name}, {row.parameters!r}),")
+        out.append(f"], name={schedule.name!r}, prefer={schedule.prefer!r})")
     return out
 
 
@@ -2264,6 +2285,7 @@ def emit_sheet_script(
         *feature_lines,
         "",
         *_dimension_block(model, _names, _synth_env),
+        *_schedule_block(model, _names),
         "",
         "# ── Views ─────────────────────────────────────────────────────────────────────",
     ]

--- a/tests/test_issue_1543_feature_schedules.py
+++ b/tests/test_issue_1543_feature_schedules.py
@@ -873,3 +873,54 @@ def test_schedule_selectors_expand_once_per_row_in_each_plan(monkeypatch, planne
     else:
         selected = [dimension.feature for dimension in updated if not dimension.suppressed]
     assert len(selected) == 1 and selected[0] is features[0]
+
+
+@pytest.mark.parametrize(
+    "fields",
+    (
+        {"schedule": ""},
+        {"schedule": None},
+        {"row": 0},
+        {"row": True},
+        {"row": 1.5},
+        {"column": -1},
+        {"column": False},
+        {"column": "1"},
+        {"measurement": None},
+    ),
+)
+def test_invalid_cell_addresses_cannot_enter_registry_provenance(
+    bolt_group, schedule_bbox, fields
+):
+    plan = compile_dimensions(_model(bolt_group, schedule_bbox, parameters=("bore.diameter",)))
+    registry, _table, (cell,) = _registered_table(plan)
+    before = registry.snapshot()
+    with pytest.raises(ValueError, match="measurement cell requires"):
+        replace(cell, **fields)
+    assert registry.snapshot() == before
+
+
+@pytest.mark.parametrize(
+    "damage", ("unknown-schedule", "row-outside", "column-outside", "no-content")
+)
+def test_unresolvable_cell_address_never_reuses_table_numbers(bolt_group, schedule_bbox, damage):
+    from draftwright.linting.schedule_evidence import verified_schedule_registry
+
+    plan = compile_dimensions(_model(bolt_group, schedule_bbox, parameters=("bore.diameter",)))
+    registry, table, (cell,) = _registered_table(plan)
+    if damage == "no-content":
+        table.table_rows = None
+    else:
+        fields = {
+            "unknown-schedule": {"schedule": "absent"},
+            "row-outside": {"row": len(table.table_rows)},
+            "column-outside": {"column": len(table.table_rows[cell.row])},
+        }[damage]
+        cell = replace(cell, **fields)
+        registry.add(table, "bolts", None, cells=(cell,))
+    outcomes = verify_measurement_claims(registry, plan)
+    assert outcomes and all(row.state != "confirmed" for row in outcomes)
+    assert any(row.cell == (cell.row, cell.column) for row in outcomes)
+    verified = verified_schedule_registry(registry, plan)
+    assert not verified.cells_of("bolts")
+    assert not verified.measurement_of("bolts")

--- a/tests/test_issue_1543_feature_schedules.py
+++ b/tests/test_issue_1543_feature_schedules.py
@@ -1,0 +1,875 @@
+"""Feature schedules select exact compiler measurements, never a table of invented values."""
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+from build123d import Box, Cylinder, Pos
+
+from draftwright import Sheet, build_drawing
+from draftwright.linting.evidence import compiled_values, verify_measurement_claims
+from draftwright.model.compiled import compile_dimensions, resolve_feature
+from draftwright.model.declare import envelope, hole
+from draftwright.model.ir import (
+    ChamferFeature,
+    Datum,
+    FeatureSchedule,
+    Frame,
+    PartModel,
+    PatternFeature,
+    RequestedDimension,
+    ScheduleRow,
+)
+from draftwright.model.planner import (
+    authored_dimension_requests,
+    location_components,
+    plan_dimensions,
+    plan_locations,
+    schedule_row_dimensions,
+)
+from draftwright.registry import AnnotationRegistry, MeasurementCell
+from draftwright.view_plan import ViewPlanIncomplete
+
+
+@pytest.fixture(scope="module")
+def bolt_group():
+    return hole(
+        diameter=2.4,
+        depth=10,
+        through=True,
+        axis="z",
+        at=(2, 3, 0),
+        members=((2, 3, 0), (8, 9, 0)),
+        count=2,
+    )
+
+
+def test_schedule_keeps_identical_operations_as_distinct_targets(bolt_group):
+    other = replace(bolt_group)
+    rows = tuple(ScheduleRow(owner, ("bore.diameter",)) for owner in (bolt_group, other))
+    model = PartModel(
+        None,
+        None,
+        features=[bolt_group, other],
+        authored_dimensions=(),
+        schedules=(FeatureSchedule("bores", rows),),
+    )
+    selected = [schedule_row_dimensions(row)[0] for row in model.schedules[0].rows]
+    assert selected[0].feature is bolt_group
+    assert selected[1].feature is other
+    assert selected[0].feature is not selected[1].feature
+
+
+def test_schedule_refuses_equal_foreign_owner_and_inventory_replacement(bolt_group):
+    schedule = FeatureSchedule("bores", (ScheduleRow(bolt_group, ("bore.diameter",)),))
+    with pytest.raises(ValueError, match="identical feature"):
+        PartModel(None, None, features=[replace(bolt_group)], schedules=(schedule,))
+    model = PartModel(None, None, features=[bolt_group], schedules=(schedule,))
+    model.features[:] = [replace(bolt_group)]
+    with pytest.raises(ValueError, match="identical feature"):
+        plan_dimensions(model)
+
+
+@pytest.mark.parametrize("axis", ["x", "y", "z"])
+def test_location_alias_selects_every_physical_member_and_transverse_axis(bolt_group, axis):
+    feature = replace(bolt_group, frame=Frame((2, 3, 0), axis))
+    requests = schedule_row_dimensions(ScheduleRow(feature, ("location",)))
+    assert {(request.member, request.discriminator) for request in requests} == {
+        (member, component) for member in range(2) for component in "xyz" if component != axis
+    }
+    assert all(request.feature is feature and request.role == "location" for request in requests)
+
+
+def test_pattern_alias_does_not_substitute_anchor_for_member_locations(bolt_group):
+    pattern = PatternFeature(
+        frame=Frame((5, 6, 0), "z"),
+        pattern="bolt_circle",
+        member=bolt_group,
+        members=bolt_group.members,
+        count=2,
+        bcd=10,
+    )
+    requests = schedule_row_dimensions(ScheduleRow(pattern, ("location",)))
+    assert {(request.member, request.discriminator) for request in requests} == {
+        (0, "x"),
+        (0, "y"),
+        (1, "x"),
+        (1, "y"),
+    }
+    centre = next(item for item in location_components(pattern) if item["member"] == "centre")
+    explicit = schedule_row_dimensions(ScheduleRow(pattern, (centre["parameter_id"],)))
+    assert len(explicit) == 1 and explicit[0].member == "centre"
+
+
+def test_exact_location_parameter_preserves_one_member_axis(bolt_group):
+    component = location_components(bolt_group)[-1]
+    (request,) = schedule_row_dimensions(ScheduleRow(bolt_group, (component["parameter_id"],)))
+    assert (request.member, request.discriminator) == (1, "y")
+
+
+@pytest.mark.parametrize("selectors", [("bore",), ("made.up",), ("bore.depth",)])
+def test_invalid_or_unavailable_measurement_is_not_an_empty_credited_cell(bolt_group, selectors):
+    with pytest.raises(ValueError, match="canonical measurement"):
+        schedule_row_dimensions(ScheduleRow(bolt_group, selectors))
+
+
+def test_overlapping_alias_and_exact_component_is_refused(bolt_group):
+    component = location_components(bolt_group)[0]["parameter_id"]
+    with pytest.raises(ValueError, match="repeats measurement"):
+        schedule_row_dimensions(ScheduleRow(bolt_group, ("location", component)))
+
+
+def test_ir_freezes_input_containers_without_copying_feature_identity(bolt_group):
+    parameters = ["bore.diameter"]
+    row = ScheduleRow(bolt_group, parameters)
+    rows = [row]
+    schedule = FeatureSchedule("bores", rows)
+    parameters.clear()
+    rows.clear()
+    assert schedule.rows == (row,) and row.parameters == ("bore.diameter",)
+    assert row.feature is bolt_group
+
+
+@pytest.mark.parametrize(
+    "parameters", [(), "bore.diameter", ("",), (2,), ("location", "location")]
+)
+def test_malformed_row_refuses_before_planning(bolt_group, parameters):
+    with pytest.raises(ValueError, match="schedule"):
+        ScheduleRow(bolt_group, parameters)
+
+
+@pytest.mark.parametrize("name,prefer", [("", "tr"), ("bores", "middle")])
+def test_schedule_needs_named_existing_table_region(bolt_group, name, prefer):
+    with pytest.raises(ValueError, match="schedule"):
+        FeatureSchedule(name, (ScheduleRow(bolt_group, ("bore.diameter",)),), prefer=prefer)
+
+
+def test_empty_or_duplicate_named_schedules_are_refused(bolt_group):
+    with pytest.raises(ValueError, match="ScheduleRow"):
+        FeatureSchedule("empty", ())
+    schedule = FeatureSchedule("bores", (ScheduleRow(bolt_group, ("bore.diameter",)),))
+    with pytest.raises(ValueError, match="duplicate schedule"):
+        PartModel(None, None, features=[bolt_group], schedules=(schedule, schedule))
+
+
+@pytest.fixture(scope="module")
+def schedule_part():
+    return Box(20, 20, 10)
+
+
+@pytest.fixture(scope="module")
+def schedule_bbox(schedule_part):
+    return schedule_part.bounding_box()
+
+
+def _model(bolt_group, schedule_bbox, *, authored=(), parameters=("bore.diameter", "location")):
+    return PartModel(
+        schedule_bbox,
+        None,
+        features=[bolt_group],
+        datums=[Datum("datum_xy", "point", at=(-10, -10, -5))],
+        authored_dimensions=authored,
+        schedules=(FeatureSchedule("bolts", (ScheduleRow(bolt_group, parameters),)),),
+    )
+
+
+def test_table_only_measurements_do_not_demand_a_leader_view(bolt_group, schedule_bbox):
+    model = _model(bolt_group, schedule_bbox)
+    (group,) = plan_dimensions(model, planned_views=("front",))
+    assert [(pd.param.parameter_id, pd.suppressed) for pd in group.dims] == [
+        ("bore.diameter", False),
+    ]
+    locations = plan_locations(model)
+    assert len(locations) == 2 and all(not pd.suppressed for pd in locations)
+    assert {pd.location_member for pd in locations} == {0, 1}
+    assert model.authored_dimensions == (), "Resolving schedules must not rewrite source intent"
+
+
+def test_same_measurement_requested_as_annotation_still_requires_its_view(
+    bolt_group, schedule_bbox
+):
+    model = _model(
+        bolt_group, schedule_bbox, authored=(RequestedDimension(bolt_group, "bore.diameter"),)
+    )
+    with pytest.raises(ViewPlanIncomplete):
+        plan_dimensions(model, planned_views=("front",))
+    assert plan_dimensions(model, planned_views=("plan",))
+
+
+def test_schedule_reuses_annotation_display_policy_and_feature_tolerance(
+    bolt_group, schedule_bbox
+):
+    request = RequestedDimension(bolt_group, "bore.diameter", display_decimals=3, view="plan")
+    model = _model(bolt_group, schedule_bbox, authored=(request,))
+    model.decorations[(bolt_group, "diameter")] = 0.02
+    (group,) = plan_dimensions(model, planned_views=("plan",))
+    (diameter,) = group.dims
+    assert diameter.display_decimals == 3 and diameter.view == "plan"
+    assert diameter.param.tolerance == 0.02
+    assert authored_dimension_requests(model)[0] is request
+
+
+def test_planning_refuses_schedule_on_automatic_source(bolt_group, schedule_bbox):
+    model = _model(bolt_group, schedule_bbox, authored=None)
+    with pytest.raises(ValueError, match="authored dimension set"):
+        plan_dimensions(model)
+
+
+def test_planning_revalidates_mutated_schedule_owners(bolt_group, schedule_bbox):
+    model = _model(bolt_group, schedule_bbox)
+    model.features[:] = [replace(bolt_group)]
+    with pytest.raises(ValueError, match="identical feature"):
+        plan_dimensions(model)
+
+
+def _measured_cells(plan):
+    return [
+        cell
+        for schedule in plan.schedules
+        for row in schedule.rows
+        for cell in row
+        if cell.measurement is not None
+    ]
+
+
+def test_compiler_routes_schedule_measurements_without_ordinary_ink(bolt_group, schedule_bbox):
+    model = _model(bolt_group, schedule_bbox)
+    plan = compile_dimensions(model, include_overall=False, planned_views=("front",))
+    cells = _measured_cells(plan)
+    assert len(cells) == 5
+    assert [cell.text for cell in cells] == ["Ø2.4 THRU", "12", "13", "18", "19"]
+    assert all(resolve_feature(cell.measurement.ref) is bolt_group for cell in cells)
+    assert {cell.measurement.id.parameter for cell in cells} == {
+        "bore.diameter",
+        *(component["parameter_id"] for component in location_components(bolt_group)),
+    }
+    assert not plan.locations and not any(group.dims for group in plan.groups)
+    assert len(plan.addressable()) == 5
+    values = compiled_values(plan)
+    assert all(cell.measurement in values[cell.measurement.id] for cell in cells)
+    assert len({len(row) for row in plan.schedules[0].rows}) == 1
+
+
+def test_schedule_and_annotation_share_approved_precision_tolerance_and_span(
+    bolt_group, schedule_bbox
+):
+    request = RequestedDimension(bolt_group, "bore.diameter", display_decimals=3)
+    model = _model(bolt_group, schedule_bbox, authored=(request,), parameters=("bore.diameter",))
+    model.decorations[(bolt_group, "diameter")] = (0.002, 0.015)
+    plan = compile_dimensions(model, include_overall=False)
+    (cell,) = _measured_cells(plan)
+    (diameter,) = next(group.dims for group in plan.groups if group.dims)
+    assert cell.measurement is diameter
+    assert cell.text == "Ø2.400 +0.015 -0.002 THRU"
+    assert diameter.value == 2.4 and diameter.tolerance == (0.002, 0.015)
+
+
+def test_mixed_ordinary_and_scheduled_location_keeps_only_selected_annotation(
+    bolt_group, schedule_bbox
+):
+    model = _model(
+        bolt_group,
+        schedule_bbox,
+        authored=(RequestedDimension(bolt_group, "location", member=1, discriminator="y"),),
+        parameters=("location",),
+    )
+    plan = compile_dimensions(model, include_overall=False, planned_views=("plan",))
+    assert len(_measured_cells(plan)) == 4
+    (location,) = plan.locations
+    assert (location.location_member, location.discriminator, location.value) == (1, "y", 19)
+
+
+def test_equal_nominal_through_and_blind_operations_keep_separate_cell_meanings(
+    bolt_group, schedule_bbox
+):
+    blind = replace(bolt_group, through=False, depth=1.5, frame=Frame((2, 3, 0), "x"))
+    model = _model(bolt_group, schedule_bbox, parameters=("bore.diameter",))
+    model.features.append(blind)
+    model.schedules = (
+        FeatureSchedule(
+            "operations",
+            (
+                ScheduleRow(bolt_group, ("bore.diameter",)),
+                ScheduleRow(blind, ("bore.diameter", "bore.depth")),
+            ),
+        ),
+    )
+    cells = _measured_cells(
+        compile_dimensions(model, include_overall=False, planned_views=("front",))
+    )
+    assert [cell.text for cell in cells] == ["Ø2.4 THRU", "Ø2.4", "↓1.5"]
+    assert cells[0].measurement.id.feature is bolt_group
+    assert cells[1].measurement.id.feature is cells[2].measurement.id.feature is blind
+
+
+def test_missing_datum_refuses_schedule_instead_of_claiming_empty_location_cells(
+    bolt_group, schedule_bbox
+):
+    model = _model(bolt_group, schedule_bbox, parameters=("location",))
+    model.datums.clear()
+    with pytest.raises(ValueError, match="exactly one approved measurement; found 0"):
+        compile_dimensions(model, include_overall=False)
+
+
+def test_sheet_schedule_uses_final_feature_after_handle_edit_and_reorder(
+    bolt_group, schedule_part
+):
+    sheet = Sheet(schedule_part)
+    bolt = sheet.hole(diameter=2.4, depth=10, axis="z", at=(2, 3, 0), through=True)
+    other = sheet.add(replace(bolt_group, diameter=4))
+    sheet.schedule([(bolt, ("bore.diameter",))], name="bolts")
+    bolt.through("THROUGH")
+    bolt.tolerance(0.02)
+    sheet.features.reverse()
+    model = sheet.model()
+    (row,) = model.schedules[0].rows
+    assert row.feature is model.features[1]
+    assert row.feature is not model.features[0]
+    assert other.dimension_ids() == bolt.dimension_ids()
+    (cell,) = _measured_cells(compile_dimensions(model, include_overall=False))
+    assert cell.text == "Ø2.4 ±0.02 THROUGH"
+
+
+def test_invalid_sheet_schedule_is_transactional(bolt_group, schedule_part):
+    sheet = Sheet(schedule_part).authored_dimensions()
+    bolt = sheet.add(bolt_group)
+    with pytest.raises(ValueError, match="canonical measurement"):
+        sheet.schedule([(bolt, ("bore.diameter",)), (bolt, ("nonsense",))], name="bad")
+    assert sheet.model().schedules == ()
+    sheet.schedule([(bolt, ("bore.diameter",))], name="good")
+    with pytest.raises(ValueError, match="duplicate schedule"):
+        sheet.schedule([(bolt, ("location",))], name="good")
+    assert len(sheet.model().schedules) == 1
+
+
+@pytest.mark.parametrize("ordinary", [False, True])
+def test_scheduled_overall_height_keeps_canonical_identity_and_no_empty_ladder(
+    schedule_part, ordinary
+):
+    feature = envelope(schedule_part)
+    model = _model(
+        feature,
+        schedule_part.bounding_box(),
+        parameters=("height.length",),
+        authored=(RequestedDimension(feature, "height.length"),) if ordinary else (),
+    )
+    plan = compile_dimensions(model)
+    (cell,) = _measured_cells(plan)
+    assert cell.measurement.id.parameter == "height.length"
+    assert [(entry.role, entry.member) for entry in plan.addressable()] == [
+        ("height.length", None)
+    ]
+    assert all(ladder.rungs for ladder in plan.ladders)
+    assert bool(plan.ladder("overall_height")) is ordinary
+
+
+@pytest.mark.parametrize("other_leg,angle,expected", [(2, 45, "C2"), (1, 26.6, "2 × 26.6°")])
+def test_schedule_preserves_chamfer_form(schedule_bbox, other_leg, angle, expected):
+    feature = ChamferFeature(Frame((0, 0, 0), "z"), "z", 2, other_leg, angle)
+    model = _model(feature, schedule_bbox, parameters=("chamfer.length",))
+    (cell,) = _measured_cells(compile_dimensions(model, include_overall=False))
+    assert cell.text == expected
+
+
+def test_schedule_preserves_countersink_angle_units(bolt_group, schedule_bbox):
+    feature = replace(bolt_group, csink=(4.8, 90))
+    model = _model(feature, schedule_bbox, parameters=("countersink.angle",))
+    (cell,) = _measured_cells(compile_dimensions(model, include_overall=False))
+    assert cell.text == "90°"
+
+
+def _registered_table(plan):
+    (schedule,) = plan.schedules
+    table = SimpleNamespace(
+        table_rows=tuple(tuple(cell.text for cell in row) for row in schedule.rows)
+    )
+    table.measurement_schedule = schedule.name
+    cells = tuple(
+        MeasurementCell(schedule.name, ri, ci, cell.measurement.id)
+        for ri, row in enumerate(schedule.rows)
+        for ci, cell in enumerate(row)
+        if cell.measurement is not None
+    )
+    registry = AnnotationRegistry()
+    registry.add(table, schedule.name, None, cells=cells)
+    return registry, table, cells
+
+
+def test_cell_verifier_cannot_borrow_a_matching_number_from_another_row(bolt_group, schedule_bbox):
+    model = _model(bolt_group, schedule_bbox, parameters=("location",))
+    plan = compile_dimensions(model, include_overall=False)
+    registry, table, cells = _registered_table(plan)
+    assert len(verify_measurement_claims(registry, plan)) == 4
+    assert all(
+        outcome.state == "confirmed" for outcome in verify_measurement_claims(registry, plan)
+    )
+    target, neighbour = cells[0], cells[-1]
+    rows = [list(row) for row in table.table_rows]
+    original = rows[target.row][target.column]
+    rows[target.row][target.column] = rows[neighbour.row][neighbour.column]
+    rows[neighbour.row][neighbour.column] = original
+    table.table_rows = tuple(tuple(row) for row in rows)
+    outcomes = verify_measurement_claims(registry, plan)
+    assert {outcome.cell for outcome in outcomes if outcome.state == "value_absent"} == {
+        (target.row, target.column),
+        (neighbour.row, neighbour.column),
+    }
+    assert sum(outcome.state == "confirmed" for outcome in outcomes) == 2
+
+
+@pytest.mark.parametrize("change", ["tolerance", "through", "quantity", "axis", "row_removed"])
+def test_cell_verifier_checks_engineering_content_and_actual_row_presence(
+    bolt_group, schedule_bbox, change
+):
+    model = _model(bolt_group, schedule_bbox, parameters=("bore.diameter",))
+    model.decorations[(bolt_group, "diameter")] = 0.02
+    plan = compile_dimensions(model, include_overall=False)
+    registry, table, (cell,) = _registered_table(plan)
+    rows = [list(row) for row in table.table_rows]
+    if change == "row_removed":
+        rows.pop(cell.row)
+    elif change == "quantity":
+        rows[cell.row][rows[0].index("Qty")] = "9"
+    elif change == "axis":
+        rows[cell.row][rows[0].index("Axis")] = "X"
+    else:
+        rows[cell.row][cell.column] = rows[cell.row][cell.column].replace(
+            " ±0.02" if change == "tolerance" else " THRU", ""
+        )
+    table.table_rows = tuple(tuple(row) for row in rows)
+    (outcome,) = verify_measurement_claims(registry, plan)
+    assert outcome.state == ("unreadable" if change == "row_removed" else "value_absent")
+    assert outcome.cell == (cell.row, cell.column)
+
+
+def test_cell_provenance_refuses_equal_foreign_owner_and_unsliced_extra_claim(
+    bolt_group, schedule_bbox
+):
+    plan = compile_dimensions(_model(bolt_group, schedule_bbox), include_overall=False)
+    registry, table, cells = _registered_table(plan)
+    first = cells[0]
+    foreign = replace(first.measurement, feature=replace(bolt_group))
+    registry.add(
+        table,
+        "bolts",
+        None,
+        cells=(replace(first, measurement=foreign), *cells[1:]),
+        measurement=replace(first.measurement, parameter="invented.measurement"),
+    )
+    outcomes = verify_measurement_claims(registry, plan)
+    assert outcomes[0].state == "unresolved" and outcomes[-1].state == "unresolved"
+    assert len(outcomes) == len(cells) + 1
+
+
+def test_cell_identity_survives_rollback_but_not_removal_or_fresh_replacement(
+    bolt_group, schedule_bbox
+):
+    plan = compile_dimensions(_model(bolt_group, schedule_bbox), include_overall=False)
+    registry, table, cells = _registered_table(plan)
+    snapshot = registry.snapshot()
+    identity = registry.identity_of("bolts")
+    registry.pin("bolts")
+    registry.remove("bolts")
+    assert registry.cells_of("bolts") == () and registry.measurement_of("bolts") == ()
+    registry.add(table, "bolts", None)
+    assert registry.cells_of("bolts") == ()
+    registry.reapply("bolts", identity)
+    assert registry.cells_of("bolts") == cells
+    registry.clear(())
+    assert registry.cells_of("bolts") == ()
+    registry.restore(snapshot)
+    assert registry.cells_of("bolts") == cells
+    assert all(
+        outcome.state == "confirmed" for outcome in verify_measurement_claims(registry, plan)
+    )
+
+
+@pytest.mark.parametrize("rename", [False, True])
+def test_losing_all_cell_addresses_cannot_downgrade_to_numeric_bag(
+    bolt_group, schedule_bbox, rename
+):
+    model = _model(bolt_group, schedule_bbox, parameters=("bore.diameter",))
+    model.decorations[(bolt_group, "diameter")] = 0.02
+    plan = compile_dimensions(model, include_overall=False)
+    registry, table, (cell,) = _registered_table(plan)
+    rows = [list(row) for row in table.table_rows]
+    rows[cell.row][cell.column] = "Ø2.4"
+    table.table_rows = tuple(tuple(row) for row in rows)
+    identities = registry.measurement_of("bolts")
+    registry.remove("bolts")
+    registry.add(table, "renamed" if rename else "bolts", None, measurement=identities)
+    (outcome,) = verify_measurement_claims(registry, plan)
+    assert outcome.state == "unresolved"
+
+
+def test_raising_cell_content_is_unreadable_evidence(bolt_group, schedule_bbox):
+    plan = compile_dimensions(_model(bolt_group, schedule_bbox), include_overall=False)
+    registry, _table, cells = _registered_table(plan)
+
+    class BrokenTable:
+        @property
+        def table_rows(self):
+            raise RuntimeError("unavailable table content")
+
+    registry.add(BrokenTable(), "bolts", None, cells=cells)
+    outcomes = verify_measurement_claims(registry, plan)
+    assert len(outcomes) == 5 and all(outcome.state == "unreadable" for outcome in outcomes)
+
+
+@pytest.fixture(scope="module")
+def rendered_schedule(bolt_group):
+    part = Box(40, 40, 10)
+    for point in bolt_group.members:
+        part -= Pos(*point) * Cylinder(1.2, 10)
+    sheet = Sheet(part, page="A3", detail_view=False).authored_views()
+    feature = sheet.add(bolt_group)
+    sheet.schedule([(feature, ("bore.diameter", "location"))], name="bolts")
+    sheet.view("front")
+    return sheet, sheet.build()
+
+
+def test_public_schedule_build_places_actual_cells_through_the_table_path(rendered_schedule):
+    _sheet, drawing = rendered_schedule
+    table = drawing.get_annotation("bolts")
+    assert table is not None
+    assert set(drawing.views) == {"front"}
+    assert len(drawing.registry.cells_of("bolts")) == 5
+    outcomes = verify_measurement_claims(drawing.registry, compile_dimensions(drawing.model()))
+    assert len(outcomes) == 5 and all(outcome.state == "confirmed" for outcome in outcomes)
+    assert [
+        table.table_rows[cell.row][cell.column] for cell in drawing.registry.cells_of("bolts")
+    ] == [
+        "Ø2.4 THRU",
+        "22",
+        "23",
+        "28",
+        "29",
+    ]
+    assert not any(name.startswith(("hc_", "m_loc")) for name in drawing.annotations())
+
+
+def test_bare_ir_build_places_same_schedule_as_sheet_front_door(rendered_schedule):
+    sheet, drawing = rendered_schedule
+    replay = build_drawing(drawing.working_part, model=sheet.model(), page="A3", detail_view=False)
+    assert replay.get_annotation("bolts").table_rows == drawing.get_annotation("bolts").table_rows
+    assert len(replay.registry.cells_of("bolts")) == 5
+
+
+def test_measurement_snapshot_binds_each_actual_cell_separately(rendered_schedule):
+    from draftwright.document_evidence import bind_document_claims
+
+    _sheet, drawing = rendered_schedule
+    snapshot = drawing.measurement_snapshot()
+    claims = [claim for claim in snapshot.claims if claim.annotation == "bolts"]
+    assert len(claims) == 5
+    assert {claim.cell for claim in claims} == {
+        (cell.row, cell.column) for cell in drawing.registry.cells_of("bolts")
+    }
+    assert all(len(claim.meaning) == len(claim.approved) == 1 for claim in claims)
+    bound = bind_document_claims("features", snapshot, drawing.registry)
+    assert not bound.unknown
+    assert len(bound.claims) == 5
+    locations = [claim for claim in bound.claims if claim.address[:1] == ("location",)]
+    assert len(locations) == 4 and len({claim.address for claim in locations}) == 4
+    assert {claim.cell for claim in bound.claims} == {claim.cell for claim in claims}
+
+
+def test_wrong_schedule_cell_does_not_taint_other_cell_snapshots(rendered_schedule):
+    from draftwright.audit import compare_measurements
+
+    _sheet, drawing = rendered_schedule
+    table = drawing.get_annotation("bolts")
+    original = table.table_rows
+    before = drawing.measurement_snapshot()
+    target = drawing.registry.cells_of("bolts")[1]
+    rows = [list(row) for row in original]
+    rows[target.row][target.column] = "999"
+    try:
+        table.table_rows = tuple(tuple(row) for row in rows)
+        after = drawing.measurement_snapshot()
+        assert len(after.claims) == 4
+        assert all(claim.cell != (target.row, target.column) for claim in after.claims)
+        assert after.unknown == (("bolts", "compiled_claim_unconfirmed"),)
+        (uncertain,) = after.cell_unknown
+        assert uncertain.annotation == "bolts" and uncertain.cell == (target.row, target.column)
+        for claim in after.claims:
+            prior = next(item for item in before.claims if item.cell == claim.cell)
+            assert claim == prior
+        assert compare_measurements(before, after)["status"] == "unknown"
+    finally:
+        table.table_rows = original
+
+
+def test_document_unknown_keeps_each_bad_cell_address(rendered_schedule):
+    from draftwright.document_evidence import bind_document_claims
+
+    _sheet, drawing = rendered_schedule
+    table = drawing.get_annotation("bolts")
+    original = table.table_rows
+    cells = drawing.registry.cells_of("bolts")[1:3]
+    rows = [list(row) for row in original]
+    for cell in cells:
+        rows[cell.row][cell.column] = "999"
+    try:
+        table.table_rows = tuple(tuple(row) for row in rows)
+        snapshot = drawing.measurement_snapshot()
+        assert len(snapshot.claims) == 3
+        bound = bind_document_claims("features", snapshot, drawing.registry)
+        assert {item.cell for _, item in bound.cell_unknown} == {
+            (cell.row, cell.column) for cell in cells
+        }
+        assert all(sheet == "features" for sheet, _ in bound.cell_unknown)
+    finally:
+        table.table_rows = original
+
+
+def test_document_conflict_retains_both_schedule_cell_addresses(rendered_schedule):
+    from draftwright.document_evidence import bind_document_claims, document_conflicts
+
+    sheet, drawing = rendered_schedule
+    model = sheet.model()
+    feature = model.features[0]
+    model.decorations[(feature, "diameter")] = 0.02
+    toleranced = build_drawing(drawing.working_part, model=model, page="A3", detail_view=False)
+    assert "±0.02" in toleranced.get_annotation("bolts").table_rows[1][4]
+    snapshots = (
+        bind_document_claims("nominal", drawing.measurement_snapshot(), drawing.registry),
+        bind_document_claims("toleranced", toleranced.measurement_snapshot(), toleranced.registry),
+    )
+    assert all(not snapshot.unknown for snapshot in snapshots)
+    (conflict,) = document_conflicts(snapshots)
+    assert {claim.sheet for claim in conflict.claims} == {"nominal", "toleranced"}
+    assert all(
+        claim.parameter == "bore.diameter" and claim.cell == (1, 4) for claim in conflict.claims
+    )
+
+
+def test_unfit_schedule_preserves_ink_and_records_its_measurements(rendered_schedule):
+    _sheet, drawing = rendered_schedule
+    registry_before = drawing.registry.snapshot()
+    issues_before = list(drawing.registry.issues)
+    items_before = tuple(drawing.items)
+    font_size = drawing.draft.font_size
+    cells = drawing.registry.cells_of("bolts")
+    table = drawing.get_annotation("bolts")
+    rows = (table.table_rows[0],) + table.table_rows[1:] * 50
+    try:
+        assert (
+            drawing.add_table(
+                rows, name="unfit_schedule", _source_id="schedule:bolts", _cells=cells
+            )
+            is None
+        )
+        assert drawing.registry.cells_of("unfit_schedule") == ()
+        assert drawing.registry.measurement_of("unfit_schedule") == ()
+        assert tuple(drawing.items) == items_before
+        assert drawing.registry.snapshot() == registry_before
+        assert drawing.draft.font_size == font_size
+        issue = drawing.registry.issues[-1]
+        assert issue.code == "table_dropped"
+        assert issue.source_ids == ("schedule:bolts",)
+        assert issue.measurement_ids == tuple(cell.measurement for cell in cells)
+    finally:
+        drawing.registry.restore_issues(issues_before)
+
+
+def test_schedule_name_collision_preserves_registered_cells(rendered_schedule):
+    _sheet, drawing = rendered_schedule
+    before = drawing.registry.snapshot()
+    items = tuple(drawing.items)
+    with pytest.raises(ValueError, match="already belongs"):
+        drawing.add_table(
+            drawing.get_annotation("bolts").table_rows,
+            name="bolts",
+            _cells=drawing.registry.cells_of("bolts"),
+        )
+    assert drawing.registry.snapshot() == before
+    assert tuple(drawing.items) == items
+
+
+def test_interrupted_cell_commit_restores_registry_ink_and_pins(rendered_schedule, monkeypatch):
+    _sheet, drawing = rendered_schedule
+    original_registry = drawing.registry.snapshot()
+    drawing.pin("bolts")
+    before = drawing.registry.snapshot()
+    items = tuple(drawing.items)
+    original_add = drawing.registry.add
+    issues = drawing.registry.issues
+
+    def interrupted_add(annotation, name, view, *args, **kwargs):
+        original_add(annotation, name, view, *args, **kwargs)
+        drawing.remove("bolts")
+        drawing.registry.record_issue(SimpleNamespace(code="interrupted_side_effect"))
+        raise KeyboardInterrupt("cancel after registration")
+
+    monkeypatch.setattr(drawing.registry, "add", interrupted_add)
+    try:
+        with pytest.raises(KeyboardInterrupt, match="cancel after registration"):
+            drawing.add_table(
+                drawing.get_annotation("bolts").table_rows,
+                name="interrupted_schedule",
+                _cells=drawing.registry.cells_of("bolts"),
+            )
+        assert drawing.registry.snapshot() == before
+        assert tuple(drawing.items) == items
+        assert drawing.registry.issues == issues
+        assert drawing.registry.cells_of("interrupted_schedule") == ()
+    finally:
+        drawing.registry.restore(original_registry)
+        drawing.registry.restore_issues(issues)
+        drawing.items[:] = items
+
+
+def test_emitted_recipe_keeps_schedule_intent_and_owned_row_bindings(rendered_schedule):
+    from draftwright.sheet_emit import emit_sheet_script
+
+    sheet, drawing = rendered_schedule
+    source = emit_sheet_script(
+        sheet.model(),
+        "part = PART",
+        "unused",
+        title="Schedule",
+        number="TEST",
+        page="A3",
+        view_constraints=sheet.view_constraints,
+    )
+    assert "sheet.schedule([" in source
+    assert "sheet.dimension(" not in "\n".join(
+        line for line in source.splitlines() if not line.startswith("#")
+    )
+    namespace = {"PART": drawing.working_part}
+    exec(
+        compile(source[: source.index("drawing = sheet.build()")], "<schedule-recipe>", "exec"),
+        namespace,
+    )
+    replay_sheet = namespace["sheet"]
+    model = replay_sheet.model()
+    (schedule,) = model.schedules
+    assert schedule.name == "bolts" and schedule.prefer == "tr"
+    assert schedule.rows[0].feature is model.features[0]
+    assert schedule.rows[0].feature is not sheet.model().features[0]
+    assert schedule.rows[0].parameters == ("bore.diameter", "location")
+    replay = replay_sheet.build()
+    assert replay.get_annotation("bolts").table_rows == drawing.get_annotation("bolts").table_rows
+    assert len(replay.registry.cells_of("bolts")) == 5
+
+
+def test_combined_document_verifies_same_named_schedules_against_each_member_plan(
+    monkeypatch, tmp_path
+):
+    from build123d import export_step
+
+    from draftwright import Document
+    from draftwright.linting import requirements
+
+    source = tmp_path / "part.step"
+    export_step(Box(30, 20, 5) - Cylinder(2, 10), source)
+    document = Document.from_part(source)
+    hole = next(feature for feature in document.features if feature.kind == "hole")
+    for name, tolerance in (("first", 0.02), ("second", 0.05)):
+        sheet = document.sheet(name, detail_view=False, page="A3").authored_views()
+        sheet.view("front")
+        sheet.of(hole).tolerance(tolerance)
+        sheet.schedule([(hole, ("bore.diameter",))], name="holes")
+    result = document.build()
+    original = requirements.recognized_requirement_outcomes
+    captured = []
+
+    def observe(recognition, features, registry, omissions, **kwargs):
+        if "0:holes" in registry.names():
+            captured.extend(verify_measurement_claims(registry, kwargs["dimension_plan"]))
+        return original(recognition, features, registry, omissions, **kwargs)
+
+    monkeypatch.setattr(requirements, "recognized_requirement_outcomes", observe)
+    evaluation = result._evaluate()
+    assert len(captured) == 2
+    assert all(outcome.state == "confirmed" and outcome.cell == (1, 4) for outcome in captured)
+    assert {outcome.annotation for outcome in captured} == {"0:holes", "1:holes"}
+    assert len(evaluation.conflicts) == 1
+
+
+def test_partial_drop_of_shared_schedule_refuses_before_removing_any_ink():
+    part = Box(40, 40, 10) - Pos(-8, 0, 0) * Cylinder(1.2, 10) - Pos(8, 0, 0) * Cylinder(2, 10)
+    sheet = Sheet(part, page="A3", detail_view=False).authored_views()
+    first = sheet.hole(diameter=2.4, depth=10, through=True, at=(-8, 0, 0), axis="z")
+    second = sheet.hole(diameter=4, depth=10, through=True, at=(8, 0, 0), axis="z")
+    sheet.view("front")
+    sheet.schedule([(first, ("bore.diameter",)), (second, ("bore.diameter",))], name="operations")
+    drawing = sheet.build()
+    owner = drawing.registry.cells_of("operations")[0].measurement.feature
+    assert len(drawing.measurement_snapshot().claims) == 2
+    drawing.note("FIRST FEATURE NOTE", (20, 20), name="first_note")
+    identity = drawing.registry.identity_of("first_note")
+    identity["feature"] = owner
+    drawing.registry.reapply("first_note", identity)
+    drawing.pin("operations")
+    registry = drawing.registry.snapshot()
+    items = tuple(drawing.items)
+    before = drawing.measurement_snapshot()
+    with pytest.raises(ValueError, match="also measures other features"):
+        drawing.drop(owner)
+    assert drawing.registry.snapshot() == registry and tuple(drawing.items) == items
+    assert drawing.measurement_snapshot() == before
+    drawing.remove("operations")
+    assert drawing.registry.cells_of("operations") == ()
+
+
+def test_schedule_only_locations_do_not_reserve_an_ordinary_rear_corridor(schedule_bbox):
+    from draftwright.compose import _compose_anno_boxes
+
+    feature = hole(diameter=2.4, depth=20, through=True, axis="y", at=(2, 0, 3))
+    scheduled = _model(feature, schedule_bbox, parameters=("location",))
+    omitted = replace(scheduled, schedules=())
+    ordinary = replace(scheduled, authored_dimensions=(RequestedDimension(feature, "location"),))
+    assert compile_dimensions(scheduled).locations == ()
+    assert compile_dimensions(ordinary).locations
+    for model in (omitted, scheduled):
+        assert not any(box.side == "rear_right" for box in _compose_anno_boxes(model, 0))
+    assert any(box.side == "rear_right" for box in _compose_anno_boxes(ordinary, 0))
+
+
+@pytest.mark.parametrize("planner_name", ("plan_dimensions", "plan_locations"))
+def test_schedule_selectors_expand_once_per_row_in_each_plan(monkeypatch, planner_name):
+    from draftwright.model import planner
+
+    features = [
+        hole(diameter=2.4, depth=10, through=True, at=(index * 4, 0, 0), axis="z")
+        for index in range(80)
+    ]
+    schedule = FeatureSchedule(
+        "holes", tuple(ScheduleRow(feature, ("bore.diameter", "location")) for feature in features)
+    )
+    model = PartModel(
+        None,
+        None,
+        features=features,
+        datums=[Datum("datum_xy", "point", (-10, -10, 0))],
+        authored_dimensions=(),
+        schedules=(schedule,),
+    )
+    original = planner.schedule_row_dimensions
+    expanded = []
+
+    def observe(row):
+        expanded.append(row)
+        return original(row)
+
+    monkeypatch.setattr(planner, "schedule_row_dimensions", observe)
+    plan = getattr(planner, planner_name)(model)
+    assert plan and len(expanded) == len(features)
+    assert model.schedules == (schedule,) and model.authored_dimensions == ()
+    # A new pass must see changed public IR; a cached selection would retain the old rows.
+    model.schedules = (FeatureSchedule("first", (schedule.rows[0],)),)
+    expanded.clear()
+    updated = getattr(planner, planner_name)(model)
+    assert expanded == [schedule.rows[0]]
+    if planner_name == "plan_dimensions":
+        selected = [
+            group.feature
+            for group in updated
+            for dimension in group.dims
+            if not dimension.suppressed
+        ]
+    else:
+        selected = [dimension.feature for dimension in updated if not dimension.suppressed]
+    assert len(selected) == 1 and selected[0] is features[0]

--- a/tests/test_issue_1543_schedule_requirements.py
+++ b/tests/test_issue_1543_schedule_requirements.py
@@ -542,3 +542,55 @@ def test_verified_schedule_cells_reconcile_legacy_geometric_coverage(
     content[target.row][target.column] = "999"
     monkeypatch.setattr(table, "table_rows", tuple(tuple(row) for row in content))
     assert any(issue.code == code for issue in drawing.lint())
+
+
+def test_angle_schedule_cells_keep_exact_physical_carriers_and_lose_corrupt_credit(
+    tmp_path, monkeypatch
+):
+    from build123d import RegularPolygon, extrude
+
+    source = tmp_path / "triangle.step"
+    export_step(extrude(RegularPolygon(30, 3), amount=4), source)
+    document = Document.from_part(source)
+    sheet = document.sheet("angles", page="A3", detail_view=False).authored_views()
+    sheet.view("front")
+    angles = [feature for feature in sheet.features if feature.kind == "angle"]
+    assert len(angles) == 3
+    sheet.schedule([(feature, ("included.angle",)) for feature in angles], name="angles")
+    result = document.build()
+    drawing = result.sheets["angles"]
+    outcomes = drawing.requirement_snapshot().outcomes["outer_profile_angles"]
+    assert len(outcomes) == 3 and all(row.state == "placed" for row in outcomes)
+    for row in outcomes:
+        (carrier,) = row.carriers
+        assert carrier.cell in drawing.registry.cells_of("angles")
+        assert carrier.cell.measurement.feature is row.features[0]
+    assert not any(issue.code.startswith("angular_requirement_") for issue in drawing.lint())
+    report_rows = [
+        row
+        for row in result.report()["recognition"]["requirements"]
+        if row["family"] == "outer_profile_angles"
+    ]
+    assert len(report_rows) == 3
+    assert all(row["coverage_credit"] == 1 for row in report_rows)
+    assert all(
+        ref["cell"] is not None for row in report_rows for ref in row["carrying_annotations"]
+    )
+
+    target = drawing.registry.cells_of("angles")[0]
+    table = drawing.get_annotation("angles")
+    content = [list(row) for row in table.table_rows]
+    content[target.row][target.column] = "99°"
+    monkeypatch.setattr(table, "table_rows", tuple(tuple(row) for row in content))
+    after = drawing.requirement_snapshot().outcomes["outer_profile_angles"]
+    missing = [row for row in after if row.state != "placed"]
+    assert len(missing) == 1
+    assert missing[0].features[0] is target.measurement.feature
+    assert not missing[0].carriers
+    assert sum(issue.code.startswith("angular_requirement_") for issue in drawing.lint()) == 1
+    report_rows = [
+        row
+        for row in result.report()["recognition"]["requirements"]
+        if row["family"] == "outer_profile_angles"
+    ]
+    assert sum(row["coverage_credit"] for row in report_rows) == 2

--- a/tests/test_issue_1543_schedule_requirements.py
+++ b/tests/test_issue_1543_schedule_requirements.py
@@ -1,0 +1,544 @@
+"""Physical ledgers accept only verified ink from feature schedule cells."""
+
+import pytest
+from build123d import Box, Cylinder, Pos, export_step
+
+from draftwright import Document
+
+
+@pytest.fixture(scope="module")
+def scheduled_holes(tmp_path_factory):
+    source = tmp_path_factory.mktemp("schedule-requirements") / "part.step"
+    part = Box(60, 50, 10)
+    for point in ((-12, -8, 0), (14, 9, 0)):
+        part -= Pos(*point) * Cylinder(2, 10)
+    export_step(part, source)
+    document = Document.from_part(source)
+    holes = [feature for feature in document.features if feature.kind == "hole"]
+    assert len(holes) == 1 and holes[0].count == 2
+    sheet = document.sheet("features", detail_view=False, page="A3").authored_views()
+    sheet.view("front")
+    sheet.schedule([(holes[0], ("bore.diameter", "location"))], name="holes")
+    result = document.build()
+    return result, result.sheets["features"]
+
+
+def hole_outcomes(drawing):
+    outcomes = drawing.requirement_snapshot().outcomes["holes"]
+    return {row.parameter_id: row for row in outcomes}
+
+
+def test_verified_cells_feed_existing_physical_requirement_producers(scheduled_holes):
+    _result, drawing = scheduled_holes
+    rows = hole_outcomes(drawing)
+    assert rows["bore.diameter"].state == "placed"
+    assert rows["bore.through"].state == "placed"
+    assert rows["grouping.count"].state == "placed"
+    locations = [row for key, row in rows.items() if key.startswith("location.")]
+    assert len(locations) == 2 and all(row.state == "placed" for row in locations)
+    (carrier,) = rows["bore.diameter"].carriers
+    assert carrier.annotation == "holes"
+    assert carrier.cell in drawing.registry.cells_of("holes")
+    assert carrier.cell.measurement.parameter == "bore.diameter"
+    for key in ("bore.through", "grouping.count"):
+        assert rows[key].carriers == (
+            type(carrier)("holes", "physical_requirement", carrier.cell),
+        )
+    for row in locations:
+        assert len(row.carriers) == 2
+        assert all(item.cell in drawing.registry.cells_of("holes") for item in row.carriers)
+        assert all(
+            item.cell.measurement.parameter.endswith(row.parameter_id[-2:])
+            for item in row.carriers
+        )
+
+
+@pytest.mark.parametrize("damage", ("wrong-value", "missing-row", "lost-provenance"))
+def test_damaged_diameter_cell_loses_its_physical_riders(scheduled_holes, monkeypatch, damage):
+    _result, drawing = scheduled_holes
+    before = hole_outcomes(drawing)
+    assert all(
+        before[key].state == "placed"
+        for key in ("bore.diameter", "bore.through", "grouping.count")
+    )
+    table = drawing.get_annotation("holes")
+    cell = next(
+        cell
+        for cell in drawing.registry.cells_of("holes")
+        if cell.measurement.parameter == "bore.diameter"
+    )
+    if damage == "lost-provenance":
+        cells_of = drawing.registry.cells_of
+        monkeypatch.setattr(
+            drawing.registry,
+            "cells_of",
+            lambda name: tuple(item for item in cells_of(name) if item != cell),
+        )
+    else:
+        content = [list(row) for row in table.table_rows]
+        if damage == "wrong-value":
+            content[cell.row][cell.column] = "Ø99 THRU"
+        else:
+            del content[cell.row]
+        monkeypatch.setattr(table, "table_rows", tuple(tuple(row) for row in content))
+    after = hole_outcomes(drawing)
+    assert set(after) == set(before)
+    for key in ("bore.diameter", "bore.through", "grouping.count"):
+        assert after[key].state != "placed", (key, after[key])
+        assert not after[key].carriers
+
+
+def test_one_bad_location_cell_loses_only_that_axis_proof(scheduled_holes, monkeypatch):
+    _result, drawing = scheduled_holes
+    before = hole_outcomes(drawing)
+    assert not any(issue.code == "feature_not_located" for issue in drawing.lint())
+    target = next(
+        cell
+        for cell in drawing.registry.cells_of("holes")
+        if cell.measurement.parameter.endswith(".x")
+    )
+    table = drawing.get_annotation("holes")
+    content = [list(row) for row in table.table_rows]
+    content[target.row][target.column] = "999"
+    monkeypatch.setattr(table, "table_rows", tuple(tuple(row) for row in content))
+    after = hole_outcomes(drawing)
+    assert before["location.location.x"].state == "placed"
+    assert after["location.location.x"].state != "placed"
+    assert not after["location.location.x"].carriers
+    assert any(issue.code == "feature_not_located" for issue in drawing.lint())
+    for key in ("bore.diameter", "bore.through", "grouping.count", "location.location.y"):
+        assert after[key].state == "placed"
+        assert after[key].carriers == before[key].carriers
+
+
+def test_direct_lint_uses_verified_schedule_evidence(scheduled_holes, monkeypatch):
+    _result, drawing = scheduled_holes
+    before_codes = {issue.code for issue in drawing.lint()}
+    assert not ({"feature_not_dimensioned", "feature_not_located"} & before_codes)
+    assert "feature_no_centermark" in before_codes
+    assert not [
+        issue
+        for issue in drawing.lint()
+        if issue.code == "hole_requirement_missing" and "bore.diameter" in issue.message
+    ]
+    table = drawing.get_annotation("holes")
+    target = next(
+        cell
+        for cell in drawing.registry.cells_of("holes")
+        if cell.measurement.parameter == "bore.diameter"
+    )
+    content = [list(row) for row in table.table_rows]
+    content[target.row][target.column] = "Ø99 THRU"
+    monkeypatch.setattr(table, "table_rows", tuple(tuple(row) for row in content))
+    issues = drawing.lint()
+    assert any(issue.code == "feature_not_dimensioned" for issue in issues)
+    assert [
+        issue
+        for issue in issues
+        if issue.code == "hole_requirement_missing" and "bore.diameter" in issue.message
+    ]
+
+
+def test_rounded_schedule_cell_proves_exact_through_step_interval(monkeypatch):
+    from build123d import Rot
+
+    from draftwright import Sheet
+    from draftwright.linting.schedule_evidence import verified_schedule_registry
+    from draftwright.linting.through_step_coverage import through_step_requirement_outcomes
+    from draftwright.model import plate
+    from draftwright.model.compiled import compile_dimensions
+
+    part = Rot(90, 0, 0) * (Box(40, 30.246, 20) - Pos(15, 10.123, 0) * Box(20, 20.246, 30))
+    height = plate(axis="z", lo=0, hi=15.123, u=0, v=0)
+    position = plate(axis="x", lo=5, hi=20, u=0, v=0)
+    sheet = Sheet(part, page="A3", detail_view=False).authored_views()
+    sheet.view("front")
+    for feature in (height, position):
+        sheet.add(feature)
+    sheet.schedule(
+        [(feature, ("thickness.length",)) for feature in (height, position)], name="steps"
+    )
+    drawing = sheet.build()
+    drawing.lint()  # Explicit physical critique obtains the declared build's one aggregate.
+    plan = compile_dimensions(drawing.model())
+    table = drawing.get_annotation("steps")
+    (cell,) = [
+        cell for cell in drawing.registry.cells_of("steps") if cell.measurement.feature is height
+    ]
+    assert height.hi - height.lo == 15.123
+    assert table.table_rows[cell.row][cell.column] == "15.1"
+
+    def outcomes():
+        return through_step_requirement_outcomes(
+            drawing.recognition(),
+            drawing.model().features,
+            verified_schedule_registry(drawing.registry, plan),
+            plan=plan,
+        )
+
+    before = outcomes()
+    assert len(before) == 2 and {row.state for row in before} == {"inapplicable"}
+    vertical = next(row for row in before if row.parameter_id.endswith(".z"))
+    (alternative,) = vertical.dependency_alternatives
+    (support,) = alternative
+    assert support.lo == 0 and support.hi == 15.123 and support.feature is height
+    content = [list(row) for row in table.table_rows]
+    content[cell.row][cell.column] = "999"
+    monkeypatch.setattr(table, "table_rows", tuple(tuple(row) for row in content))
+    after = outcomes()
+    assert {row.parameter_id: row.state for row in after} == {
+        "through_step_leg.length.z": "missing",
+        "through_step_leg.length.x": "inapplicable",
+    }
+    assert all(
+        current.source_records == previous.source_records
+        for current, previous in zip(after, before, strict=True)
+    )
+
+
+def validate_schedule_report(report):
+    import json
+    from pathlib import Path
+
+    from jsonschema.validators import validator_for
+
+    schema = json.loads(
+        (
+            Path(__file__).parents[1] / "docs/reference/draftwright-report-v5.schema.json"
+        ).read_text()
+    )
+    validator_for(schema).check_schema(schema)
+    validator_for(schema)(schema).validate(report)
+    json.dumps(report, allow_nan=False)
+
+
+def test_document_report_preserves_exact_cells_and_schedule_intent(scheduled_holes):
+    result, drawing = scheduled_holes
+    report = result.report()
+    assert report["schema_version"] == 5
+    validate_schedule_report(report)
+    assert drawing.report()["schema_version"] == 3
+    (sheet,) = report["sheets"]
+    (intent,) = sheet["schedule_intents"]
+    assert intent["name"] == "holes" and intent["rows"][0]["parameters"] == [
+        "bore.diameter",
+        "location",
+    ]
+    cells = drawing.registry.cells_of("holes")
+    assert len(report["claims"]) == len(cells) == 5
+    assert {(claim["cell"]["row"], claim["cell"]["column"]) for claim in report["claims"]} == {
+        (cell.row, cell.column) for cell in cells
+    }
+    assert {claim["owner_id"] for claim in report["claims"]} == {intent["rows"][0]["owner_id"]}
+    assert all(
+        claim["sheet_id"] == sheet["id"] and claim["annotation"] == "holes"
+        for claim in report["claims"]
+    )
+    carried = [row for row in report["recognition"]["requirements"] if row["state"] == "placed"]
+    assert carried and all(row["carrying_annotations"] for row in carried)
+    assert all(
+        carrier["cell"] is not None for row in carried for carrier in row["carrying_annotations"]
+    )
+    assert "feature-schedules" in report["replay"]["serialized_declaration_scope"]
+    assert report["replay"]["script_deserialization"] is False
+
+
+def test_bad_cells_keep_specific_and_unlocated_document_uncertainty(scheduled_holes, monkeypatch):
+    result, drawing = scheduled_holes
+    cell = drawing.registry.cells_of("holes")[1]
+    table = drawing.get_annotation("holes")
+    content = [list(row) for row in table.table_rows]
+    content[cell.row][cell.column] = "999"
+    monkeypatch.setattr(table, "table_rows", tuple(tuple(row) for row in content))
+    report = result.report()
+    validate_schedule_report(report)
+    unknown = report["assessment"]["fidelity"]["unknown_claims"]
+    assert any(item["cell"] == {"row": cell.row, "column": cell.column} for item in unknown)
+    assert any(item["cell"] is None for item in unknown)
+    assert len(report["claims"]) == 4
+    assert all(
+        claim["cell"] != {"row": cell.row, "column": cell.column} for claim in report["claims"]
+    )
+    assert report["status"] == "needs-attention"
+
+
+def test_removing_schedule_retains_v5_intent_and_the_requirement_denominator(scheduled_holes):
+    result, drawing = scheduled_holes
+    before = result.report()
+    items = list(drawing.items)
+    registry = drawing.registry.snapshot()
+    issues = drawing.registry.issues
+    try:
+        drawing.remove("holes")
+        after = result.report()
+        validate_schedule_report(after)
+        assert after["schema_version"] == 5 and not after["claims"]
+        assert after["sheets"][0]["schedule_intents"] == before["sheets"][0]["schedule_intents"]
+        old_rows = before["recognition"]["requirements"]
+        rows = after["recognition"]["requirements"]
+        assert [(row["id"], row["parameter_id"], row["requirement_count"]) for row in rows] == [
+            (row["id"], row["parameter_id"], row["requirement_count"]) for row in old_rows
+        ]
+        assert not any(row["coverage_credit"] for row in rows)
+    finally:
+        drawing.items[:] = items
+        drawing.registry.restore(registry)
+        drawing.registry.restore_issues(issues)
+
+
+@pytest.fixture(scope="module")
+def schedule_report_inputs(scheduled_holes):
+    from unittest.mock import patch
+
+    import draftwright.reporting as reporting
+
+    result, _drawing = scheduled_holes
+    with patch("draftwright.document.document_report", wraps=reporting.document_report) as project:
+        report = result.report()
+    assert report["schema_version"] == 5 and report["claims"]
+    return project.call_args.kwargs
+
+
+@pytest.mark.parametrize(
+    "damage",
+    (
+        "absent-claim-cell",
+        "copied-carrier-cell",
+        "invalid-unknown-cell",
+        "missing-recipe",
+        "foreign-recipe-owner",
+    ),
+)
+def test_v5_projection_refuses_unproven_cell_and_recipe_references(schedule_report_inputs, damage):
+    from dataclasses import replace
+
+    from draftwright import ReportUnavailableError
+    from draftwright.audit import MeasurementCellUncertainty
+    from draftwright.reporting import document_report
+
+    inputs = dict(schedule_report_inputs)
+    evaluation = inputs["evaluation"]
+    expected = "cell"
+    if damage == "absent-claim-cell":
+        snapshots = list(evaluation.claims)
+        snapshot = snapshots[0]
+        claims = list(snapshot.claims)
+        claims[0] = replace(claims[0], cell=(999, 4))
+        snapshots[0] = replace(snapshot, claims=tuple(claims))
+        inputs["evaluation"] = replace(evaluation, claims=tuple(snapshots))
+    elif damage == "copied-carrier-cell":
+        rows = list(evaluation.requirements)
+        index = next(
+            index
+            for index, row in enumerate(rows)
+            if any(carrier.cell is not None for carrier in row.combined.outcome.carriers)
+        )
+        row = rows[index]
+        carriers = list(row.combined.outcome.carriers)
+        carrier = next(item for item in carriers if item.cell is not None)
+        carriers[carriers.index(carrier)] = replace(carrier, cell=replace(carrier.cell))
+        outcome = replace(row.combined.outcome, carriers=tuple(carriers))
+        rows[index] = replace(row, combined=replace(row.combined, outcome=outcome))
+        inputs["evaluation"] = replace(evaluation, requirements=tuple(rows))
+    elif damage == "invalid-unknown-cell":
+        snapshots = list(evaluation.claims)
+        snapshots[0] = replace(
+            snapshots[0],
+            cell_unknown=(("features", MeasurementCellUncertainty("holes", (0, 4), "invalid")),),
+        )
+        inputs["evaluation"] = replace(evaluation, claims=tuple(snapshots))
+    else:
+        recipes = {name: dict(recipe) for name, recipe in inputs["member_recipes"].items()}
+        recipe = recipes["features"]
+        if damage == "missing-recipe":
+            del recipe["schedules"]
+            expected = "schedule intent"
+        else:
+            schedule = recipe["schedules"][0]
+            row = schedule.rows[0]
+            recipe["schedules"] = (
+                replace(schedule, rows=(replace(row, feature=replace(row.feature)),)),
+            )
+            expected = "exact common owner"
+        inputs["member_recipes"] = recipes
+    with pytest.raises(ReportUnavailableError, match=expected):
+        document_report(**inputs)
+
+
+def test_notes_only_receive_explicit_satisfaction_beside_schedule_cells(tmp_path):
+    source = tmp_path / "part.step"
+    export_step(Box(30, 20, 5) - Cylinder(2, 10), source)
+    document = Document.from_part(source)
+    hole = next(feature for feature in document.features if feature.kind == "hole")
+    schedule = document.sheet("schedule", detail_view=False, page="A3").authored_views()
+    schedule.view("front")
+    schedule.schedule([(hole, ("location",))], name="locations")
+    schedule.note("HOLE DIAMETER 4", hole)
+    schedule.table((("Description", "Value"), ("HOLE DIAMETER", "4")), name="description")
+    note = (
+        document.sheet("instruction", detail_view=False, page="A3")
+        .authored_dimensions()
+        .authored_views()
+    )
+    note.view("front")
+    note.note("HOLE DIAMETER 4", hole, satisfies=("bore.diameter",))
+    result = document.build()
+    before = result.report()
+    validate_schedule_report(before)
+    row = next(
+        row
+        for row in before["recognition"]["requirements"]
+        if row["parameter_id"] == "bore.diameter"
+    )
+    assert row["state"] == "satisfied_by_structured_note" and row["coverage_credit"] == 1
+    (carrier,) = row["carrying_annotations"]
+    assert carrier["evidence_kind"] == "structured_note" and carrier["cell"] is None
+    assert all(claim["parameter_id"] != "bore.diameter" for claim in before["claims"])
+    result.sheets["instruction"].remove(carrier["annotation"])
+    after = result.report()
+    row = next(
+        row
+        for row in after["recognition"]["requirements"]
+        if row["parameter_id"] == "bore.diameter"
+    )
+    assert row["coverage_credit"] == 0 and not row["carrying_annotations"]
+    assert "description" in result.sheets["schedule"].annotations()
+
+
+def test_mixed_ordinary_and_schedule_members_keep_both_conflicting_claims(tmp_path):
+    from test_issue_1542_document_report import hole_document
+
+    document, _path, _raw = hole_document(tmp_path, (0.02, 0.05))
+    hole = next(feature for feature in document.features if feature.kind == "hole")
+    schedule = document.sheet("schedule", detail_view=False, page="A3").authored_views()
+    schedule.view("front")
+    schedule.of(hole).tolerance(0.02)
+    schedule.schedule([(hole, ("bore.diameter",))], name="diameter")
+    result = document.build()
+    report = result.report()
+    validate_schedule_report(report)
+    claims = report["claims"]
+    assert len(claims) == 3
+    assert sum(claim["cell"] is None for claim in claims) == 2
+    (scheduled,) = [claim for claim in claims if claim["cell"] is not None]
+    assert scheduled["cell"] == {"row": 1, "column": 4}
+    (conflict,) = report["assessment"]["fidelity"]["conflicts"]
+    assert set(conflict["claim_ids"]) == {claim["id"] for claim in claims}
+    diameter = next(
+        row
+        for row in report["recognition"]["requirements"]
+        if row["parameter_id"] == "bore.diameter"
+    )
+    assert diameter["coverage_credit"] == 1
+    assert len(diameter["carrying_annotations"]) == 3
+
+
+def test_descriptive_table_cannot_credit_unsupported_profile_values(tmp_path):
+    from test_issue_1438_report_projection import _passage_part
+
+    source = tmp_path / "profile.step"
+    export_step(_passage_part(), source)
+    document = Document.from_part(source)
+    envelope = next(feature for feature in document.features if feature.kind == "envelope")
+    sheet = document.sheet("dimensions", detail_view=False, page="A3").authored_views()
+    sheet.view("front")
+    sheet.schedule([(envelope, ("width.length",))], name="envelope")
+    result = document.build()
+    before = result.report()
+    unsupported = [
+        row for row in before["recognition"]["requirements"] if row["family"] == "section_recesses"
+    ]
+    assert unsupported and all(row["coverage_credit"] == 0 for row in unsupported)
+    result.sheets["dimensions"].add_table(
+        (("Feature", "Size"), ("HEX PROFILE", "AF 10.4 DEPTH 10")), name="description"
+    )
+    after = result.report()
+    validate_schedule_report(after)
+    assert [
+        row for row in after["recognition"]["requirements"] if row["family"] == "section_recesses"
+    ] == unsupported
+    assert not any(claim["annotation"] == "description" for claim in after["claims"])
+
+
+def test_bolt_circle_cell_cannot_cover_a_physical_bore_of_the_same_diameter(tmp_path):
+    from math import cos, pi, sin
+
+    source = tmp_path / "bolt-circle.step"
+    part = Box(100, 60, 10) - Pos(25, 0, 0) * Cylinder(10, 10)
+    for index in range(3):
+        angle = index * 2 * pi / 3
+        part -= Pos(-25 + 10 * cos(angle), 10 * sin(angle), 0) * Cylinder(1, 10)
+    export_step(part, source)
+    document = Document.from_part(source)
+    pattern = next(
+        feature
+        for feature in document.features
+        if getattr(feature, "pattern", None) == "bolt_circle"
+    )
+    assert pattern.bcd == pytest.approx(20)
+    assert any(feature.kind == "hole" and feature.diameter == 20 for feature in document.features)
+    sheet = document.sheet("bolts", page="A3", detail_view=False).authored_views()
+    sheet.view("front")
+    sheet.schedule([(pattern, ("bore.diameter", "bolt_circle.diameter"))], name="bolts")
+    drawing = document.build().sheets["bolts"]
+    claims = drawing.measurement_snapshot().claims
+    assert any(claim.parameter == "bolt_circle.diameter" for claim in claims)
+    missing = [issue for issue in drawing.lint() if issue.code == "feature_not_dimensioned"]
+    assert len(missing) == 1 and "ø20" in missing[0].message
+
+
+@pytest.mark.parametrize("kind", ("boss", "step", "pad"))
+@pytest.mark.parametrize("front_only", (False, True))
+def test_verified_schedule_cells_reconcile_legacy_geometric_coverage(
+    kind, front_only, monkeypatch
+):
+    from draftwright import Sheet
+
+    if kind == "boss":
+        solid = Pos(0, 0, 24) * Cylinder(7, 10)
+        sheet = Sheet(Box(90, 64, 38) + solid, page="A3", detail_view=False)
+        feature = sheet.boss(solid)
+        rows = [(feature, ("boss_height.length",))]
+        code = "boss_height_missing"
+    else:
+        part = {
+            "step": lambda: Cylinder(15, 30) + Pos(0, 0, 30) * Cylinder(8, 30),
+            "pad": lambda: Box(60, 50, 10) + Pos(15, 8, 10) * Box(20, 16, 10),
+        }[kind]()
+        sheet = Sheet.from_part(part, page="A3", detail_view=False).take_over(
+            dimensions="authored",
+            principal_views="authored" if front_only else "automatic",
+            derived_views="authored",
+        )
+        features = [feature for feature in sheet.features if feature.kind == kind]
+        assert features
+        rows = [
+            (
+                feature,
+                ("step.length",)
+                if kind == "step"
+                else tuple(parameter.parameter_id for parameter in feature.parameters()),
+            )
+            for feature in features
+        ]
+        code = {
+            "step": "axial_length_missing",
+            "pad": "pad_footprint_not_defined",
+        }[kind]
+    if kind == "pad":
+        sheet.note("LOCATED BY AUTHORED COORDINATES", features[0], satisfies=("location",))
+    if front_only:
+        sheet.authored_views().view("front")
+    sheet.schedule(rows, name="features")
+    drawing = sheet.build()
+    if front_only:
+        assert set(drawing.views) == {"front"}
+    assert not any(issue.code == code for issue in drawing.lint())
+    cells = drawing.registry.cells_of("features")
+    assert cells
+    target = next((cell for cell in cells if cell.measurement.parameter.endswith(".x")), cells[0])
+    table = drawing.get_annotation("features")
+    content = [list(row) for row in table.table_rows]
+    content[target.row][target.column] = "999"
+    monkeypatch.setattr(table, "table_rows", tuple(tuple(row) for row in content))
+    assert any(issue.code == code for issue in drawing.lint())

--- a/tests/test_issue_955_height_contingency.py
+++ b/tests/test_issue_955_height_contingency.py
@@ -16,7 +16,14 @@ from draftwright.model.compiled import (
     RenderableDimensionPlan,
     compile_dimensions,
 )
-from draftwright.model.ir import EnvelopeFeature, Frame, RequestedDimension, StepFeature
+from draftwright.model.ir import (
+    EnvelopeFeature,
+    FeatureSchedule,
+    Frame,
+    RequestedDimension,
+    ScheduleRow,
+    StepFeature,
+)
 from draftwright.model.planner import plan_dimensions
 
 
@@ -59,6 +66,35 @@ def test_the_compiler_owns_the_z_turned_height_contingency():
     released = plan.release_contingency("step_length")
     assert released.ladder("overall_height") == contingency.fallback
     assert _height_rows(released) == []
+
+
+@pytest.mark.parametrize("ordinary_height", [False, True])
+def test_scheduled_height_cannot_release_an_unrequested_ordinary_fallback(ordinary_height):
+    model = detect_part_model(_crowded_grooved_shaft())
+    envelope = _envelope_for(model)
+    requests = tuple(
+        RequestedDimension(feature, parameter.parameter_id)
+        for feature in model.features
+        if feature.kind in ("step", "groove")
+        for parameter in feature.parameters()
+        if parameter.kind == "length"
+    )
+    model = replace(
+        model,
+        features=[*model.features, envelope],
+        authored_dimensions=requests
+        + ((RequestedDimension(envelope, "height.length"),) if ordinary_height else ()),
+        schedules=(FeatureSchedule("height", (ScheduleRow(envelope, ("height.length",)),)),),
+    )
+    plan = compile_dimensions(model)
+    cells = [
+        cell for row in plan.schedules[0].rows for cell in row if cell.measurement is not None
+    ]
+    assert len(cells) == 1 and cells[0].measurement.value == 60
+    assert bool(plan.contingency("step_length")) is ordinary_height
+    released = plan.release_contingency("step_length")
+    assert bool(released.ladder("overall_height")) is ordinary_height
+    assert not _height_rows(released)
 
 
 def test_an_unregistered_contingency_kind_fails_closed():

--- a/tests/test_label_provenance.py
+++ b/tests/test_label_provenance.py
@@ -62,10 +62,6 @@ _FMT_BUDGET: dict[str, tuple[int, str]] = {
     # ("every value crosses as a _fmt string") is enforced there. Fixing it means the spec
     # carrying approved text — the hole-callout migration ADR 4 (was 0016) still names as pending.
     "from_model.callout_from_spec.f": (1, "the spec carries floats — the hc_ migration"),
-    # --- A chamfer's ANGLE is a form discriminator, not a planned parameter:
-    # `ChamferFeature.parameters()` emits only the leg, so the angle has no approved text to
-    # consume. That is the IR gap `_FACTS` records; the leg itself now uses `value_text`.
-    "from_model._chamfer_label": (1, "ch.angle is a fact with no DimParameter (IR gap)"),
     # --- Not dimensional plan content at all.
     "sections._overall_height_name": (1, "detail-view caption from the analysis"),
 }

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -186,6 +186,7 @@ def test_identity_of_reapply_round_trips_every_axis():
         "view": None,
         "feature": None,
         "measurement": (),
+        "cells": (),
         "satisfaction": (),
         "pinned": False,
     }

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -2896,6 +2896,8 @@ _PLAN_DIMENSIONAL_FIELDS = {
     "(`_LADDER_ROLE`), so the emitter no longer carries its own copy (#975)",
     "contingencies": "walked as approved alternative ladders; generated authored scripts "
     "must retain a fallback even when the automatic build leaves it inactive",
+    "schedules": "walked as exact approved cell measurements; emitted with original owned "
+    "schedule rows rather than duplicating their measurements as ordinary annotations",
     "diagnostics": "NOT dimensional — the omissions channel; nothing to mirror by definition",
 }
 

--- a/tests/test_sheet_identity_invariant.py
+++ b/tests/test_sheet_identity_invariant.py
@@ -84,7 +84,8 @@ def _canonical(model) -> tuple:
     features = sorted(repr(f) for f in model.features)
     decorations = sorted((repr(k), repr(v)) for k, v in getattr(model, "decorations", {}).items())
     requested = sorted(repr(r) for r in getattr(model, "requested_dimensions", ()))
-    return (features, decorations, requested)
+    schedules = sorted(repr(schedule) for schedule in getattr(model, "schedules", ()))
+    return (features, decorations, requested, schedules)
 
 
 def _canonical_sheet(sheet) -> tuple:
@@ -173,6 +174,13 @@ def _scn_dimension(s):
     return a, lambda a: s.dimension(a, "bore.diameter")
 
 
+def _scn_schedule(s):
+    """A retained schedule must follow its exact owner through reorder and aspect edits."""
+    handle, _drive = _scn_dimension(s)
+    s.schedule([(handle, ("bore.diameter",))], name="operations")
+    return handle, lambda handle: handle.tolerance(0.025)
+
+
 def _scn_add_dimension(s):
     """Retain a `DimensionIntent`, reorder, then apply its display policy.
 
@@ -233,6 +241,7 @@ _SCENARIOS = {
     "datum": _scn_datum,
     "note": _scn_note,
     "dimension": _scn_dimension,
+    "schedule": _scn_schedule,
     "section_view": _scn_section_view,
     "add_section_view": _scn_add_section_view,
 }
@@ -671,6 +680,7 @@ _STATE_CARRYING_FEATURE_REFS = frozenset(
         "_section",
         "_added_dimensions",
         "_authored",
+        "_schedules",
         "_derived_views",
         "_added_derived_views",
     }


### PR DESCRIPTION
Ordinary tables cannot prove which operation or member a value describes. This adds `Sheet.schedule()` and typed IR rows selecting exact feature owners and canonical parameter IDs. The existing compiler supplies values, units, tolerances and through/blind meaning; only verified cells that were actually placed can satisfy physical requirements.

- Reuse existing table fitting, reservations and placement. Preserve displaced ink, pins and provenance on interruption; overflow retains explicit unresolved measurements. Partial removal of a table shared by multiple owners refuses before mutation.
- Attribute claims and physical carriers to exact row/column cells across document sheets. Bad content, missing rows or lost provenance withdraw the affected credit without borrowing another cell's matching number. Structured-note satisfaction stays explicit; descriptive prose earns none.
- Emit schedule declarations through the existing source recipe. Documents with schedules use additive report schema v5; ordinary documents retain v4 and individual Drawing reports retain v3. Source recipes, rather than persisted report IDs, remain the replay surface.

Architectural fit: ADRs 1/4 own selection and compiler lowering; ADR 2's existing table solver owns placement; ADR 3's recognized inventory and exact physical ownership stay authoritative; ADR 5 verifies rendered cells and preserves unknowns, dropped requirements and cross-sheet conflicts. No ADR boundary changes.

Validation: independent Google-style review of the complete change is LGTM against all five ADRs; `scripts/pr-check --full` passed: 8,387 tests, 5 skipped, 13 expected failures, 96.1% overall coverage and 98% changed-line coverage (650 executable changed lines). Static checks and strict documentation build passed. The reviewed and tested commit is `bfd770485cf61b0b9f9b651b3dbe4a441fb412bc`. Review caught and fixed missing-view geometry access and missing angular cell coverage. Targeted mutations kill both regressions, stale planner caching, lost physical evidence and false bolt-circle diameter credit. Named corruption, interruption, ownership, unsupported-text, reduced-view and planner-mutation regressions are tracked in the two #1543 test modules. The documented two-view hole schedule was executed and its exported drawing visually inspected. The final real-frame recipe/canary remains #1544.

Closes #1543
Part of #1529; builds on #1551.
