### PR TITLE
Adopt quiddity 0.2.8: a modelled thread is no longer a stack of turned shoulders (#1135)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,12 @@
 
 ### Changed
 
+- Updated the exact Quiddity runtime and declared-inspection contract to **0.2.8**, which stops
+  a modelled thread being read as a stack of turned shoulders and coalesces contiguous
+  equal-diameter bands into the one span they physically are. Measured on the repo corpus,
+  NIST CTC-05 is again the only fixture that moves: its ⌀304.8 region was three adjacent
+  rungs and is now one, in both STEP encodings (#1135, quiddity#587).
+
 - Updated the exact Quiddity runtime and declared-inspection contract to **0.2.7**. Unlike the
   0.2.5 adoption below, this one changes drawings: the provider now requires circumferential
   cylinder support to establish a turned-profile axis line, so rounded plate corners and parallel

--- a/docs/reference/recogniser-capabilities.md
+++ b/docs/reference/recogniser-capabilities.md
@@ -70,9 +70,9 @@ issue. The contract test derives package record outputs, converter registries, l
 and emitter branches independently, so copying a new name into the declaration alone cannot make CI
 pass.
 
-### Quiddity 0.2.7 runtime contract
+### Quiddity 0.2.8 runtime contract
 
-The runtime pins the published `quiddity==0.2.7` package, following the 0.2.4 adoption in
+The runtime pins the published `quiddity==0.2.8` package, following the 0.2.4 adoption in
 [#1486](https://github.com/pzfreo/draftwright/pull/1486) and the migration in
 [#1471](https://github.com/pzfreo/draftwright/issues/1471). 0.2.7 is a patch adoption: it requires
 circumferential cylinder support to establish a turned-profile axis line, so rounded plate corners

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     # published wheels, not only uv's development resolver constraints.
     "cadquery-ocp-novtk!=7.9.3.1.1 ; python_full_version >= '3.13'",
     "build123d-drafting-helpers>=0.15.1",
-    "quiddity==0.2.7",
+    "quiddity==0.2.8",
     "numpy>=1.24",
     # PNG raster export (SVG→PDF→PNG). Both permissively licensed (Pillow HPND; pypdfium2
     # Apache-2.0 wrapping Google PDFium BSD-3) and ship pre-built wheels with NO native system

--- a/src/draftwright/inspection_contract.py
+++ b/src/draftwright/inspection_contract.py
@@ -17,7 +17,7 @@ from quiddity.inspection import inspection_api_manifest
 CONSUMER_INSPECTION_FORMAT = "draftwright-inspection-api"
 CONSUMER_INSPECTION_FORMAT_VERSION = 1
 SUPPORTED_INSPECTION_API_MAJOR = 1
-SUPPORTED_RECOGNISER_VERSION = "0.2.7"
+SUPPORTED_RECOGNISER_VERSION = "0.2.8"
 _DISTRIBUTION = "quiddity"
 _PROVIDER_FORMAT = "quiddity-inspection-api"
 _NAMESPACE = "quiddity.inspection"

--- a/tests/test_inspection_contract.py
+++ b/tests/test_inspection_contract.py
@@ -46,7 +46,7 @@ def _manifest() -> dict:
 def test_installed_pypi_wheel_satisfies_the_inspection_contract() -> None:
     distribution = importlib.metadata.distribution("quiddity")
 
-    assert distribution.version == "0.2.7"
+    assert distribution.version == "0.2.8"
     assert distribution.read_text("direct_url.json") is None
     assert (
         Path(inspect.getfile(inspection.inspection_api_manifest))

--- a/tests/test_issue_1555_turned_recognition_format_invariance.py
+++ b/tests/test_issue_1555_turned_recognition_format_invariance.py
@@ -33,11 +33,17 @@ PAIRS = ("01", "02", "03", "04", "05")
 #: A provider change that alters these values should fail here and be updated deliberately.
 CTC05_STEPS = (
     ("z", 63.5, 279.4, 482.6),
-    ("z", 304.8, 25.4, 45.72),
-    ("z", 304.8, 45.72, 54.61),
-    ("z", 304.8, 54.61, 127.0),
+    ("z", 304.8, 25.4, 127.0),
     ("z", 558.8, 0.0, 25.4),
 )
+
+#: Updated for quiddity 0.2.8 (quiddity#587). 0.2.7 reported the ⌀304.8 region as three
+#: contiguous rungs — `25.4..45.72`, `45.72..54.61`, `54.61..127.0` — and 0.2.8 coalesces
+#: contiguous equal-diameter bands into the one span they physically are. Three adjacent rungs
+#: at one diameter are not three steps, so this is the roster improving, not drifting. The pin
+#: is updated deliberately, which is what it exists to force: the invariance assertions above
+#: kept passing across the change (both encodings agreed before and after), and only these
+#: exact values failed.
 
 
 def _turned_steps(stem: str) -> list[tuple[str, float, float, float]]:

--- a/tests/test_issue_740_leader_assignment.py
+++ b/tests/test_issue_740_leader_assignment.py
@@ -139,11 +139,24 @@ def test_pre_drain_y_diameter_uses_the_shared_analytical_producer_floor(monkeypa
     assert diameter.covers_diameters == (25.0,)
     assert drawing.measurement_keys("m_dia_y0")
     # The added boss heights must not displace existing callouts at this fixed page/scale.
-    assert len([name for name in drawing.annotations() if name.startswith("m_dia_y")]) == 8
+    # Four since quiddity 0.2.8 coalesced the flange's split bands into four tiling
+    # segments (ø25, ø31, ø42, ø31). The producer-floor property under test is about which
+    # producer supplies the ray, not how many rays there are.
+    assert len([name for name in drawing.annotations() if name.startswith("m_dia_y")]) == 4
     assert len([name for name in drawing.annotations() if name.startswith("m_pad_height_")]) == 4
-    assert sorted(
-        mark.label for name, mark in drawing.iter_annotations() if name.startswith("m_bossheight")
-    ) == ["4", "6"]
+    # #1511's two restored heights are still stated, and still claimed — but since quiddity
+    # 0.2.8 they are no longer BOSS heights. Coalescing contiguous equal-diameter bands folds
+    # those two cylinders into the turned profile, so they are steps, and the crowded chain
+    # carries them in the enlarged detail. Assert the values reach the sheet with provenance,
+    # which is what "must not displace existing callouts" was protecting; asserting the old
+    # annotation prefix would now be asserting a classification this fixture no longer has.
+    heights = {
+        mark.label: name
+        for name, mark in drawing.iter_annotations()
+        if name.startswith(("m_bossheight", "dim_detail_a_steplen"))
+    }
+    assert {"4", "6"} <= set(heights)
+    assert all(drawing.measurement_keys(heights[label]) for label in ("4", "6"))
     trace = json.loads(trace_path.read_text(encoding="utf-8"))
     event = next(
         item for item in trace["pass_events"] if item["label"] == "Y-axis step diameter_callouts"

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -9482,7 +9482,11 @@ class TestTurnedDiameters:
         diameter_owners = [
             feature for feature in dwg.model().features if feature.kind in {"step", "boss"}
         ]
-        assert len(diameter_owners) == 8
+        # Four since quiddity 0.2.8, which coalesces contiguous equal-diameter bands: the
+        # flange's profile is four tiling segments (ø25 -16..-8, ø31 -8..-2, ø42 -2..2,
+        # ø31 2..4) where the provider previously reported each split in two. #890's subject
+        # is per-leader provenance, which four distinct owners exercise exactly as eight did.
+        assert len(diameter_owners) == 4
         for name in (n for n in dwg.annotations() if n.startswith("m_dia_y")):
             ann = dwg.get_annotation(name)
             owner = dwg.registry.feature_of(name)
@@ -9501,8 +9505,23 @@ class TestTurnedDiameters:
         assert step_labels >= {"8", "4"}
         assert "2" in step_labels or "4× 2" in step_labels
         assert {dwg.view_of(n) for n in dwg.annotations() if n.startswith("m_steplen")} == {"side"}
+        # Since quiddity 0.2.8 the chain is 8 | 6 | 4 | 2, and the 2 mm segment is below the
+        # legibility floor, so this fixture now routes to an enlarged detail. That splits the
+        # provenance in two, exactly as `test_issue_892_short_y_step_chain_moves_to_enlarged_
+        # side_detail` documents: the detail carries one claimed dimension per step, and the
+        # main view keeps the aggregate block, which claims nothing because it "is not any one
+        # approved step measurement". Assert both halves rather than only the surviving one.
+        detail_steps = [n for n in dwg.annotations() if n.startswith("dim_detail_a_steplen")]
+        assert detail_steps, "the crowded chain must be sized somewhere"
+        assert all(len(dwg.measurement_keys(n)) == 1 for n in detail_steps)
         for name in (n for n in dwg.annotations() if n.startswith("m_steplen")):
-            expected = 4 if dwg.get_annotation(name).label == "4× 2" else 1
+            label = dwg.get_annotation(name).label
+            if label == "4× 2":
+                expected = 4
+            elif "detail_a" in dwg.views:
+                expected = 0  # the aggregate block
+            else:
+                expected = 1
             assert len(dwg.measurement_keys(name)) == expected
 
         # The central Y-axis bore shares the detected turned-profile axis. Its
@@ -9780,23 +9799,24 @@ class TestTurnedDiameters:
             auto.lint_summary()["by_code"]
             == replayed.lint_summary()["by_code"]
             == {
-                "annotation_ink_overlap": 2,
                 "hole_requirement_missing": 2,
                 "leader_crosses_silhouette": 1,
                 "section_recess_recognition_refused": 4,
             }
         )
 
-        # PENDING #1512: restored 6/4 boss witnesses cross the repeated step label.
-        # Both bounded repair and deferred chain placement were tried without resolving
-        # this cross-pass pair. Policy B retains the requirements and reports the ink.
+        # #1512's two crossings no longer occur on this fixture. They were the restored 6 mm
+        # and 4 mm boss-height witnesses cutting the step chain's `4× 2` repeat label, and
+        # quiddity 0.2.8 leaves neither on this view: the coalesced 8 | 6 | 4 | 2 chain routes
+        # to an enlarged detail, which carries all four as claimed dimensions. Nothing was
+        # dropped to achieve that — the detail assertions above account for every step.
+        #
+        # This is the reproduction disappearing, NOT the placement debt being paid: the
+        # bounded same-batch ink solver still never considers the combined cross-pass set,
+        # which is what #1512 is actually about. Asserted as absence so a reappearance here
+        # fails rather than passing quietly under a laxer check.
         for drawing in (auto, replayed):
-            pairs = [
-                tuple(issue.message.split("'")[index] for index in (1, 3))
-                for issue in drawing.lint()
-                if issue.code == "annotation_ink_overlap"
-            ]
-            assert sorted(pairs) == [("4", "4× 2"), ("6", "4× 2")]
+            assert [i for i in drawing.lint() if i.code == "annotation_ink_overlap"] == []
 
         # ── from #881: the Y-step furniture lands in the right views on the replay ──
         assert replayed.view_of("centerline_side") == "side"

--- a/tests/test_recogniser_capabilities.py
+++ b/tests/test_recogniser_capabilities.py
@@ -159,7 +159,7 @@ def test_section_recess_family_covers_the_published_geometry_and_occurrence_cont
     assert not retired & package.keys()
     assert not retired & consumer.keys()
     family = package["section-recesses"]
-    assert INSTALLED_PACKAGE_VERSION == "0.2.7"
+    assert INSTALLED_PACKAGE_VERSION == "0.2.8"
     assert family["introduced_in"] == "0.2.0"
     assert family["census_output"] == "RecognitionResult.section_recesses"
     expected_fields = {

--- a/uv.lock
+++ b/uv.lock
@@ -752,7 +752,7 @@ requires-dist = [
     { name = "ocp-gordon", specifier = "<0.3" },
     { name = "pillow", specifier = ">=10" },
     { name = "pypdfium2", specifier = ">=4" },
-    { name = "quiddity", specifier = "==0.2.7" },
+    { name = "quiddity", specifier = "==0.2.8" },
     { name = "reportlab", specifier = ">=4.0" },
     { name = "rich", specifier = ">=10.11" },
     { name = "steputils", specifier = "==0.1" },
@@ -2582,15 +2582,15 @@ wheels = [
 
 [[package]]
 name = "quiddity"
-version = "0.2.7"
+version = "0.2.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "build123d", version = "0.10.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.13'" },
     { name = "build123d", version = "0.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a1/44/dedf3805e8478e82d4171aee1148bc625eb994f07b5e20699f551d9f231a/quiddity-0.2.7.tar.gz", hash = "sha256:25969c03c997a5c80acc0e33c7f37d48b7f401d4bcb81c87c1952037745bdd96", size = 14880671, upload-time = "2026-09-10T13:50:37.151Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/b0/ce0b1d1646198676a8dfbca9b396c06bd43b51a2beb864755ec94526f2be/quiddity-0.2.8.tar.gz", hash = "sha256:d6cc91625e20eeb4187afa723ae1921f9c28429e6f879d72151ca222016bc294", size = 14883433, upload-time = "2026-09-10T15:48:53.33Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/2b/5a465fb54c0c82f9cd6dd54dd267c7342e1cc862bf169de34edd23f42b09/quiddity-0.2.7-py3-none-any.whl", hash = "sha256:0359f3a5fa51226fe1278a1b7504bf8637d12fc4b30b7ebe4e80f4f9361a9601", size = 526521, upload-time = "2026-09-10T13:50:33.215Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/48/387001a0840965ee723a96cba29dbecfdbe664fac5ec41fb7f85ee77d8ad/quiddity-0.2.8-py3-none-any.whl", hash = "sha256:0e832a7acde3343cbb1670e5dd82d7fc7b78a588edd1bb6d7dc6da3ce8e66154", size = 527823, upload-time = "2026-09-10T15:48:51.462Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #1135. Narrows #1132. Part of #1564.

Adopts [quiddity 0.2.8](https://github.com/pzfreo/quiddity/releases/tag/quiddity-v0.2.8)
(quiddity#587, PR quiddity#591), which stops a modelled thread being read as a stack of
turned shoulders and coalesces contiguous equal-diameter bands into the one span they
physically are.

I reviewed #591 before it merged; quiddity's `main` CI is green on it.

## What changes, measured

`recognise_turned_steps` on both versions, one script, per fixture in its own process:

| fixture | 0.2.7 | 0.2.8 |
|---|---|---|
| **CADGenBench 109** (the #1135 connector) | **101** steps | **7** |
| NIST CTC-05 (both encodings) | 5 steps — ⌀304.8 as three adjacent rungs | **3** — those three coalesced into `25.4..127.0` |
| CADGenBench 114, 132, every other repo fixture | — | unchanged |

## 109 still does not emit, and that is now the honest answer

The thread is no longer a hundred shoulders, but the seven real steps leave
`z 343.13..366.82` unclaimed — which is exactly where the thread is, correctly no longer
claimed as a step chain and claimed by nothing else.

So **both** remaining #1132 fixtures now fail the span guard because the parts genuinely are
not fully spanned, not because recognition invented steps. That removes the last recognition
fault from #1132 and narrows it to the single product decision it always contained: should a
detection-sourced step set that truly does not span the body raise out of
`generate_sheet_script`, or build and report the shortfall through lint while a hand-authored
`.step()` misuse (#631's actual report) keeps raising?

## Three test updates — consequences, not defects

I want to be explicit that none of these weakens a guard, because I nearly did weaken one.

- **`test_issue_881`** — the flange has four tiling segments (ø25, ø31, ø42, ø31) rather than
  eight split ones. Its provenance check now asserts *both* halves of the split the detail
  view creates: the detail carries one claimed dimension per step, and the main view's
  aggregate block claims nothing — the rule `test_issue_892` already documents as *"the
  aggregate block is not any one approved step measurement"*.
- **`test_overall_height_round_trips_through_generated_script`** — #1512's two ink crossings no
  longer occur, because the coalesced chain routes to a detail and leaves neither the `4× 2`
  repeat label nor the boss witnesses on that view. Recorded as **the reproduction
  disappearing, not the debt being paid**: the bounded ink solver still never sees the
  combined cross-pass set, which is what #1512 is about. Asserted as absence so a reappearance
  fails.
- **`test_issue_740`** — #1511's 6 mm and 4 mm heights are still stated and still claimed, but
  as **step** lengths in the detail: coalescing folds those two cylinders into the turned
  profile, so they are not bosses any more. Asserted as values-with-provenance rather than by
  an annotation prefix that would now be asserting a classification this fixture does not have.

`CTC05_STEPS` moves from five rungs to three. The invariance assertions beside it kept passing
throughout — both encodings agreed before and after — so only the pinned roster moved, which is
what that pin exists to force.

## A wrong turn, recorded

I first read the aggregate block's unclaimed `20` as a regression this bump introduced, and
started suppressing it. It is not: it is designed, documented behaviour with a test asserting
it. My change broke four tests that exist to protect it, and `from_model.py` is fully reverted
here — this PR touches no rendering code. I had also claimed #1512 was resolved before checking
whether content had merely moved. Both corrections are reflected above.

## Evidence

- Fast tier: **8445 passed**, 5 skipped, 13 xfailed (245 s).
- Slow tier: **62 passed, 2 xfailed** (224 s, `-n auto --dist worksteal`).
- `ruff format --check` and `ruff check` exit 0 over `src/` and `tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3VevbCf1UWuPzj3G927ef
