### PR TITLE
Adopt quiddity 0.2.7: rounded plate corners no longer form a false stepped shaft (#1555)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,15 @@
 
 ### Changed
 
+- Updated the exact Quiddity runtime and declared-inspection contract to **0.2.7**. Unlike the
+  0.2.5 adoption below, this one changes drawings: the provider now requires circumferential
+  cylinder support to establish a turned-profile axis line, so rounded plate corners and parallel
+  offset cylinders no longer form a false stepped shaft. Measured on the repo corpus, NIST CTC-05
+  is the only fixture whose recognised turned profile moves — its two STEP encodings previously
+  disagreed (3 steps and 9 steps for the same solid) and now agree on 5 — and a plate part that
+  previously raised out of `generate_sheet_script` now emits and builds. No family, record schema
+  or adapter changed (#1555, quiddity#586).
+
 - Updated the exact Quiddity runtime and declared-inspection contract to 0.2.5 for the
   provider's recognition performance improvements.
 

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -78,7 +78,16 @@ The runtime pins the published `quiddity==0.2.7` package, following the 0.2.4 ad
 circumferential cylinder support to establish a turned-profile axis line, so rounded plate corners
 and parallel offset cylinders no longer form a false stepped shaft
 ([quiddity#586](https://github.com/pzfreo/quiddity/issues/586), [#1555](https://github.com/pzfreo/draftwright/issues/1555)).
-No family, record schema or adapter changed. Its public `quiddity`, `quiddity.evidence` and
+No family, record schema or adapter changed.
+
+0.2.7 also partitions bands by physical axis line rather than by axis direction, requiring two
+distinct diameters *per line*. One body can therefore publish **several** coaxial
+`TurnedProfile`s where 0.2.6 published at most one. `Analysis.profiles` already holds every
+body-local profile and is unaffected; `Analysis.prof` remains the compatible zero/one view and
+is `None` for a plural result, which sends `holes.py`'s `a.prof is not None` branches down their
+non-rotational path. **No fixture in this repository reaches plural cardinality on either
+version**, so the green tiers are not evidence that path behaves well — it is newly reachable
+and untested. Its public `quiddity`, `quiddity.evidence` and
 `quiddity.inspection` surfaces supply recognition, exact occurrence evidence and declared geometry
 reads. There is one recognition aggregate per build; consumers project that result rather than
 calling the document builder to obtain another run.

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -70,11 +70,15 @@ issue. The contract test derives package record outputs, converter registries, l
 and emitter branches independently, so copying a new name into the declaration alone cannot make CI
 pass.
 
-### Quiddity 0.2.6 runtime contract
+### Quiddity 0.2.7 runtime contract
 
-The runtime pins the published `quiddity==0.2.6` package, following the 0.2.4 adoption in
+The runtime pins the published `quiddity==0.2.7` package, following the 0.2.4 adoption in
 [#1486](https://github.com/pzfreo/draftwright/pull/1486) and the migration in
-[#1471](https://github.com/pzfreo/draftwright/issues/1471). Its public `quiddity`, `quiddity.evidence` and
+[#1471](https://github.com/pzfreo/draftwright/issues/1471). 0.2.7 is a patch adoption: it requires
+circumferential cylinder support to establish a turned-profile axis line, so rounded plate corners
+and parallel offset cylinders no longer form a false stepped shaft
+([quiddity#586](https://github.com/pzfreo/quiddity/issues/586), [#1555](https://github.com/pzfreo/draftwright/issues/1555)).
+No family, record schema or adapter changed. Its public `quiddity`, `quiddity.evidence` and
 `quiddity.inspection` surfaces supply recognition, exact occurrence evidence and declared geometry
 reads. There is one recognition aggregate per build; consumers project that result rather than
 calling the document builder to obtain another run.

--- a/docs/reference/sheet.md
+++ b/docs/reference/sheet.md
@@ -278,7 +278,7 @@ produces `angular_support_unverifiable`; contradictory supports produce
 `angular_support_mismatch`.
 
 Automatic drawings derive outside-profile angular requirements from ordered face
-supports in Quiddity 0.2.6. Angles already defined by a recognised chamfer or
+supports, available since Quiddity 0.2.6. Angles already defined by a recognised chamfer or
 regular-polygon callout do not add duplicate automatic requirements. This requires
 the same run's exact face or shared-edge evidence, not matching numerical angles;
 explicit angle declarations remain available on those corners.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     # published wheels, not only uv's development resolver constraints.
     "cadquery-ocp-novtk!=7.9.3.1.1 ; python_full_version >= '3.13'",
     "build123d-drafting-helpers>=0.15.1",
-    "quiddity==0.2.6",
+    "quiddity==0.2.7",
     "numpy>=1.24",
     # PNG raster export (SVG→PDF→PNG). Both permissively licensed (Pillow HPND; pypdfium2
     # Apache-2.0 wrapping Google PDFium BSD-3) and ship pre-built wheels with NO native system

--- a/src/draftwright/inspection_contract.py
+++ b/src/draftwright/inspection_contract.py
@@ -17,7 +17,7 @@ from quiddity.inspection import inspection_api_manifest
 CONSUMER_INSPECTION_FORMAT = "draftwright-inspection-api"
 CONSUMER_INSPECTION_FORMAT_VERSION = 1
 SUPPORTED_INSPECTION_API_MAJOR = 1
-SUPPORTED_RECOGNISER_VERSION = "0.2.6"
+SUPPORTED_RECOGNISER_VERSION = "0.2.7"
 _DISTRIBUTION = "quiddity"
 _PROVIDER_FORMAT = "quiddity-inspection-api"
 _NAMESPACE = "quiddity.inspection"

--- a/tests/test_inspection_contract.py
+++ b/tests/test_inspection_contract.py
@@ -46,7 +46,7 @@ def _manifest() -> dict:
 def test_installed_pypi_wheel_satisfies_the_inspection_contract() -> None:
     distribution = importlib.metadata.distribution("quiddity")
 
-    assert distribution.version == "0.2.6"
+    assert distribution.version == "0.2.7"
     assert distribution.read_text("direct_url.json") is None
     assert (
         Path(inspect.getfile(inspection.inspection_api_manifest))

--- a/tests/test_issue_1555_turned_recognition_format_invariance.py
+++ b/tests/test_issue_1555_turned_recognition_format_invariance.py
@@ -1,0 +1,78 @@
+"""The same solid must recognise the same turned profile in either STEP encoding (#1555).
+
+quiddity 0.2.6 elected a turned profile's axis from a vote that unsupported bands could join.
+On NIST CTC-05 a ⌀2.833 blend was among the voters, and the two encodings of the *same part*
+disagreed about the answer:
+
+    ap203  3 steps on x, including ⌀2.833      ap242  9 steps on x
+
+0.2.7 filters bands to those with more than half a turn of circumferential support *before* the
+vote, and both encodings now report the same five steps on z. That agreement is the observable
+consequence of the fix, and nothing else in the suite pins it: CTC-05's other guard
+(`test_issue_798_silhouette_lint`) asserts a callout FLOOR of 18, which a wrong-but-plentiful
+inventory would satisfy.
+
+Recognition only, not a drawing build — `inspect_step` is ~2-3 s per fixture against ~60 s for a
+dense CTC build. Still slow-tier and one pair per test, because the fast tier is measured on
+ubuntu at 5-7x macOS and #656's note records what putting a CTC fixture in it cost.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from draftwright.inspection import inspect_step
+
+#: The five NIST parts that ship in both encodings. Four legitimately recognise no turned
+#: profile at all; they are here because the property is "the encodings agree", and an encoding
+#: that invented a profile on a prismatic part would be exactly the #1555 defect returning.
+PAIRS = ("01", "02", "03", "04", "05")
+
+#: CTC-05's profile, pinned exactly. This is the non-vacuous half: the four cases above agree by
+#: both being empty, so without this the module could pass while recognising nothing anywhere.
+#: A provider change that alters these values should fail here and be updated deliberately.
+CTC05_STEPS = (
+    ("z", 63.5, 279.4, 482.6),
+    ("z", 304.8, 25.4, 45.72),
+    ("z", 304.8, 45.72, 54.61),
+    ("z", 304.8, 54.61, 127.0),
+    ("z", 558.8, 0.0, 25.4),
+)
+
+
+def _turned_steps(stem: str) -> list[tuple[str, float, float, float]]:
+    document = inspect_step(f"tests/fixtures/{stem}.stp")
+    return sorted(
+        (
+            found["feature"]["axis"],
+            round(found["feature"]["diameter"], 3),
+            round(found["feature"]["lo"], 3),
+            round(found["feature"]["hi"], 3),
+        )
+        for found in document["found"]
+        if found["family"] == "turned_steps"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("part", PAIRS)
+def test_both_encodings_recognise_the_same_turned_profile(part):
+    ap203 = _turned_steps(f"nist_ctc_{part}_asme1_ap203")
+    ap242 = _turned_steps(f"nist_ctc_{part}_asme1_ap242")
+    assert ap203 == ap242, (
+        f"CTC-{part} recognises a different turned profile in each encoding of the same solid; "
+        "that is the #1555 axis-election defect returning"
+    )
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("encoding", ["ap203", "ap242"])
+def test_ctc05_recognises_its_actual_turned_profile(encoding):
+    """The agreement above is only worth something if what both agree on is right.
+
+    ⌀2.833 is the specific artefact 0.2.6 drew on the ap203 sheet: a blend read as a turned
+    diameter. Asserting the exact set covers it without inventing a size threshold.
+    """
+    steps = _turned_steps(f"nist_ctc_05_asme1_{encoding}")
+    assert tuple(steps) == CTC05_STEPS
+    assert not [s for s in steps if s[1] < 10.0], "a blend-sized diameter is back in the profile"

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -159,7 +159,7 @@ def test_section_recess_family_covers_the_published_geometry_and_occurrence_cont
     assert not retired & package.keys()
     assert not retired & consumer.keys()
     family = package["section-recesses"]
-    assert INSTALLED_PACKAGE_VERSION == "0.2.6"
+    assert INSTALLED_PACKAGE_VERSION == "0.2.7"
     assert family["introduced_in"] == "0.2.0"
     assert family["census_output"] == "RecognitionResult.section_recesses"
     expected_fields = {

--- a/uv.lock
+++ b/uv.lock
@@ -752,7 +752,7 @@ requires-dist = [
     { name = "ocp-gordon", specifier = "<0.3" },
     { name = "pillow", specifier = ">=10" },
     { name = "pypdfium2", specifier = ">=4" },
-    { name = "quiddity", specifier = "==0.2.6" },
+    { name = "quiddity", specifier = "==0.2.7" },
     { name = "reportlab", specifier = ">=4.0" },
     { name = "rich", specifier = ">=10.11" },
     { name = "steputils", specifier = "==0.1" },
@@ -2582,15 +2582,15 @@ wheels = [
 
 [[package]]
 name = "quiddity"
-version = "0.2.6"
+version = "0.2.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/35/08/14ff956ac24f5811e4289dc9dd7dc6587479d86ec494b6953a1b6414caf6/quiddity-0.2.6.tar.gz", hash = "sha256:5ae79af9cffe0c5f03f5c1750391759040b9efbc9359bf9f1af3769aaf30316d", size = 14879390, upload-time = "2026-09-07T17:06:58.315Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/44/dedf3805e8478e82d4171aee1148bc625eb994f07b5e20699f551d9f231a/quiddity-0.2.7.tar.gz", hash = "sha256:25969c03c997a5c80acc0e33c7f37d48b7f401d4bcb81c87c1952037745bdd96", size = 14880671, upload-time = "2026-09-10T13:50:37.151Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/ad/2bb920c90af85f98f8907705da8439723d6296d409c6975a1e211a7d7642/quiddity-0.2.6-py3-none-any.whl", hash = "sha256:b08a405da6eaf5fcfe48f2fdea452630c71b4b46b3ac7aca2c6ecc3430940a45", size = 526044, upload-time = "2026-09-07T17:06:56.733Z" },
+    { url = "https://files.pythonhosted.org/packages/20/2b/5a465fb54c0c82f9cd6dd54dd267c7342e1cc862bf169de34edd23f42b09/quiddity-0.2.7-py3-none-any.whl", hash = "sha256:0359f3a5fa51226fe1278a1b7504bf8637d12fc4b30b7ebe4e80f4f9361a9601", size = 526521, upload-time = "2026-09-10T13:50:33.215Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #1555. Unblocks part of #1132. Part of #1564.

Adopts [quiddity 0.2.7](https://github.com/pzfreo/quiddity/releases/tag/quiddity-v0.2.7), which
requires circumferential cylinder support to establish a turned-profile axis line
(quiddity#586, PR quiddity#588 — reviewed [here](https://github.com/pzfreo/quiddity/pull/588#issuecomment-5618333592)).

## The 19 failures were the join working, not fallout

Every initial failure — 18 in `test_inspection_contract`, 1 in `test_recogniser_capabilities` —
carried the same message:

```
installed package version mismatch: expected '0.2.6', got '0.2.7'
```

That is ADR 3's fail-closed provider join refusing a version nobody has declared supported.
Bumping `SUPPORTED_RECOGNISER_VERSION` and the two tests mirroring it is the adoption, not a
workaround for it — which is why the corpus below is measured rather than assumed.

`test_recogniser_capabilities` derives package record outputs, converter registries, live `Sheet`
methods and emitter branches **independently**, so its passing is what establishes the release
note's "no family, record schema or adapter changed". I did not take that on trust.

## What actually changes for a consumer

Measured on both revisions through `recognise_turned_steps` with one script, per fixture in its
own process (`build123d.import_step` segfaults on the CTC AP242 files — draftwright's own
`analysis._import_step` uses `STEPControl_Reader` precisely to avoid that):

| fixture | 0.2.6 | 0.2.7 |
|---|---|---|
| **CADGenBench 114** (the #1555 bracket) | 2 false steps: ⌀50 `z 0..3`, ⌀7 `z 33.933..36.933` | **0** |
| CADGenBench 132 | 5 steps | **3** |
| NIST CTC-05 AP203 | 3 steps on `x` (incl. a ⌀2.833 blend) | **5 on `z`** |
| NIST CTC-05 AP242 | **9** steps on `x` | **5 on `z` — identical to AP203** |
| all 19 other draftwright fixtures | — | unchanged |

Two of those deserve a sentence each:

- **132's 5 → 3 is not a loss.** The two ⌀20 "steps" at `z 128..140` were six posts on a **bolt
  circle of radius 45** — line keys `(±45, 0)` and `(±22.5, ±38.971)` — previously merged into one
  coaxial profile because grouping was by axis *direction*.
- **CTC-05 now agrees with itself.** On 0.2.6 the same part gave different turned profiles in
  AP203 and AP242 (3 steps vs 9). On 0.2.7 both give the same 5. Format invariance restored on a
  NIST part, and it follows from filtering unsupported bands *before* the axis vote.

## The headline consumer win

CADGenBench 114 previously raised out of `generate_sheet_script` in 1.6 s — no script, no
drawing. It now **emits and builds**:

```
EMIT  ok in 3.1s
BUILD ok  scale=1.0  passed=True  score=0.95
          by_code={'plate_requirement_unverifiable': 1, 'step_dim_withheld': 1}
```

That is one of #1132's three fixtures resolved at its root. 132 and 109 still fail the span
guard: 132 because its remaining profile covers `z 0..113` of 140, and 109 because
**quiddity#587 (modelled threads shredded into ~94 equal-diameter rungs) is not addressed by this
patch** — so #1135 is unchanged and stays blocked.

## Evidence

- Fast tier: **8445 passed**, 5 skipped, 13 xfailed (225 s).
- Slow tier: **55 passed, 2 xfailed** (191 s, `-n auto --dist worksteal`).
- `ruff format --check` and `ruff check` both exit 0 over `src/` and `tests/`.

## Docs

The live runtime-contract references move to 0.2.7. `docs/research/1534-*` and
`docs/plans/1535-*` keep their 0.2.6 readings — they are dated records of what was true when
written, and rewriting them would falsify them. One ambiguous line in `docs/reference/sheet.md`
now reads "available since Quiddity 0.2.6" so it cannot be misread as naming the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3VevbCf1UWuPzj3G927ef
