### PR TITLE
Re-plan the sheet when a required dimension has no room (#1590)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,51 @@
 
 ## Unreleased
 
+### Fixed
+
+- **A required dimension with nowhere to go now re-plans the sheet instead of being
+  reported and left (#1590).** The automatic recovery ladder — larger scales on the
+  selected page, then dropping the optional pictorial, then a larger page — already
+  existed and already refused any candidate that had not fixed the problem. It ran on
+  two symptoms: a turned part missing an axial station, and an **authored** intent that
+  failed to place. A required *envelope* dimension that found no room was neither, so
+  these drawings never entered the ladder at all — `scale_decision["attempts"]` came
+  back empty and an `overall_dim_withheld` error was reported on the first sheet tried.
+
+  `overall_dim_withheld` is deliberately not a scale blocker, and that is right:
+  reporting it through `placement_unsatisfiable` once made `build_drawing(part,
+  scale=...)` raise on parts that had always built. But that argument is about refusing
+  the scale a **caller asked for**. Choosing one automatically is a different question,
+  and one predicate was answering both.
+
+  What it changes, measured:
+
+  | part | before | after |
+  |---|---|---|
+  | stepped `Box(80, 60, 30)` | A4 1:1, overall depth withheld (error) | A4 1:1, **clean**, pictorial dropped |
+  | 80 × 60 plate, two close bores | A4 1:1, `incomplete`: unlocated hole, dropped location, withheld depth | A2 2:1, **clean**, every dimension placed |
+
+  Dropping the optional pictorial is the first lever, which is the order #443/#1299
+  already argue for — a pictorial cannot outrank a dimension needed to manufacture the
+  part. Pin `page=` or `scale=` to opt out; a pinned sheet still reports honestly rather
+  than replanning.
+
+- **A generated `--script` reproduces a re-planned layout.** A declared build does what
+  it is told and never enters the recovery ladder, so `generate_sheet_script` pins the
+  settled page, scale and view set into the script. It used to do that only for the two
+  families whose replan could be predicted from the model; nothing predicts the new
+  trigger, because whether a mark fits is a fact about a measured sheet. The reference
+  build is now unconditional — one extra `build_drawing` per generated script, measured
+  at 0.19 s for a plain box, 0.34 s for a pocket and 1.17 s for a part that actually
+  replans — and an **undrawable** source can never be the reason a script is not
+  written, the standard the inspection sidecar beside it already meets. A deliberate
+  refusal (an unknown page size, `ScaleIncompatibilityError`, `ViewPlanIncomplete`)
+  still reaches the caller.
+
+  A script that keeps `auto_dimensions()` is not handed a pinned view set: `Sheet`
+  refuses `authored_views()` beside it, so the two together wrote a script that raised
+  when run. The settled set is reported in a comment instead.
+
 ### Changed
 
 - **The title block carries every ISO 7200:2004 mandatory data field.** Three had

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@
   | stepped `Box(80, 60, 30)` | A4 1:1, overall depth withheld (error) | A4 1:1, **clean**, pictorial dropped |
   | 80 × 60 plate, two close bores | A4 1:1, `incomplete`: unlocated hole, dropped location, withheld depth | A2 2:1, **clean**, every dimension placed |
 
+  **ADR 2 invariant 13 is amended** to match. It read "the optional isometric yields only
+  to close missing axial coverage", which had been one trigger behind the code since
+  2026-08-23 — the record was consolidated twelve days later and transcribed the narrower
+  claim. It now states the principle the triggers share: the isometric yields only to
+  preserve manufacturing completeness, never for space, crowding or preference. The list
+  itself is `builder._ISO_YIELD_TRIGGERS`, and a guard fails if it changes, so the next
+  widening is caught by a test rather than by a reader.
+
   Dropping the optional pictorial is the first lever, which is the order #443/#1299
   already argue for — a pictorial cannot outrank a dimension needed to manufacture the
   part. Pin `page=` or `scale=` to opt out; a pinned sheet still reports honestly rather

--- a/docs/adr/0002-sheet-layout-and-view-planning.md
+++ b/docs/adr/0002-sheet-layout-and-view-planning.md
@@ -72,10 +72,13 @@ dependency runs one way: requirements determine views.
     Authored views with `auto_dimensions()` raises at the verb; an approved dimension no authored view
     can carry raises `ViewPlanIncomplete` naming the view to add; `view_decision` is always present.
     `test_issue_1260_view_constraints.py`, `test_adr0018_view_routing.py`.
-13. **View removal is requirement-aware.** The optional isometric yields only to close missing axial
-    coverage, on the settled page and arrangement, with every gate recorded; no principal view is
-    removed automatically. `test_adr0018_view_selection.py`, `test_issue_1262_automatic_turned_views.py`,
-    `test_issue_443_grm03_axial_coverage.py`, `test_issue_1190_section_decision.py`.
+13. **View removal is requirement-aware.** The optional isometric yields only to preserve
+    manufacturing completeness — never for space, crowding or preference — on the settled page and
+    arrangement, with the triggering symptom recorded in `scale_decision`; no principal view is
+    removed automatically. The triggers are `builder._ISO_YIELD_TRIGGERS`, and that tuple is what
+    this invariant is about: adding one amends this record. `test_adr0018_view_selection.py`,
+    `test_issue_1262_automatic_turned_views.py`, `test_issue_443_grm03_axial_coverage.py`,
+    `test_issue_1190_section_decision.py`.
 14. **Exact detail/iso factors; unequal principal scales refused.** `test_issue_1204_multiscale_view_issues.py`.
 15. **The solve is recordable.** `build_drawing(trace=…)` dumps every corridor solve and pass event;
     a strip-full drop names its occupants. `test_solve_trace.py`.

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -1590,6 +1590,22 @@ _REPLANNABLE_LOSS_CODES = tuple(
 )
 
 
+#: Every symptom that may make the optional isometric yield, in the order the gate tests
+#: them, and the vocabulary of the `remove_optional_iso` attempt status.
+#:
+#: **ADR 2 invariant 13 is about this tuple.** The isometric yields only to preserve
+#: manufacturing completeness, and these are the three ways a drawing can fail to be
+#: complete: a turned part missing an axial station, an authored requirement that cannot
+#: place, and a required dimension with nowhere to go. Adding a fourth is an amendment to
+#: that record — maintainer's sign-off, the record updated, and only then this tuple.
+#: `test_adr0018_view_selection.py::TestWhatMakesTheIsometricYield` fails if it changes.
+_ISO_YIELD_TRIGGERS = (
+    "axial_coverage_incomplete",
+    "required_outcome_dropped",
+    "required_dimension_withheld",
+)
+
+
 def _replannable_losses(issues) -> tuple:
     """Required dimensions that found no room, from one already-materialised lint pass.
 
@@ -2512,15 +2528,17 @@ def build_drawing(
             withheld = _replannable_losses(original_issues)
             if original_has_axial_gap or source_blockers or withheld:
                 # The recorded status names WHICH symptom opened the ladder, so the
-                # decision reads back honestly. `required_outcome_dropped` would be wrong
-                # for a withheld dimension: nothing was dropped as a blocker — the mark
-                # was approved and had nowhere to go.
+                # decision reads back honestly, and the vocabulary is
+                # `_ISO_YIELD_TRIGGERS` — the declared list ADR 2 invariant 13 is about.
+                # `required_outcome_dropped` would be wrong for a withheld dimension:
+                # nothing was dropped as a blocker — the mark was approved and had
+                # nowhere to go.
                 if original_has_axial_gap:
-                    entry_status = "axial_coverage_incomplete"
+                    entry_status = _ISO_YIELD_TRIGGERS[0]
                 elif source_blockers:
-                    entry_status = "required_outcome_dropped"
+                    entry_status = _ISO_YIELD_TRIGGERS[1]
                 else:
-                    entry_status = "required_dimension_withheld"
+                    entry_status = _ISO_YIELD_TRIGGERS[2]
                 _record_attempt(
                     drawing.scale,
                     entry_status,

--- a/src/draftwright/builder.py
+++ b/src/draftwright/builder.py
@@ -59,6 +59,7 @@ from draftwright.annotations._common import (
 )
 from draftwright.annotations.gears import render_gear_tables
 from draftwright.annotations.orchestrator import (
+    _WITHHOLDING_CODES,
     _auto_annotate,
     build_model,
     build_rotational_feature,
@@ -1567,6 +1568,44 @@ def _is_required_scale_drop(issue) -> bool:
     return True
 
 
+#: Placement failures a different sheet or scale can repair, which must NOT refuse an
+#: explicitly requested one.
+#:
+#: :func:`_is_required_scale_drop` answers one question — may this drawing be returned at the
+#: scale the CALLER asked for? — and these codes deliberately answer no to it. Reporting a
+#: withheld overall extent through `placement_unsatisfiable` made `build_drawing(part,
+#: scale=...)` raise `ScaleIncompatibilityError` on parts that had built for as long as the
+#: defect had existed, because that predicate matches by code name (#1216 review r9); the
+#: comment in `annotations/from_model.py` records the measurement.
+#:
+#: Choosing a sheet AUTOMATICALLY is a different question. There is no caller request to
+#: honour and nothing to refuse — a required dimension with nowhere to go is precisely what
+#: the recovery ladder exists to repair. One predicate served both questions, so the ladder
+#: could not see this symptom at all (#1590).
+#:
+#: The `*_dropped` member of the withholding vocabulary is excluded: it already ends in the
+#: suffix `_is_required_scale_drop` matches, so it is a blocker and needs no second route in.
+_REPLANNABLE_LOSS_CODES = tuple(
+    code for code in _WITHHOLDING_CODES if not code.endswith("_dropped")
+)
+
+
+def _replannable_losses(issues) -> tuple:
+    """Required dimensions that found no room, from one already-materialised lint pass.
+
+    The automatic path's third recovery trigger, beside an axial-coverage gap and an
+    authored-intent blocker. Severity is checked rather than assumed: the same codes are
+    recorded at `info` when the measurement is merely too small to letter at this scale,
+    which a larger sheet does fix — but by re-selecting the scale, not by replanning the
+    arrangement, and `step_dim_withheld` at `info` fires on ordinary complete drawings.
+    """
+    return tuple(
+        issue
+        for issue in issues
+        if issue.code in _REPLANNABLE_LOSS_CODES and issue.severity == "error"
+    )
+
+
 def _scale_blockers_from_issues(issues) -> tuple[dict, ...]:
     """Required placement failures from one already-materialised lint pass."""
     blockers = []
@@ -1840,10 +1879,25 @@ def _has_detail_view(views) -> bool:
     return any(name.startswith("detail_") for name in views)
 
 
+#: The ValueError messages a speculative build may raise WITHOUT it meaning a bug. Matched on
+#: message because the engine raises bare `ValueError` here; a purpose-built type would be
+#: better and is not this change's to introduce. Everything else — `ScaleIncompatibilityError`,
+#: `ViewPlanIncomplete`, `MultipleTurnedProfilesError`, an unknown page size — is a deliberate
+#: refusal under ADR 5 and must reach the caller rather than be logged and stepped over.
+_EXPECTED_CANDIDATE_FAILURES = (
+    # The speculative-page path: a scale at which the part's own geometry collapses.
+    "drawing geometry degenerates",
+    # A source with no solid body — a STEP file holding a bare curve projects nothing. The
+    # settled-layout reference build in `sheet_emit` sees this and must still write a script.
+    "project_to_viewport returned empty geometry",
+)
+
+
 def _is_expected_candidate_build_failure(exc: Exception) -> bool:
     """Whether a speculative build may reject without hiding an invariant bug."""
     return isinstance(exc, Standard_Failure) or (
-        isinstance(exc, ValueError) and "drawing geometry degenerates" in str(exc)
+        isinstance(exc, ValueError)
+        and any(known in str(exc) for known in _EXPECTED_CANDIDATE_FAILURES)
     )
 
 
@@ -2446,14 +2500,30 @@ def build_drawing(
             )
             settled_issues = original_issues
             recovered_on_selected_page = False
-            if original_has_axial_gap or source_blockers:
+            # #1590: the third symptom. A required envelope or step dimension that found no
+            # room is not a blocker by design (see `_REPLANNABLE_LOSS_CODES`), so the ladder
+            # used to skip these drawings entirely — `attempts` came back empty and an
+            # `overall_dim_withheld` error was reported on the first sheet tried.
+            #
+            # Scoped by the enclosing gate, which is worth stating so the next reader does
+            # not assume otherwise: this block runs only for a drawing that HAS the optional
+            # isometric. One that settled without it never replans for this symptom, however
+            # starved. Widening that is a separate question from the trigger.
+            withheld = _replannable_losses(original_issues)
+            if original_has_axial_gap or source_blockers or withheld:
+                # The recorded status names WHICH symptom opened the ladder, so the
+                # decision reads back honestly. `required_outcome_dropped` would be wrong
+                # for a withheld dimension: nothing was dropped as a blocker — the mark
+                # was approved and had nowhere to go.
+                if original_has_axial_gap:
+                    entry_status = "axial_coverage_incomplete"
+                elif source_blockers:
+                    entry_status = "required_outcome_dropped"
+                else:
+                    entry_status = "required_dimension_withheld"
                 _record_attempt(
                     drawing.scale,
-                    (
-                        "axial_coverage_incomplete"
-                        if original_has_axial_gap
-                        else "required_outcome_dropped"
-                    ),
+                    entry_status,
                     source_blockers,
                     reason="remove_optional_iso",
                     candidate=drawing,
@@ -2475,7 +2545,9 @@ def build_drawing(
                     settled_issues = upscaled_issues
                     replanned = True
                     recovered_on_selected_page = True
-            if (original_has_axial_gap or source_blockers) and not recovered_on_selected_page:
+            if (
+                original_has_axial_gap or source_blockers or withheld
+            ) and not recovered_on_selected_page:
                 try:
                     without_iso_proposal = _build(
                         None,

--- a/src/draftwright/sheet_emit.py
+++ b/src/draftwright/sheet_emit.py
@@ -47,6 +47,7 @@ from build123d import Shape
 from draftwright._core import _dimension_draft
 from draftwright.builder import (
     _detect_part_model_analysis,
+    _is_expected_candidate_build_failure,
     build_drawing,
 )
 from draftwright.fits import FitClass
@@ -1413,6 +1414,18 @@ def _is_mirrorable(model) -> bool:
     return not unmirrored_dimensions(model)
 
 
+def _mirrors_dimensions(model) -> bool:
+    """Whether the emitted script declares its own dimension set, or keeps the planner's.
+
+    False means the script keeps ``sheet.auto_dimensions()`` — a feature the emitter has no
+    line for would make a mirrored set silently incomplete (#938/#945), so the whole set
+    stays automatic. That is also what makes it load-bearing OUTSIDE the dimension block:
+    ``Sheet`` refuses ``authored_views()`` beside ``auto_dimensions()`` (ADR 2: requirements
+    determine views), so a script in that state cannot be handed a pinned view set either.
+    """
+    return model.authored_dimensions is not None or _is_mirrorable(model)
+
+
 def _mirrored_requests(declared, declared_envelope=None):
     """The compiler's feature/role/axis/member selectors, serialized for the mirror.
 
@@ -1495,7 +1508,7 @@ def _dimension_block(model, names: dict[int, str], synthesised_envelope=None) ->
     A generated script must state its source either way (ADR 4 (was 0016) / #874): a dimension the
     script does not name only means "omitted" inside a set that says it is complete.
     """
-    if model.authored_dimensions is None and not _is_mirrorable(model):
+    if not _mirrors_dimensions(model):
         # A feature with no declarative verb carries planned dimensions, so a mirrored set
         # would silently omit them and claim completeness it does not have (#938).
         # WHY, specifically. `_is_mirrorable` now fails for any dimension the compiler
@@ -2065,6 +2078,53 @@ def _adopted_view_block(constraints: ViewConstraints, names: Mapping[int, str]) 
     return lines
 
 
+def _settled_reference_build(*args, **kwargs):
+    """One reference build, or ``None`` if this source cannot be DRAWN.
+
+    Its only job is to reveal an automatic replan for :func:`settled_layout_for` to pin, so an
+    undrawable source must not be the reason a script is not written: a STEP file holding a
+    bare curve projects no side view, and `generate_sheet_script` still owes the caller a
+    script — the standard the inspection sidecar beside it already meets.
+
+    Narrow on purpose. It reuses `builder._is_expected_candidate_build_failure`, the
+    predicate the recovery ladder already uses to decide whether a speculative build may
+    reject quietly. A blanket `except ValueError` would also swallow
+    `ScaleIncompatibilityError`, `ViewPlanIncomplete`, `MultipleTurnedProfilesError` and an
+    unknown page size — deliberate refusals under ADR 5, which must reach the caller now and
+    not be demoted to a log line plus a script that fails when someone runs it.
+    """
+    try:
+        return build_drawing(*args, **kwargs)
+    except Exception as error:  # noqa: BLE001 — re-raised below unless expected
+        if not _is_expected_candidate_build_failure(error):
+            raise
+        _log.warning("No settled-layout reference build for this source: %s", error)
+        return None
+
+
+def settled_layout_for(drawing) -> dict | None:
+    """The layout an automatic build REPLANNED onto, for :func:`emit_sheet_script` to pin.
+
+    ``None`` when the build took its first plan, which is the common case and needs no
+    pinning: a declared script re-planning the same way from the same model reaches the same
+    sheet. It is the replan that a model cannot reproduce — the automatic path measures a
+    built sheet, finds a required mark has nowhere to go, and drops the optional pictorial or
+    spends a larger page. A declared build never enters that ladder (ADR 4: a declared script
+    does what it is told), so the resolved page, scale and view set have to be written down.
+
+    One function because two callers must agree on what "the settled layout" is:
+    :func:`generate_sheet_script`, and the round-trip parity tests that assert a generated
+    script draws and lints exactly what the automatic build did.
+    """
+    if drawing.scale_decision.get("status") != "automatic_replanned":
+        return None
+    return {
+        "scale": drawing.scale,
+        "page": (drawing.page_w, drawing.page_h),
+        "views": tuple(drawing.views),
+    }
+
+
 def emit_sheet_script(
     model,
     part_expr: str,
@@ -2320,12 +2380,29 @@ def emit_sheet_script(
     )
     if view_constraints is not None:
         lines += _adopted_view_block(view_constraints, _names)
-    elif principal_views and principal_views != ("front", "plan", "side", "iso"):
+    elif (
+        principal_views
+        and principal_views != ("front", "plan", "side", "iso")
+        and _mirrors_dimensions(model)
+    ):
         lines += [
             "# The automatic build settled on this complete view set; it is declared so",
             "# the editable authored-dimension mirror reproduces that resolved layout.",
             "sheet.authored_views()",
             *(f'sheet.view("{name}")' for name in principal_views),
+        ]
+    elif principal_views and principal_views != ("front", "plan", "side", "iso"):
+        # The settled set is known and deliberately NOT declared. This script keeps
+        # `sheet.auto_dimensions()` (see the dimension block above for why), and `Sheet`
+        # refuses `authored_views()` beside it — emitting both would write a script that
+        # raises the moment anyone runs it. Requirement-driven view selection may well reach
+        # this same set; it is not guaranteed to, and saying so beats a script that cannot
+        # run.
+        lines += [
+            "# The automatic build settled on: " + ", ".join(principal_views) + ".",
+            "# Not declared here: this script keeps auto_dimensions(), and a sheet cannot",
+            "# author its views and its dimensions separately (ADR 2 — requirements",
+            "# determine views). The view set is re-derived on each run and may differ.",
         ]
     else:
         lines.append("# front / plan / side / iso are produced automatically.")
@@ -2585,13 +2662,25 @@ def generate_sheet_script(
                     "No inspection sidecar written for %s: %s", source_display.name, error
                 )
         settled_layout = None
-        # Generated scripts mirror dimensions as an authored set. Resolve the two established
-        # semantic-correction families against the same immutable STEP snapshot as recognition.
-        may_need_semantic_correction = model.orientation is not None or any(
-            feature.kind == "step_level" for feature in model.features
-        )
-        if scale is None and may_need_semantic_correction:
-            settled = build_drawing(
+        # Generated scripts mirror dimensions as an authored set, and a declared build does
+        # what it is told — it never enters the automatic recovery ladder. So any replan the
+        # automatic path performs has to be BAKED IN here, against the same immutable STEP
+        # snapshot as recognition, or the script draws a different sheet from the part.
+        #
+        # This used to run only for the two families whose replan could be PREDICTED from the
+        # model (an orientation correction, a step_level ladder). #1590 adds a third trigger
+        # — a required dimension that found no room — and no property of the model predicts
+        # it: whether the mark fits is a fact about the measured sheet. A prediction that is
+        # wrong here is not a slow script, it is a script that silently disagrees with the
+        # part, so the filter is gone and the reference build is unconditional.
+        #
+        # It costs one extra `build_drawing` per generated script: measured 0.19 s for a
+        # plain box, 0.34 s for a pocket, and 1.17 s for a part that actually replans (where
+        # the ladder itself rebuilds — the case the extra build is FOR). `--script` writes a
+        # file for a person to read; paying that for a script that matches its own part is
+        # the right trade.
+        if scale is None:
+            settled = _settled_reference_build(
                 detection_source,
                 title=title,
                 number=number,
@@ -2615,12 +2704,7 @@ def generate_sheet_script(
                 pmi=pmi,
                 model=model,
             )
-            if settled.scale_decision.get("status") == "automatic_replanned":
-                settled_layout = {
-                    "scale": settled.scale,
-                    "page": (settled.page_w, settled.page_h),
-                    "views": tuple(settled.views),
-                }
+            settled_layout = None if settled is None else settled_layout_for(settled)
         script = emit_sheet_script(
             model,
             part_expr,

--- a/tests/refactor_golden/pocketed.json
+++ b/tests/refactor_golden/pocketed.json
@@ -51,6 +51,24 @@
     },
     {
       "geom_bbox": [
+        131.4,
+        79.0,
+        191.5,
+        110.4
+      ],
+      "label": "60",
+      "label_bbox": [
+        159.8,
+        107.3,
+        163.0,
+        109.4
+      ],
+      "name": "m_env_depth",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
         30.7,
         83.0,
         110.8,
@@ -159,24 +177,6 @@
     },
     {
       "geom_bbox": [
-        196.7,
-        92.9,
-        221.0,
-        95.6
-      ],
-      "label": "ISO VIEW (NTS)",
-      "label_bbox": [
-        196.7,
-        92.9,
-        221.0,
-        95.6
-      ],
-      "name": "note_iso_nts",
-      "type": "Note",
-      "view": null
-    },
-    {
-      "geom_bbox": [
         273.1,
         46.0,
         283.0,
@@ -222,11 +222,6 @@
   ],
   "build_issues": [
     [
-      "error",
-      "overall_dim_withheld",
-      "overall depth dimension not placed (side-view below and above strips full; below occupied by: title_block; above occupied by: m_locy1, m_locy0)"
-    ],
-    [
       "info",
       "step_dim_withheld",
       "1 approved step height(s) span less than 12.4 mm on the page from the ladder's datum and are not dimensioned at this scale"
@@ -243,12 +238,6 @@
       55.0,
       110.7,
       75.0
-    ],
-    "iso": [
-      145.2,
-      100.3,
-      272.5,
-      194.7
     ],
     "plan": [
       30.7,

--- a/tests/refactor_golden/prismatic_ladder.json
+++ b/tests/refactor_golden/prismatic_ladder.json
@@ -56,6 +56,24 @@
     },
     {
       "geom_bbox": [
+        146.5,
+        84.0,
+        206.6,
+        105.9
+      ],
+      "label": "60",
+      "label_bbox": [
+        174.9,
+        102.8,
+        178.1,
+        104.9
+      ],
+      "name": "m_env_depth",
+      "type": "Dimension",
+      "view": "side"
+    },
+    {
+      "geom_bbox": [
         30.0,
         88.0,
         110.1,
@@ -71,24 +89,6 @@
       "name": "m_env_width",
       "type": "Dimension",
       "view": "plan"
-    },
-    {
-      "geom_bbox": [
-        196.3,
-        97.7,
-        220.7,
-        100.3
-      ],
-      "label": "ISO VIEW (NTS)",
-      "label_bbox": [
-        196.3,
-        97.7,
-        220.7,
-        100.3
-      ],
-      "name": "note_iso_nts",
-      "type": "Note",
-      "view": null
     },
     {
       "geom_bbox": [
@@ -135,13 +135,7 @@
       "view": null
     }
   ],
-  "build_issues": [
-    [
-      "error",
-      "overall_dim_withheld",
-      "overall depth dimension not placed (side-view below and above strips full; below occupied by: title_block; above occupied by: dim_shoulder_y0)"
-    ]
-  ],
+  "build_issues": [],
   "item_count": 8,
   "page": [
     297.0,
@@ -153,12 +147,6 @@
       50.0,
       110.0,
       80.0
-    ],
-    "iso": [
-      153.9,
-      105.0,
-      263.1,
-      195.0
     ],
     "plan": [
       30.0,

--- a/tests/test_adr0018_view_selection.py
+++ b/tests/test_adr0018_view_selection.py
@@ -621,3 +621,75 @@ class TestTheCaseStudy:
             build_drawing(self._plate(), _views=("plan", "side"))
         assert caught.value.uncovered
         assert all(item.preferred_view == "front" for item in caught.value.uncovered)
+
+
+class TestWhatMakesTheIsometricYield:
+    """ADR 2 invariant 13, made machine-checkable.
+
+    The record used to enumerate one trigger — "yields only to close missing axial
+    coverage" — while the code had two. The second (an authored requirement that cannot
+    place) went in on 2026-08-23; the corpus was consolidated on 2026-09-04 and
+    transcribed the older, narrower claim. Nothing caught it, because the invariant's
+    four cited guards all test what happens AFTER the isometric yields, and none pins WHY
+    it may.
+
+    So the record now states the principle — the isometric yields only to preserve
+    manufacturing completeness — and this pins the list it is a principle about. A fourth
+    trigger fails the first test here, which is the intended cost: it is an amendment, and
+    an amendment needs the maintainer before it needs code.
+    """
+
+    def test_the_trigger_list_is_exactly_these_three(self):
+        from draftwright.builder import _ISO_YIELD_TRIGGERS
+
+        assert _ISO_YIELD_TRIGGERS == (
+            "axial_coverage_incomplete",  # a turned part missing an axial station
+            "required_outcome_dropped",  # an authored requirement that cannot place
+            "required_dimension_withheld",  # a required dimension with nowhere to go
+        ), (
+            "Adding or renaming a trigger changes ADR 2 invariant 13. Get the maintainer's "
+            "sign-off, amend docs/adr/0002-sheet-layout-and-view-planning.md, then this."
+        )
+
+    def test_each_trigger_is_a_completeness_failure_not_a_preference(self):
+        """The principle the record now states, checked rather than asserted in prose.
+
+        Every trigger must be a way the drawing is INCOMPLETE. A trigger that fired on a
+        crowded sheet, a tight margin or an aesthetic judgement would satisfy the tuple
+        above and still break the invariant, so the names are matched against the
+        engine's own completeness vocabulary rather than eyeballed.
+        """
+        from draftwright.builder import _ISO_YIELD_TRIGGERS
+
+        for trigger in _ISO_YIELD_TRIGGERS:
+            assert any(word in trigger for word in ("incomplete", "dropped", "withheld")), (
+                f"{trigger!r} does not name a completeness failure"
+            )
+
+    def test_a_withheld_required_dimension_makes_it_yield(self):
+        """The third trigger, end to end (#1590).
+
+        Its precondition is that this part HAS an isometric to give up and cannot place its
+        overall depth while it keeps it — otherwise the test passes without the trigger
+        ever firing.
+        """
+        part = Box(80, 60, 30) - Pos(0, -20, 7.5) * Box(80, 20, 15)
+        pinned = build_drawing(part, number="X", page="A4", scale=1.0, scale_policy="permissive")
+        assert "iso" in pinned.views
+        assert [i.code for i in pinned.lint() if i.severity == "error"] == ["overall_dim_withheld"]
+
+        automatic = build_drawing(part, number="X")
+        assert "iso" not in automatic.views
+        assert automatic.get_annotation("m_env_depth") is not None
+        assert not [i for i in automatic.lint() if i.severity == "error"]
+
+    def test_no_principal_view_is_removed_to_recover(self):
+        """The half of invariant 13 that did NOT move: only the OPTIONAL view yields.
+
+        A recovery that reached for a principal view would buy the same room and lose a
+        face of the part, so the ladder must never do it however starved the sheet.
+        """
+        part = Box(80, 60, 30) - Pos(0, -20, 7.5) * Box(80, 20, 15)
+        automatic = build_drawing(part, number="X")
+        assert automatic.scale_decision["status"] == "automatic_replanned"
+        assert {"front", "plan", "side"} <= set(automatic.views)

--- a/tests/test_issue_1215_no_approved_tolerance_is_dropped.py
+++ b/tests/test_issue_1215_no_approved_tolerance_is_dropped.py
@@ -609,7 +609,14 @@ def test_a_doubly_starved_extent_is_still_reported(monkeypatch):
         return real(*args, **kwargs)
 
     monkeypatch.setattr(fm, "place_strip_candidates", refuse_fallthrough)
-    drawing = build_drawing(_starved_extent_plate(), title="T", number="N")
+    # `_include_iso=False` so the automatic recovery ladder cannot act. #1590 made a withheld
+    # required dimension a replan trigger, and the ladder's first move — drop the optional
+    # ISO — frees this fixture's below strip. That is the engine doing the right thing, and it
+    # would leave this test asserting a report on a drawing that no longer starves (its own
+    # precondition catches that). Starting without the ISO both removes the lever and keeps
+    # the strips full, so the subject survives: when both strips ARE full, the drop is
+    # reported rather than vanishing.
+    drawing = build_drawing(_starved_extent_plate(), _include_iso=False, title="T", number="N")
     assert "m_env_width" not in drawing.registry.names(), (
         "precondition: the refusal did not apply — the fallthrough placed the width anyway, "
         "so nothing below tests the report"

--- a/tests/test_issue_1460_step_inspection.py
+++ b/tests/test_issue_1460_step_inspection.py
@@ -794,3 +794,40 @@ def test_the_cli_prints_the_document_path_and_no_report_suppresses_it(tmp_path, 
     assert result.exit_code == 0, result.output
     assert "without.draftwright-inspection.json" not in result.output
     assert not (tmp_path / "without.draftwright-inspection.json").exists()
+
+
+def test_an_undrawable_source_still_generates_a_script(tmp_path, monkeypatch, caplog):
+    """The settled-layout reference build (#1590) is held to the sidecar's standard.
+
+    It exists only to reveal an automatic replan worth pinning, so a source that cannot be
+    DRAWN must not cost the caller their script. A STEP file holding a bare curve projects
+    no side view, which is the case that motivated the catch.
+    """
+    from draftwright.sheet_emit import generate_sheet_script
+
+    monkeypatch.chdir(tmp_path)
+    export_step(Line((0, 0, 0), (10, 0, 0)), "curve.step")
+
+    with caplog.at_level(logging.WARNING, logger="draftwright.sheet_emit"):
+        py_path = generate_sheet_script("curve.step", out="curve")
+
+    assert Path(py_path).exists()
+    assert "No settled-layout reference build" in caplog.text
+
+
+def test_a_deliberate_refusal_is_not_demoted_to_a_warning(tmp_path, monkeypatch, caplog):
+    """The counterpart, and the reason the catch is narrow.
+
+    A blanket `except ValueError` around that build would also swallow every deliberate
+    refusal the engine raises — an unknown page size, `ScaleIncompatibilityError`,
+    `ViewPlanIncomplete` — turning a hard failure the caller must see into a log line and a
+    script that fails only when somebody runs it. `_is_expected_candidate_build_failure`
+    admits the undrawable-source messages and nothing else.
+    """
+    from draftwright.sheet_emit import generate_sheet_script
+
+    monkeypatch.chdir(tmp_path)
+    with caplog.at_level(logging.WARNING, logger="draftwright.sheet_emit"):
+        with pytest.raises(ValueError, match="unknown page size"):
+            generate_sheet_script(Box(40, 30, 12), out="box", page="A11")
+    assert "No settled-layout reference build" not in caplog.text

--- a/tests/test_issue_1593_title_block_keepout.py
+++ b/tests/test_issue_1593_title_block_keepout.py
@@ -94,22 +94,52 @@ def test_a_displaced_dimension_stays_on_the_sheet(name, monkeypatch):
     assert not [issue for issue in after.lint() if issue.severity == "error"]
 
 
-def test_a_dimension_with_nowhere_to_go_is_reported_not_dropped(monkeypatch):
-    """The remaining cost, stated rather than hidden.
+def test_a_dimension_with_nowhere_to_go_is_replanned_onto_a_sheet_that_fits():
+    """The cost, and what #1590 then does about it.
 
-    On A4 at 1:1 this part's side view has the title block below and a shoulder dim
-    above, so the overall depth has no clear strip. Before #1593 it was drawn through
-    the block; now it is withheld, as an ERROR that names the block. A larger sheet or a
-    smaller scale places it — choosing one without knowing the dimension needed the room
-    is #1590.
+    Pinned to this sheet, the part's side view has the title block below and a shoulder
+    dim above, so the overall depth has no clear strip: it is withheld as an ERROR that
+    names the block, rather than drawn through it as before #1593. Left automatic, that
+    error is now a replan trigger (#1590) and the engine returns a sheet that carries the
+    dimension — here by dropping the optional pictorial, which #443/#1299 already rank
+    below a dimension needed to manufacture the part.
     """
-    drawing = _build("stepped", keep_out=True, monkeypatch=monkeypatch)
-    (withheld,) = [i for i in drawing.lint() if i.code == "overall_dim_withheld"]
-    assert withheld.severity == "error"
-    assert "title_block" in withheld.message
+    # Page and scale pinned, so the recovery ladder does not run and this sheet is the one
+    # under test. No `scale_policy` is needed and that is the point worth pinning: an
+    # explicitly requested scale is still HONOURED, under every policy, because
+    # `overall_dim_withheld` is not a scale blocker. Reporting it as one made
+    # `build_drawing(scale=...)` raise on parts that had always built (#1216 review r9), and
+    # #1590 makes the withheld dimension a replan trigger WITHOUT disturbing that.
+    for policy in ("strict", "fallback", "permissive"):
+        pinned = build_drawing(
+            CASES["stepped"][0], number="X", page="A4", scale=1.0, scale_policy=policy
+        )
+        assert pinned.scale_decision["status"] == "honored"
+        assert pinned.scale_decision.get("blockers", ()) == ()
+        (withheld,) = [i for i in pinned.lint() if i.code == "overall_dim_withheld"]
+        assert withheld.severity == "error"
+        assert "title_block" in withheld.message
+        assert _inside_the_block(pinned) == []
 
-    monkeypatch.undo()
-    roomier = build_drawing(CASES["stepped"][0], number="X", page="A3")
-    assert roomier.get_annotation("m_env_depth") is not None
-    assert _inside_the_block(roomier) == []
-    assert not [issue for issue in roomier.lint() if issue.severity == "error"]
+    automatic = build_drawing(CASES["stepped"][0], number="X")
+    assert automatic.scale_decision["status"] == "automatic_replanned"
+    assert automatic.get_annotation("m_env_depth") is not None
+    assert _inside_the_block(automatic) == []
+    assert not [issue for issue in automatic.lint() if issue.severity == "error"]
+
+
+def test_the_recorded_attempt_names_the_symptom_that_opened_the_ladder():
+    """The decision reads back honestly (#1590).
+
+    `required_outcome_dropped` would be wrong here: nothing was dropped as a blocker — the
+    mark was approved and had nowhere to go, which is precisely why the ladder could not see
+    it before. The sibling statuses are pinned the same way in
+    `test_issue_1299_page_escalation`; this one had no test at all.
+    """
+    drawing = build_drawing(CASES["stepped"][0], number="X")
+    attempts = drawing.scale_decision["attempts"]
+    assert [a["status"] for a in attempts][0] == "required_dimension_withheld"
+    assert attempts[0]["reason"] == "remove_optional_iso"
+    # ...and the ladder went on to find a sheet that carries the dimension.
+    assert attempts[-1]["status"] == "complete"
+    assert drawing.get_annotation("m_env_depth") is not None

--- a/tests/test_layout_cleanliness.py
+++ b/tests/test_layout_cleanliness.py
@@ -88,7 +88,17 @@ _KNOWN_OVERLAPS: dict[str, set[frozenset[str]]] = {
         frozenset({"m_slot0_length", "m_locx1"}),
         frozenset({"m_locy0", "m_locy1"}),
     },
-    "plate_holes": {frozenset({"m_locx0", "m_locx1"}), frozenset({"m_locy0", "m_locy1"})},
+    "plate_holes": {
+        frozenset({"m_locx0", "m_locx1"}),
+        frozenset({"m_locy0", "m_locy1"}),
+        # BENIGN, same class as dshape/side_drilled's `<location dim>, m_env_depth` above.
+        # New because the dimension is new: #1590 replans this part off its withheld overall
+        # depth, so `m_env_depth` now exists and joins the y-chain's corridor. All three
+        # boxes start at x=150.63 — one shared datum witness, the ISO 129-1 running-dimension
+        # presentation, not a dim-line overprint.
+        frozenset({"m_locy0", "m_env_depth"}),
+        frozenset({"m_locy1", "m_env_depth"}),
+    },
     "side_drilled": {
         frozenset({"dim_loc_side_y2000", "m_env_depth"}),
     },

--- a/tests/test_make_drawing.py
+++ b/tests/test_make_drawing.py
@@ -5734,7 +5734,13 @@ class TestLintSummaryAndDrops:
         part = Box(80, 60, 20)
         part -= Pos(-39.3, 0, 0) * Cylinder(0.4, 20)  # ~0.7 mm from datum_x: skipped
         part -= Pos(-36.5, 0, 0) * Cylinder(1.5, 20)  # ~2.8 mm from the edge hole
-        dwg = build_drawing(part)
+        # A4 at 1:1 pinned, because that is where the 0.7 mm location is too short to draw
+        # and this test is about what the gate does then. Left automatic, #1590 now escalates
+        # this part to A2 at 2:1 — the overall depth was withheld here, and the larger sheet
+        # places it, locates the second hole, AND makes the 0.7 mm location drawable, so the
+        # skip under test stops happening. `permissive` because the A4 plan is incomplete;
+        # that is the premise, not a surprise.
+        dwg = build_drawing(part, page="A4", scale=1.0, scale_policy="permissive")
         # The real neighbour is dimensioned...
         assert any(n.startswith("m_locx") for n in dwg.annotations())
         # ...and the gate did not record a spurious X spacing drop.

--- a/tests/test_sheet_emit.py
+++ b/tests/test_sheet_emit.py
@@ -44,6 +44,7 @@ from draftwright.sheet_emit import (
     generate_sheet_script,
     mirror_model,
     resolve_object_spec,
+    settled_layout_for,
     unmirrored_dimensions,
 )
 
@@ -2711,8 +2712,20 @@ class TestTheDimensionMirror:
         #932. A corpus rather than one part, because single-fixture guards are how whole
         paths stayed uncovered twice in this series (#925 had no holes, #934 had one ladder).
         """
+        from draftwright.sheet_emit import settled_layout_for
+
         part, model, automatic, _initial = mirror_automatic_drawings[name]
-        src = emit_sheet_script(model, "part", "s", title="T", number="N")
+        # As in `test_the_script_lints_the_same_as_the_direct_build`: an automatic replan is
+        # pinned into the script by `generate_sheet_script`, because the model cannot carry
+        # it (#1590).
+        src = emit_sheet_script(
+            model,
+            "part",
+            "s",
+            title="T",
+            number="N",
+            settled_layout=settled_layout_for(automatic),
+        )
         regenerated = self._run(src, part)["sheet"].build()
 
         names = {n for n, _ in automatic.iter_annotations()}
@@ -4092,10 +4105,23 @@ class TestTheDeclaredModelMatchesTheDetectedOne:
         from unittest.mock import patch
 
         from draftwright import Drawing, build_drawing
+        from draftwright.sheet_emit import settled_layout_for
 
         part = self._corpus()[name]
         direct = build_drawing(part, title="T", number="N")
-        src = emit_sheet_script(detect_part_model(part), "part", "s", title="T", number="N")
+        # `settled_layout` is what `generate_sheet_script` passes, and for the same reason: a
+        # replan is a fact about a MEASURED sheet, so no property of the model reproduces it
+        # and a declared script never re-derives it (#1590). Emitting without it here would
+        # test an emitter call production does not make, and would assert the script matches
+        # a decision it was never told about.
+        src = emit_sheet_script(
+            detect_part_model(part),
+            "part",
+            "s",
+            title="T",
+            number="N",
+            settled_layout=settled_layout_for(direct),
+        )
         captured: dict = {"part": part}
         with patch.object(
             Drawing, "export", lambda self, *a, **k: captured.setdefault("dwg", self)
@@ -4399,6 +4425,31 @@ def test_the_object_reference_doc_quotes_real_generated_output(tmp_path):
     assert not missing, "the doc quotes lines the tool does not emit:\n  " + "\n  ".join(
         missing[:5]
     )
+
+
+def test_a_settled_view_set_is_not_pinned_beside_auto_dimensions(monkeypatch):
+    """#1590 widened who reaches the view pin; this is the combination it must not write.
+
+    A model the emitter cannot mirror keeps `sheet.auto_dimensions()`, and `Sheet` refuses
+    `authored_views()` beside it (ADR 2 — requirements determine views). Pinning a replanned
+    view set there emitted a script that raised the moment anyone ran it. The settled set is
+    still REPORTED, in a comment, because a script that quietly re-derives a different
+    layout is its own defect.
+    """
+    from draftwright import sheet_emit as se
+
+    part = Box(80, 60, 30) - Pos(0, -20, 7.5) * Box(80, 20, 15)
+    settled = settled_layout_for(build_drawing(part, title="T", number="N"))
+    assert settled is not None, "precondition: this part must replan, or nothing is pinned"
+    assert "iso" not in settled["views"], "precondition: the settled set must differ"
+
+    monkeypatch.setattr(se, "_is_mirrorable", lambda _model: False)
+    src = emit_sheet_script(
+        detect_part_model(part), "part", "s", title="T", number="N", settled_layout=settled
+    )
+    assert "sheet.auto_dimensions()" in src, "precondition: the mirror must be refused"
+    assert "sheet.authored_views()" not in src
+    assert "# The automatic build settled on: front, plan, side." in src
 
 
 def test_the_new_iso_7200_fields_reach_the_generated_script():


### PR DESCRIPTION
> **ADR 2 invariant 13 amended, with sign-off.** Maintainer chose to restate the principle rather than extend the enumeration. The record read *"the optional isometric yields only to close missing axial coverage"* — already one trigger behind the code when it was written (the authored-requirement trigger landed 2026-08-23, the corpus was consolidated 2026-09-04 and transcribed the narrower claim). It now reads *"yields only to preserve manufacturing completeness — never for space, crowding or preference"*, and the list it is about is `builder._ISO_YIELD_TRIGGERS`, pinned by `TestWhatMakesTheIsometricYield`. A fourth trigger now fails a test instead of needing a reviewer to notice.

> #1591 has landed (`ac38692`), so this now sits directly on `main`. **8502 passed, 0 failed, 14 xfailed**, `scripts/pr-check --static` clean.

Closes #1590.

## The finding

The recovery ladder was never missing. `build_drawing` already tries larger scales on the selected page, then drops the optional pictorial, then spends a larger page — and `_qualify_candidate` rejects any candidate still carrying an error, so one that has **not** recovered the dimension is already refused. The ladder simply never ran:

```
prismatic_ladder: page=(297,210) scale=1.0 status=automatic
   attempts=[]            <- never entered
   blockers=[]
   errors=[overall_dim_withheld]
```

Its entry gate reads two symptoms — an axial-coverage gap, and a blocker carrying `source_ids` (**authored** intent that failed to place). A required *envelope* dimension that found no room is neither.

## Why it isn't simply made a blocker

`overall_dim_withheld` is deliberately not one. Reporting it through `placement_unsatisfiable` made `build_drawing(part, scale=...)` raise `ScaleIncompatibilityError` on parts that had always built, because `_is_required_scale_drop` matches by code name (#1216 review r9). That argument is about refusing the scale a **caller asked for**. Choosing one automatically is a different question — there is nothing to refuse, and a larger sheet is exactly the repair. One predicate was answering both; `_REPLANNABLE_LOSS_CODES` is the second answer.

Severity is checked rather than assumed: the same codes are recorded at `info` when a measurement is merely too small to letter, which fires on ordinary complete drawings. Deleting that filter fails `bracket_section`'s golden.

## What changes

| part | before | after |
|---|---|---|
| stepped `Box(80, 60, 30)` | A4 1:1, overall depth withheld (error) | A4 1:1, **clean**, pictorial dropped |
| 80 × 60 plate, two close bores | A4 1:1, `incomplete` — unlocated hole, dropped location, withheld depth, `plan_incomplete` | A2 2:1, **clean**, every dimension placed |

Dropping the optional pictorial first is the order #443/#1299 already argue for: a pictorial cannot outrank a dimension needed to manufacture the part. Pinning `page=` or `scale=` opts out — a pinned sheet reports honestly rather than replanning.

## Script parity — the real work

A declared build does what it is told and never enters the ladder (ADR 4), so `generate_sheet_script` pins the settled page, scale and view set into the emitted script. It did that only for the two families whose replan could be **predicted from the model**. Nothing predicts this one: whether a mark fits is a fact about a measured sheet. So the reference build is unconditional.

- **Cost**: one extra `build_drawing` per generated script. Measured through the call: **0.19 s** for a plain box, **0.34 s** for a pocket, **1.17 s** for a part that actually replans (where the ladder itself rebuilds — the case the extra build is *for*).
- **An undrawable source can never fail script generation**, the standard the inspection sidecar beside it already meets: a STEP file holding a bare curve projects no side view and still owes the caller a script. The catch is narrow — it reuses `_is_expected_candidate_build_failure`, the predicate the ladder already uses for this judgement, so a deliberate refusal (unknown page size, `ScaleIncompatibilityError`, `ViewPlanIncomplete`) still reaches the caller instead of becoming a log line plus a script that fails when run.
- **A script keeping `auto_dimensions()` is not handed a pinned view set.** `Sheet` refuses `authored_views()` beside it, so the pair wrote a script that raised the moment anyone ran it. `_mirrors_dimensions` is now one predicate shared by the dimension block and the view pin; when it is false the settled set is reported in a comment rather than declared.
- `settled_layout_for` puts the policy in one place, shared with the round-trip parity tests. Those previously emitted from the model alone, so they asserted the script matched a decision it was never told about — an emitter call production does not make.

## Tests: premises moved, not assertions inverted

Four fixtures stop exhibiting their defect because the automatic path now rescues them. Each pins the sheet or removes the lever so it keeps testing its own subject:

- `test_short_location_does_not_displace_its_legible_neighbour` — A4 1:1 pinned; left automatic it escalates to A2 2:1, which draws the 0.7 mm location the spacing gate exists to skip.
- `test_a_doubly_starved_extent_is_still_reported` — `_include_iso=False`, because the ladder's first move frees this fixture's below strip. Its own precondition assertion is what caught this.
- `test_a_dimension_with_nowhere_to_go_...` (from #1591) — now asserts both halves: pinned, it is withheld and named; automatic, it is replanned onto a sheet that fits.
- `plate_holes` gains two allowlisted overlaps, of the class already accepted on `dshape` and `side_drilled`: `m_env_depth` and the y-chain share one datum witness at x=150.63 — the ISO 129-1 running-dimension presentation, not a dim-line overprint.

Two goldens re-blessed: `pocketed` and `prismatic_ladder` lose their pictorial and regain their overall depth; `prismatic_ladder`'s build issues return to `[]`.

## Independent review, and what it changed

Reviewed in a fresh context with no knowledge of the author's reasoning, briefed to verify the load-bearing claims by execution rather than by reading. It returned **request changes**, on two findings, both now fixed in `06b3e66`:

1. **A script that cannot run.** An unmirrorable model keeps `auto_dimensions()`; pinning `authored_views()` beside it raises. Latent — 0 of 151 STEP fixtures produce an unmirrorable model — but this PR widened the set of models that reach the pin. Fixed, with a guard test.
2. **The catch was too broad.** A blanket `except ValueError` swallowed four deliberate refusals. Narrowed to the repo's own predicate, with a caplog test on each side.

It also refuted three of my prose claims, all corrected: the 1.5 s timing (~4× overstated), a `scale_policy="permissive"` that was inert with a false stated reason — now a loop asserting all three policies return `honored`, which is the #1216 r9 invariant the split had to preserve — and a local OCP import whose comment claimed a saving that did not exist.

And it confirmed what mattered: both mutation claims reproduce exactly, the predicate split creates no second source of truth (`_REPLANNABLE_LOSS_CODES` is *derived* from `_WITHHOLDING_CODES`), the explicit-scale path is untouched, the measured before/after numbers hold, the `plate_holes` allowlist justification is true of the geometry rather than a plausible story, and the re-premised tests still fail when the behaviour they guard is broken. On a real STEP part it found the ladder entering, trying five candidates, rejecting all, and still reporting the error — honest failure rather than a silent claim of repair.

## Mutation evidence

- Trigger never fires → 4 named tests fail across 3 modules.
- Severity filter deleted → `bracket_section` golden fails.

## Architectural fit

One predicate split into two because it was answering two questions (ADR 5: honest failure — a drawing that reports incompleteness it could have repaired is not honest, it is unfinished). No new lever, no new selection policy, no change to the acceptance gates. The emitter change is ADR 4: declared intent does not re-derive an automatic decision, so the decision is written down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeWRqP9V6ZrAnHNW2Cibn6



