### PR TITLE
Account for default projection symbols in the slow furniture inventory

### DIFF
--- a/tests/test_issue_1217_the_facility_is_shared.py
+++ b/tests/test_issue_1217_the_facility_is_shared.py
@@ -375,9 +375,10 @@ class TestNoMeasuredAnnotationEscapesUnclaimed:
 
     @pytest.mark.slow
     def test_the_furniture_really_is_silent(self):
-        # The other side of the same claim: on nist_ctc_02 the 89 unclaimed annotations are
-        # centre marks, bolt circles, notes and the title block. The allow-list is exactly the
-        # four types measured there — a wider set asserts nothing about types that never occur
+        # The other side of the same claim: on nist_ctc_02 the silent annotations are
+        # centre marks, bolt circles, notes, the projection symbol and the title block.
+        # The allow-list is exactly the types observed — a wider set asserts nothing about
+        # types that never occur
         # (#1225 review, finding 7).
         #
         # "Silent" here means silent TO THE READER, and the title block is the honest edge of
@@ -387,7 +388,7 @@ class TestNoMeasuredAnnotationEscapesUnclaimed:
         # exactly the limit `evidence.py` now states rather than the stronger one it claimed.
         #
         # Built with a title on purpose: without `title=`/`number=` no TitleBlock is placed at
-        # all (88 silent annotations, not 89), and the test would then characterise a sheet the
+        # all, and the test would then characterise a sheet the
         # ratchet never sweeps.
         drawing = _drawing(
             "tests/fixtures/nist_ctc_02_asme1_ap203.stp",
@@ -400,4 +401,10 @@ class TestNoMeasuredAnnotationEscapesUnclaimed:
             and not rendered_numbers(drawing.registry.named(n))
         ]
         assert len(silent) > 50, f"too little furniture to characterise: {len(silent)}"
-        assert set(silent) == {"CenterMark", "CenterlineCircle", "Note", "TitleBlock"}, set(silent)
+        assert set(silent) == {
+            "CenterMark",
+            "CenterlineCircle",
+            "Note",
+            "ProjectionSymbol",
+            "TitleBlock",
+        }, set(silent)


### PR DESCRIPTION
The post-merge slow suite now observes `ProjectionSymbol` among the non-measurement furniture on the NIST CTC-02 drawing, following #1561. Its exact type-set expectation still described the old default and failed. Include the new symbol and remove obsolete counts from the explanatory comment.

This changes one test only. The assertion still requires exact observed types, more than 50 silent annotations, no measurement provenance and no numbers visible to the evidence reader. Runtime code and measurement verification are unchanged.

Validation: the main slow run reported this one failure with 52 passes and 2 expected failures. Ruff and formatting checks pass. All three slow tests in the affected module pass. Independent Google-style review of ea97984f against all five ADRs is clean. The full slow suite passed: 53 tests, 2 expected failures in 193.64 seconds.

Architecture: preserves ADR 5's distinction between measured claims and drawing furniture. No compiler, layout, recognition or declared-intent changes (ADRs 1–4), and no ADR amendments.
