### PR TITLE
Do not impose ISO 2768-m when no general tolerance is authored (#1157)

### DIFF
--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -176,10 +176,11 @@ _TB_CLEAR = _MARGIN + 1.0  # title-block inset: one extra mm over _MARGIN for cl
 
 #: What the general-tolerance cell states when no tolerance was authored or sourced.
 #: A blank cell is indistinguishable from an oversight and invites a shop to assume its
-#: own house standard, so the absent case is named rather than left empty (#1157). Shorter
-#: than "NOT SPECIFIED" so it clears the cell at the narrowest supported title-block width
-#: — `tests/test_issue_1157_no_implicit_general_tolerance.py` measures that against the
-#: block's own `cell_bbox`, so a longer word fails rather than overflowing silently.
+#: own house standard, so the absent case is named rather than left empty (#1157).
+#: The cell is not tight — 48 mm on A4's 120 mm block, 60 mm above it, against 16.9 mm of
+#: ink here — so this is a wording choice, not a width-forced one. The paired test still
+#: measures it against the block's own `cell_bbox` on A4, the narrowest supported width,
+#: because a longer replacement (a sentence, say) would overflow there and nowhere else.
 _TOLERANCE_UNSPECIFIED = "UNSPECIFIED"
 
 _FONT_SIZE = 3.0  # annotation text height (page-mm); the draft preset is built with this

--- a/src/draftwright/_core.py
+++ b/src/draftwright/_core.py
@@ -174,6 +174,14 @@ def _zone_divisions(page_w: float, page_h: float) -> tuple[int, int]:
 
 _TB_CLEAR = _MARGIN + 1.0  # title-block inset: one extra mm over _MARGIN for clearance
 
+#: What the general-tolerance cell states when no tolerance was authored or sourced.
+#: A blank cell is indistinguishable from an oversight and invites a shop to assume its
+#: own house standard, so the absent case is named rather than left empty (#1157). Shorter
+#: than "NOT SPECIFIED" so it clears the cell at the narrowest supported title-block width
+#: — `tests/test_issue_1157_no_implicit_general_tolerance.py` measures that against the
+#: block's own `cell_bbox`, so a longer word fails rather than overflowing silently.
+_TOLERANCE_UNSPECIFIED = "UNSPECIFIED"
+
 _FONT_SIZE = 3.0  # annotation text height (page-mm); the draft preset is built with this
 
 
@@ -1236,7 +1244,12 @@ class Analysis:
     step_file: str | Path | Shape
     title: str
     number: str
-    tolerance: str
+    #: The general tolerance for the title block. ``None`` means the caller supplied none
+    #: and none was sourced — a distinct state from an explicitly authored string, because a
+    #: general tolerance is a manufacturing requirement and defaulting one invents intent
+    #: the source model may not carry (#1157). ``""`` is the explicit request for a blank
+    #: cell. `_make_title_block` renders `None` as `_TOLERANCE_UNSPECIFIED`.
+    tolerance: str | None
     drawn_by: str
     out: str
     # Canonical AP242 source census + extraction outcomes for a STEP input, including off mode
@@ -1351,7 +1364,7 @@ def _make_title_block(dwg, a: Analysis):
     so the two never drift."""
     title = _font_safe_text(a.title)
     number = _font_safe_text(a.number)
-    tolerance = _font_safe_text(a.tolerance)
+    tolerance = _font_safe_text(_TOLERANCE_UNSPECIFIED if a.tolerance is None else a.tolerance)
     designed_by = _font_safe_text(_attribution_author(a.drawn_by))
     material = _font_safe_text(a.material)
     date = _font_safe_text(a.date)

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -461,9 +461,7 @@ def _check_dimension_sources(model: PartModel) -> None:
 def _detect_part_model_analysis(part, *, pmi="off") -> tuple[PartModel, Analysis]:
     """Return one detected model together with the exact analysis run that produced it."""
 
-    a = _analyse(
-        part, title="", number="", tolerance="ISO 2768-m", drawn_by="", out="model", pmi=pmi
-    )
+    a = _analyse(part, title="", number="", tolerance=None, drawn_by="", out="model", pmi=pmi)
     # `_analyse` already detected and stored the model, so calling `build_model(a)`
     # unconditionally re-ran every detector `build_part_model` doesn't take by injection —
     # the #602 duplicate-detection bug, fixed in `_assemble` but never here. It went unnoticed
@@ -1175,7 +1173,7 @@ def _build_drawing_once(
     out: str | None = None,
     title: str | None = None,
     number: str = "DWG-001",
-    tolerance: str = "ISO 2768-m",
+    tolerance: str | None = None,
     drawn_by: str = "",
     scale: float | None = None,
     page: str | tuple | None = None,
@@ -1881,7 +1879,7 @@ def build_drawing(
     out: str | None = None,
     title: str | None = None,
     number: str = "DWG-001",
-    tolerance: str = "ISO 2768-m",
+    tolerance: str | None = None,
     drawn_by: str = "",
     scale: float | None = None,
     page: str | tuple | None = None,
@@ -2839,7 +2837,7 @@ def make_drawing(
     out: str | None = None,
     title: str | None = None,
     number: str = "DWG-001",
-    tolerance: str = "ISO 2768-m",
+    tolerance: str | None = None,
     drawn_by: str = "",
     scale: float | None = None,
     page: str | tuple | None = None,
@@ -2871,7 +2869,10 @@ def make_drawing(
             when a build123d object is passed).
         title: Part title for the title block (default: stem uppercased).
         number: Drawing number (e.g. ``"DWG-042"``).
-        tolerance: General tolerance string (e.g. ``"ISO 2768-m"``).
+        tolerance: General tolerance string (e.g. ``"ISO 2768-m"``). ``None`` (the
+            default) states none: the title block says the tolerance is unspecified
+            rather than inventing a manufacturing requirement the source never
+            carried (#1157). ``""`` requests a blank cell.
         drawn_by: Designer name for the title block.
         scale: Drawing-scale override (e.g. ``5`` for 5:1, ``0.5`` for 1:2).
             Default: chosen automatically by :func:`choose_scale`.

--- a/src/draftwright/cli.py
+++ b/src/draftwright/cli.py
@@ -159,7 +159,10 @@ def main(
     out: str | None = typer.Option(None, help="Output prefix (default: input stem)"),
     title: str | None = typer.Option(None, help="Part title for title block"),
     number: str = typer.Option("DWG-001", help="Drawing number"),
-    tolerance: str = typer.Option("ISO 2768-m", help="General tolerance"),
+    tolerance: str | None = typer.Option(
+        None,
+        help="General tolerance (e.g. 'ISO 2768-m'); omitted, the title block says UNSPECIFIED",
+    ),
     drawn_by: str = typer.Option("", "--drawn-by", help="Designer name"),
     material: str = typer.Option("", help="Material for the title block"),
     date: str = typer.Option("", help="Date for the title block"),

--- a/src/draftwright/sheet.py
+++ b/src/draftwright/sheet.py
@@ -1188,7 +1188,10 @@ class Sheet:
             out=out,
         )
         # drawn_by / tolerance (title block, #474) forward to build_drawing only when set, so an
-        # unset value keeps build_drawing's own defaults ("" / "ISO 2768-m") rather than None.
+        # unset value keeps build_drawing's own defaults rather than None. Since #1157 the
+        # tolerance default IS None — an unauthored general tolerance is stated as unspecified
+        # instead of silently becoming ISO 2768-m — so this branch now carries only an explicit
+        # choice, including `tolerance=""` for a deliberately blank cell.
         if drawn_by is not None:
             self._opts["drawn_by"] = drawn_by
         if tolerance is not None:

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -2073,7 +2073,7 @@ def emit_sheet_script(
     title: str,
     number: str,
     drawn_by: str = "",
-    tolerance: str = "ISO 2768-m",
+    tolerance: str | None = None,
     scale=None,
     scale_policy="fallback",
     page=None,
@@ -2190,7 +2190,7 @@ def emit_sheet_script(
     ctor = [f"title={title!r}", f"number={number!r}"]
     if drawn_by:
         ctor.append(f"drawn_by={drawn_by!r}")
-    if tolerance != "ISO 2768-m":
+    if tolerance is not None:
         ctor.append(f"tolerance={tolerance!r}")
     emitted_scale = scale
     if emitted_scale is None and settled_layout is not None:
@@ -2472,7 +2472,7 @@ def generate_sheet_script(
     *,
     title: str | None = None,
     number: str = "DWG-001",
-    tolerance: str = "ISO 2768-m",
+    tolerance: str | None = None,
     drawn_by: str = "",
     scale=None,
     scale_policy="fallback",

--- a/tests/test_issue_1157_no_implicit_general_tolerance.py
+++ b/tests/test_issue_1157_no_implicit_general_tolerance.py
@@ -64,10 +64,12 @@ def test_an_explicit_empty_tolerance_leaves_the_cell_blank():
 
 
 def test_the_unspecified_text_clears_its_own_cell(unauthored):
-    """Chosen for width, so assert the width rather than trusting the choice."""
+    """Chosen for width, so assert the width rather than trusting the choice — and measure
+    what the block actually rendered, not a literal repeated here, or a longer replacement
+    would overflow the cell while this test went on passing."""
     block = unauthored.get_annotation("title_block")
     ink = Text(
-        "UNSPECIFIED",
+        _fields(unauthored)["general_tolerance"],
         font_size=3,
         font_path=PLEX_SANS_CONDENSED,
         align=(Align.CENTER, Align.CENTER),

--- a/tests/test_issue_1157_no_implicit_general_tolerance.py
+++ b/tests/test_issue_1157_no_implicit_general_tolerance.py
@@ -40,6 +40,15 @@ def authored():
     return _sheet(tolerance="ISO 2768-m").build()
 
 
+@pytest.fixture(scope="module")
+def narrowest():
+    """A4 carries the 120 mm title block; every larger page gets 150 mm. Cell overflow, if
+    it happens at all, happens here first."""
+    sheet = Sheet(_PART, title="BLOCK", page="A4", scale=1)
+    sheet.authored_dimensions()
+    return sheet.build()
+
+
 def test_the_title_block_has_a_general_tolerance_cell(unauthored):
     """Precondition: the field exists and is populated, so a later assertion about its
     CONTENT is not passing merely because the cell was dropped."""
@@ -63,13 +72,13 @@ def test_an_explicit_empty_tolerance_leaves_the_cell_blank():
     assert "general_tolerance" not in _fields(_sheet(tolerance="").build())
 
 
-def test_the_unspecified_text_clears_its_own_cell(unauthored):
-    """Chosen for width, so assert the width rather than trusting the choice — and measure
-    what the block actually rendered, not a literal repeated here, or a longer replacement
-    would overflow the cell while this test went on passing."""
-    block = unauthored.get_annotation("title_block")
+def test_the_unspecified_text_clears_its_own_cell(narrowest):
+    """Measure what the block actually rendered, on the narrowest block, rather than a
+    literal repeated here — otherwise a longer replacement overflows A4 while this test
+    goes on passing."""
+    block = narrowest.get_annotation("title_block")
     ink = Text(
-        _fields(unauthored)["general_tolerance"],
+        _fields(narrowest)["general_tolerance"],
         font_size=3,
         font_path=PLEX_SANS_CONDENSED,
         align=(Align.CENTER, Align.CENTER),
@@ -78,7 +87,7 @@ def test_the_unspecified_text_clears_its_own_cell(unauthored):
     assert ink.size.X < block.cell_bbox("general_tolerance")["width"]
     overflow = [
         issue
-        for issue in unauthored.lint()
+        for issue in narrowest.lint()
         if issue.code == "title_field_overflow" and "general_tolerance" in issue.message
     ]
     assert overflow == []

--- a/tests/test_issue_1157_no_implicit_general_tolerance.py
+++ b/tests/test_issue_1157_no_implicit_general_tolerance.py
@@ -1,0 +1,129 @@
+"""An unauthored general tolerance is stated as unspecified, never invented (#1157).
+
+A general tolerance is a manufacturing requirement. Defaulting the title block to
+``ISO 2768-m`` asserted one on every drawing whose caller never supplied it and whose
+source model never carried it — including every STEP-derived generated script, which
+emits no ``tolerance=`` at all.
+"""
+
+import inspect
+
+import pytest
+from build123d import Align, Box, Mode, Text
+
+from draftwright import Sheet
+from draftwright.builder import build_drawing, make_drawing
+from draftwright.fonts import PLEX_SANS_CONDENSED
+
+_PART = Box(30, 20, 10)
+
+
+def _sheet(**options):
+    sheet = Sheet(_PART, title="BLOCK", page="A3", **options)
+    sheet.authored_dimensions()
+    return sheet
+
+
+def _fields(drawing) -> dict[str, str]:
+    """The exact non-empty strings the title block rendered, by ISO 7200 field name."""
+    block = drawing.get_annotation("title_block")
+    return {field: value for field, value, _size, _font in block.title_field_specs}
+
+
+@pytest.fixture(scope="module")
+def unauthored():
+    return _sheet().build()
+
+
+@pytest.fixture(scope="module")
+def authored():
+    return _sheet(tolerance="ISO 2768-m").build()
+
+
+def test_the_title_block_has_a_general_tolerance_cell(unauthored):
+    """Precondition: the field exists and is populated, so a later assertion about its
+    CONTENT is not passing merely because the cell was dropped."""
+    assert "general_tolerance" in _fields(unauthored)
+    assert unauthored.get_annotation("title_block").cell_bbox("general_tolerance")["width"] > 0
+
+
+def test_unauthored_general_tolerance_is_stated_unspecified(unauthored):
+    fields = _fields(unauthored)
+    assert fields["general_tolerance"] == "UNSPECIFIED"
+    # The defect this replaces: the string reached the sheet with nobody having authored it.
+    assert "ISO 2768-m" not in fields.values()
+
+
+def test_an_authored_tolerance_round_trips(authored):
+    assert _fields(authored)["general_tolerance"] == "ISO 2768-m"
+
+
+def test_an_explicit_empty_tolerance_leaves_the_cell_blank():
+    """`""` stays available as the deliberate blank, distinct from both other states."""
+    assert "general_tolerance" not in _fields(_sheet(tolerance="").build())
+
+
+def test_the_unspecified_text_clears_its_own_cell(unauthored):
+    """Chosen for width, so assert the width rather than trusting the choice."""
+    block = unauthored.get_annotation("title_block")
+    ink = Text(
+        "UNSPECIFIED",
+        font_size=3,
+        font_path=PLEX_SANS_CONDENSED,
+        align=(Align.CENTER, Align.CENTER),
+        mode=Mode.PRIVATE,
+    ).bounding_box()
+    assert ink.size.X < block.cell_bbox("general_tolerance")["width"]
+    overflow = [
+        issue
+        for issue in unauthored.lint()
+        if issue.code == "title_field_overflow" and "general_tolerance" in issue.message
+    ]
+    assert overflow == []
+
+
+@pytest.mark.parametrize("entry", [build_drawing, make_drawing, Sheet.__init__])
+def test_no_public_entry_point_defaults_to_a_manufacturing_tolerance(entry):
+    default = inspect.signature(entry).parameters["tolerance"].default
+    assert default is None, (
+        f"{entry.__qualname__} still authors {default!r} on its caller's behalf"
+    )
+
+
+def test_the_cli_default_authors_nothing():
+    from draftwright.cli import main as cli_main
+
+    assert inspect.signature(cli_main).parameters["tolerance"].default.default is None
+
+
+@pytest.mark.slow
+def test_a_generated_script_never_authors_a_tolerance(tmp_path):
+    """The emitted `Sheet(...)` carries an aspect only when it differs from the default, so
+    an unauthored tolerance must leave no trace for a re-run to resurrect."""
+    from draftwright.sheet_emit import generate_sheet_script
+
+    plain = generate_sheet_script(
+        _PART, out=str(tmp_path / "plain"), title="BLOCK", formats=("svg",), inspect=False
+    )
+    ctor = _constructor_line(plain)
+    assert "tolerance=" not in ctor
+    assert "2768" not in ctor
+
+    asked = generate_sheet_script(
+        _PART,
+        out=str(tmp_path / "asked"),
+        title="BLOCK",
+        tolerance="ISO 2768-m",
+        formats=("svg",),
+        inspect=False,
+    )
+    assert "tolerance='ISO 2768-m'" in _constructor_line(asked)
+
+
+def _constructor_line(script_path) -> str:
+    from pathlib import Path
+
+    for line in Path(script_path).read_text().splitlines():
+        if line.startswith("sheet = Sheet("):
+            return line
+    raise AssertionError(f"no Sheet constructor in {script_path}")

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -671,7 +671,8 @@ class TestEmit:
         assert "page='A3'" in ctor
 
     def test_default_aspects_stay_off_the_constructor(self):
-        # unset aspects (and tolerance left at the ISO 2768-m default) never appear.
+        # unset aspects never appear — including tolerance, whose default is None since
+        # #1157, so an unauthored general tolerance leaves no trace for a re-run to revive.
         ctor = next(ln for ln in _script_for(_plate()).splitlines() if "Sheet(part" in ln)
         assert ctor == "sheet = Sheet(part, title='T', number='N')"
 


### PR DESCRIPTION
Closes #1157. Closes #501. Part of #1564.

## The defect

The title block defaulted its general-tolerance cell to `ISO 2768-m` in `build_drawing`,
`make_drawing`, `Sheet`, both emitter entry points and the CLI. A general tolerance is a
manufacturing requirement, not presentation metadata, so every drawing whose caller supplied
none asserted a requirement neither the caller nor the source model carried.

That is every STEP-derived generated script: the emitter carries an aspect into the emitted
`Sheet(...)` only when it differs from the default, so an unauthored tolerance emitted nothing
and the drawing printed `ISO 2768-m` anyway. It reached a production PDF that way
(#1157's GRM-04 evidence).

## The change

`Analysis.tolerance` becomes `str | None`, and `None` is the new public default:

| caller says | cell shows |
|---|---|
| nothing (the default) | `UNSPECIFIED` |
| `tolerance="ISO 2768-m"` | `ISO 2768-m` |
| `tolerance=""` | blank |

Three states, because two are not enough: `""` has to stay available as the deliberate blank,
and "nobody said" must be distinguishable from both. The absent case is *named* rather than
left empty because an empty cell is indistinguishable from an oversight and invites a shop to
apply its own house standard — the same failure the default caused, one step removed.

The emitter's non-default gate becomes `if tolerance is not None`, so a re-run cannot resurrect
a tolerance nobody asked for. **That gate is exactly what #501 predicted would silently
diverge** when the default changed, and with the default gone there is no sentinel left to
dedupe — one docstring example is the only `"ISO 2768-m"` literal remaining in `src/`.

## Evidence

- Full fast tier green on this branch: **8432 passed, 5 skipped, 13 xfailed** in 242 s. No
  existing test needed changing — which is itself the finding that the old default was never
  load-bearing. One stale *comment* in `test_sheet_emit.py` claimed the tolerance was "left at
  the ISO 2768-m default"; corrected.
- Slow tier run locally before opening this PR: **54 passed, 2 xfailed** in 21m41s.
- CLI checked end-to-end on `grm04_drive_plate.step` with and without `--tolerance`; both exit 0.

**Mutation-checked** — each of these fails a *named* test:

| mutation | fails |
|---|---|
| restore `"ISO 2768-m"` on the three builder entry points | `test_unauthored_general_tolerance_is_stated_unspecified`, both `test_no_public_entry_point_defaults_to_a_manufacturing_tolerance` cases |
| widen `_TOLERANCE_UNSPECIFIED` past the cell | `…is_stated_unspecified`, `test_the_unspecified_text_clears_its_own_cell` |
| drop the `None` branch, blank the cell instead | `test_the_title_block_has_a_general_tolerance_cell`, `…is_stated_unspecified` |
| revert the emitter gate to `!= "ISO 2768-m"` | `test_a_generated_script_never_authors_a_tolerance` |

## One correction on the record

The first version of the comment beside `_TOLERANCE_UNSPECIFIED` claimed the word was chosen
because it clears the cell where `NOT SPECIFIED` would not. Measured: the cell is 60 mm on A3
and larger, 48 mm on A4, against 16.9 mm of ink — every candidate fits, including a
31-character sentence. The rationale was invented. The comment now says what is true, and the
width test moved to A4, the narrowest supported title block, where a long replacement does
overflow and nowhere else (that move is what made the mutation above fail).

## Architectural fit

No boundary moves. `Analysis` is rank-1 and already owns the title-block fields; the rendering
decision stays in `_core._make_title_block`, its single existing site. ADR 5: an unknown is
stated as unknown instead of being filled in with a plausible default.

## Compatibility

Breaking for any caller relying on the implicit `ISO 2768-m`. They pass it explicitly. The CLI
gains no new flag — `--tolerance "ISO 2768-m"` was always the way to ask for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3VevbCf1UWuPzj3G927ef
