### PR TITLE
feat: make reproducible exports the default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ## Unreleased
 
+### Changed
+
+- **Exports are reproducible by default.** `reproducible` now defaults to `True`
+  on `build_drawing`, `make_drawing`, `Drawing` and `Drawing.export`, so two
+  exports of one drawing are byte-identical without asking. Pass
+  `reproducible=False` to opt out.
+
+  It was opt-in on a cost argument, and the cost turns out to be small at the
+  scale most drawings are made: on the NIST CTC-01 AP242 fixture, +0.27 s on a
+  13.4 s job (+3.2% of export, +2.0% overall). The +32% of export measured when
+  the flag was introduced was a 358-part assembly; the ordering work is one
+  bounding box and one edge walk per part, so it scales with part count and a
+  part-heavy sheet is still the case to opt out of.
+
+  Two things pushed the default over. A file that changes between runs cannot be
+  diffed, checksummed or cached — the reason to want it is not speed-shaped. And
+  neither the CLI nor `Sheet` exposes the flag at all, so every drawing made
+  through those surfaces was non-reproducible with no way to change it.
+
+  One behaviour follows from the default rather than from this change: a DXF
+  export that cannot reach the ezdxf document to pin its metadata now raises
+  rather than writing live data, because every export now claims
+  reproducibility. Opting out restores the old fallback.
+
+
 ### Added
 
 - Report schema v1 now projects one recognition-owned physical requirement ledger shared with

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -507,7 +507,7 @@ def _assemble(
     trace=None,
     shape=None,
     critique_recognition_cache=None,
-    reproducible=False,
+    reproducible=True,
 ) -> Drawing:
     """Project the 4 views for analysis *a*, run the automatic annotation
     passes, and fit the iso.  This is pass 1 of :func:`build_drawing`; with a
@@ -816,7 +816,7 @@ def _repack(
     authored=None,
     trace=None,
     critique_recognition_cache=None,
-    reproducible=False,
+    reproducible=True,
 ):
     """Measure the laid-out drawing's *real* per-view annotation footprints and,
     when a view collides across views, pack the blocks disjoint — escalating the
@@ -1045,7 +1045,7 @@ def _repack_to_fixed_point(
     authored=None,
     trace=None,
     critique_recognition_cache=None,
-    reproducible=False,
+    reproducible=True,
 ):
     """Iterate measure→repack→assemble until stable or bounded (#302)."""
     cur_a, cur_dwg = a, dwg
@@ -1145,7 +1145,7 @@ def _build_drawing_once(
     projection: str | None = None,
     projection_symbol: bool = True,
     zones: bool = False,
-    reproducible: bool = False,
+    reproducible: bool = True,
     framed_recognition: bool = False,
     text_position: str = "inline",
     text_orientation: str = "aligned",
@@ -1201,10 +1201,14 @@ def _build_drawing_once(
         reproducible: write files that do not carry the run that produced them, so
             two exports of one drawing are byte-identical and a written drawing can be
             diffed or checksummed to see whether its content really changed. Sets the
-            default for :meth:`Drawing.export`'s own ``reproducible=``. ``False``
-            because it is not free: settling the element order costs roughly a third
-            of DXF export time again (one bounding box and one edge walk per part),
-            while the metadata pinning it also turns on is ~1 ms.
+            default for :meth:`Drawing.export`'s own ``reproducible=``. ``True``:
+            a drawing that differs between runs cannot be diffed, checksummed or
+            cached, and the cost is small on a part — measured on the NIST CTC-01
+            AP242 fixture it is +0.27 s on a 13.4 s job (+3.2% of export, +2.0%
+            overall). Pass ``False`` to opt out where it is not small: the cost is
+            one bounding box and one edge walk per part, so it grows with part
+            count and reached +32% of export on a 358-part assembly. The metadata
+            pinning the flag also turns on is ~1 ms either way.
         framed_recognition: opt an automatic build into the provider-owned local recognition
             frame. Caller geometry remains provenance, the exact local solid feeds downstream
             geometry stages, and a typed refusal has one visible top-level raw fallback. Raw
@@ -1858,7 +1862,7 @@ def build_drawing(
     projection: str | None = None,
     zones: bool = False,
     scale_policy: Literal["strict", "fallback", "permissive"] = "fallback",
-    reproducible: bool = False,
+    reproducible: bool = True,
     framed_recognition: bool = False,
     text_position: str = "inline",
     text_orientation: str = "aligned",
@@ -2816,7 +2820,7 @@ def make_drawing(
     projection: str | None = None,
     zones: bool = False,
     scale_policy: Literal["strict", "fallback", "permissive"] = "fallback",
-    reproducible: bool = False,
+    reproducible: bool = True,
     framed_recognition: bool = False,
     text_position: str = "inline",
     text_orientation: str = "aligned",

--- a/src/draftwright/drawing.py
+++ b/src/draftwright/drawing.py
@@ -662,8 +662,8 @@ class Drawing:
             multi-solid part as an assembly (per-part bores at ``info``),
             ``True``/``False`` forces it (#69).
         reproducible: default for :meth:`export`'s ``reproducible=`` — when true, two
-            exports of this drawing are byte-identical. ``False`` by default because
-            it costs roughly a third of DXF export time again (see
+            exports of this drawing are byte-identical. ``True`` by default; pass
+            ``False`` to trade that for export speed on a part-heavy sheet (see
             :func:`draftwright.export._elements`).
 
     The constructor also accepts ``cyls``, a precomputed
@@ -687,7 +687,7 @@ class Drawing:
         working_part=None,
         cyls=None,
         assembly=None,
-        reproducible=False,
+        reproducible=True,
     ):
         self.scale = scale
         # Public, JSON-friendly record of how the requested drawing scale was resolved
@@ -4682,7 +4682,7 @@ class Drawing:
         else:
             _log.info("Lint: OK")
 
-    def _write_svg(self, out: str, *, reproducible: bool = False) -> str:
+    def _write_svg(self, out: str, *, reproducible: bool = True) -> str:
         """Write the SVG (part/hidden/dims layers, page-size fix, arc sanitise, hyperlink +
         metadata) and return its path. The PDF and PNG renders both read this SVG.
 
@@ -4713,7 +4713,7 @@ class Drawing:
         _log.info("SVG → %s", svg_path)
         return svg_path
 
-    def _write_dxf(self, out: str, *, reproducible: bool = False) -> str:
+    def _write_dxf(self, out: str, *, reproducible: bool = True) -> str:
         """Write the DXF (part/hidden/dims layers + metadata) and return its path.
 
         *reproducible* orders the entities and pins the metadata ezdxf stamps from
@@ -5351,11 +5351,12 @@ class Drawing:
         order is settled and the metadata the exporters take from the clock is pinned,
         so a written drawing can be diffed or checksummed to see whether its content
         actually changed. ``None`` (the default) uses :attr:`reproducible`, which
-        :func:`~draftwright.build_drawing` sets and which is ``False`` unless asked
-        for: ordering costs roughly a third of DXF export time again (see
-        :func:`draftwright.export._elements`), so it is opted into rather than paid
-        by every caller. Passing the keyword here overrides the drawing's default for
-        this call only.
+        :func:`~draftwright.build_drawing` sets and which is ``True`` unless the
+        caller opts out: a file that changes between runs cannot be diffed,
+        checksummed or cached, and that is worth more than the ordering costs on a
+        part (+2.0% of a whole CTC-01 job). The cost grows with part count, so a
+        part-heavy sheet may want ``False`` — see :func:`draftwright.export._elements`.
+        Passing the keyword here overrides the drawing's default for this call only.
         """
         self.finalize()  # #426: drain any recorded intents before export (no-op if none)
         # An explicit keyword wins; otherwise the drawing's own default (build_drawing's).

--- a/src/draftwright/export.py
+++ b/src/draftwright/export.py
@@ -372,7 +372,7 @@ def set_dxf_metadata(dxf) -> None:
         pass
 
 
-def write_dxf(dxf, path: str, page_w: float, page_h: float, reproducible: bool = False) -> None:
+def write_dxf(dxf, path: str, page_w: float, page_h: float, reproducible: bool = True) -> None:
     """Write *dxf* with the viewport zoomed to the known page window.
 
     ``ExportDXF.write`` resets the viewport via ``ezdxf.zoom.extents`` — a
@@ -542,7 +542,7 @@ def _render_pdf(
     pdf_path: str,
     link_rect=None,
     text_runs=(),
-    reproducible: bool = False,
+    reproducible: bool = True,
 ) -> None:
     """Render *svg_path* to *pdf_path* via svglib + reportlab, adding draftwright
     metadata and — when *link_rect* (drawing page coords, Y up) is given — a

--- a/tests/test_export_dxf_zoom.py
+++ b/tests/test_export_dxf_zoom.py
@@ -60,6 +60,23 @@ def test_write_dxf_falls_back_without_ezdxf_internals(tmp_path):
         def write(self, path):
             self.wrote = path
 
+    # The fallback still writes when reproducibility is not being claimed.
     exp = Opaque()
-    write_dxf(exp, str(tmp_path / "o.dxf"), 210.0, 297.0)
+    write_dxf(exp, str(tmp_path / "o.dxf"), 210.0, 297.0, reproducible=False)
     assert exp.wrote == str(tmp_path / "o.dxf")
+
+
+def test_write_dxf_refuses_rather_than_write_live_data_when_pinning_is_impossible(tmp_path):
+    """Reproducible is the default now, so this is the default path too.
+
+    Without the ezdxf document the metadata cannot be pinned, and a file that
+    silently carries the clock while the caller believes it reproducible is
+    worse than no file.
+    """
+
+    class Opaque:
+        def write(self, path):  # pragma: no cover - must not be reached
+            raise AssertionError("wrote a live-data DXF while claiming reproducibility")
+
+    with pytest.raises(RuntimeError, match="requires access to the ezdxf document"):
+        write_dxf(Opaque(), str(tmp_path / "o.dxf"), 210.0, 297.0)

--- a/tests/test_export_reproducible.py
+++ b/tests/test_export_reproducible.py
@@ -346,12 +346,19 @@ def test_write_dxf_reproducible_pins_the_creation_marker_too(tmp_path):
     assert text.count(_CONST_MARKER) == 2  # CREATED_BY_EZDXF and WRITTEN_BY_EZDXF
 
 
-def test_write_dxf_is_not_reproducible_by_default(tmp_path):
-    """Opt-in: an unasked-for export pays nothing and carries the clock, as before."""
-    assert _write(tmp_path, "default.dxf") != _write(tmp_path, "pinned.dxf", reproducible=True)
+def test_write_dxf_is_reproducible_by_default(tmp_path):
+    """On unless refused: a file nobody asked to pin still must not carry the run."""
+    assert _write(tmp_path, "default.dxf") == _write(tmp_path, "pinned.dxf", reproducible=True)
     default = _write(tmp_path, "default2.dxf")
-    assert _header_value(default, "TDCREATE") != _FIXED_JULIAN
-    assert _LIVE_MARKER.search(default)
+    assert _header_value(default, "TDCREATE") == _FIXED_JULIAN
+    assert not _LIVE_MARKER.search(default)
+
+
+def test_write_dxf_opting_out_still_lets_the_clock_through(tmp_path):
+    """The escape hatch is the point of keeping the flag: it must still work."""
+    opted_out = _write(tmp_path, "opted.dxf", reproducible=False)
+    assert _header_value(opted_out, "TDCREATE") != _FIXED_JULIAN
+    assert _LIVE_MARKER.search(opted_out)
 
 
 def test_the_classes_entries_we_seed_are_registered_in_sorted_order(tmp_path):
@@ -499,10 +506,10 @@ def test_render_pdf_reproducible_writes_the_same_bytes_twice(small_svg, tmp_path
     assert a.read_bytes() == b.read_bytes()
 
 
-def test_render_pdf_is_not_reproducible_by_default(small_svg, tmp_path):
+def test_render_pdf_is_reproducible_by_default(small_svg, tmp_path):
     out = tmp_path / "default.pdf"
     _render_pdf(small_svg, str(out))
-    assert _FIXED_PDF_DATE not in out.read_bytes()
+    assert _FIXED_PDF_DATE in out.read_bytes()
 
 
 def test_reproducible_pdf_does_not_fall_back_to_a_live_render(small_svg, tmp_path, monkeypatch):
@@ -557,15 +564,26 @@ def _spy(monkeypatch):
     return seen
 
 
-def test_export_does_no_reproducibility_work_by_default(plate, tmp_path, monkeypatch):
-    """The default export must not pay for what it was not asked for.
+def test_export_does_the_reproducibility_work_by_default(plate, tmp_path, monkeypatch):
+    """The default export must actually do the work, not merely produce a file.
 
-    Not "produces a file that happens to differ" — that is unobservable in one run.
-    This asserts the work is *not requested*: no canonicalisation pass over the SVG,
-    nothing ordered, nothing pinned.
+    Not "produces a file that happens to match" — that is unobservable in one run.
+    This asserts the work is *requested*: the SVG is canonicalised, the DXF is
+    ordered, the metadata is pinned. The SVG is deliberately handed its shapes
+    unordered even so; it reaches the guarantee by canonicalising the written
+    file, and ordering it too would pay the expensive half twice.
     """
     seen = _spy(monkeypatch)
     plate.export(str(tmp_path / "d"), formats=("svg", "dxf"))
+    assert seen["canonicalized"] == 1
+    assert seen["ordered"] == {("ExportSVG", False), ("_DraftwrightDXF", True)}
+    assert seen["pinned"] == {True}
+
+
+def test_export_opting_out_does_no_reproducibility_work(plate, tmp_path, monkeypatch):
+    """The opt-out must buy back the whole cost, not just the metadata pin."""
+    seen = _spy(monkeypatch)
+    plate.export(str(tmp_path / "d"), formats=("svg", "dxf"), reproducible=False)
     assert seen["canonicalized"] == 0
     assert seen["ordered"] == {("ExportSVG", False), ("_DraftwrightDXF", False)}
     assert seen["pinned"] == {False}
@@ -605,8 +623,9 @@ def test_build_drawing_sets_the_drawings_own_default(tmp_path, monkeypatch):
     assert seen["pinned"] == {True}
 
 
-def test_build_drawing_defaults_to_off(tmp_path):
-    assert build_drawing(Box(30, 20, 10)).reproducible is False
+def test_build_drawing_defaults_to_on(tmp_path):
+    assert build_drawing(Box(30, 20, 10)).reproducible is True
+    assert build_drawing(Box(30, 20, 10), reproducible=False).reproducible is False
 
 
 def test_reproducible_is_appended_after_the_existing_positional_scale_policy():
@@ -615,12 +634,12 @@ def test_reproducible_is_appended_after_the_existing_positional_scale_policy():
         assert parameters.index("scale_policy") < parameters.index("reproducible")
 
 
-def test_a_directly_constructed_drawing_defaults_to_off():
+def test_a_directly_constructed_drawing_defaults_to_on():
     """``build_drawing`` is not the only door: ``Drawing`` is public and constructible.
 
     Separate from the test above because that one cannot see this: ``build_drawing``
     passes its own ``reproducible=`` down explicitly, so it would keep reporting
-    ``False`` even if the constructor's default were flipped.
+    its own default even if the constructor's were left behind.
     """
     drawing = Drawing(
         scale=1.0,
@@ -633,7 +652,7 @@ def test_a_directly_constructed_drawing_defaults_to_off():
         centroid=(0.0, 0.0, 0.0),
         out="x",
     )
-    assert drawing.reproducible is False
+    assert drawing.reproducible is True
 
 
 @pytest.mark.parametrize("drawing_default", [True, False])
@@ -651,7 +670,9 @@ def test_the_pdf_render_follows_the_same_flag(plate, tmp_path):
     b = plate.export(str(tmp_path / "p2"), formats=("pdf",), reproducible=True)["pdf"]
     assert Path(a).read_bytes() == Path(b).read_bytes()
     plain = plate.export(str(tmp_path / "p3"), formats=("pdf",))["pdf"]
-    assert _FIXED_PDF_DATE not in Path(plain).read_bytes()
+    assert _FIXED_PDF_DATE in Path(plain).read_bytes()
+    opted_out = plate.export(str(tmp_path / "p4"), formats=("pdf",), reproducible=False)["pdf"]
+    assert _FIXED_PDF_DATE not in Path(opted_out).read_bytes()
 
 
 # ------------------------------------------------------- the gate: two real runs


### PR DESCRIPTION
Closes nothing — this is the default flip you asked for after we measured the cost on a real part.

## Why the default moves

`reproducible` was made opt-in in `d643cc4` on a measured cost: **+32% of export time**. That number came from a 358-part assembly. On a part it is much smaller.

NIST CTC-01 AP242, A3 sheet, interleaved, 5 runs each, minima:

```
build                                    4.790 s
export svg+dxf+pdf  reproducible=False   8.564 s
export svg+dxf+pdf  reproducible=True    8.835 s
cost                                    +0.271 s   (+3.2% of export, +2.0% of the job)
```

The ordering work is one bounding box and one edge walk per part, so it scales with part count:

| Workload | Ordering cost |
|---|---|
| Simple bracket | +6% of export |
| **NIST CTC-01** | **+3.2% of export, +2.0% of job** |
| 358-part assembly (the original measurement) | +32% of export |

A part-heavy sheet is still the case to opt out of, and the flag stays for exactly that.

## What decided it

Two things, neither of them the 2%.

**A file that changes between runs cannot be diffed, checksummed or cached.** The reason to want reproducibility is not speed-shaped, so it does not trade cleanly against a percentage.

**Neither the CLI nor `Sheet` exposes the flag at all.** `grep reproducible src/draftwright/cli.py src/draftwright/sheet.py` returns nothing — so every drawing made through those surfaces was non-reproducible, with no way to change it. That is the majority of users, and the flag was unreachable to them.

Verified after the change, three separate processes each:

```
CLI PDF (no flag exists on this surface)   0cc93aee23e2f0c2  ×3
library svg/dxf, no flag passed            82e5c4b29735 / 9d1f7b0933a3  ×3
```

Both match what `reproducible=True` produced before the change, and the pre-change default produced three different digests each.

## Tests

Six tests pinned the old default. Each guarded something worth keeping, so each is **inverted rather than deleted**, and the opt-out path it implicitly covered is now covered explicitly — the DXF clock, the PDF date, the spy on which work is actually requested, and both constructor doors (`build_drawing` and a directly built `Drawing`). `test_export_reproducible.py` goes 39 → 41.

## One behavioural consequence, not just a default

`write_dxf` refuses rather than writing live data when it cannot reach the ezdxf document to pin metadata. That refusal was written for a *requested* reproducible export — and every export now requests one, so it is reachable by default where it was not before. The fallback still works under `reproducible=False`, and there is now a test for each side.

It is not reachable through the shipped exporter, which always carries the document; `test_write_dxf_falls_back_without_ezdxf_internals` constructs a fake to exercise the seam. Flagging it because it is the one place where flipping a default changes behaviour rather than just cost.

Full fast tier 8465 passed. `scripts/pr-check --static` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeWRqP9V6ZrAnHNW2Cibn6