### PR TITLE
Stop reporting the drawing's own rounding as a topology error (#1600)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@
 
 ### Fixed
 
+- **`label_vs_measured` no longer reports the drawing's own rounding as a topology error
+  (#1600).** A sheet at one decimal place prints 4.450 as `4.5`; the check then compared
+  `4.5` against 4.450 and said "possible axis swap or wrong endpoint". The comparison was
+  *relative*, so the same 0.05 mm of rounding passed silently on a 100 mm dimension and was
+  an error on a 4 mm one — it fired on smallness, not on wrongness.
+
+  A label now states its own precision: `4.5` shows one place, `4.45` two, `12` none. A
+  difference within half of the last displayed place is the label doing its job; anything
+  beyond it is still reported, and an axis swap or wrong endpoint misses by far more.
+
+  This is a prerequisite for #1602's proposed CI gate: `label_vs_measured` sits in the
+  register of codes meaning *the sheet says something untrue*, and a code that fires on
+  correct rounding cannot be hard-failed on.
+
+### Fixed
+
 - **A required dimension with nowhere to go now re-plans the sheet instead of being
   reported and left (#1590).** The automatic recovery ladder — larger scales on the
   selected page, then dropping the optional pictorial, then a larger page — already

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,28 @@
   register of codes meaning *the sheet says something untrue*, and a code that fires on
   correct rounding cannot be hard-failed on.
 
+### Added
+
+- **`nominal_rounded` says where the sheet's precision loses the model value.** Silencing
+  the false alarm above left nothing reporting it at all, and `4.5` for 4.450 is still a
+  real 0.05 mm between drawing and model — on a part carrying 0.05 mm clearances, the whole
+  clearance. One `info` per sheet, naming the worst case:
+
+  > 7 dimension(s) print a nominal the model does not have, rounded to the sheet's
+  > precision; the largest is '15.7' for 15.6500 (0.0500 mm). Within a general tolerance
+  > this is ordinary; where a fit depends on it, raise that dimension's places with
+  > `.format(decimals=...)`
+
+  It does **not** guess, and does not change any rounding. `4.450` locating a hinge axis is
+  design intent; `71.595` as an overall envelope is parametric fallout no drafter would
+  print in full — and telling them apart needs to know what the part is *for*, which a STEP
+  file does not carry (the same gap as #1597). So the engine reports and the author decides:
+  `.format(decimals=…)` already sets places per dimension and survives the `--script` round
+  trip.
+
+  Measured: 7 of 25 numeric dimension labels on `whistle_frame_reference.step`; silent on
+  every golden fixture, all of which are built from round numbers.
+
 ### Fixed
 
 - **A required dimension with nowhere to go now re-plans the sheet instead of being

--- a/src/draftwright/linting/quality.py
+++ b/src/draftwright/linting/quality.py
@@ -312,6 +312,13 @@ _UNSCORED_CODES = frozenset(
         "authored_omission",
         "axial_length_missing",
         "boss_height_missing",
+        # Where the sheet's precision prints a nominal the model does not have (#1600). Not
+        # fidelity: the label IS the measurement written to the places the sheet uses, and a
+        # general tolerance covers the difference — the check that treated it as a false
+        # statement was the defect. Not legibility either; the sheet reads perfectly. It is a
+        # statement about precision POLICY, which has no register of its own until #1602
+        # builds one.
+        "nominal_rounded",
         # The `*_withheld` family (#1216), kept together and in place alphabetically. Each is a
         # claim the drawing declined to make because it could not make it honestly, and said
         # so: a jittered pattern pitch, a step height the page cannot carry, and an `n×` mark

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -696,6 +696,12 @@ def lint_drawing(
         if hasattr(part_bbox.min, "Z") and hasattr(part_bbox.max, "Z"):
             _check_extent("Z", part_bbox.max.Z - part_bbox.min.Z)
 
+    # After the per-item pass, because it is an observation about the sheet rather than about
+    # any one annotation. That orders it within THIS function only: structural issues still
+    # precede the recognition-derived ones in a finished `Drawing.lint()`, so a caller that
+    # wants a particular finding must select it by code — `issues[0]` was never a stable
+    # address and one test was relying on it.
+    _lint_display_precision(items, issues, drawing_scale)
     return issues
 
 
@@ -762,6 +768,67 @@ def _view_edge_entries(vs, cache):
         entries = None
     cache[key] = (vs, entries)
     return entries
+
+
+#: Below this, in millimetres, a difference between the label and the model value is float
+#: noise from projection arithmetic rather than the sheet's precision losing anything real.
+_NOMINAL_SHIFT_FLOOR = 5e-4
+
+
+def _lint_display_precision(items, issues, drawing_scale: float = 1.0) -> None:
+    """Say where the sheet's precision prints a nominal the model does not have (#1600).
+
+    Correct rounding is not a defect, and since #1600 `label_vs_measured` no longer reports it
+    — rightly, because it was reporting it only on SHORT dimensions, where the same 0.05 mm
+    was a large enough fraction to trip a relative threshold. But that left nothing saying it
+    at all, and 4.450 printed as `4.5` is a real 0.05 mm between the drawing and the model. On
+    a part carrying 0.05 mm clearances, that is the whole clearance.
+
+    The engine cannot tell which of those matter. `4.450` locating a hinge axis is design
+    intent; `71.595` as an overall envelope is parametric fallout that no drafter would print
+    in full. Deciding between them needs to know what the part is FOR, which a STEP file does
+    not carry — the same gap as #1597.
+
+    So this does not guess and does not change the rounding. It reports, once per sheet with
+    the worst case named, so the difference is visible and the author can raise the places on
+    the dimensions that carry the function: `.format(decimals=…)` already does that per
+    dimension, and survives the `--script` round trip.
+
+    `info`, because within the title block's general tolerance a rounded nominal is ordinary
+    drafting. It is the parts whose real tolerance is tighter than the stated one where this
+    matters, and the sheet cannot know that either.
+    """
+    shortfalls = []
+    for item in items:
+        label = _item_label(item)
+        label_val = _label_reading(item, label)
+        measurement = dimension_path_measurement(item, drawing_scale)
+        if label_val is None or measurement is None:
+            continue
+        measured, item_scale = measurement
+        effective = measured / item_scale
+        if effective <= 1e-6:
+            continue
+        shift = abs(label_val - effective)
+        if shift > _NOMINAL_SHIFT_FLOOR:
+            shortfalls.append((shift, label, effective))
+    if not shortfalls:
+        return
+    shortfalls.sort(key=lambda entry: (-entry[0], entry[1]))
+    worst_shift, worst_label, worst_value = shortfalls[0]
+    issues.append(
+        LintIssue(
+            severity="info",
+            code="nominal_rounded",
+            message=(
+                f"{len(shortfalls)} dimension(s) print a nominal the model does not have, "
+                f"rounded to the sheet's precision; the largest is '{worst_label}' for "
+                f"{worst_value:.4f} ({worst_shift:.4f} mm). Within a general tolerance this is "
+                f"ordinary; where a fit depends on it, raise that dimension's places with "
+                f".format(decimals=...)"
+            ),
+        )
+    )
 
 
 def _lint_scale_stated(items, issues) -> None:

--- a/src/draftwright/linting/structural.py
+++ b/src/draftwright/linting/structural.py
@@ -182,6 +182,38 @@ def _label_bbox(item, warned=None):
         return None
 
 
+_DECIMALS_IN_LABEL = re.compile(r"\d+\.(\d+)")
+
+
+def _displayed_decimals(label: str) -> int:
+    """How many decimal places the label actually PRINTS.
+
+    The drawing's precision is not reachable from a placed dimension — it carries no draft —
+    and it need not be one number anyway, since an authored dimension may set its own with
+    ``.format(decimals=…)``. But the label states its own precision by being written: `4.5`
+    shows one place, `4.45` two, `12` none. Reading it back is exact and needs no coupling to
+    a constant that a later per-dimension policy would make wrong.
+    """
+    match = _DECIMALS_IN_LABEL.search(label)
+    return len(match.group(1)) if match else 0
+
+
+def _is_correctly_rounded(label_val: float, measured: float, label: str) -> bool:
+    """Whether the label is the measurement, written to the precision the label uses.
+
+    A drawing prints 4.450 as `4.5` at one decimal place, and the engine then compared `4.5`
+    against 4.450 and called the 1.1% difference "possible axis swap or wrong endpoint"
+    (#1600). The comparison was relative, so the SAME 0.05 mm of rounding passed silently on
+    a 100 mm dimension and was reported as a topology error on a 4 mm one — the check fired
+    on smallness, not on wrongness.
+
+    Rounding can move a value by at most half of the last displayed place, so anything within
+    that is the label doing its job. Anything beyond it is a real disagreement and still
+    reported: an axis swap or a wrong endpoint misses by far more than half a display unit.
+    """
+    return abs(label_val - measured) <= 0.5 * 10.0 ** -_displayed_decimals(label) + 1e-9
+
+
 def _label_reading(item, label: str) -> float | None:
     """The value *item*'s label asserts about the path it is drawn on, or ``None``.
 
@@ -1222,7 +1254,9 @@ def _lint_dim(item, part_bbox, issues, drawing_scale: float = 1.0, box_cache=Non
     if label_val is not None and measurement is not None:
         measured, item_scale = measurement
         effective_measured = measured / item_scale
-        if effective_measured > 1e-6:
+        if effective_measured > 1e-6 and not _is_correctly_rounded(
+            label_val, effective_measured, label
+        ):
             ratio = abs(label_val - effective_measured) / effective_measured
             if ratio > 0.005:
                 issues.append(

--- a/tests/test_issue_1058_wheel_profile.py
+++ b/tests/test_issue_1058_wheel_profile.py
@@ -331,12 +331,21 @@ def test_real_wheel_no_longer_gets_a_confident_envelope_only_result(wheel_drawin
     summary = wheel_drawing.lint_summary()
     assert summary["by_code"] == {
         "gear_semantics_missing": 1,
+        # The wheel's turned profile gives lengths that are not round at one decimal place,
+        # so the sheet prints nominals a few microns off the model and says so (#1600). An
+        # `info`; the two findings this test is about are unchanged.
+        "nominal_rounded": 1,
         "unrecognised_defining_geometry": 1,
     }
     assert summary["score"] < 1.0
-    assert "unsupported outer boundary" in summary["issues"][0]["message"]
-    assert "13 evenly spaced common-circle arcs" in summary["issues"][0]["message"]
-    assert "gear" not in summary["issues"][0]["message"].lower()
+    # Selected by code, not by index: `issues[0]` happened to be this finding and stopped
+    # being so as soon as another code joined the sheet (#1600's `nominal_rounded`).
+    (unrecognised,) = [
+        issue for issue in summary["issues"] if issue["code"] == "unrecognised_defining_geometry"
+    ]
+    assert "unsupported outer boundary" in unrecognised["message"]
+    assert "13 evenly spaced common-circle arcs" in unrecognised["message"]
+    assert "gear" not in unrecognised["message"].lower()
 
 
 def test_synthetic_double_d_profile_is_recognised_without_lint_rescans():

--- a/tests/test_issue_1308_machined_leader_analytics.py
+++ b/tests/test_issue_1308_machined_leader_analytics.py
@@ -58,7 +58,13 @@ EXPECTED = {
             "scale_note": ("Note", (254.67, 46.0, 267.0, 48.166)),
             "note_iso_nts": ("Note", (155.693, 115.549, 180.026, 118.243)),
         },
-        {"gear_semantics_missing": 1, "unrecognised_defining_geometry": 1},
+        # `nominal_rounded` (#1600): this wheel's lengths are not round at one decimal
+        # place, so the sheet reports that its printed nominals differ from the model.
+        {
+            "gear_semantics_missing": 1,
+            "nominal_rounded": 1,
+            "unrecognised_defining_geometry": 1,
+        },
     ),
     "nist_ctc_01_asme1_ap242.stp": (
         {

--- a/tests/test_issue_909_sloped_profile.py
+++ b/tests/test_issue_909_sloped_profile.py
@@ -108,8 +108,13 @@ def test_case_study_pad_reaches_the_drawing_with_complete_owned_footprint(monkey
     ) == Counter({"51.1°": 1, "128.9°": 1})
     # An angle label over a blank region inside the view extents is legitimate;
     # every diagnostic must describe that informational condition only.
+    # `nominal_rounded` joins it: this part's sloped profile gives lengths that are not
+    # round at one decimal place, so the sheet prints nominals a few microns off the model
+    # and now says so (#1600). Also informational, and the assertion below still holds the
+    # line that matters — nothing here is a warning or an error.
     assert all(
-        issue.severity == "info" and issue.code == "view_annotation_inside_extents"
+        issue.severity == "info"
+        and issue.code in {"view_annotation_inside_extents", "nominal_rounded"}
         for issue in drawing.lint()
     )
 

--- a/tests/test_lint_structural.py
+++ b/tests/test_lint_structural.py
@@ -689,3 +689,48 @@ class TestDisplayedDecimals:
         from draftwright.linting.structural import _displayed_decimals
 
         assert _displayed_decimals(label) == expected
+
+
+class TestNominalRounded:
+    """The honest counterpart to #1600's fix.
+
+    Correct rounding is not a defect, so `label_vs_measured` stopped reporting it. But 4.450
+    printed as `4.5` is still a real 0.05 mm between the drawing and the model, and after that
+    fix nothing said so at all. This says it — once, with the worst case named — without
+    guessing which dimensions care.
+    """
+
+    @staticmethod
+    def _dim(draft, label, path_mm):
+        from build123d_drafting.helpers import Dimension
+
+        return Dimension((0, 0, 0), (path_mm, 0, 0), "above", 8, draft, label=label)
+
+    def _reports(self, issues):
+        return [i for i in issues if i.code == "nominal_rounded"]
+
+    def test_a_rounded_nominal_is_reported_once_naming_the_worst(self, draft):
+        issues = lint_drawing(
+            [
+                self._dim(draft, "4.5", 4.450),  # 0.05 out — the worst
+                self._dim(draft, "57.1", 57.095),  # 0.005 out
+            ]
+        )
+        (report,) = self._reports(issues)
+        assert report.severity == "info"
+        assert "2 dimension(s)" in report.message
+        assert "'4.5'" in report.message and "4.4500" in report.message
+
+    def test_an_exact_drawing_reports_nothing(self, draft):
+        assert self._reports(lint_drawing([self._dim(draft, "40", 40.0)])) == []
+
+    def test_projection_noise_is_not_a_rounded_nominal(self, draft):
+        """The floor exists so float arithmetic in the projection does not read as a
+        precision decision. A tenth of a micron is not the sheet losing anything."""
+        assert self._reports(lint_drawing([self._dim(draft, "40", 40.0000001)])) == []
+
+    def test_it_does_not_fire_on_a_label_that_is_simply_wrong(self, draft):
+        """That is `label_vs_measured`'s job, and it still does it. This one is about
+        precision, so a 35-for-20 mislabel must not be laundered into an `info`."""
+        issues = lint_drawing([self._dim(draft, "35", 20.0)])
+        assert [i.code for i in issues if i.code == "label_vs_measured"]

--- a/tests/test_lint_structural.py
+++ b/tests/test_lint_structural.py
@@ -615,3 +615,77 @@ class TestScaleNotStated:
         drawing = build_drawing(Box(40, 30, 12), number="X")
         assert not [i for i in drawing.lint() if i.code == "scale_not_stated"]
         assert drawing.get_annotation("scale_note") is not None
+
+
+class TestRoundingIsNotADiscrepancy:
+    """`label_vs_measured` must not report the drawing's own rounding (#1600).
+
+    A sheet at one decimal place prints 4.450 as `4.5`. The check then compared `4.5`
+    against 4.450 and called the difference "possible axis swap or wrong endpoint". Because
+    the comparison was RELATIVE, the same 0.05 mm of rounding passed silently on a 100 mm
+    dimension and was an error on a 4 mm one — it fired on smallness, not on wrongness.
+
+    This matters beyond the noise: `label_vs_measured` is in `_FIDELITY_CODES`, the register
+    of codes meaning *the sheet says something untrue*, and #1602 proposes hard-failing CI on
+    that register. A code that fires on correct rounding cannot be in it.
+    """
+
+    @staticmethod
+    def _dim(draft, label, path_mm):
+        from build123d_drafting.helpers import Dimension
+
+        return Dimension((0, 0, 0), (path_mm, 0, 0), "above", 8, draft, label=label)
+
+    def test_a_correctly_rounded_label_is_not_reported(self, draft):
+        # The #1595 case: 4.450 printed at one decimal place.
+        issues = lint_drawing([self._dim(draft, "4.5", 4.450)])
+        assert [i for i in issues if i.code == "label_vs_measured"] == []
+
+    def test_the_same_rounding_on_a_long_dimension_is_also_not_reported(self, draft):
+        """The asymmetry that gave it away: 0.05 mm is 0.05% of 100 and 1.1% of 4.45, so a
+        relative threshold reported one and not the other. Both are the same rounding."""
+        issues = lint_drawing([self._dim(draft, "100.0", 100.05)])
+        assert [i for i in issues if i.code == "label_vs_measured"] == []
+
+    def test_a_label_that_is_not_the_rounding_is_still_reported(self, draft):
+        """The check keeps its job. 4.6 is not 4.450 rounded to one place — half a display
+        unit is 0.05, and this misses by 0.15."""
+        issues = [
+            i
+            for i in lint_drawing([self._dim(draft, "4.6", 4.450)])
+            if i.code == "label_vs_measured"
+        ]
+        assert issues, "a label that is not the rounded measurement must still be reported"
+
+    def test_an_axis_swap_is_still_reported(self, draft):
+        issues = [
+            i
+            for i in lint_drawing([self._dim(draft, "35", 20.0)])
+            if i.code == "label_vs_measured"
+        ]
+        assert issues and all(i.severity == "error" for i in issues)
+
+    def test_the_tolerance_follows_the_places_the_label_prints(self, draft):
+        """Two decimal places means a tenth of the slack one place gets. `4.45` may be
+        4.4451; it may not be 4.45 plus half of one decimal place."""
+        assert not [
+            i
+            for i in lint_drawing([self._dim(draft, "4.45", 4.4501)])
+            if i.code == "label_vs_measured"
+        ]
+        assert [
+            i
+            for i in lint_drawing([self._dim(draft, "4.45", 4.4900)])
+            if i.code == "label_vs_measured"
+        ]
+
+
+class TestDisplayedDecimals:
+    @pytest.mark.parametrize(
+        ("label", "expected"),
+        [("4.5", 1), ("4.45", 2), ("12", 0), ("⌀12.75", 2), ("2× ⌀2.4 THRU", 1), ("", 0)],
+    )
+    def test_it_reads_the_places_the_label_prints(self, label, expected):
+        from draftwright.linting.structural import _displayed_decimals
+
+        assert _displayed_decimals(label) == expected


### PR DESCRIPTION
Closes #1600. Part of epic #1595. **8522 passed, 0 failed, 14 xfailed**, real-part canary 8 passed, `scripts/pr-check --static` clean.

> **Reviewed independently and revised.** The review found two regressions I introduced and one misleading message; all three are fixed in `2bf7442`. Summary at the bottom.

## The defect

A sheet at one decimal place prints 4.450 as `4.5`. The check then compared `4.5` against 4.450 and reported:

```
[warning] label_vs_measured: Dim '4.5': label value 4.500 differs from measured path
length 4.450 by 1.1% — possible axis swap or wrong endpoint
```

Nothing is wrong with the geometry, the endpoints or the axis.

## Why it fired

The comparison is **relative**: `|label − measured| / measured > 0.005`. Rounding to one place moves a value by at most 0.05 mm, which is 0.05% of a 100 mm dimension and 1.1% of a 4.45 mm one. **The check fired on smallness, not on wrongness** — the same rounding passed silently on the long dimension and was reported as a topology error on the short one.

## The fix

A label states its own precision by being written: `4.5` shows one place, `4.45` two, `12` none. A difference within **half of the last displayed place** is the label doing its job. Beyond that it is still reported — an axis swap or a wrong endpoint misses by far more.

Reading the precision off the label rather than from `decimal_precision` matters: a placed dimension does not carry a draft, and the sheet's precision will not be one number once `.format(decimals=…)` reaches automatic dimensions.

## Why it is a prerequisite, not just noise

`label_vs_measured` is in `_FIDELITY_CODES` — the register of codes meaning *the sheet says something untrue* — and #1602 proposes hard-failing CI on exactly that register. A code that fires on correct rounding cannot be in it.

## Evidence

On `tests/fixtures/whistle_frame_reference.step`, **7 of 25** numeric dimension labels differ from the model value purely by rounding (up to 0.05 mm). The warning is gone; nothing else on the sheet changes.

| mutation | result |
|---|---|
| rounding allowance removed | 1 named test fails |
| displayed places hardcoded to 3 | 7 named tests fail |

## What this does *not* do

It stops the tool misreporting rounding. It does not change the rounding. See the note on the issue about display precision — on that same part six labels state a nominal the model does not have, and 1 dp is currently a hardcoded constant with no policy behind it. That is a drafting decision, not a bug fix, so it is written up separately rather than decided here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeWRqP9V6ZrAnHNW2Cibn6



## Independent review, and what it changed

Reviewed in a fresh context with no knowledge of the author's reasoning. It returned **request changes**, correctly, on three findings:

1. **The allowance was 10× too loose where it mattered.** `_fmt` trims a trailing `.0`, so a 1 dp sheet prints 40.0 as `40` — zero places in the string, 0.05 mm of real precision behind it. Reading places off the string granted **half a millimetre** of slack to every whole-numbered label, so `40` on a 40.45 mm path passed as ordinary rounding. That is a 1.1% mislabel the check used to catch, moved out of the fidelity register and into an `info` asserting it is ordinary — the opposite of what this PR exists to enable. My stated reason for not using the sheet's precision was also false: an engine-built dimension carries it on `_dw_spec.draft`. The sheet is now the floor; a bare numeric label may raise it.

2. **`nominal_rounded` counted genuine mislabels as rounding**, and being the largest shift one became the "worst case" named — displacing the thing the info exists to surface. Now gated on the rounding test. The test named for this never tested it.

3. **The remedy did not work for the dimensions it named.** Six of seven offenders on the fixture are location dimensions, and `.format()` refuses a location intent outright. The message no longer prescribes something that raises `ValueError`; the gap is #1610.

It also found that the test stand-ins built raw `Dimension`s carrying no `_dw_spec`, so they exercised the no-draft fallback rather than the path every real sheet takes — which is why nothing caught (1). They now go through `_core._dim`, and a standing guard pins the real fixture's behaviour.

Two prose corrections: comments saying "a few microns" where the measurements are 0.05 mm and 0.027 mm, and this PR's own test count, which had been measured on the first commit and not re-run.

What it confirmed: "7 of 25 numeric labels" exact, "silent on every golden fixture" exact, both stated mutations reproduce, `_UNSCORED_CODES` is the right register, and the `issues[0]` → select-by-code change is a real improvement.
